### PR TITLE
[services][feat] #81: Add test for ingesting path payments

### DIFF
--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -220,8 +220,7 @@ func TestIngestPayments(t *testing.T) {
 	})
 
 	t.Run("test_op_path_payment_send", func(t *testing.T) {
-		err := models.Account.Insert(context.Background(), srcAccount)
-		require.NoError(t, err)
+		_ = models.Account.Insert(context.Background(), srcAccount)
 
 		path := []txnbuild.Asset{
 			txnbuild.CreditAsset{Code: "USD", Issuer: usdIssuer},
@@ -237,24 +236,20 @@ func TestIngestPayments(t *testing.T) {
 			DestAsset:     txnbuild.NativeAsset{},
 			Path:          path,
 		}
-		transaction, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		transaction, _ := txnbuild.NewTransaction(txnbuild.TransactionParams{
 			SourceAccount: &txnbuild.SimpleAccount{
 				AccountID: keypair.MustRandom().Address(),
 			},
 			Operations:    []txnbuild.Operation{&pathPaymentOp},
 			Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(10)},
 		})
-		require.NoError(t, err)
 
 		signer := keypair.MustRandom()
-		errSigner := models.Account.Insert(context.Background(), signer.Address())
-		require.NoError(t, errSigner)
+		_ = models.Account.Insert(context.Background(), signer.Address())
 
-		signedTx, err := transaction.Sign(network.TestNetworkPassphrase, signer)
-		require.NoError(t, err)
+		signedTx, _ := transaction.Sign(network.TestNetworkPassphrase, signer)
 
-		txEnvXDR, err := signedTx.Base64()
-		require.NoError(t, err)
+		txEnvXDR, _ := signedTx.Base64()
 
 		ledgerTransaction := entities.Transaction{
 			Status:           entities.SuccessStatus,
@@ -284,8 +279,7 @@ func TestIngestPayments(t *testing.T) {
 	})
 
 	t.Run("test_op_path_payment_receive", func(t *testing.T) {
-		err := models.Account.Insert(context.Background(), srcAccount)
-		require.NoError(t, err)
+		_ = models.Account.Insert(context.Background(), srcAccount)
 
 		path := []txnbuild.Asset{
 			txnbuild.CreditAsset{Code: "USD", Issuer: usdIssuer},
@@ -301,24 +295,20 @@ func TestIngestPayments(t *testing.T) {
 			DestAsset:     txnbuild.NativeAsset{},
 			Path:          path,
 		}
-		transaction, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		transaction, _ := txnbuild.NewTransaction(txnbuild.TransactionParams{
 			SourceAccount: &txnbuild.SimpleAccount{
 				AccountID: keypair.MustRandom().Address(),
 			},
 			Operations:    []txnbuild.Operation{&pathPaymentOp},
 			Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(10)},
 		})
-		require.NoError(t, err)
 
 		signer := keypair.MustRandom()
-		errSigner := models.Account.Insert(context.Background(), signer.Address())
-		require.NoError(t, errSigner)
+		_ = models.Account.Insert(context.Background(), signer.Address())
 
-		signedTx, err := transaction.Sign(network.TestNetworkPassphrase, signer)
-		require.NoError(t, err)
+		signedTx, _ := transaction.Sign(network.TestNetworkPassphrase, signer)
 
-		txEnvXDR, err := signedTx.Base64()
-		require.NoError(t, err)
+		txEnvXDR, _ := signedTx.Base64()
 
 		ledgerTransaction := entities.Transaction{
 			Status:           entities.SuccessStatus,

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -289,7 +289,93 @@ func TestIngestPathPaymentsSend(t *testing.T) {
 		payments, _, _, err := models.Payments.GetPaymentsPaginated(context.Background(), srcAccount, "", "", data.ASC, 1)
 		require.NoError(t, err)
 		require.NotEmpty(t, payments, "Expected at least one payment")
-		assert.Equal(t, payments[0].TransactionHash, "efgh")
+		assert.Equal(t, payments[0].TransactionHash, *&ledgerTransaction.Hash)
+		assert.Equal(t, payments[0].SrcAmount, int64(100000000))
+		assert.Equal(t, payments[0].SrcAssetType, xdr.AssetTypeAssetTypeNative.String())
+		assert.Equal(t, payments[0].ToAddress, destAccount)
+		assert.Equal(t, payments[0].FromAddress, srcAccount)
+		assert.Equal(t, payments[0].SrcAssetCode, "XLM")
+		assert.Equal(t, payments[0].DestAssetCode, "XLM")
 	})
+}
 
+func TestIngestPathPaymentsReceive(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+	models, _ := data.NewModels(dbConnectionPool)
+	mockAppTracker := apptracker.MockAppTracker{}
+	mockRPCService := RPCServiceMock{}
+	mockRouter := tssrouter.MockRouter{}
+	tssStore, _ := tssstore.NewStore(dbConnectionPool)
+	ingestService, _ := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, &mockRouter, tssStore)
+	srcAccount := keypair.MustRandom().Address()
+	destAccount := keypair.MustRandom().Address()
+	usdIssuer := keypair.MustRandom().Address()
+	eurIssuer := keypair.MustRandom().Address()
+
+	t.Run("test_op_path_payment_receive", func(t *testing.T) {
+		err := models.Account.Insert(context.Background(), srcAccount)
+		require.NoError(t, err)
+
+		path := []txnbuild.Asset{
+			txnbuild.CreditAsset{Code: "USD", Issuer: usdIssuer},
+			txnbuild.CreditAsset{Code: "EUR", Issuer: eurIssuer},
+		}
+
+		pathPaymentOp := txnbuild.PathPaymentStrictReceive{
+			SourceAccount: srcAccount,
+			Destination:   destAccount,
+			SendMax:       "11",
+			DestAmount:    "10",
+			SendAsset:     txnbuild.NativeAsset{},
+			DestAsset:     txnbuild.NativeAsset{},
+			Path:          path,
+		}
+		transaction, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+			SourceAccount: &txnbuild.SimpleAccount{
+				AccountID: keypair.MustRandom().Address(),
+			},
+			Operations:    []txnbuild.Operation{&pathPaymentOp},
+			Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(10)},
+		})
+		require.NoError(t, err)
+
+		signer := keypair.MustRandom()
+		errSigner := models.Account.Insert(context.Background(), signer.Address())
+		require.NoError(t, errSigner)
+
+		signedTx, err := transaction.Sign(network.TestNetworkPassphrase, signer)
+		require.NoError(t, err)
+
+		txEnvXDR, err := signedTx.Base64()
+		require.NoError(t, err)
+
+		ledgerTransaction := entities.Transaction{
+			Status:           entities.SuccessStatus,
+			Hash:             "efgh",
+			ApplicationOrder: 1,
+			FeeBump:          false,
+			EnvelopeXDR:      txEnvXDR,
+			ResultXDR:        "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAACAAAAAAAAAAAAAAAAjOiEfRh4kaFVQDu/CSTZLMtnyg0DbNowZ/G2nLES3KwAAAAAAAAAAAVdSoAAAAAA",
+			Ledger:           1,
+		}
+
+		ledgerTransactions := []entities.Transaction{ledgerTransaction}
+
+		err = ingestService.ingestPayments(context.Background(), ledgerTransactions)
+
+		payments, _, _, err := models.Payments.GetPaymentsPaginated(context.Background(), srcAccount, "", "", data.ASC, 1)
+		require.NoError(t, err)
+		require.NotEmpty(t, payments, "Expected at least one payment")
+		assert.Equal(t, payments[0].TransactionHash, *&ledgerTransaction.Hash)
+		assert.Equal(t, payments[0].SrcAssetType, xdr.AssetTypeAssetTypeNative.String())
+		assert.Equal(t, payments[0].ToAddress, destAccount)
+		assert.Equal(t, payments[0].FromAddress, srcAccount)
+		assert.Equal(t, payments[0].SrcAssetCode, "XLM")
+		assert.Equal(t, payments[0].DestAssetCode, "XLM")
+	})
 }


### PR DESCRIPTION
Closes #81 

### What
Add test for ingest of path payments

### Why
Current test cases only cover regular payments

### Known limitations
N/A

### Issue that this PR addresses
#81 

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
