### PR TITLE
all: use fmt for error wrapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/lib/pq v1.10.9
-	github.com/pkg/errors v0.9.1
 	github.com/rubenv/sql-migrate v1.6.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
@@ -34,6 +33,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.17.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect

--- a/internal/data/payments.go
+++ b/internal/data/payments.go
@@ -2,9 +2,8 @@ package data
 
 import (
 	"context"
+	"fmt"
 	"wallet-backend/internal/db"
-
-	"github.com/stellar/go/support/errors"
 )
 
 type PaymentModel struct {
@@ -15,7 +14,7 @@ func (m *PaymentModel) SubscribeAddress(ctx context.Context, address string) err
 	const query = `INSERT INTO accounts (stellar_address) VALUES ($1) ON CONFLICT DO NOTHING`
 	_, err := m.db.ExecContext(ctx, query, address)
 	if err != nil {
-		return errors.Wrapf(err, "subscribing address %s to payments tracking", address)
+		return fmt.Errorf("subscribing address %s to payments tracking: %w", address, err)
 	}
 
 	return nil
@@ -25,7 +24,7 @@ func (m *PaymentModel) UnsubscribeAddress(ctx context.Context, address string) e
 	const query = `DELETE FROM accounts WHERE stellar_address = $1`
 	_, err := m.db.ExecContext(ctx, query, address)
 	if err != nil {
-		return errors.Wrapf(err, "unsubscribing address %s to payments tracking", address)
+		return fmt.Errorf("unsubscribing address %s to payments tracking: %w", address, err)
 	}
 
 	return nil

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -2,10 +2,10 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/stellar/go/support/errors"
 )
 
 type ConnectionPool interface {
@@ -34,14 +34,14 @@ const (
 func OpenDBConnectionPool(dataSourceName string) (ConnectionPool, error) {
 	sqlxDB, err := sqlx.Open("postgres", dataSourceName)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating app DB connection pool")
+		return nil, fmt.Errorf("error creating app DB connection pool: %w", err)
 	}
 	sqlxDB.SetConnMaxIdleTime(MaxDBConnIdleTime)
 	sqlxDB.SetMaxOpenConns(MaxOpenDBConns)
 
 	err = sqlxDB.Ping()
 	if err != nil {
-		return nil, errors.Wrap(err, "error pinging app DB connection pool")
+		return nil, fmt.Errorf("error pinging app DB connection pool: %w", err)
 	}
 
 	return &DBConnectionPoolImplementation{DB: sqlxDB}, nil

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -10,7 +10,6 @@ import (
 	"wallet-backend/internal/serve/httphandler"
 
 	"github.com/go-chi/chi"
-	"github.com/pkg/errors"
 	supporthttp "github.com/stellar/go/support/http"
 	supportlog "github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/health"
@@ -30,7 +29,7 @@ type handlerDeps struct {
 func Serve(cfg Configs) error {
 	deps, err := getHandlerDeps(cfg)
 	if err != nil {
-		return errors.Wrap(err, "setting up handler depedencies")
+		return fmt.Errorf("setting up handler dependencies: %w", err)
 	}
 
 	addr := fmt.Sprintf(":%d", cfg.Port)
@@ -51,11 +50,11 @@ func Serve(cfg Configs) error {
 func getHandlerDeps(cfg Configs) (handlerDeps, error) {
 	dbConnectionPool, err := db.OpenDBConnectionPool(cfg.DatabaseURL)
 	if err != nil {
-		return handlerDeps{}, errors.Wrap(err, "error connecting to the database")
+		return handlerDeps{}, fmt.Errorf("error connecting to the database: %w", err)
 	}
 	models, err := data.NewModels(dbConnectionPool)
 	if err != nil {
-		return handlerDeps{}, errors.Wrap(err, "error creating models for Serve")
+		return handlerDeps{}, fmt.Errorf("error creating models for Serve: %w", err)
 	}
 
 	return handlerDeps{


### PR DESCRIPTION
### What

Use the `fmt` package for error wrapping.

### Why

The third-party errors package is unnecessary because we can now use the standard library.

### Known limitations

N/A

### Issue that this PR addresses


### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
