### PR TITLE
Locking channel accounts to transactions

### DIFF
--- a/internal/db/migrations/2025-01-22.0-add_locked_tx_hash_to_channel_accounts.sql
+++ b/internal/db/migrations/2025-01-22.0-add_locked_tx_hash_to_channel_accounts.sql
@@ -1,0 +1,9 @@
+-- +migrate Up
+
+ALTER TABLE channel_accounts
+ADD COLUMN locked_tx_hash TEXT;
+CREATE INDEX idx_locked_tx_hash ON channel_accounts(locked_tx_hash);
+-- +migrate Down
+DROP INDEX IF EXISTS idx_locked_tx_hash;
+ALTER TABLE channel_accounts
+DROP COLUMN locked_tx_hash;

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -156,6 +156,8 @@ func initHandlerDeps(cfg Configs) (handlerDeps, error) {
 	}
 	go rpcService.TrackRPCServiceHealth(context.Background())
 
+	channelAccountStore := store.NewChannelAccountModel(dbConnectionPool)
+
 	accountService, err := services.NewAccountService(models)
 	if err != nil {
 		return handlerDeps{}, fmt.Errorf("instantiating account service: %w", err)
@@ -183,6 +185,7 @@ func initHandlerDeps(cfg Configs) (handlerDeps, error) {
 	tssTxService, err := tssservices.NewTransactionService(tssservices.TransactionServiceOptions{
 		DistributionAccountSignatureClient: cfg.DistributionAccountSignatureClient,
 		ChannelAccountSignatureClient:      cfg.ChannelAccountSignatureClient,
+		ChannelAccountStore:                channelAccountStore,
 		RPCService:                         rpcService,
 		BaseFee:                            int64(cfg.BaseFee),
 	})
@@ -228,10 +231,12 @@ func initHandlerDeps(cfg Configs) (handlerDeps, error) {
 	webhookChannel := tsschannel.NewWebhookChannel(tsschannel.WebhookChannelConfigs{
 		HTTPClient:           &httpClient,
 		Store:                tssStore,
+		ChannelAccountStore:  channelAccountStore,
 		MaxBufferSize:        cfg.WebhookHandlerServiceChannelMaxBufferSize,
 		MaxWorkers:           cfg.WebhookHandlerServiceChannelMaxWorkers,
 		MaxRetries:           cfg.WebhookHandlerServiceChannelMaxRetries,
 		MinWaitBtwnRetriesMS: cfg.WebhookHandlerServiceChannelMinWaitBtwnRetriesMS,
+		NetworkPassphrase:    cfg.NetworkPassphrase,
 	})
 
 	router := tssrouter.NewRouter(tssrouter.RouterConfigs{

--- a/internal/signing/channel_account_db_signature_client.go
+++ b/internal/signing/channel_account_db_signature_client.go
@@ -43,9 +43,16 @@ func (sc *channelAccountDBSignatureClient) NetworkPassphrase() string {
 	return sc.networkPassphrase
 }
 
-func (sc *channelAccountDBSignatureClient) GetAccountPublicKey(ctx context.Context) (string, error) {
+func (sc *channelAccountDBSignatureClient) GetAccountPublicKey(ctx context.Context, opts ...int) (string, error) {
+	var lockedUntil time.Duration
+	if len(opts) > 0 {
+		lockedUntil = time.Duration(opts[0]) * time.Second
+	} else {
+		lockedUntil = time.Minute
+	}
 	for range store.ChannelAccountWaitTime {
-		channelAccount, err := sc.channelAccountStore.GetIdleChannelAccount(ctx, time.Minute)
+		// check to see if the variadic parameter for time exists and if so, use it here
+		channelAccount, err := sc.channelAccountStore.GetIdleChannelAccount(ctx, lockedUntil)
 		if err != nil {
 			if errors.Is(err, store.ErrNoIdleChannelAccountAvailable) {
 				log.Ctx(ctx).Warn("All channel accounts are in use. Retry in 1 second.")

--- a/internal/signing/channel_account_db_signature_client_test.go
+++ b/internal/signing/channel_account_db_signature_client_test.go
@@ -30,7 +30,7 @@ func TestChannelAccountDBSignatureClientGetAccountPublicKey(t *testing.T) {
 
 	t.Run("returns_error_when_couldn't_get_an_idle_channel_account", func(t *testing.T) {
 		channelAccountStore.
-			On("GetIdleChannelAccount", ctx, time.Minute).
+			On("GetIdleChannelAccount", ctx, time.Duration(100)*time.Second).
 			Return(nil, store.ErrNoIdleChannelAccountAvailable).
 			Times(6).
 			On("Count", ctx).
@@ -40,7 +40,7 @@ func TestChannelAccountDBSignatureClientGetAccountPublicKey(t *testing.T) {
 
 		getEntries := log.DefaultLogger.StartTest(log.WarnLevel)
 
-		publicKey, err := sc.GetAccountPublicKey(ctx)
+		publicKey, err := sc.GetAccountPublicKey(ctx, 100)
 		assert.ErrorIs(t, err, store.ErrNoIdleChannelAccountAvailable)
 		assert.Empty(t, publicKey)
 

--- a/internal/signing/env_signature_client.go
+++ b/internal/signing/env_signature_client.go
@@ -36,7 +36,7 @@ func (sc *envSignatureClient) NetworkPassphrase() string {
 	return sc.networkPassphrase
 }
 
-func (sc *envSignatureClient) GetAccountPublicKey(ctx context.Context) (string, error) {
+func (sc *envSignatureClient) GetAccountPublicKey(ctx context.Context, opts ...int) (string, error) {
 	return sc.distributionAccountFull.Address(), nil
 }
 

--- a/internal/signing/kms_signature_client.go
+++ b/internal/signing/kms_signature_client.go
@@ -59,7 +59,7 @@ func NewKMSSignatureClient(publicKey string, networkPassphrase string, keypairSt
 	}, nil
 }
 
-func (sc *kmsSignatureClient) GetAccountPublicKey(ctx context.Context) (string, error) {
+func (sc *kmsSignatureClient) GetAccountPublicKey(ctx context.Context, opts ...int) (string, error) {
 	return sc.distributionAccountPublicKey, nil
 }
 

--- a/internal/signing/mocks.go
+++ b/internal/signing/mocks.go
@@ -18,7 +18,7 @@ func (s *SignatureClientMock) NetworkPassphrase() string {
 	return args.String(0)
 }
 
-func (s *SignatureClientMock) GetAccountPublicKey(ctx context.Context) (string, error) {
+func (s *SignatureClientMock) GetAccountPublicKey(ctx context.Context, opts ...int) (string, error) {
 	args := s.Called(ctx)
 	return args.String(0), args.Error(1)
 }

--- a/internal/signing/signature_client.go
+++ b/internal/signing/signature_client.go
@@ -15,7 +15,8 @@ var (
 
 type SignatureClient interface {
 	NetworkPassphrase() string
-	GetAccountPublicKey(ctx context.Context) (string, error)
+	// change the signature of this method to accept variadic parameters
+	GetAccountPublicKey(ctx context.Context, opts ...int) (string, error)
 	SignStellarTransaction(ctx context.Context, tx *txnbuild.Transaction, stellarAccounts ...string) (*txnbuild.Transaction, error)
 	SignStellarFeeBumpTransaction(ctx context.Context, feeBumpTx *txnbuild.FeeBumpTransaction) (*txnbuild.FeeBumpTransaction, error)
 }

--- a/internal/signing/store/channel_accounts_model.go
+++ b/internal/signing/store/channel_accounts_model.go
@@ -29,6 +29,7 @@ func (ca *ChannelAccountModel) GetIdleChannelAccount(ctx context.Context, locked
 	query := fmt.Sprintf(`
 		UPDATE channel_accounts
 		SET 
+			locked_tx_hash = NULL,
 			locked_at = NOW(),
 			locked_until = NOW() + INTERVAL '%d seconds'
 		WHERE public_key = (
@@ -36,13 +37,12 @@ func (ca *ChannelAccountModel) GetIdleChannelAccount(ctx context.Context, locked
 				public_key
 			FROM channel_accounts
 			WHERE 
-				locked_until IS NULL
-				OR locked_until < NOW()
+				(locked_tx_hash IS NULL AND (locked_until IS NULL OR locked_until < NOW()))
 			ORDER BY random()
 			LIMIT 1
 			FOR UPDATE SKIP LOCKED
 		)
-		RETURNING *
+		RETURNING *;
 	`, int64(lockedUntil.Seconds()))
 
 	var channelAccount ChannelAccount
@@ -82,6 +82,25 @@ func (ca *ChannelAccountModel) GetAllByPublicKey(ctx context.Context, sqlExec db
 	}
 
 	return channelAccounts, nil
+}
+
+func (ca *ChannelAccountModel) LockChannelAccountToTx(ctx context.Context, publicKey string, txHash string) error {
+	const query = `UPDATE channel_accounts SET locked_tx_hash = $1 WHERE public_key = $2`
+	_, err := ca.DB.ExecContext(ctx, query, txHash, publicKey)
+	if err != nil {
+		return fmt.Errorf("locking channel account: %w", err)
+	}
+	return nil
+}
+
+func (ca *ChannelAccountModel) UnlockChannelAccountFromTx(ctx context.Context, txHash string) error {
+	fmt.Println("or am i getting here")
+	const query = `UPDATE channel_accounts SET locked_tx_hash = NULL, locked_at = NULL, locked_until = NULL WHERE locked_tx_hash = $1`
+	_, err := ca.DB.ExecContext(ctx, query, txHash)
+	if err != nil {
+		return fmt.Errorf("unlocking channel account: %w", err)
+	}
+	return nil
 }
 
 func (ca *ChannelAccountModel) BatchInsert(ctx context.Context, sqlExec db.SQLExecuter, channelAccounts []*ChannelAccount) error {

--- a/internal/signing/store/mocks.go
+++ b/internal/signing/store/mocks.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/stellar/wallet-backend/internal/db"
@@ -36,6 +37,17 @@ func (s *ChannelAccountStoreMock) GetAllByPublicKey(ctx context.Context, sqlExec
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]*ChannelAccount), args.Error(1)
+}
+
+func (s *ChannelAccountStoreMock) LockChannelAccountToTx(ctx context.Context, publicKey string, txHash string) error {
+	args := s.Called(ctx, publicKey, txHash)
+	return args.Error(0)
+}
+
+func (s *ChannelAccountStoreMock) UnlockChannelAccountFromTx(ctx context.Context, txHash string) error {
+	fmt.Println("Am I getting here")
+	args := s.Called(ctx, txHash)
+	return args.Error(0)
 }
 
 func (s *ChannelAccountStoreMock) BatchInsert(ctx context.Context, sqlExec db.SQLExecuter, channelAccounts []*ChannelAccount) error {

--- a/internal/signing/store/types.go
+++ b/internal/signing/store/types.go
@@ -9,18 +9,21 @@ import (
 )
 
 type ChannelAccount struct {
-	PublicKey           string       `db:"public_key"`
-	EncryptedPrivateKey string       `db:"encrypted_private_key"`
-	UpdatedAt           time.Time    `db:"updated_at"`
-	CreatedAt           time.Time    `db:"created_at"`
-	LockedAt            sql.NullTime `db:"locked_at"`
-	LockedUntil         sql.NullTime `db:"locked_until"`
+	PublicKey           string         `db:"public_key"`
+	EncryptedPrivateKey string         `db:"encrypted_private_key"`
+	UpdatedAt           time.Time      `db:"updated_at"`
+	CreatedAt           time.Time      `db:"created_at"`
+	LockedAt            sql.NullTime   `db:"locked_at"`
+	LockedUntil         sql.NullTime   `db:"locked_until"`
+	LockedTxHash        sql.NullString `db:"locked_tx_hash"`
 }
 
 type ChannelAccountStore interface {
 	GetIdleChannelAccount(ctx context.Context, lockedUntil time.Duration) (*ChannelAccount, error)
 	Get(ctx context.Context, sqlExec db.SQLExecuter, publicKey string) (*ChannelAccount, error)
 	GetAllByPublicKey(ctx context.Context, sqlExec db.SQLExecuter, publicKeys ...string) ([]*ChannelAccount, error)
+	LockChannelAccountToTx(ctx context.Context, publicKey string, txHash string) error
+	UnlockChannelAccountFromTx(ctx context.Context, txHash string) error
 	BatchInsert(ctx context.Context, sqlExec db.SQLExecuter, channelAccounts []*ChannelAccount) error
 	Count(ctx context.Context) (int64, error)
 }

--- a/internal/tss/channels/webhook_channel.go
+++ b/internal/tss/channels/webhook_channel.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/alitto/pond"
 	"github.com/stellar/go/support/log"
+	"github.com/stellar/go/txnbuild"
+	channelAccountStore "github.com/stellar/wallet-backend/internal/signing/store"
 	"github.com/stellar/wallet-backend/internal/tss"
 	"github.com/stellar/wallet-backend/internal/tss/store"
 	tssutils "github.com/stellar/wallet-backend/internal/tss/utils"
@@ -16,20 +19,24 @@ import (
 )
 
 type WebhookChannelConfigs struct {
-	HTTPClient           utils.HTTPClient
 	Store                store.Store
-	MaxBufferSize        int
-	MaxWorkers           int
+	ChannelAccountStore  channelAccountStore.ChannelAccountStore
+	HTTPClient           utils.HTTPClient
 	MaxRetries           int
 	MinWaitBtwnRetriesMS int
+	NetworkPassphrase    string
+	MaxBufferSize        int
+	MaxWorkers           int
 }
 
 type webhookPool struct {
 	Pool                 *pond.WorkerPool
 	Store                store.Store
+	ChannelAccountStore  channelAccountStore.ChannelAccountStore
 	HTTPClient           utils.HTTPClient
 	MaxRetries           int
 	MinWaitBtwnRetriesMS int
+	NetworkPassphrase    string
 }
 
 var WebhookChannelName = "WebhookChannel"
@@ -41,9 +48,11 @@ func NewWebhookChannel(cfg WebhookChannelConfigs) *webhookPool {
 	return &webhookPool{
 		Pool:                 pool,
 		Store:                cfg.Store,
+		ChannelAccountStore:  cfg.ChannelAccountStore,
 		HTTPClient:           cfg.HTTPClient,
 		MaxRetries:           cfg.MaxRetries,
 		MinWaitBtwnRetriesMS: cfg.MinWaitBtwnRetriesMS,
+		NetworkPassphrase:    cfg.NetworkPassphrase,
 	}
 
 }
@@ -64,6 +73,10 @@ func (p *webhookPool) Receive(payload tss.Payload) {
 	var i int
 	sent := false
 	ctx := context.Background()
+	err = p.UnlockChannelAccount(ctx, payload.TransactionXDR)
+	if err != nil {
+		log.Errorf("%s: error unlocking channel account from transaction: %e", WebhookChannelName, err)
+	}
 	for i = 0; i < p.MaxRetries; i++ {
 		httpResp, err := p.HTTPClient.Post(payload.WebhookURL, "application/json", bytes.NewBuffer(jsonData))
 		if err != nil {
@@ -91,6 +104,31 @@ func (p *webhookPool) Receive(payload tss.Payload) {
 		}
 	}
 
+}
+
+func (p *webhookPool) UnlockChannelAccount(ctx context.Context, txXDR string) error {
+	genericTx, err := txnbuild.TransactionFromXDR(txXDR)
+	if err != nil {
+		return fmt.Errorf("bad transaction xdr: %w", err)
+	}
+	var tx *txnbuild.Transaction
+	feeBumpTx, isFeeBumpTx := genericTx.FeeBump()
+	if isFeeBumpTx {
+		tx = feeBumpTx.InnerTransaction()
+	}
+	simpleTx, isTransaction := genericTx.Transaction()
+	if isTransaction {
+		tx = simpleTx
+	}
+	txHash, err := tx.HashHex(p.NetworkPassphrase)
+	if err != nil {
+		return fmt.Errorf("unable to hashhex transaction: %w", err)
+	}
+	err = p.ChannelAccountStore.UnlockChannelAccountFromTx(ctx, txHash)
+	if err != nil {
+		return fmt.Errorf("unable to unlock channel account associated with transaction: %w", err)
+	}
+	return nil
 }
 
 func (p *webhookPool) Stop() {

--- a/internal/tss/channels/webhook_channel_test.go
+++ b/internal/tss/channels/webhook_channel_test.go
@@ -4,13 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/wallet-backend/internal/db"
 	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	channelAccountStore "github.com/stellar/wallet-backend/internal/signing/store"
 	"github.com/stellar/wallet-backend/internal/tss"
 	"github.com/stellar/wallet-backend/internal/tss/store"
 	tssutils "github.com/stellar/wallet-backend/internal/tss/utils"
@@ -26,14 +30,17 @@ func TestWebhookHandlerServiceChannel(t *testing.T) {
 	require.NoError(t, err)
 	defer dbConnectionPool.Close()
 	store, _ := store.NewStore(dbConnectionPool)
+	channelAccountStore := channelAccountStore.ChannelAccountStoreMock{}
 	mockHTTPClient := utils.MockHTTPClient{}
 	cfg := WebhookChannelConfigs{
 		HTTPClient:           &mockHTTPClient,
 		Store:                store,
+		ChannelAccountStore:  &channelAccountStore,
 		MaxBufferSize:        1,
 		MaxWorkers:           1,
 		MaxRetries:           3,
 		MinWaitBtwnRetriesMS: 5,
+		NetworkPassphrase:    "networkpassphrase",
 	}
 	channel := NewWebhookChannel(cfg)
 
@@ -71,4 +78,92 @@ func TestWebhookHandlerServiceChannel(t *testing.T) {
 	tx, err := store.GetTransaction(context.Background(), payload.TransactionHash)
 	assert.Equal(t, string(tss.SentStatus), tx.Status)
 	assert.NoError(t, err)
+}
+
+func TestUnlockChannelAccount(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+	store, _ := store.NewStore(dbConnectionPool)
+	channelAccountStore := channelAccountStore.ChannelAccountStoreMock{}
+	mockHTTPClient := utils.MockHTTPClient{}
+	cfg := WebhookChannelConfigs{
+		HTTPClient:           &mockHTTPClient,
+		Store:                store,
+		ChannelAccountStore:  &channelAccountStore,
+		MaxBufferSize:        1,
+		MaxWorkers:           1,
+		MaxRetries:           3,
+		MinWaitBtwnRetriesMS: 5,
+		NetworkPassphrase:    "networkpassphrase",
+	}
+	channel := NewWebhookChannel(cfg)
+	account := keypair.MustRandom()
+	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount:        &txnbuild.SimpleAccount{AccountID: account.Address()},
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			&txnbuild.Payment{
+				Destination: keypair.MustRandom().Address(),
+				Amount:      "10",
+				Asset:       txnbuild.NativeAsset{},
+			},
+		},
+		BaseFee:       txnbuild.MinBaseFee,
+		Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(30)},
+	})
+	require.NoError(t, err)
+
+	distributionAccount := keypair.MustRandom()
+
+	feeBumpTx, err := txnbuild.NewFeeBumpTransaction(txnbuild.FeeBumpTransactionParams{
+		Inner:      tx,
+		FeeAccount: distributionAccount.Address(),
+		BaseFee:    txnbuild.MinBaseFee,
+	})
+	require.NoError(t, err)
+
+	t.Run("simple_tx", func(t *testing.T) {
+		txXDR, err := tx.Base64()
+		assert.NoError(t, err)
+		txHash, err := tx.HashHex(cfg.NetworkPassphrase)
+		assert.NoError(t, err)
+		channelAccountStore.
+			On("UnlockChannelAccountFromTx", context.Background(), txHash).
+			Return(nil).
+			Once()
+
+		err = channel.UnlockChannelAccount(context.Background(), txXDR)
+		assert.NoError(t, err)
+	})
+
+	t.Run("feebump_tx", func(t *testing.T) {
+		txXDR, err := feeBumpTx.Base64()
+		assert.NoError(t, err)
+		txHash, err := tx.HashHex(cfg.NetworkPassphrase)
+		assert.NoError(t, err)
+		channelAccountStore.
+			On("UnlockChannelAccountFromTx", context.Background(), txHash).
+			Return(nil).
+			Once()
+
+		err = channel.UnlockChannelAccount(context.Background(), txXDR)
+		assert.NoError(t, err)
+	})
+
+	t.Run("unlock_channel_account_from_tx_returns_error", func(t *testing.T) {
+		txXDR, err := tx.Base64()
+		assert.NoError(t, err)
+		txHash, err := tx.HashHex(cfg.NetworkPassphrase)
+		assert.NoError(t, err)
+		channelAccountStore.
+			On("UnlockChannelAccountFromTx", context.Background(), txHash).
+			Return(errors.New("unabe to unlock channel account")).
+			Once()
+
+		err = channel.UnlockChannelAccount(context.Background(), txXDR)
+		assert.Equal(t, "unable to unlock channel account associated with transaction: unabe to unlock channel account", err.Error())
+	})
 }


### PR DESCRIPTION
Instead of locking channel accounts for an arbitrary amount of time like we are currently doing, lock them for the same amount of time as the transaction time bounds and also explicitly lock them to transactions, unlocking them in the webhook channel

### What

Instead of locking channel accounts for an arbitrary amount of time like we are currently doing, lock them for the same amount of time as the transaction time bounds and also explicitly lock them to transactions, unlocking them in the webhook channel


### Why

If the channel account is specified as the source of a transaction that hasn't been accepted by the network yet, and the same channel account is "unlocked" and then used as the source for a different transaction that gets accepted by the network prior to the original, the original transaction is invalidated. We want to avoid this behavior

### Known limitations

N/A

### Issue that this PR addresses

https://github.com/orgs/stellar/projects/58/views/2?pane=issue&itemId=92871835&issue=stellar%7Cwallet-backend%7C102
### Checklist

#### PR Structure

- [ ] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.
- [ ] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.
- [ ] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [ ] This is not a breaking change.
- [ ] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
