### PR TITLE
all: Accounting for protocol 22 related RPC changes

### DIFF
--- a/internal/entities/rpc.go
+++ b/internal/entities/rpc.go
@@ -31,6 +31,7 @@ type RPCGetTransactionResult struct {
 	OldestLedger          int64     `json:"oldestLedger"`
 	OldestLedgerCloseTime string    `json:"oldestLedgerCloseTime"`
 	ApplicationOrder      int64     `json:"applicationOrder"`
+	Hash                  string    `json:"txHash"`
 	EnvelopeXDR           string    `json:"envelopeXdr"`
 	ResultXDR             string    `json:"resultXdr"`
 	ResultMetaXDR         string    `json:"resultMetaXdr"`
@@ -41,7 +42,7 @@ type RPCGetTransactionResult struct {
 
 type Transaction struct {
 	Status              RPCStatus `json:"status"`
-	Hash                string    `json:"hash"`
+	Hash                string    `json:"txHash"`
 	ApplicationOrder    int64     `json:"applicationOrder"`
 	FeeBump             bool      `json:"feeBump"`
 	EnvelopeXDR         string    `json:"envelopeXdr"`
@@ -49,7 +50,7 @@ type Transaction struct {
 	ResultMetaXDR       string    `json:"resultMetaXdr"`
 	Ledger              int64     `json:"ledger"`
 	DiagnosticEventsXDR string    `json:"diagnosticEventsXdr"`
-	CreatedAt           int64     `json:"createdAt"`
+	CreatedAt           uint32    `json:"createdAt"`
 }
 
 type RPCGetTransactionsResult struct {

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -163,7 +163,7 @@ func (m *ingestService) ingestPayments(ctx context.Context, ledgerTransactions [
 					TransactionID:   utils.TransactionID(int32(tx.Ledger), int32(tx.ApplicationOrder)),
 					TransactionHash: tx.Hash,
 					FromAddress:     utils.SourceAccount(op, txEnvelopeXDR),
-					CreatedAt:       time.Unix(tx.CreatedAt, 0),
+					CreatedAt:       time.Unix(int64(tx.CreatedAt), 0),
 					Memo:            txMemo,
 					MemoType:        txMemoType,
 				}
@@ -231,7 +231,7 @@ func (m *ingestService) processTSSTransactions(ctx context.Context, ledgerTransa
 			Code:        txCode,
 			EnvelopeXDR: tx.EnvelopeXDR,
 			ResultXDR:   tx.ResultXDR,
-			CreatedAt:   tx.CreatedAt,
+			CreatedAt:   int64(tx.CreatedAt),
 		}
 		payload := tss.Payload{
 			RpcGetIngestTxResponse: tssGetIngestResponse,


### PR DESCRIPTION
### What

Making sure that the RPC changes listed in protocol 22: https://gist.github.com/Shaptic/6d5c76c5fe2b29e42d1d190241110281 are reflected in the wallet backend

### Why

Ensuring that the latest RPC build does not break the wallet backend

### Known limitations

N/A

### Issue that this PR addresses

https://github.com/orgs/stellar/projects/58/views/2?filterQuery=&sliceBy%5Bvalue%5D=In+progress&pane=issue&itemId=84956784&issue=stellar%7Cwallet-backend%7C64

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
