### PR TITLE
serve: account registration endpoints renamed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.45.26
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/go-playground/validator/v10 v10.20.0
+	github.com/google/uuid v1.5.0
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/lib/pq v1.10.9
 	github.com/rubenv/sql-migrate v1.6.1
@@ -44,7 +45,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
-	github.com/google/uuid v1.5.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
 	github.com/gorilla/schema v1.2.0 // indirect

--- a/internal/serve/httphandler/account_handler.go
+++ b/internal/serve/httphandler/account_handler.go
@@ -12,8 +12,47 @@ import (
 )
 
 type AccountHandler struct {
+	AccountService            services.AccountService
 	AccountSponsorshipService services.AccountSponsorshipService
 	SupportedAssets           []entities.Asset
+}
+
+type AccountRegistrationRequest struct {
+	Address string `json:"address" validate:"required,public_key"`
+}
+
+func (h AccountHandler) RegisterAccount(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var reqParams AccountRegistrationRequest
+	httpErr := DecodePathAndValidate(ctx, r, &reqParams)
+	if httpErr != nil {
+		httpErr.Render(w)
+		return
+	}
+
+	err := h.AccountService.RegisterAccount(ctx, reqParams.Address)
+	if err != nil {
+		httperror.InternalServerError(ctx, "", err, nil).Render(w)
+		return
+	}
+}
+
+func (h AccountHandler) DeregisterAccount(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var reqParams AccountRegistrationRequest
+	httpErr := DecodePathAndValidate(ctx, r, &reqParams)
+	if httpErr != nil {
+		httpErr.Render(w)
+		return
+	}
+
+	err := h.AccountService.DeregisterAccount(ctx, reqParams.Address)
+	if err != nil {
+		httperror.InternalServerError(ctx, "", err, nil).Render(w)
+		return
+	}
 }
 
 type SponsorAccountCreationRequest struct {

--- a/internal/serve/httphandler/account_handler_test.go
+++ b/internal/serve/httphandler/account_handler_test.go
@@ -1,23 +1,214 @@
 package httphandler
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"strings"
 	"testing"
 
+	"github.com/go-chi/chi"
+	"github.com/google/uuid"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
+	"github.com/stellar/wallet-backend/internal/data"
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
 	"github.com/stellar/wallet-backend/internal/entities"
 	"github.com/stellar/wallet-backend/internal/services"
 	"github.com/stellar/wallet-backend/internal/services/servicesmocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAccountHandlerRegisterAccount(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	models, err := data.NewModels(dbConnectionPool)
+	require.NoError(t, err)
+	accountService, err := services.NewAccountService(models)
+	require.NoError(t, err)
+	handler := &AccountHandler{
+		AccountService: accountService,
+	}
+
+	// Setup router
+	r := chi.NewRouter()
+	r.Post("/accounts/{address}", handler.RegisterAccount)
+
+	clearAccounts := func(ctx context.Context) {
+		_, err = dbConnectionPool.ExecContext(ctx, "TRUNCATE accounts")
+		require.NoError(t, err)
+	}
+
+	t.Run("success_happy_path", func(t *testing.T) {
+		// Prepare request
+		address := keypair.MustRandom().Address()
+		req, err := http.NewRequest(http.MethodPost, path.Join("/accounts", address), nil)
+		require.NoError(t, err)
+
+		// Serve request
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		// Assert 200 response
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		ctx := context.Background()
+		var dbAddress sql.NullString
+		err = dbConnectionPool.GetContext(ctx, &dbAddress, "SELECT stellar_address FROM accounts")
+		require.NoError(t, err)
+
+		// Assert address persisted in DB
+		assert.True(t, dbAddress.Valid)
+		assert.Equal(t, address, dbAddress.String)
+
+		clearAccounts(ctx)
+	})
+
+	t.Run("address_already_exists", func(t *testing.T) {
+		address := keypair.MustRandom().Address()
+		ctx := context.Background()
+
+		// Insert address in DB
+		_, err = dbConnectionPool.ExecContext(ctx, "INSERT INTO accounts (stellar_address) VALUES ($1)", address)
+		require.NoError(t, err)
+
+		// Prepare request
+		req, err := http.NewRequest(http.MethodPost, path.Join("/accounts", address), nil)
+		require.NoError(t, err)
+
+		// Serve request
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		// Assert 200 response
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var dbAddress sql.NullString
+		err = dbConnectionPool.GetContext(ctx, &dbAddress, "SELECT stellar_address FROM accounts")
+		require.NoError(t, err)
+
+		// Assert address persisted in DB
+		assert.True(t, dbAddress.Valid)
+		assert.Equal(t, address, dbAddress.String)
+
+		clearAccounts(ctx)
+	})
+
+	t.Run("invalid_address", func(t *testing.T) {
+		// Prepare request
+		randomString := uuid.NewString()
+		req, err := http.NewRequest(http.MethodPost, path.Join("/accounts", randomString), nil)
+		require.NoError(t, err)
+
+		// Serve request
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		resp := rr.Result()
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.JSONEq(t, `{"error":"Validation error.", "extras": {"address":"Invalid public key provided"}}`, string(respBody))
+	})
+}
+
+func TestAccountHandlerDeregisterAccount(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	models, err := data.NewModels(dbConnectionPool)
+	require.NoError(t, err)
+	accountService, err := services.NewAccountService(models)
+	require.NoError(t, err)
+	handler := &AccountHandler{
+		AccountService: accountService,
+	}
+
+	// Setup router
+	r := chi.NewRouter()
+	r.Delete("/accounts/{address}", handler.DeregisterAccount)
+
+	t.Run("successHappyPath", func(t *testing.T) {
+		address := keypair.MustRandom().Address()
+		ctx := context.Background()
+
+		// Insert address in DB
+		_, err = dbConnectionPool.ExecContext(ctx, "INSERT INTO accounts (stellar_address) VALUES ($1)", address)
+		require.NoError(t, err)
+
+		// Prepare request
+		req, err := http.NewRequest(http.MethodDelete, path.Join("/accounts", address), nil)
+		require.NoError(t, err)
+
+		// Serve request
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		// Assert 200 response
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		// Assert no address no longer in DB
+		var dbAddress sql.NullString
+		err = dbConnectionPool.GetContext(ctx, &dbAddress, "SELECT stellar_address FROM accounts")
+		assert.ErrorIs(t, err, sql.ErrNoRows)
+	})
+
+	t.Run("idempotency", func(t *testing.T) {
+		address := keypair.MustRandom().Address()
+		ctx := context.Background()
+
+		// Make sure DB is empty
+		_, err = dbConnectionPool.ExecContext(ctx, "DELETE FROM accounts")
+		require.NoError(t, err)
+
+		// Prepare request
+		req, err := http.NewRequest(http.MethodDelete, path.Join("/accounts", address), nil)
+		require.NoError(t, err)
+
+		// Serve request
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		// Assert 200 response
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("invalid_address", func(t *testing.T) {
+		// Prepare request
+		randomString := uuid.NewString()
+		req, err := http.NewRequest(http.MethodDelete, path.Join("/accounts", randomString), nil)
+		require.NoError(t, err)
+
+		// Serve request
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		resp := rr.Result()
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.JSONEq(t, `{"error":"Validation error.", "extras": {"address":"Invalid public key provided"}}`, string(respBody))
+	})
+}
 
 func TestAccountHandlerSponsorAccountCreation(t *testing.T) {
 	asService := servicesmocks.AccountSponsorshipServiceMock{}

--- a/internal/serve/httphandler/payment_handler.go
+++ b/internal/serve/httphandler/payment_handler.go
@@ -11,46 +11,7 @@ import (
 )
 
 type PaymentHandler struct {
-	Models  *data.Models
-	Service *services.PaymentService
-}
-
-type PaymentsSubscribeRequest struct {
-	Address string `json:"address" validate:"required,public_key"`
-}
-
-func (h PaymentHandler) SubscribeAddress(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	var reqBody PaymentsSubscribeRequest
-	httpErr := DecodeJSONAndValidate(ctx, r, &reqBody)
-	if httpErr != nil {
-		httpErr.Render(w)
-		return
-	}
-
-	err := h.Models.Account.Insert(ctx, reqBody.Address)
-	if err != nil {
-		httperror.InternalServerError(ctx, "", err, nil).Render(w)
-		return
-	}
-}
-
-func (h PaymentHandler) UnsubscribeAddress(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	var reqBody PaymentsSubscribeRequest
-	httpErr := DecodeJSONAndValidate(ctx, r, &reqBody)
-	if httpErr != nil {
-		httpErr.Render(w)
-		return
-	}
-
-	err := h.Models.Account.Delete(ctx, reqBody.Address)
-	if err != nil {
-		httperror.InternalServerError(ctx, "", err, nil).Render(w)
-		return
-	}
+	PaymentService services.PaymentService
 }
 
 type PaymentsRequest struct {
@@ -76,7 +37,7 @@ func (h PaymentHandler) GetPayments(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	payments, pagination, err := h.Service.GetPaymentsPaginated(ctx, reqQuery.Address, reqQuery.BeforeID, reqQuery.AfterID, reqQuery.Sort, reqQuery.Limit)
+	payments, pagination, err := h.PaymentService.GetPaymentsPaginated(ctx, reqQuery.Address, reqQuery.BeforeID, reqQuery.AfterID, reqQuery.Sort, reqQuery.Limit)
 	if err != nil {
 		httperror.InternalServerError(ctx, "", err, nil).Render(w)
 		return

--- a/internal/serve/httphandler/payment_handler_test.go
+++ b/internal/serve/httphandler/payment_handler_test.go
@@ -2,17 +2,13 @@ package httphandler
 
 import (
 	"context"
-	"database/sql"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-chi/chi"
-	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/xdr"
 	"github.com/stellar/wallet-backend/internal/data"
 	"github.com/stellar/wallet-backend/internal/db"
@@ -23,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPaymentsHandlerSubscribeAddress(t *testing.T) {
+func TestPaymentHandlerGetPayments(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()
 
@@ -33,195 +29,10 @@ func TestPaymentsHandlerSubscribeAddress(t *testing.T) {
 
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
-	handler := &PaymentHandler{
-		Models: models,
-	}
-
-	// Setup router
-	r := chi.NewRouter()
-	r.Post("/payments/subscribe", handler.SubscribeAddress)
-
-	clearAccounts := func(ctx context.Context) {
-		_, err = dbConnectionPool.ExecContext(ctx, "TRUNCATE accounts")
-		require.NoError(t, err)
-	}
-
-	t.Run("success_happy_path", func(t *testing.T) {
-		// Prepare request
-		address := keypair.MustRandom().Address()
-		payload := fmt.Sprintf(`{ "address": %q }`, address)
-		req, err := http.NewRequest(http.MethodPost, "/payments/subscribe", strings.NewReader(payload))
-		require.NoError(t, err)
-
-		// Serve request
-		rr := httptest.NewRecorder()
-		r.ServeHTTP(rr, req)
-
-		// Assert 200 response
-		assert.Equal(t, http.StatusOK, rr.Code)
-
-		ctx := context.Background()
-		var dbAddress sql.NullString
-		err = dbConnectionPool.GetContext(ctx, &dbAddress, "SELECT stellar_address FROM accounts")
-		require.NoError(t, err)
-
-		// Assert address persisted in DB
-		assert.True(t, dbAddress.Valid)
-		assert.Equal(t, address, dbAddress.String)
-
-		clearAccounts(ctx)
-	})
-
-	t.Run("address_already_exists", func(t *testing.T) {
-		address := keypair.MustRandom().Address()
-		ctx := context.Background()
-
-		// Insert address in DB
-		_, err = dbConnectionPool.ExecContext(ctx, "INSERT INTO accounts (stellar_address) VALUES ($1)", address)
-		require.NoError(t, err)
-
-		// Prepare request
-		payload := fmt.Sprintf(`{ "address": %q }`, address)
-		req, err := http.NewRequest(http.MethodPost, "/payments/subscribe", strings.NewReader(payload))
-		require.NoError(t, err)
-
-		// Serve request
-		rr := httptest.NewRecorder()
-		r.ServeHTTP(rr, req)
-
-		// Assert 200 response
-		assert.Equal(t, http.StatusOK, rr.Code)
-
-		var dbAddress sql.NullString
-		err = dbConnectionPool.GetContext(ctx, &dbAddress, "SELECT stellar_address FROM accounts")
-		require.NoError(t, err)
-
-		// Assert address persisted in DB
-		assert.True(t, dbAddress.Valid)
-		assert.Equal(t, address, dbAddress.String)
-
-		clearAccounts(ctx)
-	})
-
-	t.Run("invalid_address", func(t *testing.T) {
-		// Prepare request
-		payload := fmt.Sprintf(`{ "address": %q }`, "invalid")
-		req, err := http.NewRequest(http.MethodPost, "/payments/subscribe", strings.NewReader(payload))
-		require.NoError(t, err)
-
-		// Serve request
-		rr := httptest.NewRecorder()
-		r.ServeHTTP(rr, req)
-
-		resp := rr.Result()
-		respBody, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		assert.JSONEq(t, `{"error":"Validation error.", "extras": {"address":"Invalid public key provided"}}`, string(respBody))
-	})
-}
-
-func TestPaymentsHandlerUnsubscribeAddress(t *testing.T) {
-	dbt := dbtest.Open(t)
-	defer dbt.Close()
-
-	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
-	require.NoError(t, err)
-	defer dbConnectionPool.Close()
-
-	models, err := data.NewModels(dbConnectionPool)
+	paymentService, err := services.NewPaymentService(models, "http://testing.com")
 	require.NoError(t, err)
 	handler := &PaymentHandler{
-		Models: models,
-	}
-
-	// Setup router
-	r := chi.NewRouter()
-	r.Post("/payments/unsubscribe", handler.UnsubscribeAddress)
-
-	t.Run("successHappyPath", func(t *testing.T) {
-		address := keypair.MustRandom().Address()
-		ctx := context.Background()
-
-		// Insert address in DB
-		_, err = dbConnectionPool.ExecContext(ctx, "INSERT INTO accounts (stellar_address) VALUES ($1)", address)
-		require.NoError(t, err)
-
-		// Prepare request
-		payload := fmt.Sprintf(`{ "address": %q }`, address)
-		req, err := http.NewRequest(http.MethodPost, "/payments/unsubscribe", strings.NewReader(payload))
-		require.NoError(t, err)
-
-		// Serve request
-		rr := httptest.NewRecorder()
-		r.ServeHTTP(rr, req)
-
-		// Assert 200 response
-		assert.Equal(t, http.StatusOK, rr.Code)
-
-		// Assert no address no longer in DB
-		var dbAddress sql.NullString
-		err = dbConnectionPool.GetContext(ctx, &dbAddress, "SELECT stellar_address FROM accounts")
-		assert.ErrorIs(t, err, sql.ErrNoRows)
-	})
-
-	t.Run("idempotency", func(t *testing.T) {
-		address := keypair.MustRandom().Address()
-		ctx := context.Background()
-
-		// Make sure DB is empty
-		_, err = dbConnectionPool.ExecContext(ctx, "DELETE FROM accounts")
-		require.NoError(t, err)
-
-		// Prepare request
-		payload := fmt.Sprintf(`{ "address": %q }`, address)
-		req, err := http.NewRequest(http.MethodPost, "/payments/unsubscribe", strings.NewReader(payload))
-		require.NoError(t, err)
-
-		// Serve request
-		rr := httptest.NewRecorder()
-		r.ServeHTTP(rr, req)
-
-		// Assert 200 response
-		assert.Equal(t, http.StatusOK, rr.Code)
-	})
-
-	t.Run("invalid_address", func(t *testing.T) {
-		// Prepare request
-		payload := fmt.Sprintf(`{ "address": %q }`, "invalid")
-		req, err := http.NewRequest(http.MethodPost, "/payments/unsubscribe", strings.NewReader(payload))
-		require.NoError(t, err)
-
-		// Serve request
-		rr := httptest.NewRecorder()
-		r.ServeHTTP(rr, req)
-
-		resp := rr.Result()
-		respBody, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		assert.JSONEq(t, `{"error":"Validation error.", "extras": {"address":"Invalid public key provided"}}`, string(respBody))
-	})
-}
-
-func TestPaymentsHandlerGetPayments(t *testing.T) {
-	dbt := dbtest.Open(t)
-	defer dbt.Close()
-
-	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
-	require.NoError(t, err)
-	defer dbConnectionPool.Close()
-
-	models, err := data.NewModels(dbConnectionPool)
-	require.NoError(t, err)
-	handler := &PaymentHandler{
-		Models: models,
-		Service: &services.PaymentService{
-			Models:        models,
-			ServerBaseURL: "http://testing.com",
-		},
+		PaymentService: paymentService,
 	}
 
 	// Setup router

--- a/internal/serve/httphandler/request_params_validator.go
+++ b/internal/serve/httphandler/request_params_validator.go
@@ -28,6 +28,15 @@ func DecodeQueryAndValidate(ctx context.Context, req *http.Request, reqQuery int
 	return ValidateRequestParams(ctx, reqQuery)
 }
 
+func DecodePathAndValidate(ctx context.Context, req *http.Request, reqPath interface{}) *httperror.ErrorResponse {
+	err := httpdecode.DecodePath(req, reqPath)
+	if err != nil {
+		return httperror.BadRequest("Invalid request path.", nil)
+	}
+
+	return ValidateRequestParams(ctx, reqPath)
+}
+
 func ValidateRequestParams(ctx context.Context, reqParams interface{}) *httperror.ErrorResponse {
 	val := validators.NewValidator()
 	if err := val.StructCtx(ctx, reqParams); err != nil {

--- a/internal/services/account_service.go
+++ b/internal/services/account_service.go
@@ -1,0 +1,51 @@
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"errors"
+
+	"github.com/stellar/wallet-backend/internal/data"
+)
+
+type AccountService interface {
+	// RegisterAccount registers an externally created Stellar account to be sponsored, and tracked by ingestion
+	RegisterAccount(ctx context.Context, address string) error
+	// DeregisterAccount deregisters a Stellar account, no longer sponsoring its transactions, nor tracking it on ingestion
+	DeregisterAccount(ctx context.Context, address string) error
+}
+
+var _ AccountService = (*accountService)(nil)
+
+type accountService struct {
+	models *data.Models
+}
+
+func NewAccountService(models *data.Models) (*accountService, error) {
+	if models == nil {
+		return nil, errors.New("models cannot be nil")
+	}
+
+	return &accountService{
+		models: models,
+	}, nil
+}
+
+func (s *accountService) RegisterAccount(ctx context.Context, address string) error {
+	err := s.models.Account.Insert(ctx, address)
+	if err != nil {
+		return fmt.Errorf("registering account %s: %w", address, err)
+	}
+
+	return nil
+}
+
+func (s *accountService) DeregisterAccount(ctx context.Context, address string) error {
+	err := s.models.Account.Delete(ctx, address)
+	if err != nil {
+		return fmt.Errorf("deregistering account %s: %w", address, err)
+	}
+
+	return nil
+}

--- a/internal/services/account_service_test.go
+++ b/internal/services/account_service_test.go
@@ -1,0 +1,69 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/wallet-backend/internal/data"
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountRegister(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	models, err := data.NewModels(dbConnectionPool)
+	require.NoError(t, err)
+	accountService, err := NewAccountService(models)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	address := keypair.MustRandom().Address()
+	err = accountService.RegisterAccount(ctx, address)
+	require.NoError(t, err)
+
+	var dbAddress sql.NullString
+	err = dbConnectionPool.GetContext(ctx, &dbAddress, "SELECT stellar_address FROM accounts LIMIT 1")
+	require.NoError(t, err)
+
+	assert.True(t, dbAddress.Valid)
+	assert.Equal(t, address, dbAddress.String)
+}
+
+func TestAccountDeregister(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	models, err := data.NewModels(dbConnectionPool)
+	require.NoError(t, err)
+	accountService, err := NewAccountService(models)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	address := keypair.MustRandom().Address()
+	result, err := dbConnectionPool.ExecContext(ctx, "INSERT INTO accounts (stellar_address) VALUES ($1)", address)
+	require.NoError(t, err)
+	rowAffected, err := result.RowsAffected()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rowAffected)
+
+	err = accountService.DeregisterAccount(ctx, address)
+	require.NoError(t, err)
+
+	var dbAddress sql.NullString
+	err = dbConnectionPool.GetContext(ctx, &dbAddress, "SELECT stellar_address FROM accounts LIMIT 1")
+	assert.ErrorIs(t, err, sql.ErrNoRows)
+}

--- a/internal/services/payment_service_test.go
+++ b/internal/services/payment_service_test.go
@@ -25,10 +25,8 @@ func TestPaymentServiceGetPaymentsPaginated(t *testing.T) {
 
 	models, err := data.NewModels(dbConnectionPool)
 	require.NoError(t, err)
-	service := &PaymentService{
-		Models:        models,
-		ServerBaseURL: "http://testing.com",
-	}
+	service, err := NewPaymentService(models, "http://testing.com")
+	require.NoError(t, err)
 	ctx := context.Background()
 
 	dbPayments := []data.Payment{


### PR DESCRIPTION
### What

- Renames `POST /payments/subscribe` to `POST /accounts/{address}`;
- Renames `POST /payments/unsubscribe` to `DELETE /accounts/{address}`;

### Why

These endpoints not only add an account for payments tracking by the ingestion service, but also starts sponsoring their transactions on `POST /tx/create-fee-bump` from that point on. The new route names are therefore more adequate.

### Known limitations

N/A

### Issue that this PR addresses

[[Wallet Backend] Rename /payments/(un)subscribe endpoints](https://app.asana.com/0/1202672669313222/1207656913249561/f)

### Checklist

#### PR Structure

- [ ] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.
- [X] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [X] This PR adds tests for the new functionality or fixes.
- [X] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [ ] This is not a breaking change.
- [X] This is ready to be tested in development.
- [X] The new functionality is gated with a feature flag if this is not ready for production.
