### PR TITLE
Fix data race in RPC health check test

### DIFF
--- a/internal/services/rpc_service_test.go
+++ b/internal/services/rpc_service_test.go
@@ -442,10 +442,8 @@ func TestTrackRPCServiceHealth_UnhealthyService(t *testing.T) {
 	mockHTTPClient.On("Post", rpcURL, "application/json", mock.Anything).
 		Return(mockResponse, nil)
 
-	go rpcService.TrackRPCServiceHealth(ctx)
-
-	// Wait long enough for warning to trigger
-	time.Sleep(65 * time.Second)
+	// The ctx will timeout after 70 seconds, which is enough for the warning to trigger
+	rpcService.TrackRPCServiceHealth(ctx)
 
 	entries := getLogs()
 	testFailed := true
@@ -466,7 +464,7 @@ func TestTrackRPCService_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	go rpcService.TrackRPCServiceHealth(ctx)
+	rpcService.TrackRPCServiceHealth(ctx)
 
 	// Verify channel is closed after context cancellation
 	time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
### What

Do not start goroutine in tests

### Why

It looks like running these goroutines in tests is triggering data race conditions in our builds.

### Known limitations

NA

### Issue that this PR addresses

[TODO: Attach the link to the GitHub issue or task. Include the priority of the task here in addition to the link.]

### Checklist

#### PR Structure

- [ ] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.
- [ ] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.
- [ ] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [ ] This is not a breaking change.
- [ ] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
