### PR TITLE
rpc: Fix error wrapping chain in GetAccountLedgerSequence #136

### DIFF
--- a/internal/services/rpc_service.go
+++ b/internal/services/rpc_service.go
@@ -158,7 +158,7 @@ func (r *rpcService) GetAccountLedgerSequence(address string) (int64, error) {
 		return 0, fmt.Errorf("getting ledger entry for account public key: %w", err)
 	}
 	if len(result.Entries) == 0 {
-		return 0, fmt.Errorf("entry not found for account public key")
+		return 0, fmt.Errorf("%w: entry not found for account public key", ErrAccountNotFound)
 	}
 	accountEntry, err := utils.GetAccountFromLedgerEntry(result.Entries[0])
 	if err != nil {


### PR DESCRIPTION
### What

Fixes the error handling in the GetAccountLedgerSequence function to correctly wrap ErrAccountNotFound, allowing proper error detection in the account sponsorship flow.

### Why
Currently, when creating a sponsored account via /tx/create-sponsored-account, the process fails because the error wrapping is incorrect. The error check errors.Is(err, ErrAccountNotFound) fails since the error is returned as a plain string. This fix ensures the error is properly wrapped, allowing correct handling of missing accounts.

### Known limitations

 N/A

### Issue that this PR addresses
Fixes: [rpc: Fix error wrapping chain in GetAccountLedgerSequence #136](https://github.com/stellar/wallet-backend/issues/136)
Priority: High

### Checklist

#### PR Structure

- [ ] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.
- [ ] This PR's title starts with the name of the package most changed in the PR (rpc).

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.
- [ ] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [ ] This is not a breaking change.
- [ ] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
