### PR TITLE
cmd: rpc url env added to ingest cmd

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -25,6 +25,7 @@ func (c *ingestCmd) Command() *cobra.Command {
 		utils.NetworkPassphraseOption(&cfg.NetworkPassphrase),
 		utils.SentryDSNOption(&sentryDSN),
 		utils.StellarEnvironmentOption(&stellarEnvironment),
+		utils.RPCClientURLOption(&cfg.RPCURL),
 		{
 			Name:           "captive-core-bin-path",
 			Usage:          "Path to Captive Core's binary file.",

--- a/cmd/utils/global_options.go
+++ b/cmd/utils/global_options.go
@@ -67,6 +67,16 @@ func HorizonClientURLOption(configKey *string) *config.ConfigOption {
 	}
 }
 
+func RPCClientURLOption(configKey *string) *config.ConfigOption {
+	return &config.ConfigOption{
+		Name:      "rpc-url",
+		Usage:     "The URL of the Stellar RPC server which this application will communicate with.",
+		OptType:   types.String,
+		ConfigKey: configKey,
+		Required:  true,
+	}
+}
+
 func ChannelAccountEncryptionPassphraseOption(configKey *string) *config.ConfigOption {
 	return &config.ConfigOption{
 		Name:      "channel-account-encryption-passphrase",


### PR DESCRIPTION
### What

Adds a new `RPC_URL` environment variable to the `ingest` command.

### Why

It was previously not being read from the envs.

### Known limitations

N/A

### Issue that this PR addresses

N/A

### Checklist

#### PR Structure

- [X] It is not possible to break this PR down into smaller PRs.
- [X] This PR does not mix refactoring changes with feature changes.
- [X] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [X] This PR adds tests for the new functionality or fixes.
- [X] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [X] This is not a breaking change.
- [X] This is ready to be tested in development.
- [X] The new functionality is gated with a feature flag if this is not ready for production.
