### PR TITLE
state change schema & type definitions

### DIFF
--- a/internal/db/migrations/2025-02-19.0-statechange_schema.sql
+++ b/internal/db/migrations/2025-02-19.0-statechange_schema.sql
@@ -1,0 +1,116 @@
+-- +migrate Up
+
+
+CREATE TYPE statechangetype_enum AS ENUM (
+    'DEBIT',
+    'CREDIT',
+    'HOMEDOMAIN',
+    'FLAGS',
+    'SIGNERS',
+    'DATAENTRY',
+    'ALLOWANCE',
+    'BALANCEAUTHORIZATION',
+    'THRESHOLDS',
+    'AUTHORIZATION'
+);
+
+CREATE TYPE statechangereason_enum AS ENUM (
+    'CREATEACCOUNT',
+    'MERGEACCOUNT',
+    'PAYMENT',
+    'CREATECLAIMABLEBALANCE',
+    'CLAIMCLAIMABLEBALANCE',
+    'CLAWBACK',
+    'LIQUIDITYPOOLDEPOSIT',
+    'LIQUIDITYPOOLWITHDRAW',
+    'OFFERS',
+    'PATHPAYMENT',
+    'FEE'
+    'TRANSFER',
+    'CONTRACT_TRANSFER',
+    'CONTRACT_MINT',
+    'CONTRACT_BURN',
+    'CONTRACT_CLAWBACK'
+    'FLAGS_CLEARED',
+    'FLAGS_SET',
+    'SIGNERS_ADDED',
+    'SIGNERS_UPDATED',
+    'SINGERS_REMOVED',
+    'ALLOWANCE_SET',
+    'ALLOWANCE_CONSUMED'
+);
+
+-- Transactions Table
+CREATE TABLE transactions (
+    txhash VARCHAR(64) PRIMARY KEY,
+    transactionxdr TEXT NOT NULL,
+    txmeta TEXT,
+    ts TIMESTAMP NOT NULL
+);
+
+-- Operations Table
+CREATE TABLE operations (
+    toid TEXT PRIMARY KEY,
+    txhash VARCHAR(64) NOT NULL REFERENCES transactions(txhash) ON DELETE CASCADE,
+    operationindex INTEGER NOT NULL,
+    operationtype INTEGER NOT NULL,
+    ts TIMESTAMP NOT NULL
+);
+
+-- State Changes Table
+CREATE TABLE statechanges (
+    id SERIAL PRIMARY KEY,
+    acctid TEXT NOT NULL,
+    operationtoid TEXT REFERENCES operations(toid) ON DELETE CASCADE,
+    txhash VARCHAR(64) NOT NULL REFERENCES transactions(txhash) ON DELETE CASCADE,
+    statechangetype statechangetype_enum NOT NULL,
+    statechangereason statechangereason_enum NOT NULL,
+    changemetadata JSONB,
+    asset TEXT,
+    amount FLOAT,
+    lowthreshold INTEGER,
+    mediumthreshold INTEGER,
+    highthreshold INTEGER,
+    flags_cleared TEXT[],
+    flags_set TEXT[],
+    homedomain TEXT,
+    signer_added JSONB,
+    signer_removed JSONB,
+    signer_updated JSONB,
+    data_entry JSONB,
+    balance_authorization BOOLEAN,
+    contract_address TEXT,
+    function_name TEXT,
+    ts TIMESTAMP NOT NULL
+);
+
+-- Indexes for optimized queries
+CREATE INDEX idx_transactions_ts ON transactions (ts);
+
+CREATE INDEX idx_operations_txhash ON operations (txhash);
+CREATE INDEX idx_operations_operationtype ON operations (operationtype);
+CREATE INDEX idx_operations_ts ON operations (ts);
+
+CREATE INDEX idx_statechanges_acctid ON statechanges (acctid);
+CREATE INDEX idx_statechanges_statechangetype ON statechanges (statechangetype);
+CREATE INDEX idx_statechanges_statechangereason ON statechanges (statechangereason);
+CREATE INDEX idx_statechanges_ts ON statechanges (ts);
+
+-- +migrate Down
+
+DROP INDEX IF EXISTS idx_transactions_ts;
+DROP INDEX IF EXISTS idx_operations_txhash;
+DROP INDEX IF EXISTS idx_operations_operationtype;
+DROP INDEX IF EXISTS idx_operations_ts;
+DROP INDEX IF EXISTS idx_statechanges_acctid;
+DROP INDEX IF EXISTS idx_statechanges_statechangetype;
+DROP INDEX IF EXISTS idx_statechanges_statechangereason;
+DROP INDEX IF EXISTS idx_statechanges_ts;
+
+DROP TABLE IF EXISTS statechanges;
+DROP TABLE IF EXISTS operations;
+DROP TABLE IF EXISTS transactions;
+
+DROP TYPE IF EXISTS operationtype_enum;
+DROP TYPE IF EXISTS statechangetype_enum;
+DROP TYPE IF EXISTS statechangereason_enum;

