### PR TITLE
httphandler: limit param on payments capped at 200

### DIFF
--- a/internal/serve/httphandler/account_handler_test.go
+++ b/internal/serve/httphandler/account_handler_test.go
@@ -279,7 +279,7 @@ func TestAccountHandlerSponsorAccountCreation(t *testing.T) {
 				"error": "Validation error.",
 				"extras": {
 					"address": "Invalid public key provided",
-					"signers": "Should have at least 1 element"
+					"signers": "Should have at least 1 element(s)"
 				}
 			}
 		`

--- a/internal/serve/httphandler/payment_handler.go
+++ b/internal/serve/httphandler/payment_handler.go
@@ -21,7 +21,7 @@ type PaymentsRequest struct {
 	AfterID  string         `query:"afterId"`
 	BeforeID string         `query:"beforeId"`
 	Sort     data.SortOrder `query:"sort" validate:"oneof=ASC DESC"`
-	Limit    int            `query:"limit" validate:"gt=0"`
+	Limit    int            `query:"limit" validate:"gt=0,lte=200"`
 }
 
 type PaymentsResponse struct {

--- a/internal/serve/httphandler/payment_handler_test.go
+++ b/internal/serve/httphandler/payment_handler_test.go
@@ -233,7 +233,7 @@ func TestPaymentHandlerGetPayments(t *testing.T) {
 		assert.JSONEq(t, expectedRespBody, string(respBody))
 	})
 
-	t.Run("invalid_params", func(t *testing.T) {
+	t.Run("invalid_params_1", func(t *testing.T) {
 		// Prepare request
 		req, err := http.NewRequest(http.MethodGet, "/payments?address=12345&limit=0&sort=BS", nil)
 		require.NoError(t, err)
@@ -254,6 +254,30 @@ func TestPaymentHandlerGetPayments(t *testing.T) {
 				"limit": "Should be greater than 0",
 				"address": "Invalid public key provided",
 				"sort": "Unexpected value \"BS\". Expected one of the following values: ASC, DESC"
+			}
+		}`
+		assert.JSONEq(t, expectedRespBody, string(respBody))
+	})
+
+	t.Run("invalid_params_2", func(t *testing.T) {
+		// Prepare request
+		req, err := http.NewRequest(http.MethodGet, "/payments?limit=210", nil)
+		require.NoError(t, err)
+
+		// Serve request
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		// Assert 400 response
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+		resp := rr.Result()
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		expectedRespBody := `{
+			"error": "Validation error.",
+			"extras": {
+				"limit": "Should be less than or equal to 200"
 			}
 		}`
 		assert.JSONEq(t, expectedRespBody, string(respBody))

--- a/internal/validators/validate.go
+++ b/internal/validators/validate.go
@@ -51,7 +51,7 @@ func msgForFieldError(fieldError validator.FieldError) string {
 				log.Errorf(`Error parsing "gt" param %q to integer: %s`, fieldError.Param(), err.Error())
 				return "Should have at least 1 element" // Fallback to this error message
 			}
-			return fmt.Sprintf("Should have at least %d element", v+1) // For instance, if "gt" is 0 (zero) then it should have at least 1 element
+			return fmt.Sprintf("Should have at least %d element(s)", v+1) // For instance, if "gt" is 0 (zero) then it should have at least 1 element
 		}
 		return fmt.Sprintf("Should be greater than %s", fieldError.Param())
 	case "gte":
@@ -61,9 +61,29 @@ func msgForFieldError(fieldError validator.FieldError) string {
 				log.Errorf(`Error parsing "gte" param %q to integer: %s`, fieldError.Param(), err.Error())
 				return "Should have at least 1 element" // Fallback to this error message
 			}
-			return fmt.Sprintf("Should have at least %d element", v)
+			return fmt.Sprintf("Should have at least %d element(s)", v)
 		}
 		return fmt.Sprintf("Should be greater than or equal to %s", fieldError.Param())
+	case "lt":
+		if fieldError.Kind() == reflect.Slice || fieldError.Kind() == reflect.Array {
+			v, err := strconv.Atoi(fieldError.Param())
+			if err != nil {
+				log.Errorf(`Error parsing "lt" param %q to integer: %s`, fieldError.Param(), err.Error())
+				return "Should have at most 1 element" // Fallback to this error message
+			}
+			return fmt.Sprintf("Should have at most %d element(s)", v-1)
+		}
+		return fmt.Sprintf("Should be less than %s", fieldError.Param())
+	case "lte":
+		if fieldError.Kind() == reflect.Slice || fieldError.Kind() == reflect.Array {
+			v, err := strconv.Atoi(fieldError.Param())
+			if err != nil {
+				log.Errorf(`Error parsing "lte" param %q to integer: %s`, fieldError.Param(), err.Error())
+				return "Should have at most 1 element" // Fallback to this error message
+			}
+			return fmt.Sprintf("Should have at most %d element(s)", v)
+		}
+		return fmt.Sprintf("Should be less than or equal to %s", fieldError.Param())
 	default:
 		return "Invalid value"
 	}


### PR DESCRIPTION
### What

Adds a cap of 200 to the `limit` parameter of the `GET /payments` endpoint.

### Why

So that unreasonably high limits are not allowed which could drain too many resources of the app.

### Known limitations

N/A

### Issue that this PR addresses

[[Wallet Backend] Add a limit to the page size parameter in GET /payments](https://app.asana.com/0/1202672669313222/1208148132244616/f)

### Checklist

#### PR Structure

- [X] It is not possible to break this PR down into smaller PRs.
- [X] This PR does not mix refactoring changes with feature changes.
- [X] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [X] This PR adds tests for the new functionality or fixes.
- [X] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [X] This is not a breaking change.
- [X] This is ready to be tested in development.
- [X] The new functionality is gated with a feature flag if this is not ready for production.
