### PR TITLE
payment: tx and operation id types made string

### DIFF
--- a/internal/data/payments_test.go
+++ b/internal/data/payments_test.go
@@ -32,9 +32,9 @@ func TestPaymentModelAddPayment(t *testing.T) {
 		toAddress   = "GDDEAH46MNFO6JD7NTQ5FWJBC4ZSA47YEK3RKFHQWADYTS6NDVD5CORW"
 	)
 	payment := Payment{
-		OperationID:     2120562792996865,
+		OperationID:     "2120562792996865",
 		OperationType:   xdr.OperationTypePayment.String(),
-		TransactionID:   2120562792996864,
+		TransactionID:   "2120562792996864",
 		TransactionHash: "a3daffa64dc46db84888b1206dc8014a480042e7fe8b19fd5d05465709f4e887",
 		FromAddress:     fromAddress,
 		ToAddress:       toAddress,
@@ -108,7 +108,7 @@ func TestPaymentModelAddPayment(t *testing.T) {
 		updatedPayment := Payment{
 			OperationID:     payment.OperationID, // Same OperationID
 			OperationType:   xdr.OperationTypePathPaymentStrictSend.String(),
-			TransactionID:   2120562792996865,
+			TransactionID:   "2120562792996865",
 			TransactionHash: "a3daffa64dc46db84888b1206dc8014a480042e7fe8b19fd5d05465709f4e888",
 			FromAddress:     fromAddress,
 			ToAddress:       toAddress,
@@ -199,16 +199,16 @@ func TestPaymentModelGetPaymentsPaginated(t *testing.T) {
 	}
 
 	dbPayments := []Payment{
-		{OperationID: 1, OperationType: xdr.OperationTypePayment.String(), TransactionID: 11, TransactionHash: "c370ff20144e4c96b17432b8d14664c1", FromAddress: "GAZ37ZO4TU3H", ToAddress: "GDD2HQO6IOFT", SrcAssetCode: "XLM", SrcAssetIssuer: "", SrcAssetType: xdr.AssetTypeAssetTypeNative.String(), SrcAmount: 10, DestAssetCode: "XLM", DestAssetIssuer: "", DestAssetType: xdr.AssetTypeAssetTypeNative.String(), DestAmount: 10, CreatedAt: time.Date(2024, 6, 21, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
-		{OperationID: 2, OperationType: xdr.OperationTypePayment.String(), TransactionID: 22, TransactionHash: "30850d8fc7d1439782885103390cd975", FromAddress: "GBZ5Q56JKHJQ", ToAddress: "GASV72SENBSY", SrcAssetCode: "XLM", SrcAssetIssuer: "", SrcAssetType: xdr.AssetTypeAssetTypeNative.String(), SrcAmount: 20, DestAssetCode: "XLM", DestAssetIssuer: "", DestAssetType: xdr.AssetTypeAssetTypeNative.String(), DestAmount: 20, CreatedAt: time.Date(2024, 6, 22, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
-		{OperationID: 3, OperationType: xdr.OperationTypePayment.String(), TransactionID: 33, TransactionHash: "d9521ed7057d4d1e9b9dd22ab515cbf1", FromAddress: "GAYFAYPOECBT", ToAddress: "GDWDPNMALNIT", SrcAssetCode: "XLM", SrcAssetIssuer: "", SrcAssetType: xdr.AssetTypeAssetTypeNative.String(), SrcAmount: 30, DestAssetCode: "XLM", DestAssetIssuer: "", DestAssetType: xdr.AssetTypeAssetTypeNative.String(), DestAmount: 30, CreatedAt: time.Date(2024, 6, 23, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
-		{OperationID: 4, OperationType: xdr.OperationTypePayment.String(), TransactionID: 44, TransactionHash: "2af98496a86741c6a6814200e06027fd", FromAddress: "GACKTNR2QQXU", ToAddress: "GBZ5KUZHAAVI", SrcAssetCode: "USDC", SrcAssetIssuer: "GAHLU7PDIQMZ", SrcAssetType: xdr.AssetTypeAssetTypeCreditAlphanum4.String(), SrcAmount: 40, DestAssetCode: "USDC", DestAssetIssuer: "GAHLU7PDIQMZ", DestAssetType: xdr.AssetTypeAssetTypeCreditAlphanum4.String(), DestAmount: 40, CreatedAt: time.Date(2024, 6, 24, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
-		{OperationID: 5, OperationType: xdr.OperationTypePayment.String(), TransactionID: 55, TransactionHash: "edfab36f9f104c4fb74b549de44cfbcc", FromAddress: "GA4CMYJEC5W5", ToAddress: "GAZ37ZO4TU3H", SrcAssetCode: "USDC", SrcAssetIssuer: "GAHLU7PDIQMZ", SrcAssetType: xdr.AssetTypeAssetTypeCreditAlphanum4.String(), SrcAmount: 50, DestAssetCode: "USDC", DestAssetIssuer: "GAHLU7PDIQMZ", DestAssetType: xdr.AssetTypeAssetTypeCreditAlphanum4.String(), DestAmount: 50, CreatedAt: time.Date(2024, 6, 25, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
+		{OperationID: "1", OperationType: xdr.OperationTypePayment.String(), TransactionID: "11", TransactionHash: "c370ff20144e4c96b17432b8d14664c1", FromAddress: "GAZ37ZO4TU3H", ToAddress: "GDD2HQO6IOFT", SrcAssetCode: "XLM", SrcAssetIssuer: "", SrcAssetType: xdr.AssetTypeAssetTypeNative.String(), SrcAmount: 10, DestAssetCode: "XLM", DestAssetIssuer: "", DestAssetType: xdr.AssetTypeAssetTypeNative.String(), DestAmount: 10, CreatedAt: time.Date(2024, 6, 21, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
+		{OperationID: "2", OperationType: xdr.OperationTypePayment.String(), TransactionID: "22", TransactionHash: "30850d8fc7d1439782885103390cd975", FromAddress: "GBZ5Q56JKHJQ", ToAddress: "GASV72SENBSY", SrcAssetCode: "XLM", SrcAssetIssuer: "", SrcAssetType: xdr.AssetTypeAssetTypeNative.String(), SrcAmount: 20, DestAssetCode: "XLM", DestAssetIssuer: "", DestAssetType: xdr.AssetTypeAssetTypeNative.String(), DestAmount: 20, CreatedAt: time.Date(2024, 6, 22, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
+		{OperationID: "3", OperationType: xdr.OperationTypePayment.String(), TransactionID: "33", TransactionHash: "d9521ed7057d4d1e9b9dd22ab515cbf1", FromAddress: "GAYFAYPOECBT", ToAddress: "GDWDPNMALNIT", SrcAssetCode: "XLM", SrcAssetIssuer: "", SrcAssetType: xdr.AssetTypeAssetTypeNative.String(), SrcAmount: 30, DestAssetCode: "XLM", DestAssetIssuer: "", DestAssetType: xdr.AssetTypeAssetTypeNative.String(), DestAmount: 30, CreatedAt: time.Date(2024, 6, 23, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
+		{OperationID: "4", OperationType: xdr.OperationTypePayment.String(), TransactionID: "44", TransactionHash: "2af98496a86741c6a6814200e06027fd", FromAddress: "GACKTNR2QQXU", ToAddress: "GBZ5KUZHAAVI", SrcAssetCode: "USDC", SrcAssetIssuer: "GAHLU7PDIQMZ", SrcAssetType: xdr.AssetTypeAssetTypeCreditAlphanum4.String(), SrcAmount: 40, DestAssetCode: "USDC", DestAssetIssuer: "GAHLU7PDIQMZ", DestAssetType: xdr.AssetTypeAssetTypeCreditAlphanum4.String(), DestAmount: 40, CreatedAt: time.Date(2024, 6, 24, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
+		{OperationID: "5", OperationType: xdr.OperationTypePayment.String(), TransactionID: "55", TransactionHash: "edfab36f9f104c4fb74b549de44cfbcc", FromAddress: "GA4CMYJEC5W5", ToAddress: "GAZ37ZO4TU3H", SrcAssetCode: "USDC", SrcAssetIssuer: "GAHLU7PDIQMZ", SrcAssetType: xdr.AssetTypeAssetTypeCreditAlphanum4.String(), SrcAmount: 50, DestAssetCode: "USDC", DestAssetIssuer: "GAHLU7PDIQMZ", DestAssetType: xdr.AssetTypeAssetTypeCreditAlphanum4.String(), DestAmount: 50, CreatedAt: time.Date(2024, 6, 25, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
 	}
 	InsertTestPayments(t, ctx, dbPayments, dbConnectionPool)
 
 	t.Run("no_filter_desc", func(t *testing.T) {
-		payments, prevExists, nextExists, err := m.GetPaymentsPaginated(ctx, "", 0, 0, DESC, 2)
+		payments, prevExists, nextExists, err := m.GetPaymentsPaginated(ctx, "", "", "", DESC, 2)
 		require.NoError(t, err)
 
 		assert.False(t, prevExists)
@@ -221,7 +221,7 @@ func TestPaymentModelGetPaymentsPaginated(t *testing.T) {
 	})
 
 	t.Run("no_filter_asc", func(t *testing.T) {
-		payments, prevExists, nextExists, err := m.GetPaymentsPaginated(ctx, "", 0, 0, ASC, 2)
+		payments, prevExists, nextExists, err := m.GetPaymentsPaginated(ctx, "", "", "", ASC, 2)
 		require.NoError(t, err)
 
 		assert.False(t, prevExists)
@@ -234,7 +234,7 @@ func TestPaymentModelGetPaymentsPaginated(t *testing.T) {
 	})
 
 	t.Run("filter_address", func(t *testing.T) {
-		payments, prevExists, nextExists, err := m.GetPaymentsPaginated(ctx, dbPayments[1].FromAddress, 0, 0, DESC, 2)
+		payments, prevExists, nextExists, err := m.GetPaymentsPaginated(ctx, dbPayments[1].FromAddress, "", "", DESC, 2)
 		require.NoError(t, err)
 
 		assert.False(t, prevExists)
@@ -246,7 +246,7 @@ func TestPaymentModelGetPaymentsPaginated(t *testing.T) {
 	})
 
 	t.Run("filter_after_id_desc", func(t *testing.T) {
-		payments, prevExists, nextExists, err := m.GetPaymentsPaginated(ctx, "", 0, dbPayments[3].OperationID, DESC, 2)
+		payments, prevExists, nextExists, err := m.GetPaymentsPaginated(ctx, "", "", dbPayments[3].OperationID, DESC, 2)
 		require.NoError(t, err)
 
 		assert.True(t, prevExists)
@@ -259,7 +259,7 @@ func TestPaymentModelGetPaymentsPaginated(t *testing.T) {
 	})
 
 	t.Run("filter_after_id_asc", func(t *testing.T) {
-		payments, prevExists, nextExists, err := m.GetPaymentsPaginated(ctx, "", 0, dbPayments[3].OperationID, ASC, 2)
+		payments, prevExists, nextExists, err := m.GetPaymentsPaginated(ctx, "", "", dbPayments[3].OperationID, ASC, 2)
 		require.NoError(t, err)
 
 		assert.True(t, prevExists)
@@ -271,7 +271,7 @@ func TestPaymentModelGetPaymentsPaginated(t *testing.T) {
 	})
 
 	t.Run("filter_before_id_desc", func(t *testing.T) {
-		payments, prevExists, nextExists, err := m.GetPaymentsPaginated(ctx, "", dbPayments[2].OperationID, 0, DESC, 2)
+		payments, prevExists, nextExists, err := m.GetPaymentsPaginated(ctx, "", dbPayments[2].OperationID, "", DESC, 2)
 		require.NoError(t, err)
 
 		assert.False(t, prevExists)
@@ -284,7 +284,7 @@ func TestPaymentModelGetPaymentsPaginated(t *testing.T) {
 	})
 
 	t.Run("filter_before_id_asc", func(t *testing.T) {
-		payments, prevExists, nextExists, err := m.GetPaymentsPaginated(ctx, "", dbPayments[2].OperationID, 0, ASC, 2)
+		payments, prevExists, nextExists, err := m.GetPaymentsPaginated(ctx, "", dbPayments[2].OperationID, "", ASC, 2)
 		require.NoError(t, err)
 
 		assert.False(t, prevExists)

--- a/internal/serve/httphandler/payment_handler.go
+++ b/internal/serve/httphandler/payment_handler.go
@@ -55,8 +55,8 @@ func (h PaymentHandler) UnsubscribeAddress(w http.ResponseWriter, r *http.Reques
 
 type PaymentsRequest struct {
 	Address  string         `query:"address" validate:"public_key"`
-	AfterID  int64          `query:"afterId"`
-	BeforeID int64          `query:"beforeId"`
+	AfterID  string         `query:"afterId"`
+	BeforeID string         `query:"beforeId"`
 	Sort     data.SortOrder `query:"sort" validate:"oneof=ASC DESC"`
 	Limit    int            `query:"limit" validate:"gt=0"`
 }

--- a/internal/serve/httphandler/payment_handler_test.go
+++ b/internal/serve/httphandler/payment_handler_test.go
@@ -233,9 +233,9 @@ func TestPaymentsHandlerGetPayments(t *testing.T) {
 
 	dbPayments := []data.Payment{
 		{
-			OperationID:     1,
+			OperationID:     "1",
 			OperationType:   xdr.OperationTypePayment.String(),
-			TransactionID:   11,
+			TransactionID:   "11",
 			TransactionHash: "c370ff20144e4c96b17432b8d14664c1",
 			FromAddress:     "GD73EG2IJJQQTCD33JKPKEGS76CJJ4TQ7NHDQYMS4D3Z5FBHPML6M66W",
 			ToAddress:       "GCJ4LXZIQRSS5Z7YVIH5YLA7RXMYB64DQN3XMKWEBHUUAFXIXOL3GYVT",
@@ -252,9 +252,9 @@ func TestPaymentsHandlerGetPayments(t *testing.T) {
 			MemoType:        xdr.MemoTypeMemoText.String(),
 		},
 		{
-			OperationID:     2,
+			OperationID:     "2",
 			OperationType:   xdr.OperationTypePayment.String(),
-			TransactionID:   22,
+			TransactionID:   "22",
 			TransactionHash: "30850d8fc7d1439782885103390cd975",
 			FromAddress:     "GASP7HTICNNA2U5RKMPRQELEUJFO7PBB3AKKRGTAG23QVG255ESPZW2L",
 			ToAddress:       "GDB4RW6QFWMGHGI6JTIKMGVUUQO7NNOLSFDMCOMUCCWHMAMFL3FH4Q2J",
@@ -271,9 +271,9 @@ func TestPaymentsHandlerGetPayments(t *testing.T) {
 			MemoType:        xdr.MemoTypeMemoId.String(),
 		},
 		{
-			OperationID:     3,
+			OperationID:     "3",
 			OperationType:   xdr.OperationTypePathPaymentStrictSend.String(),
-			TransactionID:   33,
+			TransactionID:   "33",
 			TransactionHash: "d9521ed7057d4d1e9b9dd22ab515cbf1",
 			FromAddress:     "GCXBGEYNIEIUJ56YX5UVBM27NTKCBMLDD2NEPTTXZGQMBA2EOKG5VA2W",
 			ToAddress:       "GAX6VPTVC2YNJM52OYMJAZKTQMSLNQ6NKYYU77KSGRVHINZ2D3EUJWAN",
@@ -323,7 +323,7 @@ func TestPaymentsHandlerGetPayments(t *testing.T) {
 					"fromAddress": "GCXBGEYNIEIUJ56YX5UVBM27NTKCBMLDD2NEPTTXZGQMBA2EOKG5VA2W",
 					"memo": null,
 					"memoType": "MemoTypeMemoNone",
-					"operationId": 3,
+					"operationId": "3",
 					"operationType": "OperationTypePathPaymentStrictSend",
 					"srcAmount": 300,
 					"srcAssetCode": "XLM",
@@ -331,7 +331,7 @@ func TestPaymentsHandlerGetPayments(t *testing.T) {
 					"srcAssetType": "AssetTypeAssetTypeNative",
 					"toAddress": "GAX6VPTVC2YNJM52OYMJAZKTQMSLNQ6NKYYU77KSGRVHINZ2D3EUJWAN",
 					"transactionHash": "d9521ed7057d4d1e9b9dd22ab515cbf1",
-					"transactionId": 33
+					"transactionId": "33"
 				},
 				{
 					"createdAt": "2024-06-22T00:00:00Z",
@@ -342,7 +342,7 @@ func TestPaymentsHandlerGetPayments(t *testing.T) {
 					"fromAddress": "GASP7HTICNNA2U5RKMPRQELEUJFO7PBB3AKKRGTAG23QVG255ESPZW2L",
 					"memo": "123",
 					"memoType": "MemoTypeMemoId",
-					"operationId": 2,
+					"operationId": "2",
 					"operationType": "OperationTypePayment",
 					"srcAmount": 20,
 					"srcAssetCode": "USDC",
@@ -350,7 +350,7 @@ func TestPaymentsHandlerGetPayments(t *testing.T) {
 					"srcAssetType": "AssetTypeAssetTypeCreditAlphanum4",
 					"toAddress": "GDB4RW6QFWMGHGI6JTIKMGVUUQO7NNOLSFDMCOMUCCWHMAMFL3FH4Q2J",
 					"transactionHash": "30850d8fc7d1439782885103390cd975",
-					"transactionId": 22
+					"transactionId": "22"
 				},
 				{
 					"createdAt": "2024-06-21T00:00:00Z",
@@ -361,7 +361,7 @@ func TestPaymentsHandlerGetPayments(t *testing.T) {
 					"fromAddress": "GD73EG2IJJQQTCD33JKPKEGS76CJJ4TQ7NHDQYMS4D3Z5FBHPML6M66W",
 					"memo": "test",
 					"memoType": "MemoTypeMemoText",
-					"operationId": 1,
+					"operationId": "1",
 					"operationType": "OperationTypePayment",
 					"srcAmount": 10,
 					"srcAssetCode": "XLM",
@@ -369,7 +369,7 @@ func TestPaymentsHandlerGetPayments(t *testing.T) {
 					"srcAssetType": "AssetTypeAssetTypeNative",
 					"toAddress": "GCJ4LXZIQRSS5Z7YVIH5YLA7RXMYB64DQN3XMKWEBHUUAFXIXOL3GYVT",
 					"transactionHash": "c370ff20144e4c96b17432b8d14664c1",
-					"transactionId": 11
+					"transactionId": "11"
 				}
 			]
 		}`
@@ -407,7 +407,7 @@ func TestPaymentsHandlerGetPayments(t *testing.T) {
 					"fromAddress": "GASP7HTICNNA2U5RKMPRQELEUJFO7PBB3AKKRGTAG23QVG255ESPZW2L",
 					"memo": "123",
 					"memoType": "MemoTypeMemoId",
-					"operationId": 2,
+					"operationId": "2",
 					"operationType": "OperationTypePayment",
 					"srcAmount": 20,
 					"srcAssetCode": "USDC",
@@ -415,7 +415,7 @@ func TestPaymentsHandlerGetPayments(t *testing.T) {
 					"srcAssetType": "AssetTypeAssetTypeCreditAlphanum4",
 					"toAddress": "GDB4RW6QFWMGHGI6JTIKMGVUUQO7NNOLSFDMCOMUCCWHMAMFL3FH4Q2J",
 					"transactionHash": "30850d8fc7d1439782885103390cd975",
-					"transactionId": 22
+					"transactionId": "22"
 				}
 			]
 		}`

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -173,7 +173,7 @@ func (m *IngestManager) processLedger(ctx context.Context, ledger uint32, ledger
 
 				err = m.PaymentModel.AddPayment(ctx, dbTx, payment)
 				if err != nil {
-					return fmt.Errorf("adding payment for ledger %d, tx %q (%d), operation %d (%d): %w", ledgerSequence, txHash, tx.Index, payment.OperationID, opIdx, err)
+					return fmt.Errorf("adding payment for ledger %d, tx %s (%d), operation %s (%d): %w", ledgerSequence, txHash, tx.Index, payment.OperationID, opIdx, err)
 				}
 			}
 		}

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -126,9 +126,9 @@ func TestProcessLedger(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, data.Payment{
-		OperationID:     528280981505,
+		OperationID:     "528280981505",
 		OperationType:   xdr.OperationTypePayment.String(),
-		TransactionID:   528280981504,
+		TransactionID:   "528280981504",
 		TransactionHash: "c20936e363c85799b31fd321b67aa49ecd88f04fc41297959387e445245080db",
 		FromAddress:     "GB3H2CRRTO7W5WF54K53A3MRAFEUISHZ7Y5YGRVGRGHUZESLV5VYYWXI",
 		ToAddress:       "GBLI2OE4H3HAW7Z2GXLYZQNQ57XLHJ5OILFPVL33EPA4GDAIQ5F33JGA",

--- a/internal/services/payment_service.go
+++ b/internal/services/payment_service.go
@@ -15,7 +15,7 @@ type PaymentService struct {
 	ServerBaseURL string
 }
 
-func (s *PaymentService) GetPaymentsPaginated(ctx context.Context, address string, beforeID, afterID int64, sort data.SortOrder, limit int) ([]data.Payment, entities.Pagination, error) {
+func (s *PaymentService) GetPaymentsPaginated(ctx context.Context, address string, beforeID, afterID string, sort data.SortOrder, limit int) ([]data.Payment, entities.Pagination, error) {
 	payments, prevExists, nextExists, err := s.Models.Payments.GetPaymentsPaginated(ctx, address, beforeID, afterID, sort, limit)
 	if err != nil {
 		return nil, entities.Pagination{}, fmt.Errorf("getting payments: %w", err)
@@ -29,7 +29,7 @@ func (s *PaymentService) GetPaymentsPaginated(ctx context.Context, address strin
 
 	if prevExists {
 		firstElementID := data.FirstPaymentOperationID(payments)
-		prev, err = buildURL(s.ServerBaseURL, address, firstElementID, 0, sort, limit)
+		prev, err = buildURL(s.ServerBaseURL, address, firstElementID, "", sort, limit)
 		if err != nil {
 			return nil, entities.Pagination{}, fmt.Errorf("building prev link: %w", err)
 		}
@@ -37,7 +37,7 @@ func (s *PaymentService) GetPaymentsPaginated(ctx context.Context, address strin
 
 	if nextExists {
 		lastElementID := data.LastPaymentOperationID(payments)
-		next, err = buildURL(s.ServerBaseURL, address, 0, lastElementID, sort, limit)
+		next, err = buildURL(s.ServerBaseURL, address, "", lastElementID, sort, limit)
 		if err != nil {
 			return nil, entities.Pagination{}, fmt.Errorf("building next link: %w", err)
 		}
@@ -53,7 +53,7 @@ func (s *PaymentService) GetPaymentsPaginated(ctx context.Context, address strin
 	return payments, pagination, nil
 }
 
-func buildURL(baseURL string, address string, beforeID, afterID int64, sort data.SortOrder, limit int) (string, error) {
+func buildURL(baseURL string, address string, beforeID, afterID string, sort data.SortOrder, limit int) (string, error) {
 	url, err := url.ParseRequestURI(baseURL)
 	if err != nil {
 		return "", fmt.Errorf("parsing base URL: %s: %w", baseURL, err)
@@ -65,11 +65,11 @@ func buildURL(baseURL string, address string, beforeID, afterID int64, sort data
 	if address != "" {
 		values.Add("address", string(address))
 	}
-	if beforeID != 0 {
-		values.Add("beforeId", strconv.FormatInt(beforeID, 10))
+	if beforeID != "" {
+		values.Add("beforeId", beforeID)
 	}
-	if afterID != 0 {
-		values.Add("afterId", strconv.FormatInt(afterID, 10))
+	if afterID != "" {
+		values.Add("afterId", afterID)
 	}
 	url.RawQuery = values.Encode()
 

--- a/internal/services/payment_service_test.go
+++ b/internal/services/payment_service_test.go
@@ -32,16 +32,16 @@ func TestPaymentServiceGetPaymentsPaginated(t *testing.T) {
 	ctx := context.Background()
 
 	dbPayments := []data.Payment{
-		{OperationID: 1, OperationType: xdr.OperationTypePayment.String(), TransactionID: 11, TransactionHash: "c370ff20144e4c96b17432b8d14664c1", FromAddress: "GAZ37ZO4TU3H", ToAddress: "GDD2HQO6IOFT", SrcAssetCode: "XLM", SrcAssetIssuer: "", SrcAssetType: xdr.AssetTypeAssetTypeNative.String(), SrcAmount: 10, DestAssetCode: "XLM", DestAssetIssuer: "", DestAssetType: xdr.AssetTypeAssetTypeNative.String(), DestAmount: 10, CreatedAt: time.Date(2024, 6, 21, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
-		{OperationID: 2, OperationType: xdr.OperationTypePayment.String(), TransactionID: 22, TransactionHash: "30850d8fc7d1439782885103390cd975", FromAddress: "GBZ5Q56JKHJQ", ToAddress: "GASV72SENBSY", SrcAssetCode: "XLM", SrcAssetIssuer: "", SrcAssetType: xdr.AssetTypeAssetTypeNative.String(), SrcAmount: 20, DestAssetCode: "XLM", DestAssetIssuer: "", DestAssetType: xdr.AssetTypeAssetTypeNative.String(), DestAmount: 20, CreatedAt: time.Date(2024, 6, 22, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
-		{OperationID: 3, OperationType: xdr.OperationTypePayment.String(), TransactionID: 33, TransactionHash: "d9521ed7057d4d1e9b9dd22ab515cbf1", FromAddress: "GAYFAYPOECBT", ToAddress: "GDWDPNMALNIT", SrcAssetCode: "XLM", SrcAssetIssuer: "", SrcAssetType: xdr.AssetTypeAssetTypeNative.String(), SrcAmount: 30, DestAssetCode: "XLM", DestAssetIssuer: "", DestAssetType: xdr.AssetTypeAssetTypeNative.String(), DestAmount: 30, CreatedAt: time.Date(2024, 6, 23, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
-		{OperationID: 4, OperationType: xdr.OperationTypePayment.String(), TransactionID: 44, TransactionHash: "2af98496a86741c6a6814200e06027fd", FromAddress: "GACKTNR2QQXU", ToAddress: "GBZ5KUZHAAVI", SrcAssetCode: "USDC", SrcAssetIssuer: "GAHLU7PDIQMZ", SrcAssetType: xdr.AssetTypeAssetTypeCreditAlphanum4.String(), SrcAmount: 40, DestAssetCode: "USDC", DestAssetIssuer: "GAHLU7PDIQMZ", DestAssetType: xdr.AssetTypeAssetTypeCreditAlphanum4.String(), DestAmount: 40, CreatedAt: time.Date(2024, 6, 24, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
-		{OperationID: 5, OperationType: xdr.OperationTypePayment.String(), TransactionID: 55, TransactionHash: "edfab36f9f104c4fb74b549de44cfbcc", FromAddress: "GA4CMYJEC5W5", ToAddress: "GAZ37ZO4TU3H", SrcAssetCode: "USDC", SrcAssetIssuer: "GAHLU7PDIQMZ", SrcAssetType: xdr.AssetTypeAssetTypeCreditAlphanum4.String(), SrcAmount: 50, DestAssetCode: "USDC", DestAssetIssuer: "GAHLU7PDIQMZ", DestAssetType: xdr.AssetTypeAssetTypeCreditAlphanum4.String(), DestAmount: 50, CreatedAt: time.Date(2024, 6, 25, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
+		{OperationID: "1", OperationType: xdr.OperationTypePayment.String(), TransactionID: "11", TransactionHash: "c370ff20144e4c96b17432b8d14664c1", FromAddress: "GAZ37ZO4TU3H", ToAddress: "GDD2HQO6IOFT", SrcAssetCode: "XLM", SrcAssetIssuer: "", SrcAssetType: xdr.AssetTypeAssetTypeNative.String(), SrcAmount: 10, DestAssetCode: "XLM", DestAssetIssuer: "", DestAssetType: xdr.AssetTypeAssetTypeNative.String(), DestAmount: 10, CreatedAt: time.Date(2024, 6, 21, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
+		{OperationID: "2", OperationType: xdr.OperationTypePayment.String(), TransactionID: "22", TransactionHash: "30850d8fc7d1439782885103390cd975", FromAddress: "GBZ5Q56JKHJQ", ToAddress: "GASV72SENBSY", SrcAssetCode: "XLM", SrcAssetIssuer: "", SrcAssetType: xdr.AssetTypeAssetTypeNative.String(), SrcAmount: 20, DestAssetCode: "XLM", DestAssetIssuer: "", DestAssetType: xdr.AssetTypeAssetTypeNative.String(), DestAmount: 20, CreatedAt: time.Date(2024, 6, 22, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
+		{OperationID: "3", OperationType: xdr.OperationTypePayment.String(), TransactionID: "33", TransactionHash: "d9521ed7057d4d1e9b9dd22ab515cbf1", FromAddress: "GAYFAYPOECBT", ToAddress: "GDWDPNMALNIT", SrcAssetCode: "XLM", SrcAssetIssuer: "", SrcAssetType: xdr.AssetTypeAssetTypeNative.String(), SrcAmount: 30, DestAssetCode: "XLM", DestAssetIssuer: "", DestAssetType: xdr.AssetTypeAssetTypeNative.String(), DestAmount: 30, CreatedAt: time.Date(2024, 6, 23, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
+		{OperationID: "4", OperationType: xdr.OperationTypePayment.String(), TransactionID: "44", TransactionHash: "2af98496a86741c6a6814200e06027fd", FromAddress: "GACKTNR2QQXU", ToAddress: "GBZ5KUZHAAVI", SrcAssetCode: "USDC", SrcAssetIssuer: "GAHLU7PDIQMZ", SrcAssetType: xdr.AssetTypeAssetTypeCreditAlphanum4.String(), SrcAmount: 40, DestAssetCode: "USDC", DestAssetIssuer: "GAHLU7PDIQMZ", DestAssetType: xdr.AssetTypeAssetTypeCreditAlphanum4.String(), DestAmount: 40, CreatedAt: time.Date(2024, 6, 24, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
+		{OperationID: "5", OperationType: xdr.OperationTypePayment.String(), TransactionID: "55", TransactionHash: "edfab36f9f104c4fb74b549de44cfbcc", FromAddress: "GA4CMYJEC5W5", ToAddress: "GAZ37ZO4TU3H", SrcAssetCode: "USDC", SrcAssetIssuer: "GAHLU7PDIQMZ", SrcAssetType: xdr.AssetTypeAssetTypeCreditAlphanum4.String(), SrcAmount: 50, DestAssetCode: "USDC", DestAssetIssuer: "GAHLU7PDIQMZ", DestAssetType: xdr.AssetTypeAssetTypeCreditAlphanum4.String(), DestAmount: 50, CreatedAt: time.Date(2024, 6, 25, 0, 0, 0, 0, time.UTC), Memo: nil, MemoType: xdr.MemoTypeMemoNone.String()},
 	}
 	data.InsertTestPayments(t, ctx, dbPayments, dbConnectionPool)
 
 	t.Run("page_1", func(t *testing.T) {
-		payments, pagination, err := service.GetPaymentsPaginated(ctx, "", 0, 0, data.DESC, 2)
+		payments, pagination, err := service.GetPaymentsPaginated(ctx, "", "", "", data.DESC, 2)
 		require.NoError(t, err)
 
 		assert.Equal(t, []data.Payment{
@@ -52,13 +52,13 @@ func TestPaymentServiceGetPaymentsPaginated(t *testing.T) {
 			Links: entities.PaginationLinks{
 				Self: "http://testing.com?limit=2&sort=DESC",
 				Prev: "",
-				Next: fmt.Sprintf("http://testing.com?afterId=%d&limit=2&sort=DESC", dbPayments[3].OperationID),
+				Next: fmt.Sprintf("http://testing.com?afterId=%s&limit=2&sort=DESC", dbPayments[3].OperationID),
 			},
 		}, pagination)
 	})
 
 	t.Run("page_2_after", func(t *testing.T) {
-		payments, pagination, err := service.GetPaymentsPaginated(ctx, "", 0, dbPayments[3].OperationID, data.DESC, 2)
+		payments, pagination, err := service.GetPaymentsPaginated(ctx, "", "", dbPayments[3].OperationID, data.DESC, 2)
 		require.NoError(t, err)
 
 		assert.Equal(t, []data.Payment{
@@ -67,15 +67,15 @@ func TestPaymentServiceGetPaymentsPaginated(t *testing.T) {
 		}, payments)
 		assert.Equal(t, entities.Pagination{
 			Links: entities.PaginationLinks{
-				Self: fmt.Sprintf("http://testing.com?afterId=%d&limit=2&sort=DESC", dbPayments[3].OperationID),
-				Prev: fmt.Sprintf("http://testing.com?beforeId=%d&limit=2&sort=DESC", dbPayments[2].OperationID),
-				Next: fmt.Sprintf("http://testing.com?afterId=%d&limit=2&sort=DESC", dbPayments[1].OperationID),
+				Self: fmt.Sprintf("http://testing.com?afterId=%s&limit=2&sort=DESC", dbPayments[3].OperationID),
+				Prev: fmt.Sprintf("http://testing.com?beforeId=%s&limit=2&sort=DESC", dbPayments[2].OperationID),
+				Next: fmt.Sprintf("http://testing.com?afterId=%s&limit=2&sort=DESC", dbPayments[1].OperationID),
 			},
 		}, pagination)
 	})
 
 	t.Run("page_3_after", func(t *testing.T) {
-		payments, pagination, err := service.GetPaymentsPaginated(ctx, "", 0, dbPayments[1].OperationID, data.DESC, 2)
+		payments, pagination, err := service.GetPaymentsPaginated(ctx, "", "", dbPayments[1].OperationID, data.DESC, 2)
 		require.NoError(t, err)
 
 		assert.Equal(t, []data.Payment{
@@ -83,15 +83,15 @@ func TestPaymentServiceGetPaymentsPaginated(t *testing.T) {
 		}, payments)
 		assert.Equal(t, entities.Pagination{
 			Links: entities.PaginationLinks{
-				Self: fmt.Sprintf("http://testing.com?afterId=%d&limit=2&sort=DESC", dbPayments[1].OperationID),
-				Prev: fmt.Sprintf("http://testing.com?beforeId=%d&limit=2&sort=DESC", dbPayments[0].OperationID),
+				Self: fmt.Sprintf("http://testing.com?afterId=%s&limit=2&sort=DESC", dbPayments[1].OperationID),
+				Prev: fmt.Sprintf("http://testing.com?beforeId=%s&limit=2&sort=DESC", dbPayments[0].OperationID),
 				Next: "",
 			},
 		}, pagination)
 	})
 
 	t.Run("page_2_before", func(t *testing.T) {
-		payments, pagination, err := service.GetPaymentsPaginated(ctx, "", dbPayments[0].OperationID, 0, data.DESC, 2)
+		payments, pagination, err := service.GetPaymentsPaginated(ctx, "", dbPayments[0].OperationID, "", data.DESC, 2)
 		require.NoError(t, err)
 
 		assert.Equal(t, []data.Payment{
@@ -100,15 +100,15 @@ func TestPaymentServiceGetPaymentsPaginated(t *testing.T) {
 		}, payments)
 		assert.Equal(t, entities.Pagination{
 			Links: entities.PaginationLinks{
-				Self: fmt.Sprintf("http://testing.com?beforeId=%d&limit=2&sort=DESC", dbPayments[0].OperationID),
-				Prev: fmt.Sprintf("http://testing.com?beforeId=%d&limit=2&sort=DESC", dbPayments[2].OperationID),
-				Next: fmt.Sprintf("http://testing.com?afterId=%d&limit=2&sort=DESC", dbPayments[1].OperationID),
+				Self: fmt.Sprintf("http://testing.com?beforeId=%s&limit=2&sort=DESC", dbPayments[0].OperationID),
+				Prev: fmt.Sprintf("http://testing.com?beforeId=%s&limit=2&sort=DESC", dbPayments[2].OperationID),
+				Next: fmt.Sprintf("http://testing.com?afterId=%s&limit=2&sort=DESC", dbPayments[1].OperationID),
 			},
 		}, pagination)
 	})
 
 	t.Run("page_1_before", func(t *testing.T) {
-		payments, pagination, err := service.GetPaymentsPaginated(ctx, "", dbPayments[2].OperationID, 0, data.DESC, 2)
+		payments, pagination, err := service.GetPaymentsPaginated(ctx, "", dbPayments[2].OperationID, "", data.DESC, 2)
 		require.NoError(t, err)
 
 		assert.Equal(t, []data.Payment{
@@ -117,9 +117,9 @@ func TestPaymentServiceGetPaymentsPaginated(t *testing.T) {
 		}, payments)
 		assert.Equal(t, entities.Pagination{
 			Links: entities.PaginationLinks{
-				Self: fmt.Sprintf("http://testing.com?beforeId=%d&limit=2&sort=DESC", dbPayments[2].OperationID),
+				Self: fmt.Sprintf("http://testing.com?beforeId=%s&limit=2&sort=DESC", dbPayments[2].OperationID),
 				Prev: "",
-				Next: fmt.Sprintf("http://testing.com?afterId=%d&limit=2&sort=DESC", dbPayments[3].OperationID),
+				Next: fmt.Sprintf("http://testing.com?afterId=%s&limit=2&sort=DESC", dbPayments[3].OperationID),
 			},
 		}, pagination)
 	})

--- a/internal/utils/ingestion_utils.go
+++ b/internal/utils/ingestion_utils.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-func OperationID(ledgerNumber, txNumber, opNumber int32) int64 {
-	return toid.New(ledgerNumber, txNumber, opNumber).ToInt64()
+func OperationID(ledgerNumber, txNumber, opNumber int32) string {
+	return toid.New(ledgerNumber, txNumber, opNumber).String()
 }
 
 func OperationResult(tx ingest.LedgerTransaction, opNumber int) *xdr.OperationResultTr {
@@ -18,8 +18,8 @@ func OperationResult(tx ingest.LedgerTransaction, opNumber int) *xdr.OperationRe
 	return &tr
 }
 
-func TransactionID(ledgerNumber, txNumber int32) int64 {
-	return toid.New(int32(ledgerNumber), int32(txNumber), 0).ToInt64()
+func TransactionID(ledgerNumber, txNumber int32) string {
+	return toid.New(int32(ledgerNumber), int32(txNumber), 0).String()
 }
 
 func TransactionHash(ledgerMeta xdr.LedgerCloseMeta, txNumber int) string {


### PR DESCRIPTION
### What

Refactors the `OperationID` and `TransactionID` properties of `Payment` to be of type `string` instead of `int64`.

### Why

The number type was causing overflow problems in clients consuming the endpoint for production environments where the ID's are too large.

### Known limitations

The database columns types are still `bigint`, but the mapping doesn't seem to be a problem.

### Issue that this PR addresses

[Change operationId prop type to string on /payments endpoint](https://app.asana.com/0/1202672669313222/1207811711125272/f)

### Checklist

#### PR Structure

- [X] It is not possible to break this PR down into smaller PRs.
- [X] This PR does not mix refactoring changes with feature changes.
- [X] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [X] This PR adds tests for the new functionality or fixes.
- [X] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [X] This is not a breaking change.
- [X] This is ready to be tested in development.
- [X] The new functionality is gated with a feature flag if this is not ready for production.
