### PR TITLE
services: rpc service

### DIFF
--- a/internal/entities/rpc.go
+++ b/internal/entities/rpc.go
@@ -18,20 +18,10 @@ const (
 	SuccessStatus  RPCStatus = "SUCCESS"
 )
 
-type RPCEntry struct {
-	Key                   string `json:"key"`
-	XDR                   string `json:"xdr"`
-	LastModifiedLedgerSeq int64  `json:"lastModifiedLedgerSeq"`
-}
-
 type RPCResponse struct {
 	Result  json.RawMessage `json:"result"`
 	JSONRPC string          `json:"jsonrpc"`
 	ID      int64           `json:"id"`
-}
-
-type RPCGetLedgerEntriesResult struct {
-	Entries []RPCEntry `json:"entries"`
 }
 
 type RPCGetTransactionResult struct {

--- a/internal/entities/rpc.go
+++ b/internal/entities/rpc.go
@@ -35,24 +35,24 @@ type RPCGetLedgerEntriesResult struct {
 }
 
 type RPCGetTransactionResult struct {
-	Status                string `json:"status"`
-	LatestLedger          int64  `json:"latestLedger"`
-	LatestLedgerCloseTime string `json:"latestLedgerCloseTime"`
-	OldestLedger          int64  `json:"oldestLedger"`
-	OldestLedgerCloseTime string `json:"oldestLedgerCloseTime"`
-	ApplicationOrder      int64  `json:"applicationOrder"`
-	EnvelopeXDR           string `json:"envelopeXdr"`
-	ResultXDR             string `json:"resultXdr"`
-	ResultMetaXDR         string `json:"resultMetaXdr"`
-	Ledger                int64  `json:"ledger"`
-	CreatedAt             string `json:"createdAt"`
-	ErrorResultXDR        string `json:"errorResultXdr"`
+	Status                RPCStatus `json:"status"`
+	LatestLedger          int64     `json:"latestLedger"`
+	LatestLedgerCloseTime string    `json:"latestLedgerCloseTime"`
+	OldestLedger          int64     `json:"oldestLedger"`
+	OldestLedgerCloseTime string    `json:"oldestLedgerCloseTime"`
+	ApplicationOrder      int64     `json:"applicationOrder"`
+	EnvelopeXDR           string    `json:"envelopeXdr"`
+	ResultXDR             string    `json:"resultXdr"`
+	ResultMetaXDR         string    `json:"resultMetaXdr"`
+	Ledger                int64     `json:"ledger"`
+	CreatedAt             string    `json:"createdAt"`
+	ErrorResultXDR        string    `json:"errorResultXdr"`
 }
 
 type RPCSendTransactionResult struct {
-	Status                string `json:"status"`
-	LatestLedger          int64  `json:"latestLedger"`
-	LatestLedgerCloseTime string `json:"latestLedgerCloseTime"`
-	Hash                  string `json:"hash"`
-	ErrorResultXDR        string `json:"errorResultXdr"`
+	Status                RPCStatus `json:"status"`
+	LatestLedger          int64     `json:"latestLedger"`
+	LatestLedgerCloseTime string    `json:"latestLedgerCloseTime"`
+	Hash                  string    `json:"hash"`
+	ErrorResultXDR        string    `json:"errorResultXdr"`
 }

--- a/internal/entities/rpc.go
+++ b/internal/entities/rpc.go
@@ -38,13 +38,13 @@ type RPCGetTransactionResult struct {
 	Status                string `json:"status"`
 	LatestLedger          int64  `json:"latestLedger"`
 	LatestLedgerCloseTime string `json:"latestLedgerCloseTime"`
-	OldestLedger          string `json:"oldestLedger"`
+	OldestLedger          int64  `json:"oldestLedger"`
 	OldestLedgerCloseTime string `json:"oldestLedgerCloseTime"`
-	ApplicationOrder      string `json:"applicationOrder"`
+	ApplicationOrder      int64  `json:"applicationOrder"`
 	EnvelopeXDR           string `json:"envelopeXdr"`
 	ResultXDR             string `json:"resultXdr"`
 	ResultMetaXDR         string `json:"resultMetaXdr"`
-	Ledger                string `json:"ledger"`
+	Ledger                int64  `json:"ledger"`
 	CreatedAt             string `json:"createdAt"`
 	ErrorResultXDR        string `json:"errorResultXdr"`
 }

--- a/internal/entities/rpc.go
+++ b/internal/entities/rpc.go
@@ -1,0 +1,47 @@
+package entities
+
+type RPCStatus string
+
+const (
+	// sendTransaction statuses
+	PendingStatus       RPCStatus = "PENDING"
+	DuplicateStatus     RPCStatus = "DUPLICATE"
+	TryAgainLaterStatus RPCStatus = "TRY_AGAIN_LATER"
+	ErrorStatus         RPCStatus = "ERROR"
+	// getTransaction statuses
+	NotFoundStatus RPCStatus = "NOT_FOUND"
+	FailedStatus   RPCStatus = "FAILED"
+	SuccessStatus  RPCStatus = "SUCCESS"
+)
+
+type RPCEntry struct {
+	Key                   string `json:"key"`
+	XDR                   string `json:"xdr"`
+	LastModifiedLedgerSeq int64  `json:"lastModifiedLedgerSeq"`
+}
+
+type RPCResult struct {
+	Status                string `json:"status"`
+	LatestLedger          int64  `json:"latestLedger"`
+	LatestLedgerCloseTime string `json:"latestLedgerCloseTime"`
+	// sendTransaction fields
+	Hash string `json:"hash"`
+	// getTransaction fields
+	OldestLedger          string `json:"oldestLedger"`
+	OldestLedgerCloseTime string `json:"oldestLedgerCloseTime"`
+	ApplicationOrder      string `json:"applicationOrder"`
+	EnvelopeXDR           string `json:"envelopeXdr"`
+	ResultXDR             string `json:"resultXdr"`
+	ResultMetaXDR         string `json:"resultMetaXdr"`
+	Ledger                string `json:"ledger"`
+	CreatedAt             string `json:"createdAt"`
+	ErrorResultXDR        string `json:"errorResultXdr"`
+	// getLedgerEntries fields
+	Entries []RPCEntry `json:"entries"`
+}
+
+type RPCResponse struct {
+	Result  RPCResult `json:"result"`
+	JSONRPC string    `json:"jsonrpc"`
+	ID      int64     `json:"id"`
+}

--- a/internal/entities/rpc.go
+++ b/internal/entities/rpc.go
@@ -1,5 +1,9 @@
 package entities
 
+import (
+	"encoding/json"
+)
+
 type RPCStatus string
 
 const (
@@ -20,13 +24,20 @@ type RPCEntry struct {
 	LastModifiedLedgerSeq int64  `json:"lastModifiedLedgerSeq"`
 }
 
-type RPCResult struct {
+type RPCResponse struct {
+	Result  json.RawMessage `json:"result"`
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int64           `json:"id"`
+}
+
+type RPCGetLedgerEntriesResult struct {
+	Entries []RPCEntry `json:"entries"`
+}
+
+type RPCGetTransactionResult struct {
 	Status                string `json:"status"`
 	LatestLedger          int64  `json:"latestLedger"`
 	LatestLedgerCloseTime string `json:"latestLedgerCloseTime"`
-	// sendTransaction fields
-	Hash string `json:"hash"`
-	// getTransaction fields
 	OldestLedger          string `json:"oldestLedger"`
 	OldestLedgerCloseTime string `json:"oldestLedgerCloseTime"`
 	ApplicationOrder      string `json:"applicationOrder"`
@@ -36,12 +47,12 @@ type RPCResult struct {
 	Ledger                string `json:"ledger"`
 	CreatedAt             string `json:"createdAt"`
 	ErrorResultXDR        string `json:"errorResultXdr"`
-	// getLedgerEntries fields
-	Entries []RPCEntry `json:"entries"`
 }
 
-type RPCResponse struct {
-	Result  RPCResult `json:"result"`
-	JSONRPC string    `json:"jsonrpc"`
-	ID      int64     `json:"id"`
+type RPCSendTransactionResult struct {
+	Status                string `json:"status"`
+	LatestLedger          int64  `json:"latestLedger"`
+	LatestLedgerCloseTime string `json:"latestLedgerCloseTime"`
+	Hash                  string `json:"hash"`
+	ErrorResultXDR        string `json:"errorResultXdr"`
 }

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -51,11 +51,11 @@ func setupDeps(cfg Configs) (services.IngestService, error) {
 	// Open DB connection pool
 	dbConnectionPool, err := db.OpenDBConnectionPool(cfg.DatabaseURL)
 	if err != nil {
-		return nil, fmt.Errorf("error connecting to the database: %w", err)
+		return nil, fmt.Errorf("connecting to the database: %w", err)
 	}
 	models, err := data.NewModels(dbConnectionPool)
 	if err != nil {
-		return nil, fmt.Errorf("error creating models for Serve: %w", err)
+		return nil, fmt.Errorf("creating models: %w", err)
 	}
 
 	// Setup Captive Core backend
@@ -69,8 +69,12 @@ func setupDeps(cfg Configs) (services.IngestService, error) {
 	}
 
 	httpClient := &http.Client{Timeout: 30 * time.Second}
+	rpcService, err := services.NewRPCService(cfg.RPCURL, httpClient)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating rpc service: %w", err)
+	}
 
-	ingestService, err := services.NewIngestService(models, ledgerBackend, cfg.NetworkPassphrase, cfg.LedgerCursorName, cfg.AppTracker, httpClient, cfg.RPCURL)
+	ingestService, err := services.NewIngestService(models, ledgerBackend, cfg.NetworkPassphrase, cfg.LedgerCursorName, cfg.AppTracker, rpcService)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating ingest service: %w", err)
 	}

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stellar/go/ingest/ledgerbackend"
@@ -27,6 +29,7 @@ type Configs struct {
 	EndLedger            int
 	LogLevel             logrus.Level
 	AppTracker           apptracker.AppTracker
+	RPCURL               string
 }
 
 func Ingest(cfg Configs) error {
@@ -44,7 +47,7 @@ func Ingest(cfg Configs) error {
 	return nil
 }
 
-func setupDeps(cfg Configs) (*services.IngestManager, error) {
+func setupDeps(cfg Configs) (services.IngestService, error) {
 	// Open DB connection pool
 	dbConnectionPool, err := db.OpenDBConnectionPool(cfg.DatabaseURL)
 	if err != nil {
@@ -65,13 +68,14 @@ func setupDeps(cfg Configs) (*services.IngestManager, error) {
 		return nil, fmt.Errorf("creating captive core backend: %w", err)
 	}
 
-	return &services.IngestManager{
-		NetworkPassphrase: cfg.NetworkPassphrase,
-		LedgerCursorName:  cfg.LedgerCursorName,
-		LedgerBackend:     ledgerBackend,
-		PaymentModel:      models.Payments,
-		AppTracker:        cfg.AppTracker,
-	}, nil
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+
+	ingestService, err := services.NewIngestService(models, ledgerBackend, cfg.NetworkPassphrase, cfg.LedgerCursorName, cfg.AppTracker, httpClient, cfg.RPCURL)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating ingest service: %w", err)
+	}
+
+	return ingestService, nil
 }
 
 const (

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -29,8 +29,7 @@ type ingestService struct {
 	networkPassphrase string
 	ledgerCursorName  string
 	appTracker        apptracker.AppTracker
-	httpClient        utils.HTTPClient
-	rpcURL            string
+	rpcService        RPCService
 }
 
 func NewIngestService(
@@ -39,8 +38,7 @@ func NewIngestService(
 	networkPassphrase string,
 	ledgerCursorName string,
 	appTracker apptracker.AppTracker,
-	httpClient utils.HTTPClient,
-	rpcURL string,
+	rpcService RPCService,
 ) (*ingestService, error) {
 	if models == nil {
 		return nil, errors.New("models cannot be nil")
@@ -57,11 +55,8 @@ func NewIngestService(
 	if appTracker == nil {
 		return nil, errors.New("appTracker cannot be nil")
 	}
-	if httpClient == nil {
-		return nil, errors.New("httpClient cannot be nil")
-	}
-	if rpcURL == "" {
-		return nil, errors.New("rpcURL cannot be nil")
+	if rpcService == nil {
+		return nil, errors.New("rpcService cannot be nil")
 	}
 
 	return &ingestService{
@@ -70,8 +65,7 @@ func NewIngestService(
 		networkPassphrase: networkPassphrase,
 		ledgerCursorName:  ledgerCursorName,
 		appTracker:        appTracker,
-		httpClient:        httpClient,
-		rpcURL:            rpcURL,
+		rpcService:        rpcService,
 	}, nil
 }
 

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -85,7 +85,7 @@ func (m *ingestService) Run(ctx context.Context, start, end uint32) error {
 		}
 
 		if lastSyncedLedger == 0 {
-			// Captive Core is not able to process genesis ledger and often has trouble processing ledger 2, so we start ingestion at ledger 3
+			// Captive Core is not able to process genesis ledger (1) and often has trouble processing ledger 2, so we start ingestion at ledger 3
 			log.Ctx(ctx).Info("No last synced ledger cursor found, initializing ingestion at ledger 3")
 			ingestLedger = 3
 		} else {

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -29,6 +29,7 @@ func TestProcessLedger(t *testing.T) {
 		networkPassphrase: network.TestNetworkPassphrase,
 		ledgerCursorName:  "last_synced_ledger",
 		ledgerBackend:     nil,
+		rpcService:        nil,
 	}
 
 	ctx := context.Background()

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -23,13 +23,12 @@ func TestProcessLedger(t *testing.T) {
 	require.NoError(t, err)
 	defer dbConnectionPool.Close()
 
-	m := &IngestManager{
-		PaymentModel: &data.PaymentModel{
-			DB: dbConnectionPool,
-		},
-		NetworkPassphrase: network.TestNetworkPassphrase,
-		LedgerCursorName:  "last_synced_ledger",
-		LedgerBackend:     nil,
+	models, _ := data.NewModels(dbConnectionPool)
+	service := &ingestService{
+		models:            models,
+		networkPassphrase: network.TestNetworkPassphrase,
+		ledgerCursorName:  "last_synced_ledger",
+		ledgerBackend:     nil,
 	}
 
 	ctx := context.Background()
@@ -111,12 +110,12 @@ func TestProcessLedger(t *testing.T) {
 
 	// Compute transaction hash and inject into ledger meta
 	components := ledgerMeta.V1.TxSet.V1TxSet.Phases[0].V0Components
-	xdrHash, err := network.HashTransactionInEnvelope((*components)[0].TxsMaybeDiscountedFee.Txs[0], m.NetworkPassphrase)
+	xdrHash, err := network.HashTransactionInEnvelope((*components)[0].TxsMaybeDiscountedFee.Txs[0], service.networkPassphrase)
 	require.NoError(t, err)
 	ledgerMeta.V1.TxProcessing[0].Result.TransactionHash = xdrHash
 
 	// Run ledger ingestion
-	err = m.processLedger(ctx, 1, ledgerMeta)
+	err = service.processLedger(ctx, 1, ledgerMeta)
 	require.NoError(t, err)
 
 	// Assert payment properly persisted to database

--- a/internal/services/rpc_service.go
+++ b/internal/services/rpc_service.go
@@ -75,7 +75,6 @@ func (r *rpcService) sendRPCRequest(method string, params map[string]string) (js
 		"params":  params,
 	}
 	jsonData, err := json.Marshal(payload)
-
 	if err != nil {
 		return nil, fmt.Errorf("marshaling payload")
 	}
@@ -95,6 +94,10 @@ func (r *rpcService) sendRPCRequest(method string, params map[string]string) (js
 	err = json.Unmarshal(body, &res)
 	if err != nil {
 		return nil, fmt.Errorf("parsing RPC response JSON: %w", err)
+	}
+
+	if res.Result == nil {
+		return nil, fmt.Errorf("response %s missing result field", string(body))
 	}
 
 	return res.Result, nil

--- a/internal/services/rpc_service.go
+++ b/internal/services/rpc_service.go
@@ -1,0 +1,101 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/stellar/wallet-backend/internal/entities"
+	"github.com/stellar/wallet-backend/internal/utils"
+)
+
+type RPCService interface {
+	GetTransaction(transactionHash string) (entities.RPCGetTransactionResult, error)
+	SendTransaction(transactionXDR string) (entities.RPCSendTransactionResult, error)
+}
+
+type rpcService struct {
+	rpcURL     string
+	httpClient utils.HTTPClient
+}
+
+var _ RPCService = (*rpcService)(nil)
+
+func NewRPCService(rpcURL string, httpClient utils.HTTPClient) (*rpcService, error) {
+	if rpcURL == "" {
+		return nil, errors.New("rpcURL cannot be nil")
+	}
+	if httpClient == nil {
+		return nil, errors.New("httpClient cannot be nil")
+	}
+
+	return &rpcService{
+		rpcURL:     rpcURL,
+		httpClient: httpClient,
+	}, nil
+}
+
+func (r *rpcService) GetTransaction(transactionHash string) (entities.RPCGetTransactionResult, error) {
+	resultBytes, err := r.sendRPCRequest("getTransaction", map[string]string{"hash": transactionHash})
+	if err != nil {
+		return entities.RPCGetTransactionResult{}, fmt.Errorf("sending getTransaction request: %w", err)
+	}
+
+	var result entities.RPCGetTransactionResult
+	err = json.Unmarshal(resultBytes, &result)
+	if err != nil {
+		return entities.RPCGetTransactionResult{}, fmt.Errorf("parsing getTransaction result JSON: %w", err)
+	}
+
+	return result, nil
+}
+
+func (r *rpcService) SendTransaction(transactionXDR string) (entities.RPCSendTransactionResult, error) {
+	resultBytes, err := r.sendRPCRequest("sendTransaction", map[string]string{"transaction": transactionXDR})
+	if err != nil {
+		return entities.RPCSendTransactionResult{}, fmt.Errorf("sending sendTransaction request: %w", err)
+	}
+
+	var result entities.RPCSendTransactionResult
+	err = json.Unmarshal(resultBytes, &result)
+	if err != nil {
+		return entities.RPCSendTransactionResult{}, fmt.Errorf("parsing sendTransaction result JSON: %w", err)
+	}
+
+	return result, nil
+}
+
+func (r *rpcService) sendRPCRequest(method string, params map[string]string) (json.RawMessage, error) {
+	payload := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  method,
+		"params":  params,
+	}
+	jsonData, err := json.Marshal(payload)
+
+	if err != nil {
+		return nil, fmt.Errorf("marshaling payload")
+	}
+
+	resp, err := r.httpClient.Post(r.rpcURL, "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("sending POST request to RPC: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshaling RPC response: %w", err)
+	}
+
+	var res entities.RPCResponse
+	err = json.Unmarshal(body, &res)
+	if err != nil {
+		return nil, fmt.Errorf("parsing RPC response JSON: %w", err)
+	}
+
+	return res.Result, nil
+}

--- a/internal/services/rpc_service_test.go
+++ b/internal/services/rpc_service_test.go
@@ -1,0 +1,314 @@
+package services
+
+// type errorReader struct{}
+
+// func (e *errorReader) Read(p []byte) (n int, err error) {
+// 	return 0, fmt.Errorf("read error")
+// }
+
+// func (e *errorReader) Close() error {
+// 	return nil
+// }
+
+// func TestSendRPCRequest(t *testing.T) {
+// 	mockHTTPClient := utils.MockHTTPClient{}
+// 	rpcURL := "http://localhost:8000/soroban/rpc"
+// 	rpcService := NewRPCService(rpcURL, &mockHTTPClient)
+// 	method := "sendTransaction"
+// 	params := map[string]string{"transaction": "ABCD"}
+// 	payload := map[string]interface{}{
+// 		"jsonrpc": "2.0",
+// 		"id":      1,
+// 		"method":  method,
+// 		"params":  params,
+// 	}
+// 	jsonData, _ := json.Marshal(payload)
+// 	t.Run("rpc_post_call_fails", func(t *testing.T) {
+// 		mockHTTPClient.
+// 			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
+// 			Return(&http.Response{}, errors.New("RPC Connection fail")).
+// 			Once()
+
+// 		resp, err := rpcService.sendRPCRequest(method, params)
+
+// 		assert.Empty(t, resp)
+// 		assert.Equal(t, "sendTransaction: sending POST request to rpc: RPC Connection fail", err.Error())
+// 	})
+
+// 	t.Run("unmarshaling_rpc_response_fails", func(t *testing.T) {
+// 		httpResponse := &http.Response{
+// 			StatusCode: http.StatusOK,
+// 			Body:       io.NopCloser(&errorReader{}),
+// 		}
+// 		mockHTTPClient.
+// 			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
+// 			Return(httpResponse, nil).
+// 			Once()
+
+// 		resp, err := rpcService.sendRPCRequest(method, params)
+
+// 		assert.Empty(t, resp)
+// 		assert.Equal(t, "sendTransaction: unmarshaling RPC response", err.Error())
+// 	})
+
+// 	t.Run("unmarshaling_json_fails", func(t *testing.T) {
+// 		httpResponse := &http.Response{
+// 			StatusCode: http.StatusOK,
+// 			Body:       io.NopCloser(strings.NewReader(`{invalid-json`)),
+// 		}
+// 		mockHTTPClient.
+// 			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
+// 			Return(httpResponse, nil).
+// 			Once()
+
+// 		resp, err := rpcService.sendRPCRequest(method, params)
+
+// 		assert.Empty(t, resp)
+// 		assert.Equal(t, "sendTransaction: parsing RPC response JSON", err.Error())
+// 	})
+
+// 	t.Run("response_has_no_result_field", func(t *testing.T) {
+// 		httpResponse := &http.Response{
+// 			StatusCode: http.StatusOK,
+// 			Body:       io.NopCloser(strings.NewReader(`{"status": "success"}`)),
+// 		}
+// 		mockHTTPClient.
+// 			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
+// 			Return(httpResponse, nil).
+// 			Once()
+
+// 		resp, err := rpcService.sendRPCRequest(method, params)
+
+// 		assert.Empty(t, resp)
+// 		assert.Equal(t, "sendTransaction: response missing result field", err.Error())
+// 	})
+
+// 	t.Run("response_has_status_field", func(t *testing.T) {
+// 		httpResponse := &http.Response{
+// 			StatusCode: http.StatusOK,
+// 			Body:       io.NopCloser(strings.NewReader(`{"result": {"status": "PENDING"}}`)),
+// 		}
+// 		mockHTTPClient.
+// 			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
+// 			Return(httpResponse, nil).
+// 			Once()
+
+// 		resp, err := rpcService.sendRPCRequest(method, params)
+
+// 		assert.Equal(t, "PENDING", resp.Result.Status)
+// 		assert.Empty(t, err)
+// 	})
+
+// 	t.Run("response_has_envelopexdr_field", func(t *testing.T) {
+// 		httpResponse := &http.Response{
+// 			StatusCode: http.StatusOK,
+// 			Body:       io.NopCloser(strings.NewReader(`{"result": {"envelopeXdr": "exdr"}}`)),
+// 		}
+// 		mockHTTPClient.
+// 			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
+// 			Return(httpResponse, nil).
+// 			Once()
+
+// 		resp, err := rpcService.sendRPCRequest(method, params)
+
+// 		assert.Equal(t, "exdr", resp.Result.EnvelopeXDR)
+// 		assert.Empty(t, err)
+// 	})
+
+// 	t.Run("response_has_resultxdr_field", func(t *testing.T) {
+// 		httpResponse := &http.Response{
+// 			StatusCode: http.StatusOK,
+// 			Body:       io.NopCloser(strings.NewReader(`{"result": {"resultXdr": "rxdr"}}`)),
+// 		}
+// 		mockHTTPClient.
+// 			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
+// 			Return(httpResponse, nil).
+// 			Once()
+
+// 		resp, err := rpcService.sendRPCRequest(method, params)
+
+// 		assert.Equal(t, "rxdr", resp.Result.ResultXDR)
+// 		assert.Empty(t, err)
+// 	})
+
+// 	t.Run("response_has_errorresultxdr_field", func(t *testing.T) {
+// 		httpResponse := &http.Response{
+// 			StatusCode: http.StatusOK,
+// 			Body:       io.NopCloser(strings.NewReader(`{"result": {"errorResultXdr": "exdr"}}`)),
+// 		}
+// 		mockHTTPClient.
+// 			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
+// 			Return(httpResponse, nil).
+// 			Once()
+
+// 		resp, err := rpcService.sendRPCRequest(method, params)
+
+// 		assert.Equal(t, "exdr", resp.Result.ErrorResultXDR)
+// 		assert.Empty(t, err)
+// 	})
+
+// 	t.Run("response_has_hash_field", func(t *testing.T) {
+// 		httpResponse := &http.Response{
+// 			StatusCode: http.StatusOK,
+// 			Body:       io.NopCloser(strings.NewReader(`{"result": {"hash": "hash"}}`)),
+// 		}
+// 		mockHTTPClient.
+// 			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
+// 			Return(httpResponse, nil).
+// 			Once()
+
+// 		resp, err := rpcService.sendRPCRequest(method, params)
+
+// 		assert.Equal(t, "hash", resp.Result.Hash)
+// 		assert.Empty(t, err)
+// 	})
+
+// 	t.Run("response_has_createdat_field", func(t *testing.T) {
+// 		httpResponse := &http.Response{
+// 			StatusCode: http.StatusOK,
+// 			Body:       io.NopCloser(strings.NewReader(`{"result": {"createdAt": "1234"}}`)),
+// 		}
+// 		mockHTTPClient.
+// 			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
+// 			Return(httpResponse, nil).
+// 			Once()
+
+// 		resp, err := rpcService.sendRPCRequest(method, params)
+
+// 		assert.Equal(t, "1234", resp.Result.CreatedAt)
+// 		assert.Empty(t, err)
+// 	})
+// }
+
+// func TestSendTransaction(t *testing.T) {
+// 	mockHTTPClient := utils.MockHTTPClient{}
+// 	rpcURL := "http://localhost:8000/soroban/rpc"
+// 	rpcService := NewRPCService(rpcURL, &mockHTTPClient)
+// 	method := "sendTransaction"
+// 	params := map[string]string{"transaction": "ABCD"}
+// 	payload := map[string]interface{}{
+// 		"jsonrpc": "2.0",
+// 		"id":      1,
+// 		"method":  method,
+// 		"params":  params,
+// 	}
+// 	jsonData, _ := json.Marshal(payload)
+
+// 	t.Run("rpc_request_fails", func(t *testing.T) {
+// 		mockHTTPClient.
+// 			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
+// 			Return(&http.Response{}, errors.New("RPC Connection fail")).
+// 			Once()
+
+// 		resp, err := rpcService.SendTransaction("ABCD")
+
+// 		assert.Equal(t, tss.RPCFailCode, resp.Code.OtherCodes)
+// 		assert.Equal(t, "RPC fail: sendTransaction: sending POST request to rpc: RPC Connection fail", err.Error())
+
+// 	})
+// 	t.Run("response_has_empty_errorResultXdr", func(t *testing.T) {
+// 		httpResponse := &http.Response{
+// 			StatusCode: http.StatusOK,
+// 			Body:       io.NopCloser(strings.NewReader(`{"result": {"status": "PENDING", "errorResultXdr": ""}}`)),
+// 		}
+// 		mockHTTPClient.
+// 			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
+// 			Return(httpResponse, nil).
+// 			Once()
+
+// 		resp, err := rpcService.SendTransaction("ABCD")
+
+// 		assert.Equal(t, entities.PendingStatus, resp.Status)
+// 		assert.Equal(t, tss.UnmarshalBinaryCode, resp.Code.OtherCodes)
+// 		assert.Equal(t, "parse error result xdr string: unable to unmarshal errorResultXdr: ", err.Error())
+
+// 	})
+// 	t.Run("response_has_unparsable_errorResultXdr", func(t *testing.T) {
+// 		httpResponse := &http.Response{
+// 			StatusCode: http.StatusOK,
+// 			Body:       io.NopCloser(strings.NewReader(`{"result": {"errorResultXdr": "ABC123"}}`)),
+// 		}
+// 		mockHTTPClient.
+// 			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
+// 			Return(httpResponse, nil).
+// 			Once()
+
+// 		resp, err := rpcService.SendTransaction("ABCD")
+
+// 		assert.Equal(t, tss.UnmarshalBinaryCode, resp.Code.OtherCodes)
+// 		assert.Equal(t, "parse error result xdr string: unable to unmarshal errorResultXdr: ABC123", err.Error())
+// 	})
+// 	t.Run("response_has_errorResultXdr", func(t *testing.T) {
+// 		httpResponse := &http.Response{
+// 			StatusCode: http.StatusOK,
+// 			Body:       io.NopCloser(strings.NewReader(`{"result": {"errorResultXdr": "AAAAAAAAAMj////9AAAAAA=="}}`)),
+// 		}
+// 		mockHTTPClient.
+// 			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
+// 			Return(httpResponse, nil).
+// 			Once()
+
+// 		resp, err := rpcService.SendTransaction("ABCD")
+
+// 		assert.Equal(t, xdr.TransactionResultCodeTxTooLate, resp.Code.TxResultCode)
+// 		assert.Empty(t, err)
+// 	})
+// }
+
+// func TestGetTransaction(t *testing.T) {
+// 	mockHTTPClient := utils.MockHTTPClient{}
+// 	rpcURL := "http://localhost:8000/soroban/rpc"
+// 	rpcService := NewRPCService(rpcURL, &mockHTTPClient)
+// 	method := "getTransaction"
+// 	params := map[string]string{"hash": "XYZ"}
+// 	payload := map[string]interface{}{
+// 		"jsonrpc": "2.0",
+// 		"id":      1,
+// 		"method":  method,
+// 		"params":  params,
+// 	}
+// 	jsonData, _ := json.Marshal(payload)
+
+// 	t.Run("rpc_request_fails", func(t *testing.T) {
+// 		mockHTTPClient.
+// 			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
+// 			Return(&http.Response{}, errors.New("RPC Connection fail")).
+// 			Once()
+
+// 		resp, err := rpcService.GetTransaction("XYZ")
+
+// 		assert.Equal(t, entities.ErrorStatus, resp.Status)
+// 		assert.Equal(t, "RPC Fail: getTransaction: sending POST request to rpc: RPC Connection fail", err.Error())
+
+// 	})
+// 	t.Run("unable_to_parse_createdAt", func(t *testing.T) {
+// 		httpResponse := &http.Response{
+// 			StatusCode: http.StatusOK,
+// 			Body:       io.NopCloser(strings.NewReader(`{"result": {"status": "SUCCESS", "createdAt": "ABCD"}}`)),
+// 		}
+// 		mockHTTPClient.
+// 			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
+// 			Return(httpResponse, nil).
+// 			Once()
+
+// 		resp, err := rpcService.GetTransaction("XYZ")
+
+// 		assert.Equal(t, entities.ErrorStatus, resp.Status)
+// 		assert.Equal(t, "unable to parse createAt: strconv.ParseInt: parsing \"ABCD\": invalid syntax", err.Error())
+// 	})
+// 	t.Run("response_has_createdAt_field", func(t *testing.T) {
+// 		httpResponse := &http.Response{
+// 			StatusCode: http.StatusOK,
+// 			Body:       io.NopCloser(strings.NewReader(`{"result": {"createdAt": "1234567"}}`)),
+// 		}
+// 		mockHTTPClient.
+// 			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
+// 			Return(httpResponse, nil).
+// 			Once()
+
+// 		resp, err := rpcService.GetTransaction("XYZ")
+
+// 		assert.Equal(t, int64(1234567), resp.CreatedAt)
+// 		assert.Empty(t, err)
+// 	})
+// }

--- a/internal/tss/types.go
+++ b/internal/tss/types.go
@@ -70,7 +70,7 @@ type RPCSendTxResponse struct {
 	Code RPCTXCode
 }
 
-func parseToRPCSendTxResponse(transactionXDR string, result entities.RPCSendTransactionResult, err error) (RPCSendTxResponse, error) {
+func ParseToRPCSendTxResponse(transactionXDR string, result entities.RPCSendTransactionResult, err error) (RPCSendTxResponse, error) {
 	sendTxResponse := RPCSendTxResponse{}
 	sendTxResponse.TransactionXDR = transactionXDR
 	if err != nil {

--- a/internal/tss/types.go
+++ b/internal/tss/types.go
@@ -1,8 +1,10 @@
 package tss
 
-import "github.com/stellar/go/xdr"
+import (
+	"github.com/stellar/go/xdr"
+	"github.com/stellar/wallet-backend/internal/entities"
+)
 
-type RPCTXStatus string
 type OtherCodes int32
 
 type TransactionResultCode int32
@@ -13,7 +15,7 @@ const (
 	// These values need to not overlap the values in xdr.TransactionResultCode
 	NewCode             OtherCodes = 100
 	RPCFailCode         OtherCodes = 101
-	UnMarshalBinaryCode OtherCodes = 102
+	UnmarshalBinaryCode OtherCodes = 102
 )
 
 type RPCTXCode struct {
@@ -21,23 +23,9 @@ type RPCTXCode struct {
 	OtherCodes   OtherCodes
 }
 
-const (
-	// Brand new transaction, not sent to RPC yet
-	NewStatus RPCTXStatus = "NEW"
-	// RPC sendTransaction statuses
-	PendingStatus       RPCTXStatus = "PENDING"
-	DuplicateStatus     RPCTXStatus = "DUPLICATE"
-	TryAgainLaterStatus RPCTXStatus = "TRY_AGAIN_LATER"
-	ErrorStatus         RPCTXStatus = "ERROR"
-	// RPC getTransaction(s) statuses
-	NotFoundStatus RPCTXStatus = "NOT_FOUND"
-	FailedStatus   RPCTXStatus = "FAILED"
-	SuccessStatus  RPCTXStatus = "SUCCESS"
-)
-
 type RPCGetIngestTxResponse struct {
 	// A status that indicated whether this transaction failed or successly made it to the ledger
-	Status RPCTXStatus
+	Status entities.RPCStatus
 	// The raw TransactionEnvelope XDR for this transaction
 	EnvelopeXDR string
 	// The raw TransactionResult XDR of the envelopeXdr
@@ -51,7 +39,7 @@ type RPCSendTxResponse struct {
 	TransactionHash string
 	TransactionXDR  string
 	// The status of an RPC sendTransaction call. Can be one of [PENDING, DUPLICATE, TRY_AGAIN_LATER, ERROR]
-	Status RPCTXStatus
+	Status entities.RPCStatus
 	// The (optional) error code that is derived by deserialzing the errorResultXdr string in the sendTransaction response
 	// list of possible errror codes: https://developers.stellar.org/docs/data/horizon/api-reference/errors/result-codes/transactions
 	Code RPCTXCode
@@ -67,19 +55,6 @@ type Payload struct {
 	RpcSubmitTxResponse RPCSendTxResponse
 	// Relevant fields in the transaction list inside the RPC getTransactions response
 	RpcGetIngestTxResponse RPCGetIngestTxResponse
-}
-
-type RPCResult struct {
-	Status         string `json:"status"`
-	EnvelopeXDR    string `json:"envelopeXdr"`
-	ResultXDR      string `json:"resultXdr"`
-	ErrorResultXDR string `json:"errorResultXdr"`
-	Hash           string `json:"hash"`
-	CreatedAt      string `json:"createdAt"`
-}
-
-type RPCResponse struct {
-	RPCResult `json:"result"`
 }
 
 type Channel interface {

--- a/internal/tss/types_test.go
+++ b/internal/tss/types_test.go
@@ -1,0 +1,81 @@
+package tss
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stellar/go/xdr"
+	"github.com/stellar/wallet-backend/internal/entities"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseToRPCSendTxResponse(t *testing.T) {
+	t.Run("rpc_request_fails", func(t *testing.T) {
+		resp, err := ParseToRPCGetIngestTxResponse(entities.RPCGetTransactionResult{}, errors.New("sending sendTransaction request: sending POST request to RPC: connection failed"))
+		require.Error(t, err)
+
+		assert.Equal(t, entities.ErrorStatus, resp.Status)
+		assert.Equal(t, "sending sendTransaction request: sending POST request to RPC: connection failed", err.Error())
+	})
+
+	t.Run("response_has_empty_errorResultXdr", func(t *testing.T) {
+		resp, err := ParseToRPCSendTxResponse("", entities.RPCSendTransactionResult{
+			Status:         "PENDING",
+			ErrorResultXDR: "",
+		}, nil)
+
+		assert.Equal(t, entities.PendingStatus, resp.Status)
+		assert.Equal(t, UnmarshalBinaryCode, resp.Code.OtherCodes)
+		assert.Equal(t, "parse error result xdr string: unable to unmarshal errorResultXDR: ", err.Error())
+	})
+
+	t.Run("response_has_unparsable_errorResultXdr", func(t *testing.T) {
+		resp, err := ParseToRPCSendTxResponse("", entities.RPCSendTransactionResult{
+			ErrorResultXDR: "ABC123",
+		}, nil)
+
+		assert.Equal(t, UnmarshalBinaryCode, resp.Code.OtherCodes)
+		assert.Equal(t, "parse error result xdr string: unable to unmarshal errorResultXDR: ABC123", err.Error())
+	})
+
+	t.Run("response_has_errorResultXdr", func(t *testing.T) {
+		resp, err := ParseToRPCSendTxResponse("", entities.RPCSendTransactionResult{
+			ErrorResultXDR: "AAAAAAAAAMj////9AAAAAA==",
+		}, nil)
+
+		assert.Equal(t, xdr.TransactionResultCodeTxTooLate, resp.Code.TxResultCode)
+		assert.Empty(t, err)
+	})
+}
+
+func TestParseToRPCGetIngestTxResponse(t *testing.T) {
+	t.Run("rpc_request_fails", func(t *testing.T) {
+		resp, err := ParseToRPCGetIngestTxResponse(entities.RPCGetTransactionResult{}, errors.New("sending getTransaction request: sending POST request to RPC: connection failed"))
+		require.Error(t, err)
+
+		assert.Equal(t, entities.ErrorStatus, resp.Status)
+		assert.Equal(t, "sending getTransaction request: sending POST request to RPC: connection failed", err.Error())
+	})
+
+	t.Run("unable_to_parse_createdAt", func(t *testing.T) {
+		resp, err := ParseToRPCGetIngestTxResponse(entities.RPCGetTransactionResult{
+			Status:    "SUCCESS",
+			CreatedAt: "ABCD",
+		}, nil)
+		require.Error(t, err)
+
+		assert.Equal(t, entities.ErrorStatus, resp.Status)
+		assert.Equal(t, "unable to parse createdAt: strconv.ParseInt: parsing \"ABCD\": invalid syntax", err.Error())
+	})
+
+	t.Run("response_has_createdAt_field", func(t *testing.T) {
+		resp, err := ParseToRPCGetIngestTxResponse(entities.RPCGetTransactionResult{
+			CreatedAt: "1234567",
+		}, nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(1234567), resp.CreatedAt)
+		assert.Empty(t, err)
+	})
+}

--- a/internal/tss/utils/transaction_service.go
+++ b/internal/tss/utils/transaction_service.go
@@ -1,38 +1,24 @@
 package utils
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	"io"
-	"strconv"
 
-	xdr3 "github.com/stellar/go-xdr/xdr3"
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/txnbuild"
-	"github.com/stellar/go/xdr"
-	"github.com/stellar/wallet-backend/internal/entities"
 	"github.com/stellar/wallet-backend/internal/signing"
-	"github.com/stellar/wallet-backend/internal/tss"
 	tsserror "github.com/stellar/wallet-backend/internal/tss/errors"
-	"github.com/stellar/wallet-backend/internal/utils"
 )
 
 type TransactionService interface {
 	SignAndBuildNewFeeBumpTransaction(ctx context.Context, origTxXdr string) (*txnbuild.FeeBumpTransaction, error)
-	SendTransaction(transactionXdr string) (tss.RPCSendTxResponse, error)
-	GetTransaction(transactionHash string) (tss.RPCGetIngestTxResponse, error)
 }
 
 type transactionService struct {
 	DistributionAccountSignatureClient signing.SignatureClient
 	ChannelAccountSignatureClient      signing.SignatureClient
 	HorizonClient                      horizonclient.ClientInterface
-	RPCURL                             string
 	BaseFee                            int64
-	HTTPClient                         utils.HTTPClient
 }
 
 var _ TransactionService = (*transactionService)(nil)
@@ -41,9 +27,7 @@ type TransactionServiceOptions struct {
 	DistributionAccountSignatureClient signing.SignatureClient
 	ChannelAccountSignatureClient      signing.SignatureClient
 	HorizonClient                      horizonclient.ClientInterface
-	RPCURL                             string
 	BaseFee                            int64
-	HTTPClient                         utils.HTTPClient
 }
 
 func (o *TransactionServiceOptions) ValidateOptions() error {
@@ -59,16 +43,8 @@ func (o *TransactionServiceOptions) ValidateOptions() error {
 		return fmt.Errorf("horizon client cannot be nil")
 	}
 
-	if o.RPCURL == "" {
-		return fmt.Errorf("rpc url cannot be empty")
-	}
-
 	if o.BaseFee < int64(txnbuild.MinBaseFee) {
 		return fmt.Errorf("base fee is lower than the minimum network fee")
-	}
-
-	if o.HTTPClient == nil {
-		return fmt.Errorf("http client cannot be nil")
 	}
 
 	return nil
@@ -82,9 +58,7 @@ func NewTransactionService(opts TransactionServiceOptions) (*transactionService,
 		DistributionAccountSignatureClient: opts.DistributionAccountSignatureClient,
 		ChannelAccountSignatureClient:      opts.ChannelAccountSignatureClient,
 		HorizonClient:                      opts.HorizonClient,
-		RPCURL:                             opts.RPCURL,
 		BaseFee:                            opts.BaseFee,
-		HTTPClient:                         opts.HTTPClient,
 	}, nil
 }
 
@@ -145,88 +119,4 @@ func (t *transactionService) SignAndBuildNewFeeBumpTransaction(ctx context.Conte
 		return nil, fmt.Errorf("signing the fee bump transaction with distribution account: %w", err)
 	}
 	return feeBumpTx, nil
-}
-
-func (t *transactionService) parseErrorResultXDR(errorResultXdr string) (tss.RPCTXCode, error) {
-	unMarshalErr := "unable to unmarshal errorResultXdr: %s"
-	decodedBytes, err := base64.StdEncoding.DecodeString(errorResultXdr)
-	if err != nil {
-		return tss.RPCTXCode{OtherCodes: tss.UnmarshalBinaryCode}, fmt.Errorf(unMarshalErr, errorResultXdr)
-	}
-	var errorResult xdr.TransactionResult
-	_, err = xdr3.Unmarshal(bytes.NewReader(decodedBytes), &errorResult)
-	if err != nil {
-		return tss.RPCTXCode{OtherCodes: tss.UnmarshalBinaryCode}, fmt.Errorf(unMarshalErr, errorResultXdr)
-	}
-	return tss.RPCTXCode{
-		TxResultCode: errorResult.Result.Code,
-	}, nil
-}
-
-func (t *transactionService) sendRPCRequest(method string, params map[string]string) (entities.RPCResponse, error) {
-	payload := map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      1,
-		"method":  method,
-		"params":  params,
-	}
-	jsonData, err := json.Marshal(payload)
-
-	if err != nil {
-		return entities.RPCResponse{}, fmt.Errorf("marshaling payload")
-	}
-
-	resp, err := t.HTTPClient.Post(t.RPCURL, "application/json", bytes.NewBuffer(jsonData))
-	if err != nil {
-		return entities.RPCResponse{}, fmt.Errorf("%s: sending POST request to rpc: %v", method, err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return entities.RPCResponse{}, fmt.Errorf("%s: unmarshaling RPC response", method)
-	}
-	var res entities.RPCResponse
-	err = json.Unmarshal(body, &res)
-	if err != nil {
-		return entities.RPCResponse{}, fmt.Errorf("%s: parsing RPC response JSON", method)
-	}
-
-	return res, nil
-}
-
-func (t *transactionService) SendTransaction(transactionXdr string) (tss.RPCSendTxResponse, error) {
-	rpcResponse, err := t.sendRPCRequest("sendTransaction", map[string]string{"transaction": transactionXdr})
-	sendTxResponse := tss.RPCSendTxResponse{}
-	sendTxResponse.TransactionXDR = transactionXdr
-	if err != nil {
-		sendTxResponse.Code.OtherCodes = tss.RPCFailCode
-		return sendTxResponse, fmt.Errorf("RPC fail: %w", err)
-	}
-	sendTxResponse.Status = entities.RPCStatus(rpcResponse.Result.Status)
-	sendTxResponse.TransactionHash = rpcResponse.Result.Hash
-	sendTxResponse.Code, err = t.parseErrorResultXDR(rpcResponse.Result.ErrorResultXDR)
-	if err != nil {
-		return sendTxResponse, fmt.Errorf("parse error result xdr string: %w", err)
-	}
-	return sendTxResponse, nil
-}
-
-func (t *transactionService) GetTransaction(transactionHash string) (tss.RPCGetIngestTxResponse, error) {
-	rpcResponse, err := t.sendRPCRequest("getTransaction", map[string]string{"hash": transactionHash})
-	if err != nil {
-		return tss.RPCGetIngestTxResponse{Status: entities.ErrorStatus}, fmt.Errorf("RPC Fail: %s", err.Error())
-	}
-	getIngestTxResponse := tss.RPCGetIngestTxResponse{
-		Status:      entities.RPCStatus(rpcResponse.Result.Status),
-		EnvelopeXDR: rpcResponse.Result.EnvelopeXDR,
-		ResultXDR:   rpcResponse.Result.ResultXDR,
-	}
-	if getIngestTxResponse.Status != entities.NotFoundStatus {
-		getIngestTxResponse.CreatedAt, err = strconv.ParseInt(rpcResponse.Result.CreatedAt, 10, 64)
-		if err != nil {
-			return tss.RPCGetIngestTxResponse{Status: entities.ErrorStatus}, fmt.Errorf("unable to parse createAt: %w", err)
-		}
-	}
-	return getIngestTxResponse, nil
 }

--- a/internal/tss/utils/transaction_service.go
+++ b/internal/tss/utils/transaction_service.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"strconv"
 
 	xdr3 "github.com/stellar/go-xdr/xdr3"
@@ -17,11 +16,8 @@ import (
 	"github.com/stellar/wallet-backend/internal/signing"
 	"github.com/stellar/wallet-backend/internal/tss"
 	tsserror "github.com/stellar/wallet-backend/internal/tss/errors"
+	"github.com/stellar/wallet-backend/internal/utils"
 )
-
-type HTTPClient interface {
-	Post(url string, t string, body io.Reader) (resp *http.Response, err error)
-}
 
 type TransactionService interface {
 	SignAndBuildNewFeeBumpTransaction(ctx context.Context, origTxXdr string) (*txnbuild.FeeBumpTransaction, error)
@@ -35,7 +31,7 @@ type transactionService struct {
 	HorizonClient                      horizonclient.ClientInterface
 	RPCURL                             string
 	BaseFee                            int64
-	HTTPClient                         HTTPClient
+	HTTPClient                         utils.HTTPClient
 }
 
 var _ TransactionService = (*transactionService)(nil)
@@ -46,7 +42,7 @@ type TransactionServiceOptions struct {
 	HorizonClient                      horizonclient.ClientInterface
 	RPCURL                             string
 	BaseFee                            int64
-	HTTPClient                         HTTPClient
+	HTTPClient                         utils.HTTPClient
 }
 
 func (o *TransactionServiceOptions) ValidateOptions() error {

--- a/internal/tss/utils/transaction_service_test.go
+++ b/internal/tss/utils/transaction_service_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stellar/wallet-backend/internal/signing"
 	"github.com/stellar/wallet-backend/internal/tss"
 	tsserror "github.com/stellar/wallet-backend/internal/tss/errors"
+	"github.com/stellar/wallet-backend/internal/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -31,7 +32,7 @@ func TestValidateOptions(t *testing.T) {
 			HorizonClient:                      &horizonclient.MockClient{},
 			RPCURL:                             "http://localhost:8000/soroban/rpc",
 			BaseFee:                            114,
-			HTTPClient:                         &MockHTTPClient{},
+			HTTPClient:                         &utils.MockHTTPClient{},
 		}
 		err := opts.ValidateOptions()
 		assert.Equal(t, "distribution account signature client cannot be nil", err.Error())
@@ -45,7 +46,7 @@ func TestValidateOptions(t *testing.T) {
 			HorizonClient:                      &horizonclient.MockClient{},
 			RPCURL:                             "http://localhost:8000/soroban/rpc",
 			BaseFee:                            114,
-			HTTPClient:                         &MockHTTPClient{},
+			HTTPClient:                         &utils.MockHTTPClient{},
 		}
 		err := opts.ValidateOptions()
 		assert.Equal(t, "channel account signature client cannot be nil", err.Error())
@@ -58,7 +59,7 @@ func TestValidateOptions(t *testing.T) {
 			HorizonClient:                      nil,
 			RPCURL:                             "http://localhost:8000/soroban/rpc",
 			BaseFee:                            114,
-			HTTPClient:                         &MockHTTPClient{},
+			HTTPClient:                         &utils.MockHTTPClient{},
 		}
 		err := opts.ValidateOptions()
 		assert.Equal(t, "horizon client cannot be nil", err.Error())
@@ -71,7 +72,7 @@ func TestValidateOptions(t *testing.T) {
 			HorizonClient:                      &horizonclient.MockClient{},
 			RPCURL:                             "",
 			BaseFee:                            114,
-			HTTPClient:                         &MockHTTPClient{},
+			HTTPClient:                         &utils.MockHTTPClient{},
 		}
 		err := opts.ValidateOptions()
 		assert.Equal(t, "rpc url cannot be empty", err.Error())
@@ -84,7 +85,7 @@ func TestValidateOptions(t *testing.T) {
 			HorizonClient:                      &horizonclient.MockClient{},
 			RPCURL:                             "http://localhost:8000/soroban/rpc",
 			BaseFee:                            txnbuild.MinBaseFee - 10,
-			HTTPClient:                         &MockHTTPClient{},
+			HTTPClient:                         &utils.MockHTTPClient{},
 		}
 		err := opts.ValidateOptions()
 		assert.Equal(t, "base fee is lower than the minimum network fee", err.Error())
@@ -116,7 +117,7 @@ func TestSignAndBuildNewFeeBumpTransaction(t *testing.T) {
 		HorizonClient:                      &horizonClient,
 		RPCURL:                             "http://localhost:8000/soroban/rpc",
 		BaseFee:                            114,
-		HTTPClient:                         &MockHTTPClient{},
+		HTTPClient:                         &utils.MockHTTPClient{},
 	})
 
 	txStr, _ := BuildTestTransaction().Base64()
@@ -288,7 +289,7 @@ func (e *errorReader) Close() error {
 }
 
 func TestSendRPCRequest(t *testing.T) {
-	mockHTTPClient := MockHTTPClient{}
+	mockHTTPClient := utils.MockHTTPClient{}
 	rpcURL := "http://localhost:8000/soroban/rpc"
 	txService, _ := NewTransactionService(TransactionServiceOptions{
 		DistributionAccountSignatureClient: &signing.SignatureClientMock{},
@@ -465,7 +466,7 @@ func TestSendRPCRequest(t *testing.T) {
 }
 
 func TestSendTransaction(t *testing.T) {
-	mockHTTPClient := MockHTTPClient{}
+	mockHTTPClient := utils.MockHTTPClient{}
 	rpcURL := "http://localhost:8000/soroban/rpc"
 	txService, _ := NewTransactionService(TransactionServiceOptions{
 		DistributionAccountSignatureClient: &signing.SignatureClientMock{},
@@ -547,7 +548,7 @@ func TestSendTransaction(t *testing.T) {
 }
 
 func TestGetTransaction(t *testing.T) {
-	mockHTTPClient := MockHTTPClient{}
+	mockHTTPClient := utils.MockHTTPClient{}
 	rpcURL := "http://localhost:8000/soroban/rpc"
 	txService, _ := NewTransactionService(TransactionServiceOptions{
 		DistributionAccountSignatureClient: &signing.SignatureClientMock{},

--- a/internal/tss/utils/transaction_service_test.go
+++ b/internal/tss/utils/transaction_service_test.go
@@ -1,26 +1,16 @@
 package utils
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
-	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/txnbuild"
-	"github.com/stellar/go/xdr"
-	"github.com/stellar/wallet-backend/internal/entities"
 	"github.com/stellar/wallet-backend/internal/signing"
-	"github.com/stellar/wallet-backend/internal/tss"
 	tsserror "github.com/stellar/wallet-backend/internal/tss/errors"
-	"github.com/stellar/wallet-backend/internal/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -31,9 +21,7 @@ func TestValidateOptions(t *testing.T) {
 			DistributionAccountSignatureClient: nil,
 			ChannelAccountSignatureClient:      &signing.SignatureClientMock{},
 			HorizonClient:                      &horizonclient.MockClient{},
-			RPCURL:                             "http://localhost:8000/soroban/rpc",
 			BaseFee:                            114,
-			HTTPClient:                         &utils.MockHTTPClient{},
 		}
 		err := opts.ValidateOptions()
 		assert.Equal(t, "distribution account signature client cannot be nil", err.Error())
@@ -45,9 +33,7 @@ func TestValidateOptions(t *testing.T) {
 			DistributionAccountSignatureClient: &signing.SignatureClientMock{},
 			ChannelAccountSignatureClient:      nil,
 			HorizonClient:                      &horizonclient.MockClient{},
-			RPCURL:                             "http://localhost:8000/soroban/rpc",
 			BaseFee:                            114,
-			HTTPClient:                         &utils.MockHTTPClient{},
 		}
 		err := opts.ValidateOptions()
 		assert.Equal(t, "channel account signature client cannot be nil", err.Error())
@@ -58,9 +44,7 @@ func TestValidateOptions(t *testing.T) {
 			DistributionAccountSignatureClient: &signing.SignatureClientMock{},
 			ChannelAccountSignatureClient:      &signing.SignatureClientMock{},
 			HorizonClient:                      nil,
-			RPCURL:                             "http://localhost:8000/soroban/rpc",
 			BaseFee:                            114,
-			HTTPClient:                         &utils.MockHTTPClient{},
 		}
 		err := opts.ValidateOptions()
 		assert.Equal(t, "horizon client cannot be nil", err.Error())
@@ -71,9 +55,7 @@ func TestValidateOptions(t *testing.T) {
 			DistributionAccountSignatureClient: &signing.SignatureClientMock{},
 			ChannelAccountSignatureClient:      &signing.SignatureClientMock{},
 			HorizonClient:                      &horizonclient.MockClient{},
-			RPCURL:                             "",
 			BaseFee:                            114,
-			HTTPClient:                         &utils.MockHTTPClient{},
 		}
 		err := opts.ValidateOptions()
 		assert.Equal(t, "rpc url cannot be empty", err.Error())
@@ -84,9 +66,7 @@ func TestValidateOptions(t *testing.T) {
 			DistributionAccountSignatureClient: &signing.SignatureClientMock{},
 			ChannelAccountSignatureClient:      &signing.SignatureClientMock{},
 			HorizonClient:                      &horizonclient.MockClient{},
-			RPCURL:                             "http://localhost:8000/soroban/rpc",
 			BaseFee:                            txnbuild.MinBaseFee - 10,
-			HTTPClient:                         &utils.MockHTTPClient{},
 		}
 		err := opts.ValidateOptions()
 		assert.Equal(t, "base fee is lower than the minimum network fee", err.Error())
@@ -97,7 +77,6 @@ func TestValidateOptions(t *testing.T) {
 			DistributionAccountSignatureClient: &signing.SignatureClientMock{},
 			ChannelAccountSignatureClient:      &signing.SignatureClientMock{},
 			HorizonClient:                      &horizonclient.MockClient{},
-			RPCURL:                             "http://localhost:8000/soroban/rpc",
 			BaseFee:                            114,
 		}
 		err := opts.ValidateOptions()
@@ -116,9 +95,7 @@ func TestSignAndBuildNewFeeBumpTransaction(t *testing.T) {
 		DistributionAccountSignatureClient: &distributionAccountSignatureClient,
 		ChannelAccountSignatureClient:      &channelAccountSignatureClient,
 		HorizonClient:                      &horizonClient,
-		RPCURL:                             "http://localhost:8000/soroban/rpc",
 		BaseFee:                            114,
-		HTTPClient:                         &utils.MockHTTPClient{},
 	})
 
 	txStr, _ := BuildTestTransaction().Base64()
@@ -277,339 +254,4 @@ func TestSignAndBuildNewFeeBumpTransaction(t *testing.T) {
 		assert.Equal(t, feeBumpTx, testFeeBumpTx)
 		assert.Empty(t, err)
 	})
-}
-
-type errorReader struct{}
-
-func (e *errorReader) Read(p []byte) (n int, err error) {
-	return 0, fmt.Errorf("read error")
-}
-
-func (e *errorReader) Close() error {
-	return nil
-}
-
-func TestSendRPCRequest(t *testing.T) {
-	mockHTTPClient := utils.MockHTTPClient{}
-	rpcURL := "http://localhost:8000/soroban/rpc"
-	txService, _ := NewTransactionService(TransactionServiceOptions{
-		DistributionAccountSignatureClient: &signing.SignatureClientMock{},
-		ChannelAccountSignatureClient:      &signing.SignatureClientMock{},
-		HorizonClient:                      &horizonclient.MockClient{},
-		RPCURL:                             rpcURL,
-		BaseFee:                            114,
-		HTTPClient:                         &mockHTTPClient,
-	})
-	method := "sendTransaction"
-	params := map[string]string{"transaction": "ABCD"}
-	payload := map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      1,
-		"method":  method,
-		"params":  params,
-	}
-	jsonData, _ := json.Marshal(payload)
-	t.Run("rpc_post_call_fails", func(t *testing.T) {
-		mockHTTPClient.
-			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
-			Return(&http.Response{}, errors.New("RPC Connection fail")).
-			Once()
-
-		resp, err := txService.sendRPCRequest(method, params)
-
-		assert.Empty(t, resp)
-		assert.Equal(t, "sendTransaction: sending POST request to rpc: RPC Connection fail", err.Error())
-	})
-
-	t.Run("unmarshaling_rpc_response_fails", func(t *testing.T) {
-		httpResponse := &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(&errorReader{}),
-		}
-		mockHTTPClient.
-			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
-			Return(httpResponse, nil).
-			Once()
-
-		resp, err := txService.sendRPCRequest(method, params)
-
-		assert.Empty(t, resp)
-		assert.Equal(t, "sendTransaction: unmarshaling RPC response", err.Error())
-	})
-
-	t.Run("unmarshaling_json_fails", func(t *testing.T) {
-		httpResponse := &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{invalid-json`)),
-		}
-		mockHTTPClient.
-			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
-			Return(httpResponse, nil).
-			Once()
-
-		resp, err := txService.sendRPCRequest(method, params)
-
-		assert.Empty(t, resp)
-		assert.Equal(t, "sendTransaction: parsing RPC response JSON", err.Error())
-	})
-
-	t.Run("response_has_no_result_field", func(t *testing.T) {
-		httpResponse := &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{"status": "success"}`)),
-		}
-		mockHTTPClient.
-			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
-			Return(httpResponse, nil).
-			Once()
-
-		resp, err := txService.sendRPCRequest(method, params)
-
-		assert.Empty(t, resp)
-		assert.Equal(t, "sendTransaction: response missing result field", err.Error())
-	})
-
-	t.Run("response_has_status_field", func(t *testing.T) {
-		httpResponse := &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{"result": {"status": "PENDING"}}`)),
-		}
-		mockHTTPClient.
-			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
-			Return(httpResponse, nil).
-			Once()
-
-		resp, err := txService.sendRPCRequest(method, params)
-
-		assert.Equal(t, "PENDING", resp.Result.Status)
-		assert.Empty(t, err)
-	})
-
-	t.Run("response_has_envelopexdr_field", func(t *testing.T) {
-		httpResponse := &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{"result": {"envelopeXdr": "exdr"}}`)),
-		}
-		mockHTTPClient.
-			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
-			Return(httpResponse, nil).
-			Once()
-
-		resp, err := txService.sendRPCRequest(method, params)
-
-		assert.Equal(t, "exdr", resp.Result.EnvelopeXDR)
-		assert.Empty(t, err)
-	})
-
-	t.Run("response_has_resultxdr_field", func(t *testing.T) {
-		httpResponse := &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{"result": {"resultXdr": "rxdr"}}`)),
-		}
-		mockHTTPClient.
-			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
-			Return(httpResponse, nil).
-			Once()
-
-		resp, err := txService.sendRPCRequest(method, params)
-
-		assert.Equal(t, "rxdr", resp.Result.ResultXDR)
-		assert.Empty(t, err)
-	})
-
-	t.Run("response_has_errorresultxdr_field", func(t *testing.T) {
-		httpResponse := &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{"result": {"errorResultXdr": "exdr"}}`)),
-		}
-		mockHTTPClient.
-			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
-			Return(httpResponse, nil).
-			Once()
-
-		resp, err := txService.sendRPCRequest(method, params)
-
-		assert.Equal(t, "exdr", resp.Result.ErrorResultXDR)
-		assert.Empty(t, err)
-	})
-
-	t.Run("response_has_hash_field", func(t *testing.T) {
-		httpResponse := &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{"result": {"hash": "hash"}}`)),
-		}
-		mockHTTPClient.
-			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
-			Return(httpResponse, nil).
-			Once()
-
-		resp, err := txService.sendRPCRequest(method, params)
-
-		assert.Equal(t, "hash", resp.Result.Hash)
-		assert.Empty(t, err)
-	})
-
-	t.Run("response_has_createdat_field", func(t *testing.T) {
-		httpResponse := &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{"result": {"createdAt": "1234"}}`)),
-		}
-		mockHTTPClient.
-			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
-			Return(httpResponse, nil).
-			Once()
-
-		resp, err := txService.sendRPCRequest(method, params)
-
-		assert.Equal(t, "1234", resp.Result.CreatedAt)
-		assert.Empty(t, err)
-	})
-}
-
-func TestSendTransaction(t *testing.T) {
-	mockHTTPClient := utils.MockHTTPClient{}
-	rpcURL := "http://localhost:8000/soroban/rpc"
-	txService, _ := NewTransactionService(TransactionServiceOptions{
-		DistributionAccountSignatureClient: &signing.SignatureClientMock{},
-		ChannelAccountSignatureClient:      &signing.SignatureClientMock{},
-		HorizonClient:                      &horizonclient.MockClient{},
-		RPCURL:                             rpcURL,
-		BaseFee:                            114,
-		HTTPClient:                         &mockHTTPClient,
-	})
-	method := "sendTransaction"
-	params := map[string]string{"transaction": "ABCD"}
-	payload := map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      1,
-		"method":  method,
-		"params":  params,
-	}
-	jsonData, _ := json.Marshal(payload)
-
-	t.Run("rpc_request_fails", func(t *testing.T) {
-		mockHTTPClient.
-			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
-			Return(&http.Response{}, errors.New("RPC Connection fail")).
-			Once()
-
-		resp, err := txService.SendTransaction("ABCD")
-
-		assert.Equal(t, tss.RPCFailCode, resp.Code.OtherCodes)
-		assert.Equal(t, "RPC fail: sendTransaction: sending POST request to rpc: RPC Connection fail", err.Error())
-
-	})
-	t.Run("response_has_empty_errorResultXdr", func(t *testing.T) {
-		httpResponse := &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{"result": {"status": "PENDING", "errorResultXdr": ""}}`)),
-		}
-		mockHTTPClient.
-			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
-			Return(httpResponse, nil).
-			Once()
-
-		resp, err := txService.SendTransaction("ABCD")
-
-		assert.Equal(t, entities.PendingStatus, resp.Status)
-		assert.Equal(t, tss.UnmarshalBinaryCode, resp.Code.OtherCodes)
-		assert.Equal(t, "parse error result xdr string: unable to unmarshal errorResultXdr: ", err.Error())
-
-	})
-	t.Run("response_has_unparsable_errorResultXdr", func(t *testing.T) {
-		httpResponse := &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{"result": {"errorResultXdr": "ABC123"}}`)),
-		}
-		mockHTTPClient.
-			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
-			Return(httpResponse, nil).
-			Once()
-
-		resp, err := txService.SendTransaction("ABCD")
-
-		assert.Equal(t, tss.UnmarshalBinaryCode, resp.Code.OtherCodes)
-		assert.Equal(t, "parse error result xdr string: unable to unmarshal errorResultXdr: ABC123", err.Error())
-	})
-	t.Run("response_has_errorResultXdr", func(t *testing.T) {
-		httpResponse := &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{"result": {"errorResultXdr": "AAAAAAAAAMj////9AAAAAA=="}}`)),
-		}
-		mockHTTPClient.
-			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
-			Return(httpResponse, nil).
-			Once()
-
-		resp, err := txService.SendTransaction("ABCD")
-
-		assert.Equal(t, xdr.TransactionResultCodeTxTooLate, resp.Code.TxResultCode)
-		assert.Empty(t, err)
-	})
-}
-
-func TestGetTransaction(t *testing.T) {
-	mockHTTPClient := utils.MockHTTPClient{}
-	rpcURL := "http://localhost:8000/soroban/rpc"
-	txService, _ := NewTransactionService(TransactionServiceOptions{
-		DistributionAccountSignatureClient: &signing.SignatureClientMock{},
-		ChannelAccountSignatureClient:      &signing.SignatureClientMock{},
-		HorizonClient:                      &horizonclient.MockClient{},
-		RPCURL:                             rpcURL,
-		BaseFee:                            114,
-		HTTPClient:                         &mockHTTPClient,
-	})
-	method := "getTransaction"
-	params := map[string]string{"hash": "XYZ"}
-	payload := map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      1,
-		"method":  method,
-		"params":  params,
-	}
-	jsonData, _ := json.Marshal(payload)
-
-	t.Run("rpc_request_fails", func(t *testing.T) {
-		mockHTTPClient.
-			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
-			Return(&http.Response{}, errors.New("RPC Connection fail")).
-			Once()
-
-		resp, err := txService.GetTransaction("XYZ")
-
-		assert.Equal(t, entities.ErrorStatus, resp.Status)
-		assert.Equal(t, "RPC Fail: getTransaction: sending POST request to rpc: RPC Connection fail", err.Error())
-
-	})
-	t.Run("unable_to_parse_createdAt", func(t *testing.T) {
-		httpResponse := &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{"result": {"status": "SUCCESS", "createdAt": "ABCD"}}`)),
-		}
-		mockHTTPClient.
-			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
-			Return(httpResponse, nil).
-			Once()
-
-		resp, err := txService.GetTransaction("XYZ")
-
-		assert.Equal(t, entities.ErrorStatus, resp.Status)
-		assert.Equal(t, "unable to parse createAt: strconv.ParseInt: parsing \"ABCD\": invalid syntax", err.Error())
-	})
-	t.Run("response_has_createdAt_field", func(t *testing.T) {
-		httpResponse := &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{"result": {"createdAt": "1234567"}}`)),
-		}
-		mockHTTPClient.
-			On("Post", rpcURL, "application/json", bytes.NewBuffer(jsonData)).
-			Return(httpResponse, nil).
-			Once()
-
-		resp, err := txService.GetTransaction("XYZ")
-
-		assert.Equal(t, int64(1234567), resp.CreatedAt)
-		assert.Empty(t, err)
-	})
-
 }

--- a/internal/tss/utils/transaction_service_test.go
+++ b/internal/tss/utils/transaction_service_test.go
@@ -50,17 +50,6 @@ func TestValidateOptions(t *testing.T) {
 		assert.Equal(t, "horizon client cannot be nil", err.Error())
 	})
 
-	t.Run("return_error_when_rpc_url_empty", func(t *testing.T) {
-		opts := TransactionServiceOptions{
-			DistributionAccountSignatureClient: &signing.SignatureClientMock{},
-			ChannelAccountSignatureClient:      &signing.SignatureClientMock{},
-			HorizonClient:                      &horizonclient.MockClient{},
-			BaseFee:                            114,
-		}
-		err := opts.ValidateOptions()
-		assert.Equal(t, "rpc url cannot be empty", err.Error())
-	})
-
 	t.Run("return_error_when_base_fee_too_low", func(t *testing.T) {
 		opts := TransactionServiceOptions{
 			DistributionAccountSignatureClient: &signing.SignatureClientMock{},
@@ -70,17 +59,6 @@ func TestValidateOptions(t *testing.T) {
 		}
 		err := opts.ValidateOptions()
 		assert.Equal(t, "base fee is lower than the minimum network fee", err.Error())
-	})
-
-	t.Run("return_error_http_client_nil", func(t *testing.T) {
-		opts := TransactionServiceOptions{
-			DistributionAccountSignatureClient: &signing.SignatureClientMock{},
-			ChannelAccountSignatureClient:      &signing.SignatureClientMock{},
-			HorizonClient:                      &horizonclient.MockClient{},
-			BaseFee:                            114,
-		}
-		err := opts.ValidateOptions()
-		assert.Equal(t, "http client cannot be nil", err.Error())
 	})
 }
 

--- a/internal/tss/utils/transaction_service_test.go
+++ b/internal/tss/utils/transaction_service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
+	"github.com/stellar/wallet-backend/internal/entities"
 	"github.com/stellar/wallet-backend/internal/signing"
 	"github.com/stellar/wallet-backend/internal/tss"
 	tsserror "github.com/stellar/wallet-backend/internal/tss/errors"
@@ -380,7 +381,7 @@ func TestSendRPCRequest(t *testing.T) {
 
 		resp, err := txService.sendRPCRequest(method, params)
 
-		assert.Equal(t, "PENDING", resp.Status)
+		assert.Equal(t, "PENDING", resp.Result.Status)
 		assert.Empty(t, err)
 	})
 
@@ -396,7 +397,7 @@ func TestSendRPCRequest(t *testing.T) {
 
 		resp, err := txService.sendRPCRequest(method, params)
 
-		assert.Equal(t, "exdr", resp.EnvelopeXDR)
+		assert.Equal(t, "exdr", resp.Result.EnvelopeXDR)
 		assert.Empty(t, err)
 	})
 
@@ -412,7 +413,7 @@ func TestSendRPCRequest(t *testing.T) {
 
 		resp, err := txService.sendRPCRequest(method, params)
 
-		assert.Equal(t, "rxdr", resp.ResultXDR)
+		assert.Equal(t, "rxdr", resp.Result.ResultXDR)
 		assert.Empty(t, err)
 	})
 
@@ -428,7 +429,7 @@ func TestSendRPCRequest(t *testing.T) {
 
 		resp, err := txService.sendRPCRequest(method, params)
 
-		assert.Equal(t, "exdr", resp.ErrorResultXDR)
+		assert.Equal(t, "exdr", resp.Result.ErrorResultXDR)
 		assert.Empty(t, err)
 	})
 
@@ -444,7 +445,7 @@ func TestSendRPCRequest(t *testing.T) {
 
 		resp, err := txService.sendRPCRequest(method, params)
 
-		assert.Equal(t, "hash", resp.Hash)
+		assert.Equal(t, "hash", resp.Result.Hash)
 		assert.Empty(t, err)
 	})
 
@@ -460,7 +461,7 @@ func TestSendRPCRequest(t *testing.T) {
 
 		resp, err := txService.sendRPCRequest(method, params)
 
-		assert.Equal(t, "1234", resp.CreatedAt)
+		assert.Equal(t, "1234", resp.Result.CreatedAt)
 		assert.Empty(t, err)
 	})
 }
@@ -510,8 +511,8 @@ func TestSendTransaction(t *testing.T) {
 
 		resp, err := txService.SendTransaction("ABCD")
 
-		assert.Equal(t, tss.PendingStatus, resp.Status)
-		assert.Equal(t, tss.UnMarshalBinaryCode, resp.Code.OtherCodes)
+		assert.Equal(t, entities.PendingStatus, resp.Status)
+		assert.Equal(t, tss.UnmarshalBinaryCode, resp.Code.OtherCodes)
 		assert.Equal(t, "parse error result xdr string: unable to unmarshal errorResultXdr: ", err.Error())
 
 	})
@@ -527,7 +528,7 @@ func TestSendTransaction(t *testing.T) {
 
 		resp, err := txService.SendTransaction("ABCD")
 
-		assert.Equal(t, tss.UnMarshalBinaryCode, resp.Code.OtherCodes)
+		assert.Equal(t, tss.UnmarshalBinaryCode, resp.Code.OtherCodes)
 		assert.Equal(t, "parse error result xdr string: unable to unmarshal errorResultXdr: ABC123", err.Error())
 	})
 	t.Run("response_has_errorResultXdr", func(t *testing.T) {
@@ -576,7 +577,7 @@ func TestGetTransaction(t *testing.T) {
 
 		resp, err := txService.GetTransaction("XYZ")
 
-		assert.Equal(t, tss.ErrorStatus, resp.Status)
+		assert.Equal(t, entities.ErrorStatus, resp.Status)
 		assert.Equal(t, "RPC Fail: getTransaction: sending POST request to rpc: RPC Connection fail", err.Error())
 
 	})
@@ -592,7 +593,7 @@ func TestGetTransaction(t *testing.T) {
 
 		resp, err := txService.GetTransaction("XYZ")
 
-		assert.Equal(t, tss.ErrorStatus, resp.Status)
+		assert.Equal(t, entities.ErrorStatus, resp.Status)
 		assert.Equal(t, "unable to parse createAt: strconv.ParseInt: parsing \"ABCD\": invalid syntax", err.Error())
 	})
 	t.Run("response_has_createdAt_field", func(t *testing.T) {

--- a/internal/utils/http_client.go
+++ b/internal/utils/http_client.go
@@ -7,6 +7,10 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+type HTTPClient interface {
+	Post(url string, t string, body io.Reader) (resp *http.Response, err error)
+}
+
 type MockHTTPClient struct {
 	mock.Mock
 }


### PR DESCRIPTION
### What

Creates a new RPC service, extracting the logic from the TSS package into a more general one to be available and used across the application.

### Why

The `Ingest Service` for the new Balances Ingestion feature will also require RPC communication, therefore the RPC functions are being extracted into its own service. 

### Known limitations

N/A

### Issue that this PR addresses

[[Wallet Backend] Refactor RPC code into a separate service](https://app.asana.com/0/1202672669313222/1208409334251161/f)

### Checklist

#### PR Structure

- [X] It is not possible to break this PR down into smaller PRs.
- [X] This PR does not mix refactoring changes with feature changes.
- [X] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [X] This PR adds tests for the new functionality or fixes.
- [X] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [X] This is not a breaking change.
- [X] This is ready to be tested in development.
- [X] The new functionality is gated with a feature flag if this is not ready for production.