--- a/internal/db/migrations/2025-02-19.0-statechange_schema.sql
+++ b/internal/db/migrations/2025-02-19.0-statechange_schema.sql
@@ -50,7 +50,7 @@ CREATE TABLE transactions (
 
 -- Operations Table
 CREATE TABLE operations (
-    toid TEXT PRIMARY KEY,
+    toid BIGINT PRIMARY KEY,
     txhash VARCHAR(64) NOT NULL REFERENCES transactions(txhash) ON DELETE CASCADE,
     operationindex INTEGER NOT NULL,
     operationtype INTEGER NOT NULL,
@@ -61,7 +61,7 @@ CREATE TABLE operations (
 CREATE TABLE statechanges (
     id SERIAL PRIMARY KEY,
     acctid TEXT NOT NULL,
-    operationtoid TEXT REFERENCES operations(toid) ON DELETE CASCADE,
+    operationtoid BIGINT REFERENCES operations(toid) ON DELETE CASCADE,
     txhash VARCHAR(64) NOT NULL REFERENCES transactions(txhash) ON DELETE CASCADE,
     statechangetype statechangetype_enum NOT NULL,
     statechangereason statechangereason_enum NOT NULL,
@@ -92,6 +92,8 @@ CREATE INDEX idx_operations_operationtype ON operations (operationtype);
 CREATE INDEX idx_operations_ts ON operations (ts);
 
 CREATE INDEX idx_statechanges_acctid ON statechanges (acctid);
+CREATE INDEX idx_statechanges_operationtoid ON statechanges (operationtoid);
+CREATE INDEX idx_statechanges_txhash ON statechanges (txhash);
 CREATE INDEX idx_statechanges_statechangetype ON statechanges (statechangetype);
 CREATE INDEX idx_statechanges_statechangereason ON statechanges (statechangereason);
 CREATE INDEX idx_statechanges_ts ON statechanges (ts);
@@ -103,6 +105,8 @@ DROP INDEX IF EXISTS idx_operations_txhash;
 DROP INDEX IF EXISTS idx_operations_operationtype;
 DROP INDEX IF EXISTS idx_operations_ts;
 DROP INDEX IF EXISTS idx_statechanges_acctid;
+DROP INDEX IF EXISTS idx_statechanges_operationtoid;
+DROP INDEX IF EXISTS idx_statechanges_txhash;
 DROP INDEX IF EXISTS idx_statechanges_statechangetype;
 DROP INDEX IF EXISTS idx_statechanges_statechangereason;
 DROP INDEX IF EXISTS idx_statechanges_ts;

--- a/internal/statechanges/types.go
+++ b/internal/statechanges/types.go
@@ -65,7 +65,7 @@ const (
 type StateChange struct {
 	ID                   int64             `db:"id"`
 	AcctID               string            `db:"acctid"`
-	OperationTOID        *string           `db:"operationtoid"`
+	OperationTOID        *int64            `db:"operationtoid"`
 	TxHash               string            `db:"txhash"`
 	StateChangeType      StateChangeType   `db:"statechangetype"`
 	StateChangeReason    StateChangeReason `db:"statechangereason"`

--- a/internal/statechanges/types.go
+++ b/internal/statechanges/types.go
@@ -1,0 +1,89 @@
+package statechanges
+
+import (
+	"time"
+)
+
+type Transaction struct {
+	TxHash         string    `db:"txhash"`
+	TransactionXDR string    `db:"transactionxdr"`
+	TxMeta         *string   `db:"txmeta"`
+	TS             time.Time `db:"ts"`
+}
+
+type Operation struct {
+	ToID           string    `db:"toid"`
+	TxHash         string    `db:"txhash"`
+	OperationIndex int       `db:"operationindex"`
+	OperationType  int       `db:"operationtype"`
+	TS             time.Time `db:"ts"`
+}
+
+type StateChangeType string
+
+const (
+	StateChangeDebit                StateChangeType = "DEBIT"
+	StateChangeCredit               StateChangeType = "CREDIT"
+	StateChangeHomeDomain           StateChangeType = "HOMEDOMAIN"
+	StateChangeFlags                StateChangeType = "FLAGS"
+	StateChangeSigners              StateChangeType = "SIGNERS"
+	StateChangeDataEntry            StateChangeType = "DATAENTRY"
+	StateChangeAllowance            StateChangeType = "ALLOWANCE"
+	StateChangeBalanceAuthorization StateChangeType = "BALANCEAUTHORIZATION"
+	StateChangeThresholds           StateChangeType = "THRESHOLDS"
+	StateChangeAuthorization        StateChangeType = "AUTHORIZATION"
+)
+
+type StateChangeReason string
+
+const (
+	ReasonCreateAccount          StateChangeReason = "CREATEACCOUNT"
+	ReasonMergeAccount           StateChangeReason = "MERGEACCOUNT"
+	ReasonPayment                StateChangeReason = "PAYMENT"
+	ReasonCreateClaimableBalance StateChangeReason = "CREATECLAIMABLEBALANCE"
+	ReasonClaimClaimableBalance  StateChangeReason = "CLAIMCLAIMABLEBALANCE"
+	ReasonClawback               StateChangeReason = "CLAWBACK"
+	ReasonLiquidityPoolDeposit   StateChangeReason = "LIQUIDITYPOOLDEPOSIT"
+	ReasonLiquidityPoolWithdraw  StateChangeReason = "LIQUIDITYPOOLWITHDRAW"
+	ReasonOffers                 StateChangeReason = "OFFERS"
+	ReasonPathPayment            StateChangeReason = "PATHPAYMENT"
+	ReasonFee                    StateChangeReason = "FEE"
+	ReasonTransfer               StateChangeReason = "TRANSFER"
+	ReasonContractTransfer       StateChangeReason = "CONTRACT_TRANSFER"
+	ReasonContractMint           StateChangeReason = "CONTRACT_MINT"
+	ReasonContractBurn           StateChangeReason = "CONTRACT_BURN"
+	ReasonContractClawback       StateChangeReason = "CONTRACT_CLAWBACK"
+	ReasonFlagsCleared           StateChangeReason = "FLAGS_CLEARED"
+	ReasonFlagsSet               StateChangeReason = "FLAGS_SET"
+	ReasonSignersAdded           StateChangeReason = "SIGNERS_ADDED"
+	ReasonSignersUpdated         StateChangeReason = "SIGNERS_UPDATED"
+	ReasonSignersRemoved         StateChangeReason = "SIGNERS_REMOVED"
+	ReasonAllowanceSet           StateChangeReason = "ALLOWANCE_SET"
+	ReasonAllowanceConsumed      StateChangeReason = "ALLOWANCE_CONSUMED"
+)
+
+type StateChange struct {
+	ID                   int64             `db:"id"`
+	AcctID               string            `db:"acctid"`
+	OperationTOID        *string           `db:"operationtoid"`
+	TxHash               string            `db:"txhash"`
+	StateChangeType      StateChangeType   `db:"statechangetype"`
+	StateChangeReason    StateChangeReason `db:"statechangereason"`
+	ChangeMetadata       string            `db:"changemetadata"` // JSONB stored as string
+	Asset                *string           `db:"asset"`
+	Amount               *float64          `db:"amount"`
+	LowThreshold         *int              `db:"lowthreshold"`
+	MediumThreshold      *int              `db:"mediumthreshold"`
+	HighThreshold        *int              `db:"highthreshold"`
+	FlagsCleared         []string          `db:"flags_cleared"`
+	FlagsSet             []string          `db:"flags_set"`
+	HomeDomain           *string           `db:"homedomain"`
+	SignerAdded          string            `db:"signer_added"`   // JSONB stored as string
+	SignerRemoved        string            `db:"signer_removed"` // JSONB stored as string
+	SignerUpdated        string            `db:"signer_updated"` // JSONB stored as string
+	DataEntry            string            `db:"data_entry"`     // JSONB stored as string
+	BalanceAuthorization *bool             `db:"balance_authorization"`
+	ContractAddress      *string           `db:"contract_address"`
+	FunctionName         *string           `db:"function_name"`
+	TS                   time.Time         `db:"ts"`
+}


### PR DESCRIPTION

state change schema + type definitions. Definitions for 

- transactions
- operations
- statechanges
- enums for statechangetype and statechangereason

NOTE: an enum for operationtype was not defined, and it is instead defined as an int, because operations are already defined here and we can reuse the same definitions: https://github.com/stellar/go/blob/master/xdr/xdr_generated.go#L26035

along with corresponding type definitions for these tables in golang - which will be used in later tasks (like building in memory maps)



