### PR TITLE
[INTERNAL] /transaction/{transactionhash} returns TSSResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ you can set it to any value. For production, you should set it to a secure passp
 3. Start the containers:
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 If things are set up correctly, you will see 4 containers started under the wallet-backend docker service: `api`, `db`, 

--- a/internal/serve/httphandler/tss_handler.go
+++ b/internal/serve/httphandler/tss_handler.go
@@ -166,7 +166,7 @@ func (t *TSSHandler) GetTransaction(w http.ResponseWriter, r *http.Request) {
 		TransactionHash:       tx.Hash,
 		TransactionResultCode: fmt.Sprint(tssTry.Code),
 		Status:                tx.Status,
-		CreatedAt:             tx.CreatedAt.Unix(),
+		CreatedAt:             tssTry.CreatedAt.Unix(),
 		EnvelopeXDR:           tssTry.XDR,
 		ResultXDR:             tssTry.ResultXDR,
 	}, httpjson.JSON)

--- a/internal/serve/httphandler/tss_handler.go
+++ b/internal/serve/httphandler/tss_handler.go
@@ -156,7 +156,7 @@ func (t *TSSHandler) GetTransaction(w http.ResponseWriter, r *http.Request) {
 		httperror.NotFound.Render(w)
 	}
 
-	tssTry, err := t.Store.GetTry(ctx, tx.Hash)
+	tssTry, err := t.Store.GetLatestTry(ctx, tx.Hash)
 	if err != nil {
 		httperror.InternalServerError(ctx, "unable to get tx try "+tx.Hash, err, nil, t.AppTracker).Render(w)
 		return

--- a/internal/serve/httphandler/tss_handler_test.go
+++ b/internal/serve/httphandler/tss_handler_test.go
@@ -268,12 +268,12 @@ func TestGetTransaction(t *testing.T) {
 		resp := rw.Result()
 		respBody, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
-		var getTxResp GetTransactionResponse
+		var getTxResp tss.TSSResponse
 		_ = json.Unmarshal(respBody, &getTxResp)
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Equal(t, "hash", getTxResp.Hash)
-		assert.Equal(t, "xdr", getTxResp.XDR)
+		assert.Equal(t, "hash", getTxResp.TransactionHash)
+		assert.Equal(t, "xdr", getTxResp.EnvelopeXDR)
 		assert.Equal(t, "NEW", getTxResp.Status)
 
 		clearTransactions(ctx)
@@ -290,12 +290,12 @@ func TestGetTransaction(t *testing.T) {
 		resp := rw.Result()
 		respBody, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
-		var getTxResp GetTransactionResponse
+		var getTxResp tss.TSSResponse
 		_ = json.Unmarshal(respBody, &getTxResp)
 
 		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
-		assert.Empty(t, getTxResp.Hash)
-		assert.Empty(t, getTxResp.XDR)
+		assert.Empty(t, getTxResp.TransactionHash)
+		assert.Empty(t, getTxResp.EnvelopeXDR)
 		assert.Empty(t, getTxResp.Status)
 
 	})

--- a/internal/serve/httphandler/tss_handler_test.go
+++ b/internal/serve/httphandler/tss_handler_test.go
@@ -270,7 +270,6 @@ func TestGetTransaction(t *testing.T) {
 		require.NoError(t, err)
 		var getTxResp tss.TSSResponse
 		_ = json.Unmarshal(respBody, &getTxResp)
-		fmt.Printf("%+v\n", getTxResp)
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, "hash", getTxResp.TransactionHash)

--- a/internal/serve/httphandler/tss_handler_test.go
+++ b/internal/serve/httphandler/tss_handler_test.go
@@ -257,8 +257,10 @@ func TestGetTransaction(t *testing.T) {
 
 	t.Run("returns_transaction", func(t *testing.T) {
 		txHash := "hash"
+		resultXdr := "resultXdr"
 		ctx := context.Background()
 		_ = store.UpsertTransaction(ctx, "localhost:8080/webhook", txHash, "xdr", tss.RPCTXStatus{OtherStatus: tss.NewStatus})
+		_ = store.UpsertTry(ctx, txHash, "feebumphash", "feebumpxdr", tss.RPCTXStatus{OtherStatus: tss.NewStatus}, tss.RPCTXCode{OtherCodes: tss.NewCode}, resultXdr)
 		req, err := http.NewRequest(http.MethodGet, path.Join(endpoint, txHash), nil)
 		require.NoError(t, err)
 
@@ -270,12 +272,12 @@ func TestGetTransaction(t *testing.T) {
 		require.NoError(t, err)
 		var tssResp tss.TSSResponse
 		_ = json.Unmarshal(respBody, &tssResp)
-		fmt.Printf("%+v\n", tssResp)
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Equal(t, "hash", tssResp.TransactionHash)
-		assert.Equal(t, "0", tssResp.TransactionResultCode)
-		assert.Equal(t, "NEW", tssResp.Status)
+		assert.Equal(t, txHash, tssResp.TransactionHash)
+		assert.Equal(t, fmt.Sprint(tss.NewCode), tssResp.TransactionResultCode)
+		assert.Equal(t, fmt.Sprint(tss.NewStatus), tssResp.Status)
+		assert.Equal(t, resultXdr, tssResp.ResultXDR)
 
 		clearTransactions(ctx)
 	})

--- a/internal/serve/httphandler/tss_handler_test.go
+++ b/internal/serve/httphandler/tss_handler_test.go
@@ -270,10 +270,11 @@ func TestGetTransaction(t *testing.T) {
 		require.NoError(t, err)
 		var getTxResp tss.TSSResponse
 		_ = json.Unmarshal(respBody, &getTxResp)
+		fmt.Printf("%+v\n", getTxResp)
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, "hash", getTxResp.TransactionHash)
-		assert.Equal(t, "xdr", getTxResp.EnvelopeXDR)
+		assert.Equal(t, "0", getTxResp.TransactionResultCode)
 		assert.Equal(t, "NEW", getTxResp.Status)
 
 		clearTransactions(ctx)

--- a/internal/serve/httphandler/tss_handler_test.go
+++ b/internal/serve/httphandler/tss_handler_test.go
@@ -268,13 +268,14 @@ func TestGetTransaction(t *testing.T) {
 		resp := rw.Result()
 		respBody, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
-		var getTxResp tss.TSSResponse
-		_ = json.Unmarshal(respBody, &getTxResp)
+		var tssResp tss.TSSResponse
+		_ = json.Unmarshal(respBody, &tssResp)
+		fmt.Printf("%+v\n", tssResp)
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Equal(t, "hash", getTxResp.TransactionHash)
-		assert.Equal(t, "0", getTxResp.TransactionResultCode)
-		assert.Equal(t, "NEW", getTxResp.Status)
+		assert.Equal(t, "hash", tssResp.TransactionHash)
+		assert.Equal(t, "0", tssResp.TransactionResultCode)
+		assert.Equal(t, "NEW", tssResp.Status)
 
 		clearTransactions(ctx)
 	})
@@ -290,13 +291,13 @@ func TestGetTransaction(t *testing.T) {
 		resp := rw.Result()
 		respBody, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
-		var getTxResp tss.TSSResponse
-		_ = json.Unmarshal(respBody, &getTxResp)
+		var tssResp tss.TSSResponse
+		_ = json.Unmarshal(respBody, &tssResp)
 
 		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
-		assert.Empty(t, getTxResp.TransactionHash)
-		assert.Empty(t, getTxResp.EnvelopeXDR)
-		assert.Empty(t, getTxResp.Status)
+		assert.Empty(t, tssResp.TransactionHash)
+		assert.Empty(t, tssResp.EnvelopeXDR)
+		assert.Empty(t, tssResp.Status)
 
 	})
 


### PR DESCRIPTION
Closes #100 

### What
Makes `GetTransaction` return a `TSSResponse` to match the webhook response.

### Why
To move towards a unified response type.

### Known limitations
N/A

### Issue that this PR addresses
https://github.com/stellar/wallet-backend/issues/100

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [ ] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
