### PR TITLE
all: channel accounts tests

### DIFF
--- a/internal/serve/middleware/middleware_test.go
+++ b/internal/serve/middleware/middleware_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi"
-	"github.com/sirupsen/logrus"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/wallet-backend/internal/serve/auth"
 	"github.com/stretchr/testify/assert"
@@ -138,11 +137,8 @@ func TestSignatureMiddleware(t *testing.T) {
 	})
 }
 
-func Test_RecoverHandler(t *testing.T) {
-	// setup logger to assert the logged texts later
-	buf := new(strings.Builder)
-	log.DefaultLogger.SetOutput(buf)
-	log.DefaultLogger.SetLevel(logrus.TraceLevel)
+func TestRecoverHandler(t *testing.T) {
+	getEntries := log.DefaultLogger.StartTest(log.ErrorLevel)
 
 	// setup
 	r := chi.NewRouter()
@@ -164,6 +160,7 @@ func Test_RecoverHandler(t *testing.T) {
 	}`
 	assert.JSONEq(t, wantJson, rr.Body.String())
 
-	// assert logged text
-	assert.Contains(t, buf.String(), "panic: test panic", "should log the panic message")
+	entries := getEntries()
+	require.Len(t, entries, 2)
+	assert.Contains(t, entries[0].Message, "panic: test panic", "should log the panic message")
 }

--- a/internal/services/channel_account_service.go
+++ b/internal/services/channel_account_service.go
@@ -70,7 +70,7 @@ func (s *channelAccountService) EnsureChannelAccounts(ctx context.Context, numbe
 	}
 
 	if err = s.submitCreateChannelAccountsOnChainTransaction(ctx, distributionAccountPublicKey, ops); err != nil {
-		return fmt.Errorf("inserting channel accounts: %w", err)
+		return fmt.Errorf("submitting create channel accounts on chain transaction: %w", err)
 	}
 
 	if err = s.ChannelAccountStore.BatchInsert(ctx, s.DB, channelAccountsToInsert); err != nil {
@@ -104,7 +104,7 @@ func (s *channelAccountService) submitCreateChannelAccountsOnChainTransaction(ct
 		return fmt.Errorf("signing transaction: %w", err)
 	}
 
-	hash, err := signedTx.Hash(s.DistributionAccountSignatureClient.NetworkPassphrase())
+	hash, err := signedTx.HashHex(s.DistributionAccountSignatureClient.NetworkPassphrase())
 	if err != nil {
 		return fmt.Errorf("getting transaction hash: %w", err)
 	}

--- a/internal/services/channel_account_service_test.go
+++ b/internal/services/channel_account_service_test.go
@@ -1,0 +1,273 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/network"
+	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/support/render/problem"
+	"github.com/stellar/go/txnbuild"
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/signing"
+	"github.com/stellar/wallet-backend/internal/signing/channelaccounts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChannelAccountServiceEnsureChannelAccounts(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	ctx := context.Background()
+	horizonClient := horizonclient.MockClient{}
+	signatureClient := signing.SignatureClientMock{}
+	channelAccountStore := channelaccounts.ChannelAccountStoreMock{}
+	privateKeyEncrypter := channelaccounts.DefaultPrivateKeyEncrypter{}
+	passphrase := "test"
+	s, err := NewChannelAccountService(ChannelAccountServiceOptions{
+		DB:                                 dbConnectionPool,
+		HorizonClient:                      &horizonClient,
+		BaseFee:                            100 * txnbuild.MinBaseFee,
+		DistributionAccountSignatureClient: &signatureClient,
+		ChannelAccountStore:                &channelAccountStore,
+		PrivateKeyEncrypter:                &privateKeyEncrypter,
+		EncryptionPassphrase:               passphrase,
+	})
+	require.NoError(t, err)
+
+	t.Run("sufficient_number_of_channel_accounts", func(t *testing.T) {
+		channelAccountStore.
+			On("Count", ctx).
+			Return(5, nil).
+			Once()
+		defer channelAccountStore.AssertExpectations(t)
+
+		err := s.EnsureChannelAccounts(ctx, 5)
+		require.NoError(t, err)
+	})
+
+	t.Run("horizon_timeout", func(t *testing.T) {
+		channelAccountStore.
+			On("Count", ctx).
+			Return(2, nil).
+			Once()
+		defer channelAccountStore.AssertExpectations(t)
+
+		distributionAccount := keypair.MustRandom()
+		channelAccountsAddressesBeingInserted := []string{}
+		signedTx := txnbuild.Transaction{}
+		signatureClient.
+			On("GetAccountPublicKey", ctx).
+			Return(distributionAccount.Address(), nil).
+			Once().
+			On("SignStellarTransaction", ctx, mock.AnythingOfType("*txnbuild.Transaction"), []string{distributionAccount.Address()}).
+			Run(func(args mock.Arguments) {
+				tx, ok := args.Get(1).(*txnbuild.Transaction)
+				require.True(t, ok)
+
+				assert.Equal(t, distributionAccount.Address(), tx.SourceAccount().AccountID)
+				assert.Len(t, tx.Operations(), 3)
+
+				for _, op := range tx.Operations() {
+					caOp, ok := op.(*txnbuild.CreateAccount)
+					require.True(t, ok)
+
+					assert.Equal(t, "1", caOp.Amount)
+					assert.Equal(t, distributionAccount.Address(), caOp.SourceAccount)
+					channelAccountsAddressesBeingInserted = append(channelAccountsAddressesBeingInserted, caOp.Destination)
+				}
+
+				tx, err = tx.Sign(network.TestNetworkPassphrase, distributionAccount)
+				require.NoError(t, err)
+
+				signedTx = *tx
+			}).
+			Return(&signedTx, nil).
+			Once().
+			On("NetworkPassphrase").
+			Return(network.TestNetworkPassphrase).
+			Once()
+		defer signatureClient.AssertExpectations(t)
+
+		horizonClient.
+			On("AccountDetail", horizonclient.AccountRequest{AccountID: distributionAccount.Address()}).
+			Return(horizon.Account{
+				AccountID: distributionAccount.Address(),
+				Sequence:  123,
+			}, nil).
+			Once().
+			On("SubmitTransaction", mock.AnythingOfType("*txnbuild.Transaction")).
+			Return(horizon.Transaction{}, horizonclient.Error{
+				Response: &http.Response{},
+				Problem: problem.P{
+					Type:   "https://stellar.org/horizon-errors/timeout",
+					Status: http.StatusRequestTimeout,
+					Detail: "Timeout",
+					Extras: map[string]interface{}{},
+				},
+			}).
+			Once()
+		defer horizonClient.AssertExpectations(t)
+
+		err := s.EnsureChannelAccounts(ctx, 5)
+		require.Error(t, err)
+
+		txHash, hashErr := signedTx.HashHex(network.TestNetworkPassphrase)
+		require.NoError(t, hashErr)
+		assert.EqualError(t, err, fmt.Sprintf("submitting create channel accounts on chain transaction: horizon request timed out while creating a channel account. Transaction hash: %s", txHash))
+	})
+
+	t.Run("horizon_bad_request", func(t *testing.T) {
+		channelAccountStore.
+			On("Count", ctx).
+			Return(2, nil).
+			Once()
+		defer channelAccountStore.AssertExpectations(t)
+
+		distributionAccount := keypair.MustRandom()
+		channelAccountsAddressesBeingInserted := []string{}
+		signedTx := txnbuild.Transaction{}
+		signatureClient.
+			On("GetAccountPublicKey", ctx).
+			Return(distributionAccount.Address(), nil).
+			Once().
+			On("SignStellarTransaction", ctx, mock.AnythingOfType("*txnbuild.Transaction"), []string{distributionAccount.Address()}).
+			Run(func(args mock.Arguments) {
+				tx, ok := args.Get(1).(*txnbuild.Transaction)
+				require.True(t, ok)
+
+				assert.Equal(t, distributionAccount.Address(), tx.SourceAccount().AccountID)
+				assert.Len(t, tx.Operations(), 3)
+
+				for _, op := range tx.Operations() {
+					caOp, ok := op.(*txnbuild.CreateAccount)
+					require.True(t, ok)
+
+					assert.Equal(t, "1", caOp.Amount)
+					assert.Equal(t, distributionAccount.Address(), caOp.SourceAccount)
+					channelAccountsAddressesBeingInserted = append(channelAccountsAddressesBeingInserted, caOp.Destination)
+				}
+
+				tx, err = tx.Sign(network.TestNetworkPassphrase, distributionAccount)
+				require.NoError(t, err)
+
+				signedTx = *tx
+			}).
+			Return(&signedTx, nil).
+			Once().
+			On("NetworkPassphrase").
+			Return(network.TestNetworkPassphrase).
+			Once()
+		defer signatureClient.AssertExpectations(t)
+
+		horizonClient.
+			On("AccountDetail", horizonclient.AccountRequest{AccountID: distributionAccount.Address()}).
+			Return(horizon.Account{
+				AccountID: distributionAccount.Address(),
+				Sequence:  123,
+			}, nil).
+			Once().
+			On("SubmitTransaction", mock.AnythingOfType("*txnbuild.Transaction")).
+			Return(horizon.Transaction{}, horizonclient.Error{
+				Response: &http.Response{},
+				Problem: problem.P{
+					Title:  "Some bad request error",
+					Status: http.StatusBadRequest,
+					Detail: "Bad Request",
+					Extras: map[string]interface{}{},
+				},
+			}).
+			Once()
+		defer horizonClient.AssertExpectations(t)
+
+		err := s.EnsureChannelAccounts(ctx, 5)
+		assert.EqualError(t, err, `submitting create channel accounts on chain transaction: submitting transaction: Type: , Title: Some bad request error, Status: 400, Detail: Bad Request, Extras: map[]: horizon error: "Some bad request error" - check horizon.Error.Problem for more information`)
+	})
+
+	t.Run("successfully_ensures_the_channel_accounts_creation", func(t *testing.T) {
+		channelAccountStore.
+			On("Count", ctx).
+			Return(2, nil).
+			Once()
+		defer channelAccountStore.AssertExpectations(t)
+
+		distributionAccount := keypair.MustRandom()
+		channelAccountsAddressesBeingInserted := []string{}
+		signedTx := txnbuild.Transaction{}
+		signatureClient.
+			On("GetAccountPublicKey", ctx).
+			Return(distributionAccount.Address(), nil).
+			Once().
+			On("SignStellarTransaction", ctx, mock.AnythingOfType("*txnbuild.Transaction"), []string{distributionAccount.Address()}).
+			Run(func(args mock.Arguments) {
+				tx, ok := args.Get(1).(*txnbuild.Transaction)
+				require.True(t, ok)
+
+				assert.Equal(t, distributionAccount.Address(), tx.SourceAccount().AccountID)
+				assert.Len(t, tx.Operations(), 3)
+
+				for _, op := range tx.Operations() {
+					caOp, ok := op.(*txnbuild.CreateAccount)
+					require.True(t, ok)
+
+					assert.Equal(t, "1", caOp.Amount)
+					assert.Equal(t, distributionAccount.Address(), caOp.SourceAccount)
+					channelAccountsAddressesBeingInserted = append(channelAccountsAddressesBeingInserted, caOp.Destination)
+				}
+
+				tx, err = tx.Sign(network.TestNetworkPassphrase, distributionAccount)
+				require.NoError(t, err)
+
+				signedTx = *tx
+			}).
+			Return(&signedTx, nil).
+			Once().
+			On("NetworkPassphrase").
+			Return(network.TestNetworkPassphrase).
+			Once()
+		defer signatureClient.AssertExpectations(t)
+
+		horizonClient.
+			On("AccountDetail", horizonclient.AccountRequest{AccountID: distributionAccount.Address()}).
+			Return(horizon.Account{
+				AccountID: distributionAccount.Address(),
+				Sequence:  123,
+			}, nil).
+			Once().
+			On("SubmitTransaction", mock.AnythingOfType("*txnbuild.Transaction")).
+			Return(horizon.Transaction{}, nil).
+			Once()
+		defer horizonClient.AssertExpectations(t)
+
+		channelAccountStore.
+			On("BatchInsert", ctx, dbConnectionPool, mock.AnythingOfType("[]*channelaccounts.ChannelAccount")).
+			Run(func(args mock.Arguments) {
+				channelAccounts, ok := args.Get(2).([]*channelaccounts.ChannelAccount)
+				require.True(t, ok)
+
+				channelAccountsAddresses := make([]string, 0, len(channelAccounts))
+				for _, ca := range channelAccounts {
+					channelAccountsAddresses = append(channelAccountsAddresses, ca.PublicKey)
+				}
+
+				assert.Equal(t, channelAccountsAddressesBeingInserted, channelAccountsAddresses)
+			}).
+			Return(nil).
+			Once()
+		defer channelAccountStore.AssertExpectations(t)
+
+		err := s.EnsureChannelAccounts(ctx, 5)
+		require.NoError(t, err)
+	})
+}

--- a/internal/signing/channel_account_db_signature_client_test.go
+++ b/internal/signing/channel_account_db_signature_client_test.go
@@ -1,0 +1,115 @@
+package signing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/network"
+	"github.com/stellar/go/txnbuild"
+	"github.com/stellar/wallet-backend/internal/signing/channelaccounts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChannelAccountDBSignatureClientGetAccountPublicKey(t *testing.T) {
+	ctx := context.Background()
+	privateKeyEncrypter := channelaccounts.DefaultPrivateKeyEncrypter{}
+	channelAccountStore := channelaccounts.ChannelAccountStoreMock{}
+	sc := channelAccountDBSignatureClient{
+		networkPassphrase:    network.TestNetworkPassphrase,
+		encryptionPassphrase: "test",
+		privateKeyEncrypter:  &privateKeyEncrypter,
+		channelAccountStore:  &channelAccountStore,
+	}
+
+	t.Run("returns_error_when_couldn't_get_an_idle_channel_account", func(t *testing.T) {
+		channelAccountStore.
+			On("GetIdleChannelAccount", ctx, time.Minute).
+			Return(nil, channelaccounts.ErrNoAvailableChannelAccount).
+			Once()
+		defer channelAccountStore.AssertExpectations(t)
+
+		publicKey, err := sc.GetAccountPublicKey(ctx)
+		assert.ErrorIs(t, err, channelaccounts.ErrNoAvailableChannelAccount)
+		assert.Empty(t, publicKey)
+	})
+
+	t.Run("gets_an_idle_channel_account", func(t *testing.T) {
+		channelAccountPublicKey := keypair.MustRandom().Address()
+		channelAccountStore.
+			On("GetIdleChannelAccount", ctx, time.Minute).
+			Return(&channelaccounts.ChannelAccount{PublicKey: channelAccountPublicKey}, nil).
+			Once()
+		defer channelAccountStore.AssertExpectations(t)
+
+		publicKey, err := sc.GetAccountPublicKey(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, channelAccountPublicKey, publicKey)
+	})
+}
+
+func TestChannelAccountDBSignatureNetworkPassphrase(t *testing.T) {
+	sc := channelAccountDBSignatureClient{networkPassphrase: network.PublicNetworkPassphrase}
+	assert.Equal(t, network.PublicNetworkPassphrase, sc.NetworkPassphrase())
+}
+
+func TestChannelAccountDBSignatureClientSignStellarTransaction(t *testing.T) {
+	ctx := context.Background()
+	privateKeyEncrypter := channelaccounts.DefaultPrivateKeyEncrypter{}
+	channelAccountStore := channelaccounts.ChannelAccountStoreMock{}
+	passphrase := "test"
+	sc := channelAccountDBSignatureClient{
+		networkPassphrase:    network.TestNetworkPassphrase,
+		encryptionPassphrase: passphrase,
+		privateKeyEncrypter:  &privateKeyEncrypter,
+		channelAccountStore:  &channelAccountStore,
+	}
+
+	t.Run("invalid_transaction", func(t *testing.T) {
+		signedTx, err := sc.SignStellarTransaction(ctx, nil)
+		assert.ErrorIs(t, err, ErrInvalidTransaction)
+		assert.Nil(t, signedTx)
+	})
+
+	t.Run("signs_transaction_successfully", func(t *testing.T) {
+		channelAccount := keypair.MustRandom()
+		sourceAccount := txnbuild.NewSimpleAccount(channelAccount.Address(), int64(9605939170639897))
+		tx, err := txnbuild.NewTransaction(
+			txnbuild.TransactionParams{
+				SourceAccount:        &sourceAccount,
+				IncrementSequenceNum: true,
+				Operations: []txnbuild.Operation{
+					&txnbuild.Payment{
+						Destination: "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
+						Amount:      "10",
+						Asset:       txnbuild.NativeAsset{},
+					},
+				},
+				BaseFee:       txnbuild.MinBaseFee,
+				Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(60)},
+			},
+		)
+		require.NoError(t, err)
+		expectedSignedTx, err := tx.Sign(network.TestNetworkPassphrase, channelAccount)
+		require.NoError(t, err)
+
+		encryptedPrivateKey, err := privateKeyEncrypter.Encrypt(ctx, channelAccount.Seed(), passphrase)
+		require.NoError(t, err)
+
+		chAcc := channelaccounts.ChannelAccount{
+			PublicKey:           channelAccount.Address(),
+			EncryptedPrivateKey: encryptedPrivateKey,
+		}
+		channelAccountStore.
+			On("Get", ctx, nil, channelAccount.Address()).
+			Return(&chAcc, nil).
+			Once()
+		defer channelAccountStore.AssertExpectations(t)
+
+		signedTx, err := sc.SignStellarTransaction(ctx, tx, channelAccount.Address())
+		require.NoError(t, err)
+		assert.Equal(t, expectedSignedTx.Signatures(), signedTx.Signatures())
+	})
+}

--- a/internal/signing/channelaccounts/channel_accounts_model.go
+++ b/internal/signing/channelaccounts/channel_accounts_model.go
@@ -93,7 +93,7 @@ func (ca *ChannelAccountModel) GetAllByPublicKey(ctx context.Context, sqlExec db
 	const query = `SELECT * FROM channel_accounts WHERE public_key = ANY($1)`
 
 	var channelAccounts []*ChannelAccount
-	err := sqlExec.SelectContext(ctx, channelAccounts, query, pq.Array(publicKeys))
+	err := sqlExec.SelectContext(ctx, &channelAccounts, query, pq.Array(publicKeys))
 	if err != nil {
 		return nil, fmt.Errorf("getting channel accounts %v: %w", publicKeys, err)
 	}

--- a/internal/signing/channelaccounts/channel_accounts_model_test.go
+++ b/internal/signing/channelaccounts/channel_accounts_model_test.go
@@ -1,0 +1,199 @@
+package channelaccounts
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/support/log"
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createChannelAccountFixture(t *testing.T, ctx context.Context, dbConnectionPool db.ConnectionPool, publicKey, encryptedPrivateKey string) {
+	t.Helper()
+	const q = `
+		INSERT INTO 
+			channel_accounts (public_key, encrypted_private_key)
+		VALUES
+			($1, $2)
+	`
+	_, err := dbConnectionPool.ExecContext(ctx, q, publicKey, encryptedPrivateKey)
+	require.NoError(t, err)
+}
+
+func TestChannelAccountModelGetIdleChannelAccount(t *testing.T) {
+	t.Parallel()
+
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	ctx := context.Background()
+	m := NewChannelAccountModel(dbConnectionPool)
+
+	t.Run("returns_error_when_there's_no_channel_account_available", func(t *testing.T) {
+		channelAccount1 := keypair.MustRandom()
+		channelAccount2 := keypair.MustRandom()
+		createChannelAccountFixture(t, ctx, dbConnectionPool, channelAccount1.Address(), channelAccount1.Seed())
+		createChannelAccountFixture(t, ctx, dbConnectionPool, channelAccount2.Address(), channelAccount2.Seed())
+
+		getEntries := log.DefaultLogger.StartTest(log.WarnLevel)
+
+		const lockChannelAccountQuery = `
+			UPDATE
+				channel_accounts
+			SET
+				locked_at = NOW(),
+				locked_until = NOW() + '5 minutes'::INTERVAL
+			WHERE
+				public_key = $1
+		`
+		_, err := dbConnectionPool.ExecContext(ctx, lockChannelAccountQuery, channelAccount1.Address())
+		require.NoError(t, err)
+		_, err = dbConnectionPool.ExecContext(ctx, lockChannelAccountQuery, channelAccount2.Address())
+		require.NoError(t, err)
+
+		ca, err := m.GetIdleChannelAccount(ctx, time.Minute)
+		assert.ErrorIs(t, err, ErrNoAvailableChannelAccount)
+		assert.Nil(t, ca)
+
+		entries := getEntries()
+		require.Len(t, entries, 6)
+
+		for _, entry := range entries {
+			assert.Equal(t, entry.Message, "All channel accounts are in use. Retry in 1 second.")
+		}
+	})
+
+	t.Run("returns_error_when_there's_no_channel_account_available", func(t *testing.T) {
+		channelAccount1 := keypair.MustRandom()
+		channelAccount2 := keypair.MustRandom()
+		createChannelAccountFixture(t, ctx, dbConnectionPool, channelAccount1.Address(), channelAccount1.Seed())
+		createChannelAccountFixture(t, ctx, dbConnectionPool, channelAccount2.Address(), channelAccount2.Seed())
+
+		const lockChannelAccountQuery = `
+			UPDATE
+				channel_accounts
+			SET
+				locked_at = NOW(),
+				locked_until = NOW() + '5 minutes'::INTERVAL
+			WHERE
+				public_key = $1
+		`
+		_, err := dbConnectionPool.ExecContext(ctx, lockChannelAccountQuery, channelAccount1.Address())
+		require.NoError(t, err)
+
+		ca, err := m.GetIdleChannelAccount(ctx, time.Minute)
+		require.NoError(t, err)
+		assert.Equal(t, ca.PublicKey, channelAccount2.Address())
+		assert.Equal(t, ca.EncryptedPrivateKey, channelAccount2.Seed())
+	})
+}
+
+func TestChannelAccountModelGet(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	ctx := context.Background()
+	m := NewChannelAccountModel(dbConnectionPool)
+
+	channelAccount := keypair.MustRandom()
+	ca, err := m.Get(ctx, dbConnectionPool, channelAccount.Address())
+	assert.ErrorIs(t, err, ErrChannelAccountNotFound)
+	assert.Nil(t, ca)
+
+	createChannelAccountFixture(t, ctx, dbConnectionPool, channelAccount.Address(), channelAccount.Seed())
+	ca, err = m.Get(ctx, dbConnectionPool, channelAccount.Address())
+	require.NoError(t, err)
+	assert.Equal(t, ca.PublicKey, channelAccount.Address())
+	assert.Equal(t, ca.EncryptedPrivateKey, channelAccount.Seed())
+}
+
+func TestChannelAccountModelBatchInsert(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	ctx := context.Background()
+	m := NewChannelAccountModel(dbConnectionPool)
+
+	t.Run("channel_accounts_empty", func(t *testing.T) {
+		err := m.BatchInsert(ctx, dbConnectionPool, []*ChannelAccount{})
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid_channel_accounts", func(t *testing.T) {
+		channelAccounts := []*ChannelAccount{
+			{
+				PublicKey: "",
+			},
+		}
+		err := m.BatchInsert(ctx, dbConnectionPool, channelAccounts)
+		assert.EqualError(t, err, "public key cannot be empty")
+
+		channelAccounts = []*ChannelAccount{
+			{
+				PublicKey: keypair.MustRandom().Address(),
+			},
+		}
+		err = m.BatchInsert(ctx, dbConnectionPool, channelAccounts)
+		assert.EqualError(t, err, "private key cannot be empty")
+	})
+
+	t.Run("inserts_channel_accounts_successfully", func(t *testing.T) {
+		channelAccount1 := keypair.MustRandom()
+		channelAccount2 := keypair.MustRandom()
+		channelAccounts := []*ChannelAccount{
+			{
+				PublicKey:           channelAccount1.Address(),
+				EncryptedPrivateKey: channelAccount1.Seed(),
+			},
+			{
+				PublicKey:           channelAccount2.Address(),
+				EncryptedPrivateKey: channelAccount2.Seed(),
+			},
+		}
+		err = m.BatchInsert(ctx, dbConnectionPool, channelAccounts)
+		require.NoError(t, err)
+
+		n, err := m.Count(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), n)
+	})
+}
+
+func TestChannelAccountModelCount(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	ctx := context.Background()
+	m := NewChannelAccountModel(dbConnectionPool)
+
+	n, err := m.Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+
+	channelAccount := keypair.MustRandom()
+	createChannelAccountFixture(t, ctx, dbConnectionPool, channelAccount.Address(), channelAccount.Seed())
+	n, err = m.Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+}

--- a/internal/signing/channelaccounts/encrypter_test.go
+++ b/internal/signing/channelaccounts/encrypter_test.go
@@ -1,0 +1,22 @@
+package channelaccounts
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultPrivateKeyEncrypterEncrypt(t *testing.T) {
+	ctx := context.Background()
+	e := DefaultPrivateKeyEncrypter{}
+
+	encryptedMsg, err := e.Encrypt(ctx, "private key", "test")
+	require.NoError(t, err)
+	assert.NotEqual(t, "private key", encryptedMsg)
+
+	decryptedMsg, err := e.Decrypt(ctx, encryptedMsg, "test")
+	require.NoError(t, err)
+	assert.Equal(t, "private key", decryptedMsg)
+}

--- a/internal/signing/channelaccounts/mocks.go
+++ b/internal/signing/channelaccounts/mocks.go
@@ -30,6 +30,14 @@ func (s *ChannelAccountStoreMock) Get(ctx context.Context, sqlExec db.SQLExecute
 	return args.Get(0).(*ChannelAccount), args.Error(1)
 }
 
+func (s *ChannelAccountStoreMock) GetAllByPublicKey(ctx context.Context, sqlExec db.SQLExecuter, publicKeys ...string) ([]*ChannelAccount, error) {
+	args := s.Called(ctx, sqlExec, publicKeys)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*ChannelAccount), args.Error(1)
+}
+
 func (s *ChannelAccountStoreMock) BatchInsert(ctx context.Context, sqlExec db.SQLExecuter, channelAccounts []*ChannelAccount) error {
 	args := s.Called(ctx, sqlExec, channelAccounts)
 	return args.Error(0)

--- a/internal/signing/channelaccounts/mocks.go
+++ b/internal/signing/channelaccounts/mocks.go
@@ -1,0 +1,41 @@
+package channelaccounts
+
+import (
+	"context"
+	"time"
+
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stretchr/testify/mock"
+)
+
+type ChannelAccountStoreMock struct {
+	mock.Mock
+}
+
+var _ ChannelAccountStore = (*ChannelAccountStoreMock)(nil)
+
+func (s *ChannelAccountStoreMock) GetIdleChannelAccount(ctx context.Context, lockedUntil time.Duration) (*ChannelAccount, error) {
+	args := s.Called(ctx, lockedUntil)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*ChannelAccount), args.Error(1)
+}
+
+func (s *ChannelAccountStoreMock) Get(ctx context.Context, sqlExec db.SQLExecuter, publicKey string) (*ChannelAccount, error) {
+	args := s.Called(ctx, sqlExec, publicKey)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*ChannelAccount), args.Error(1)
+}
+
+func (s *ChannelAccountStoreMock) BatchInsert(ctx context.Context, sqlExec db.SQLExecuter, channelAccounts []*ChannelAccount) error {
+	args := s.Called(ctx, sqlExec, channelAccounts)
+	return args.Error(0)
+}
+
+func (s *ChannelAccountStoreMock) Count(ctx context.Context) (int64, error) {
+	args := s.Called(ctx)
+	return int64(args.Int(0)), args.Error(1)
+}

--- a/internal/signing/env_signature_client_test.go
+++ b/internal/signing/env_signature_client_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEnvSignatureClientGetDistributionAccountPublicKey(t *testing.T) {
+func TestEnvSignatureClientGetAccountPublicKey(t *testing.T) {
 	ctx := context.Background()
 	distributionAccount := keypair.MustRandom()
 	sc, err := NewEnvSignatureClient(distributionAccount.Seed(), network.TestNetworkPassphrase)


### PR DESCRIPTION
### What

This PR adds tests for the channel accounts feature

### Why

Tech debit.

### Known limitations

N/A

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
