### PR TITLE
Centralize RPC health monitoring

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -63,6 +63,7 @@ func setupDeps(cfg Configs) (services.IngestService, error) {
 	if err != nil {
 		return nil, fmt.Errorf("instantiating rpc service: %w", err)
 	}
+	go rpcService.TrackRPCServiceHealth(context.Background())
 	tssStore, err := tssstore.NewStore(dbConnectionPool)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating tss store: %w", err)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -154,6 +154,7 @@ func initHandlerDeps(cfg Configs) (handlerDeps, error) {
 	if err != nil {
 		return handlerDeps{}, fmt.Errorf("instantiating rpc service: %w", err)
 	}
+	go rpcService.TrackRPCServiceHealth(context.Background())
 
 	accountService, err := services.NewAccountService(models)
 	if err != nil {

--- a/internal/services/channel_account_service.go
+++ b/internal/services/channel_account_service.go
@@ -90,12 +90,13 @@ func (s *channelAccountService) EnsureChannelAccounts(ctx context.Context, numbe
 }
 
 func (s *channelAccountService) submitCreateChannelAccountsOnChainTransaction(ctx context.Context, distributionAccountPublicKey string, ops []txnbuild.Operation) error {
+	rpcHeartbeatChannel := s.RPCService.GetHeartbeatChannel()
 	select {
 	case <-ctx.Done():
 		return fmt.Errorf("context cancelled while waiting for rpc service to become healthy: %w", ctx.Err())
 	// The channel account creation goroutine will wait in the background for the rpc service to become healthy on startup.
 	// This lets the API server startup so that users can start interacting with the API which does not depend on RPC, instead of waiting till it becomes healthy.
-	case <-s.RPCService.GetHeartbeatChannel():
+	case <-rpcHeartbeatChannel:
 		accountSeq, err := s.RPCService.GetAccountLedgerSequence(distributionAccountPublicKey)
 		if err != nil {
 			return fmt.Errorf("getting ledger sequence for distribution account public key: %s: %w", distributionAccountPublicKey, err)

--- a/internal/services/channel_account_service.go
+++ b/internal/services/channel_account_service.go
@@ -93,6 +93,8 @@ func (s *channelAccountService) submitCreateChannelAccountsOnChainTransaction(ct
 	select {
 	case <-ctx.Done():
 		return fmt.Errorf("context cancelled while waiting for rpc service to become healthy: %w", ctx.Err())
+	// The channel account creation goroutine will wait in the background for the rpc service to become healthy on startup.
+	// This lets the API server startup so that users can start interacting with the API which does not depend on RPC, instead of waiting till it becomes healthy.
 	case <-s.RPCService.GetHeartbeatChannel():
 		accountSeq, err := s.RPCService.GetAccountLedgerSequence(distributionAccountPublicKey)
 		if err != nil {

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -21,8 +21,6 @@ import (
 )
 
 const (
-	rpcHealthCheckSleepTime      = 5 * time.Second
-	rpcHealthCheckMaxWaitTime    = 60 * time.Second
 	ingestHealthCheckMaxWaitTime = 90 * time.Second
 )
 
@@ -79,12 +77,9 @@ func NewIngestService(
 }
 
 func (m *ingestService) Run(ctx context.Context, startLedger uint32, endLedger uint32) error {
-	rpcHeartbeat := make(chan entities.RPCGetHealthResult, 1)
-	ingestHeartbeat := make(chan any, 1)
-
-	// Start service health trackers
-	go trackRPCServiceHealth(ctx, rpcHeartbeat, m.appTracker, m.rpcService)
-	go trackIngestServiceHealth(ctx, ingestHeartbeat, m.appTracker)
+	ingestHeartbeatChannel := make(chan any, 1)
+	rpcHeartbeatChannel := m.rpcService.GetHeartbeatChannel()
+	go trackIngestServiceHealth(ctx, ingestHeartbeatChannel, m.appTracker)
 
 	if startLedger == 0 {
 		var err error
@@ -99,7 +94,7 @@ func (m *ingestService) Run(ctx context.Context, startLedger uint32, endLedger u
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("context cancelled: %w", ctx.Err())
-		case resp := <-rpcHeartbeat:
+		case resp := <-rpcHeartbeatChannel:
 			switch {
 			// Case-1: wallet-backend is running behind rpc's oldest ledger. In this case, we start
 			// ingestion from rpc's oldest ledger.
@@ -120,7 +115,7 @@ func (m *ingestService) Run(ctx context.Context, startLedger uint32, endLedger u
 				log.Error("getTransactions: %w", err)
 				continue
 			}
-			ingestHeartbeat <- true
+			ingestHeartbeatChannel <- true
 			err = m.ingestPayments(ctx, ledgerTransactions)
 			if err != nil {
 				return fmt.Errorf("error ingesting payments: %w", err)
@@ -276,40 +271,6 @@ func (m *ingestService) processTSSTransactions(ctx context.Context, ledgerTransa
 		}
 	}
 	return nil
-}
-
-func trackRPCServiceHealth(ctx context.Context, heartbeat chan entities.RPCGetHealthResult, tracker apptracker.AppTracker, rpcService RPCService) {
-	healthCheckTicker := time.NewTicker(rpcHealthCheckSleepTime)
-	warningTicker := time.NewTicker(rpcHealthCheckMaxWaitTime)
-	defer func() {
-		healthCheckTicker.Stop()
-		warningTicker.Stop()
-		close(heartbeat)
-	}()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-warningTicker.C:
-			warn := fmt.Sprintf("rpc service unhealthy for over %s", rpcHealthCheckMaxWaitTime)
-			log.Warn(warn)
-			if tracker != nil {
-				tracker.CaptureMessage(warn)
-			} else {
-				log.Warn("App Tracker is nil")
-			}
-			warningTicker.Reset(rpcHealthCheckMaxWaitTime)
-		case <-healthCheckTicker.C:
-			result, err := rpcService.GetHealth()
-			if err != nil {
-				log.Warnf("rpc health check failed: %v", err)
-				continue
-			}
-			heartbeat <- result
-			warningTicker.Reset(rpcHealthCheckMaxWaitTime)
-		}
-	}
 }
 
 func trackIngestServiceHealth(ctx context.Context, heartbeat chan any, tracker apptracker.AppTracker) {

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -3,8 +3,6 @@ package services
 import (
 	"bytes"
 	"context"
-	"io"
-	"net/http"
 	"os"
 	"testing"
 	"time"
@@ -26,7 +24,6 @@ import (
 	"github.com/stellar/wallet-backend/internal/tss"
 	tssrouter "github.com/stellar/wallet-backend/internal/tss/router"
 	tssstore "github.com/stellar/wallet-backend/internal/tss/store"
-	"github.com/stellar/wallet-backend/internal/utils"
 )
 
 func TestGetLedgerTransactions(t *testing.T) {
@@ -540,105 +537,4 @@ func TestIngest_LatestSyncedLedgerAheadOfRPC(t *testing.T) {
 	assert.Equal(t, uint32(100), ledger)
 
 	mockRPCService.AssertExpectations(t)
-}
-
-func TestTrackRPCServiceHealth_HealthyService(t *testing.T) {
-	mockHTTPClient := &utils.MockHTTPClient{}
-	rpcService, err := NewRPCService("http://test-url", mockHTTPClient)
-	require.NoError(t, err)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	healthResult := entities.RPCGetHealthResult{
-		Status:                "healthy",
-		LatestLedger:          100,
-		OldestLedger:          1,
-		LedgerRetentionWindow: 0,
-	}
-
-	// Mock the HTTP response for GetHealth
-	mockResponse := &http.Response{
-		Body: io.NopCloser(bytes.NewBuffer([]byte(`{
-			"jsonrpc": "2.0",
-			"id": 1,
-			"result": {
-				"status": "healthy",
-				"latestLedger": 100,
-				"oldestLedger": 1,
-				"ledgerRetentionWindow": 0
-			}
-		}`))),
-	}
-	mockHTTPClient.On("Post", "http://test-url", "application/json", mock.Anything).Return(mockResponse, nil).Once()
-
-	// Start tracking health in background
-	go rpcService.trackRPCServiceHealth(ctx)
-
-	// Get result from heartbeat channel
-	select {
-	case result := <-rpcService.GetHeartbeatChannel():
-		assert.Equal(t, healthResult, result)
-	case <-time.After(10 * time.Second):
-		t.Fatal("timeout waiting for heartbeat")
-	}
-
-	mockHTTPClient.AssertExpectations(t)
-}
-
-func TestTrackRPCServiceHealth_UnhealthyService(t *testing.T) {
-	var logBuffer bytes.Buffer
-	log.DefaultLogger.SetOutput(&logBuffer)
-	defer log.DefaultLogger.SetOutput(os.Stderr)
-
-	mockHTTPClient := &utils.MockHTTPClient{}
-	rpcService, err := NewRPCService("http://test-url", mockHTTPClient)
-	require.NoError(t, err)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 70*time.Second)
-	defer cancel()
-
-	// Mock error response for GetHealth with a valid http.Response
-	mockResponse := &http.Response{
-		Body: io.NopCloser(bytes.NewBuffer([]byte(`{
-			"jsonrpc": "2.0",
-			"id": 1,
-			"error": {
-				"code": -32601,
-				"message": "rpc error"
-			}
-		}`))),
-	}
-	mockHTTPClient.On("Post", "http://test-url", "application/json", mock.Anything).
-		Return(mockResponse, nil)
-
-	go rpcService.trackRPCServiceHealth(ctx)
-
-	// Wait long enough for warning to trigger
-	time.Sleep(65 * time.Second)
-
-	logOutput := logBuffer.String()
-	assert.Contains(t, logOutput, "rpc service unhealthy for over 1m0s")
-	mockHTTPClient.AssertExpectations(t)
-}
-
-func TestTrackRPCService_ContextCancelled(t *testing.T) {
-	mockHTTPClient := &utils.MockHTTPClient{}
-	rpcService, err := NewRPCService("http://test-url", mockHTTPClient)
-	require.NoError(t, err)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-
-	go rpcService.trackRPCServiceHealth(ctx)
-
-	// Cancel context immediately
-	cancel()
-
-	// Verify channel is closed after context cancellation
-	time.Sleep(100 * time.Millisecond)
-	_, ok := <-rpcService.GetHeartbeatChannel()
-	assert.False(t, ok, "channel should be closed")
-
-	mockHTTPClient.AssertNotCalled(t, "Post")
 }

--- a/internal/services/mocks.go
+++ b/internal/services/mocks.go
@@ -12,6 +12,11 @@ type RPCServiceMock struct {
 
 var _ RPCService = (*RPCServiceMock)(nil)
 
+func (r *RPCServiceMock) GetHeartbeatChannel() chan entities.RPCGetHealthResult {
+	args := r.Called()
+	return args.Get(0).(chan entities.RPCGetHealthResult)
+}
+
 func (r *RPCServiceMock) SendTransaction(transactionXdr string) (entities.RPCSendTransactionResult, error) {
 	args := r.Called(transactionXdr)
 	return args.Get(0).(entities.RPCSendTransactionResult), args.Error(1)

--- a/internal/services/mocks.go
+++ b/internal/services/mocks.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"context"
+
 	"github.com/stretchr/testify/mock"
 
 	"github.com/stellar/wallet-backend/internal/entities"
@@ -11,6 +13,10 @@ type RPCServiceMock struct {
 }
 
 var _ RPCService = (*RPCServiceMock)(nil)
+
+func (r *RPCServiceMock) TrackRPCServiceHealth(ctx context.Context) {
+	r.Called(ctx)
+}
 
 func (r *RPCServiceMock) GetHeartbeatChannel() chan entities.RPCGetHealthResult {
 	args := r.Called()

--- a/internal/services/rpc_service.go
+++ b/internal/services/rpc_service.go
@@ -15,6 +15,8 @@ import (
 )
 
 const (
+	rpcHealthCheckSleepTime      = 5 * time.Second
+	rpcHealthCheckMaxWaitTime    = 60 * time.Second
 	getHealthMethodName = "getHealth"
 )
 

--- a/internal/services/rpc_service.go
+++ b/internal/services/rpc_service.go
@@ -46,10 +46,14 @@ func NewRPCService(rpcURL string, httpClient utils.HTTPClient) (*rpcService, err
 		return nil, errors.New("httpClient cannot be nil")
 	}
 
-	return &rpcService{
+	heartbeatChannel := make(chan entities.RPCGetHealthResult, 1)
+	rpcService := &rpcService{
 		rpcURL:     rpcURL,
 		httpClient: httpClient,
-	}, nil
+		heartbeatChannel: heartbeatChannel,
+	}
+	go rpcService.trackRPCServiceHealth(context.Background())
+	return rpcService, nil
 }
 
 func (r *rpcService) GetHeartbeatChannel() chan entities.RPCGetHealthResult {

--- a/internal/services/rpc_service_test.go
+++ b/internal/services/rpc_service_test.go
@@ -34,9 +34,8 @@ func (e *errorReader) Close() error {
 
 func TestSendRPCRequest(t *testing.T) {
 	mockHTTPClient := utils.MockHTTPClient{}
-	rpcURL := "http://test-url-send-rpc-request"
-	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient)
-	require.NoError(t, err)
+	rpcURL := "http://api.vibrantapp.com/soroban/rpc"
+	rpcService, _ := NewRPCService(rpcURL, &mockHTTPClient)
 
 	t.Run("successful", func(t *testing.T) {
 		httpResponse := http.Response{
@@ -130,9 +129,8 @@ func TestSendRPCRequest(t *testing.T) {
 
 func TestSendTransaction(t *testing.T) {
 	mockHTTPClient := utils.MockHTTPClient{}
-	rpcURL := "http://test-url-send-transaction"
-	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient)
-	require.NoError(t, err)
+	rpcURL := "http://api.vibrantapp.com/soroban/rpc"
+	rpcService, _ := NewRPCService(rpcURL, &mockHTTPClient)
 
 	t.Run("successful", func(t *testing.T) {
 		transactionXDR := "AAAAAgAAAABYJgX6SmA2tGVDv3GXfOWbkeL869ahE0e5DG9HnXQw/QAAAGQAAjpnAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAACxaDFEbbssZfrbRgFxTYIygITSQxsUpDmneN2gAZBEFQAAAAAAAAAABfXhAAAAAAAAAAAA"
@@ -192,9 +190,9 @@ func TestSendTransaction(t *testing.T) {
 
 func TestGetTransaction(t *testing.T) {
 	mockHTTPClient := utils.MockHTTPClient{}
-	rpcURL := "http://test-url-get-transaction"
-	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient)
-	require.NoError(t, err)
+	rpcURL := "http://api.vibrantapp.com/soroban/rpc"
+	rpcService, _ := NewRPCService(rpcURL, &mockHTTPClient)
+
 	t.Run("successful", func(t *testing.T) {
 		transactionHash := "6bc97bddc21811c626839baf4ab574f4f9f7ddbebb44d286ae504396d4e752da"
 		params := entities.RPCParams{Hash: transactionHash}
@@ -268,9 +266,9 @@ func TestGetTransaction(t *testing.T) {
 
 func TestGetTransactions(t *testing.T) {
 	mockHTTPClient := utils.MockHTTPClient{}
-	rpcURL := "http://test-url-get-transactions"
-	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient)
-	require.NoError(t, err)
+	rpcURL := "http://api.vibrantapp.com/soroban/rpc"
+	rpcService, _ := NewRPCService(rpcURL, &mockHTTPClient)
+
 	t.Run("rpc_request_fails", func(t *testing.T) {
 		mockHTTPClient.
 			On("Post", rpcURL, "application/json", mock.Anything).
@@ -331,9 +329,8 @@ func TestGetTransactions(t *testing.T) {
 
 func TestSendGetHealth(t *testing.T) {
 	mockHTTPClient := utils.MockHTTPClient{}
-	rpcURL := "http://test-url-send-get-health"
-	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient)
-	require.NoError(t, err)
+	rpcURL := "http://api.vibrantapp.com/soroban/rpc"
+	rpcService, _ := NewRPCService(rpcURL, &mockHTTPClient)
 
 	t.Run("successful", func(t *testing.T) {
 		payload := map[string]interface{}{

--- a/internal/services/rpc_service_test.go
+++ b/internal/services/rpc_service_test.go
@@ -399,7 +399,7 @@ func TestTrackRPCServiceHealth_HealthyService(t *testing.T) {
 			}
 		}`))),
 	}
-	mockHTTPClient.On("Post", "http://test-url", "application/json", mock.Anything).Return(mockResponse, nil).Once()
+	mockHTTPClient.On("Post", "http://test-url", "application/json", mock.Anything).Return(mockResponse, nil)
 
 	// Get result from heartbeat channel
 	select {

--- a/internal/services/rpc_service_test.go
+++ b/internal/services/rpc_service_test.go
@@ -34,8 +34,10 @@ func (e *errorReader) Close() error {
 
 func TestSendRPCRequest(t *testing.T) {
 	mockHTTPClient := utils.MockHTTPClient{}
-	rpcURL := "http://api.vibrantapp.com/soroban/rpc"
-	rpcService, _ := NewRPCService(rpcURL, &mockHTTPClient)
+	rpcURL := "http://test-url"
+	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient)
+	require.NoError(t, err)
+	defer close(rpcService.heartbeatChannel)
 
 	t.Run("successful", func(t *testing.T) {
 		httpResponse := http.Response{
@@ -129,8 +131,10 @@ func TestSendRPCRequest(t *testing.T) {
 
 func TestSendTransaction(t *testing.T) {
 	mockHTTPClient := utils.MockHTTPClient{}
-	rpcURL := "http://api.vibrantapp.com/soroban/rpc"
-	rpcService, _ := NewRPCService(rpcURL, &mockHTTPClient)
+	rpcURL := "http://test-url"
+	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient)
+	require.NoError(t, err)
+	defer close(rpcService.heartbeatChannel)
 
 	t.Run("successful", func(t *testing.T) {
 		transactionXDR := "AAAAAgAAAABYJgX6SmA2tGVDv3GXfOWbkeL869ahE0e5DG9HnXQw/QAAAGQAAjpnAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAACxaDFEbbssZfrbRgFxTYIygITSQxsUpDmneN2gAZBEFQAAAAAAAAAABfXhAAAAAAAAAAAA"
@@ -190,8 +194,10 @@ func TestSendTransaction(t *testing.T) {
 
 func TestGetTransaction(t *testing.T) {
 	mockHTTPClient := utils.MockHTTPClient{}
-	rpcURL := "http://api.vibrantapp.com/soroban/rpc"
-	rpcService, _ := NewRPCService(rpcURL, &mockHTTPClient)
+	rpcURL := "http://test-url"
+	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient)
+	require.NoError(t, err)
+	defer close(rpcService.heartbeatChannel)
 
 	t.Run("successful", func(t *testing.T) {
 		transactionHash := "6bc97bddc21811c626839baf4ab574f4f9f7ddbebb44d286ae504396d4e752da"
@@ -266,8 +272,10 @@ func TestGetTransaction(t *testing.T) {
 
 func TestGetTransactions(t *testing.T) {
 	mockHTTPClient := utils.MockHTTPClient{}
-	rpcURL := "http://api.vibrantapp.com/soroban/rpc"
-	rpcService, _ := NewRPCService(rpcURL, &mockHTTPClient)
+	rpcURL := "http://test-url"
+	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient)
+	require.NoError(t, err)
+	defer close(rpcService.heartbeatChannel)
 
 	t.Run("rpc_request_fails", func(t *testing.T) {
 		mockHTTPClient.
@@ -329,9 +337,11 @@ func TestGetTransactions(t *testing.T) {
 
 func TestSendGetHealth(t *testing.T) {
 	mockHTTPClient := utils.MockHTTPClient{}
-	rpcURL := "http://api.vibrantapp.com/soroban/rpc"
-	rpcService, _ := NewRPCService(rpcURL, &mockHTTPClient)
-
+	rpcURL := "http://test-url"
+	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient)
+	require.NoError(t, err)
+	defer close(rpcService.heartbeatChannel)
+	
 	t.Run("successful", func(t *testing.T) {
 		payload := map[string]interface{}{
 			"jsonrpc": "2.0",
@@ -378,6 +388,7 @@ func TestTrackRPCServiceHealth_HealthyService(t *testing.T) {
 	mockHTTPClient := &utils.MockHTTPClient{}
 	rpcService, err := NewRPCService("http://test-url", mockHTTPClient)
 	require.NoError(t, err)
+	defer close(rpcService.heartbeatChannel)
 
 	healthResult := entities.RPCGetHealthResult{
 		Status:                "healthy",
@@ -420,7 +431,7 @@ func TestTrackRPCServiceHealth_UnhealthyService(t *testing.T) {
 	mockHTTPClient := &utils.MockHTTPClient{}
 	rpcService, err := NewRPCService("http://test-url", mockHTTPClient)
 	require.NoError(t, err)
-
+	defer close(rpcService.heartbeatChannel)
 	ctx, cancel := context.WithTimeout(context.Background(), 70*time.Second)
 	defer cancel()
 
@@ -452,7 +463,7 @@ func TestTrackRPCService_ContextCancelled(t *testing.T) {
 	mockHTTPClient := &utils.MockHTTPClient{}
 	rpcService, err := NewRPCService("http://test-url", mockHTTPClient)
 	require.NoError(t, err)
-
+	defer close(rpcService.heartbeatChannel)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 

--- a/internal/services/rpc_service_test.go
+++ b/internal/services/rpc_service_test.go
@@ -33,14 +33,10 @@ func (e *errorReader) Close() error {
 }
 
 func TestSendRPCRequest(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	mockHTTPClient := utils.MockHTTPClient{}
 	rpcURL := "http://test-url-send-rpc-request"
 	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient)
 	require.NoError(t, err)
-	go rpcService.TrackRPCServiceHealth(ctx)
 
 	t.Run("successful", func(t *testing.T) {
 		httpResponse := http.Response{
@@ -133,14 +129,10 @@ func TestSendRPCRequest(t *testing.T) {
 }
 
 func TestSendTransaction(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	mockHTTPClient := utils.MockHTTPClient{}
 	rpcURL := "http://test-url-send-transaction"
 	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient)
 	require.NoError(t, err)
-	go rpcService.TrackRPCServiceHealth(ctx)
 
 	t.Run("successful", func(t *testing.T) {
 		transactionXDR := "AAAAAgAAAABYJgX6SmA2tGVDv3GXfOWbkeL869ahE0e5DG9HnXQw/QAAAGQAAjpnAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAACxaDFEbbssZfrbRgFxTYIygITSQxsUpDmneN2gAZBEFQAAAAAAAAAABfXhAAAAAAAAAAAA"
@@ -199,14 +191,10 @@ func TestSendTransaction(t *testing.T) {
 }
 
 func TestGetTransaction(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	mockHTTPClient := utils.MockHTTPClient{}
 	rpcURL := "http://test-url-get-transaction"
 	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient)
 	require.NoError(t, err)
-	go rpcService.TrackRPCServiceHealth(ctx)
 	t.Run("successful", func(t *testing.T) {
 		transactionHash := "6bc97bddc21811c626839baf4ab574f4f9f7ddbebb44d286ae504396d4e752da"
 		params := entities.RPCParams{Hash: transactionHash}
@@ -279,14 +267,10 @@ func TestGetTransaction(t *testing.T) {
 }
 
 func TestGetTransactions(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	mockHTTPClient := utils.MockHTTPClient{}
 	rpcURL := "http://test-url-get-transactions"
 	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient)
 	require.NoError(t, err)
-	go rpcService.TrackRPCServiceHealth(ctx)
 	t.Run("rpc_request_fails", func(t *testing.T) {
 		mockHTTPClient.
 			On("Post", rpcURL, "application/json", mock.Anything).
@@ -346,14 +330,10 @@ func TestGetTransactions(t *testing.T) {
 }
 
 func TestSendGetHealth(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	mockHTTPClient := utils.MockHTTPClient{}
 	rpcURL := "http://test-url-send-get-health"
 	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient)
 	require.NoError(t, err)
-	go rpcService.TrackRPCServiceHealth(ctx)
 
 	t.Run("successful", func(t *testing.T) {
 		payload := map[string]interface{}{
@@ -398,7 +378,7 @@ func TestSendGetHealth(t *testing.T) {
 }
 
 func TestTrackRPCServiceHealth_HealthyService(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	mockHTTPClient := &utils.MockHTTPClient{}

--- a/internal/services/rpc_service_test.go
+++ b/internal/services/rpc_service_test.go
@@ -382,7 +382,7 @@ func TestTrackRPCServiceHealth_HealthyService(t *testing.T) {
 	rpcURL := "http://test-url-track-rpc-service-health"
 	rpcService, err := NewRPCService(rpcURL, mockHTTPClient)
 	require.NoError(t, err)
-	go rpcService.TrackRPCServiceHealth(ctx)
+
 	healthResult := entities.RPCGetHealthResult{
 		Status:                "healthy",
 		LatestLedger:          100,
@@ -403,7 +403,10 @@ func TestTrackRPCServiceHealth_HealthyService(t *testing.T) {
 			}
 		}`))),
 	}
-	mockHTTPClient.On("Post", rpcURL, "application/json", mock.Anything).Return(mockResponse, nil)
+	mockHTTPClient.On("Post", rpcURL, "application/json", mock.Anything).Return(mockResponse, nil).Run(func(args mock.Arguments) {
+		cancel()
+	})
+	rpcService.TrackRPCServiceHealth(ctx)
 
 	// Get result from heartbeat channel
 	select {


### PR DESCRIPTION
### What

- Currently, the code for tracking RPC health is duplicated across both the ingest server and the api server (when creating the channel accounts). This PR organises the RPC heartbeat tracking in a central location and simplifies its design.
- Updated tests accordingly.

### Why

The current solution for tracking rpc health was not a simple one and had some code duplication which are resolved in this PR.

### Known limitations

NA

### Issue that this PR addresses

Closes #105 

### Checklist

#### PR Structure

- [ ] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.
- [ ] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [ ] This is not a breaking change.
- [ ] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
