### PR TITLE
serve: write status header for no body responses

### DIFF
--- a/internal/serve/httphandler/account_handler.go
+++ b/internal/serve/httphandler/account_handler.go
@@ -36,6 +36,8 @@ func (h AccountHandler) RegisterAccount(w http.ResponseWriter, r *http.Request) 
 		httperror.InternalServerError(ctx, "", err, nil).Render(w)
 		return
 	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
 func (h AccountHandler) DeregisterAccount(w http.ResponseWriter, r *http.Request) {
@@ -53,6 +55,8 @@ func (h AccountHandler) DeregisterAccount(w http.ResponseWriter, r *http.Request
 		httperror.InternalServerError(ctx, "", err, nil).Render(w)
 		return
 	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
 type SponsorAccountCreationRequest struct {


### PR DESCRIPTION
### What

Sets the status header explicitly to 200 when not using `httpjson.Render`.

### Why

Header is not set by default.

### Known limitations

N/A

### Issue that this PR addresses

N/A

### Checklist

#### PR Structure

- [X] It is not possible to break this PR down into smaller PRs.
- [X] This PR does not mix refactoring changes with feature changes.
- [X] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [X] This PR adds tests for the new functionality or fixes.
- [X] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [X] This is not a breaking change.
- [X] This is ready to be tested in development.
- [X] The new functionality is gated with a feature flag if this is not ready for production.
