### PR TITLE
integrationtests: Include call to the fee bump endpoint

### DIFF
--- a/cmd/integrationtests.go
+++ b/cmd/integrationtests.go
@@ -111,6 +111,7 @@ func (c *integrationTestsCmd) Command() *cobra.Command {
 				RPCService:        rpcService,
 				WBClient:          wbClient,
 				SourceAccountKP:   sourceAccountKP,
+				DBConnectionPool:  dbConnectionPool,
 			})
 			if err != nil {
 				return fmt.Errorf("instantiating channel account services: %w", err)

--- a/internal/integrationtests/helpers.go
+++ b/internal/integrationtests/helpers.go
@@ -1,0 +1,33 @@
+package integrationtests
+
+import (
+	"fmt"
+
+	"github.com/stellar/go/txnbuild"
+)
+
+func parseTxXDR(txXDR string) (*txnbuild.Transaction, error) {
+	genericTx, err := txnbuild.TransactionFromXDR(txXDR)
+	if err != nil {
+		return nil, fmt.Errorf("building transaction from XDR: %w", err)
+	}
+
+	tx, ok := genericTx.Transaction()
+	if !ok {
+		return nil, fmt.Errorf("genericTx must be a transaction")
+	}
+	return tx, nil
+}
+
+func parseFeeBumpTxXDR(txXDR string) (*txnbuild.FeeBumpTransaction, error) {
+	genericTx, err := txnbuild.TransactionFromXDR(txXDR)
+	if err != nil {
+		return nil, fmt.Errorf("building transaction from XDR: %w", err)
+	}
+
+	feeBumpTx, ok := genericTx.FeeBump()
+	if !ok {
+		return nil, fmt.Errorf("genericTx must be a fee bump transaction")
+	}
+	return feeBumpTx, nil
+}

--- a/internal/integrationtests/integrationtests.go
+++ b/internal/integrationtests/integrationtests.go
@@ -117,8 +117,8 @@ func (it *IntegrationTests) Run(ctx context.Context) error {
 	// Step 2: call /tx/create-fee-bump for each transaction
 	fmt.Println("")
 	log.Ctx(ctx).Info("===> 2️⃣ Creating fee bump transaction...")
-	feeBumpedTxs := make([]string, len(builtTxResponse.TransactionXDRs))
-	for i, txXDR := range builtTxResponse.TransactionXDRs {
+	feeBumpedTxs := make([]string, len(signedTxXDRs))
+	for i, txXDR := range signedTxXDRs {
 		feeBumpTxResponse, err := it.WBClient.FeeBumpTransaction(ctx, txXDR)
 		if err != nil {
 			return fmt.Errorf("calling feeBumpTransaction: %w", err)

--- a/internal/integrationtests/integrationtests.go
+++ b/internal/integrationtests/integrationtests.go
@@ -54,23 +54,34 @@ type IntegrationTests struct {
 	WBClient          *wbclient.Client
 }
 
-func (i *IntegrationTests) Run(ctx context.Context) error {
+func (it *IntegrationTests) Run(ctx context.Context) error {
 	log.Ctx(ctx).Info("🆕 Starting integration tests...")
 
 	// Step 1: call /tss/transactions/build
-	log.Ctx(ctx).Info("🚧 Building transactions locally...")
-	buildTxRequest, err := i.prepareBuildTxRequest()
+	log.Ctx(ctx).Info("===> 1️⃣ Building transactions locally...")
+	buildTxRequest, err := it.prepareBuildTxRequest()
 	if err != nil {
 		return fmt.Errorf("preparing build tx request: %w", err)
 	}
 	log.Ctx(ctx).Info("⏳ Calling {WalletBackend}.BuildTransactions...")
-	builtTxResponse, err := i.WBClient.BuildTransactions(ctx, buildTxRequest.Transactions...)
+	builtTxResponse, err := it.WBClient.BuildTransactions(ctx, buildTxRequest.Transactions...)
 	if err != nil {
 		return fmt.Errorf("calling buildTransactions: %w", err)
 	}
 	log.Ctx(ctx).Infof("✅ builtTxResponse: %+v", builtTxResponse)
 
-	// TODO: feeBumpTx")
+	// Step 2: call /tx/create-fee-bump for each transaction
+	log.Ctx(ctx).Info("===> 2️⃣ Creating fee bump transaction...")
+	feeBumpedTxs := make([]string, len(builtTxResponse.TransactionXDRs))
+	for i, txXDR := range builtTxResponse.TransactionXDRs {
+		feeBumpTxResponse, err := it.WBClient.FeeBumpTransaction(ctx, txXDR)
+		if err != nil {
+			return fmt.Errorf("calling feeBumpTransaction: %w", err)
+		}
+		log.Ctx(ctx).Infof("✅ feeBumpTxResponse[%d]: %+v", i, feeBumpTxResponse)
+		feeBumpedTxs[i] = feeBumpTxResponse.Transaction
+	}
+
 	// TODO: submitTx")
 	// TODO: waitForTxToBeInLedger")
 	// TODO: verifyTxResult in wallet-backend")

--- a/internal/integrationtests/integrationtests.go
+++ b/internal/integrationtests/integrationtests.go
@@ -143,11 +143,11 @@ func assrt(condition bool, format string, args ...any) {
 	}
 }
 
-func (i *IntegrationTests) prepareBuildTxRequest() (types.BuildTransactionsRequest, error) {
+func (it *IntegrationTests) prepareBuildTxRequest() (types.BuildTransactionsRequest, error) {
 	var buildTxRequest types.BuildTransactionsRequest
 	paymentOp := &txnbuild.Payment{
-		SourceAccount: i.SourceAccountKP.Address(),
-		Destination:   i.SourceAccountKP.Address(),
+		SourceAccount: it.SourceAccountKP.Address(),
+		Destination:   it.SourceAccountKP.Address(),
 		Amount:        "10000000",
 		Asset:         txnbuild.NativeAsset{},
 	}

--- a/internal/serve/httphandler/account_handler.go
+++ b/internal/serve/httphandler/account_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stellar/wallet-backend/internal/entities"
 	"github.com/stellar/wallet-backend/internal/serve/httperror"
 	"github.com/stellar/wallet-backend/internal/services"
+	"github.com/stellar/wallet-backend/pkg/wbclient/types"
 )
 
 type AccountHandler struct {
@@ -67,15 +68,6 @@ type SponsorAccountCreationRequest struct {
 	Signers []entities.Signer `json:"signers" validate:"required,gt=0,dive"`
 }
 
-type CreateFeeBumpTransactionRequest struct {
-	Transaction string `json:"transaction" validate:"required"`
-}
-
-type TransactionEnvelopeResponse struct {
-	Transaction       string `json:"transaction"`
-	NetworkPassphrase string `json:"networkPassphrase"`
-}
-
 func (h AccountHandler) SponsorAccountCreation(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
@@ -108,7 +100,7 @@ func (h AccountHandler) SponsorAccountCreation(rw http.ResponseWriter, req *http
 		return
 	}
 
-	respBody := TransactionEnvelopeResponse{
+	respBody := types.TransactionEnvelopeResponse{
 		Transaction:       txe,
 		NetworkPassphrase: networkPassphrase,
 	}
@@ -118,7 +110,7 @@ func (h AccountHandler) SponsorAccountCreation(rw http.ResponseWriter, req *http
 func (h AccountHandler) CreateFeeBumpTransaction(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
-	var reqBody CreateFeeBumpTransactionRequest
+	var reqBody types.CreateFeeBumpTransactionRequest
 	httpErr := DecodeJSONAndValidate(ctx, req, &reqBody, h.AppTracker)
 	if httpErr != nil {
 		httpErr.Render(rw)
@@ -151,7 +143,7 @@ func (h AccountHandler) CreateFeeBumpTransaction(rw http.ResponseWriter, req *ht
 		}
 	}
 
-	respBody := TransactionEnvelopeResponse{
+	respBody := types.TransactionEnvelopeResponse{
 		Transaction:       feeBumpTxe,
 		NetworkPassphrase: networkPassphrase,
 	}

--- a/internal/tss/services/transaction_service.go
+++ b/internal/tss/services/transaction_service.go
@@ -95,10 +95,18 @@ func (t *transactionService) BuildAndSignTransactionWithChannelAccount(ctx conte
 	if timeoutInSecs <= 0 {
 		timeoutInSecs = DefaultTimeoutInSeconds
 	}
+
 	channelAccountPublicKey, err := t.ChannelAccountSignatureClient.GetAccountPublicKey(ctx, int(timeoutInSecs))
 	if err != nil {
 		return nil, fmt.Errorf("getting channel account public key: %w", err)
 	}
+
+	for _, op := range operations {
+		if op.GetSourceAccount() == channelAccountPublicKey {
+			return nil, fmt.Errorf("operation source account cannot be the channel account public key")
+		}
+	}
+
 	channelAccountSeq, err := t.RPCService.GetAccountLedgerSequence(channelAccountPublicKey)
 	if err != nil {
 		return nil, fmt.Errorf("getting ledger sequence for channel account public key %q: %w", channelAccountPublicKey, err)

--- a/internal/tss/utils/operation_builder.go
+++ b/internal/tss/utils/operation_builder.go
@@ -20,6 +20,11 @@ func BuildOperations(txOpXDRs []string) ([]txnbuild.Operation, error) {
 		if err != nil {
 			return nil, fmt.Errorf("decoding Operation FromXDR")
 		}
+
+		if op.GetSourceAccount() == "" {
+			return nil, fmt.Errorf("all operations must have a source account explicitly set")
+		}
+
 		operations = append(operations, op)
 	}
 

--- a/pkg/wbclient/client.go
+++ b/pkg/wbclient/client.go
@@ -34,17 +34,43 @@ func NewClient(baseURL string, requestSigner RequestSigner) *Client {
 
 func (c *Client) BuildTransactions(ctx context.Context, transactions ...types.Transaction) (*types.BuildTransactionsResponse, error) {
 	buildTxRequest := types.BuildTransactionsRequest{Transactions: transactions}
-	reqBody, err := json.Marshal(buildTxRequest)
+
+	resp, err := c.request(ctx, http.MethodPost, buildTransactionsPath, buildTxRequest)
 	if err != nil {
-		return nil, fmt.Errorf("marshalling request: %w", err)
+		return nil, fmt.Errorf("calling client request: %w", err)
 	}
 
-	u, err := url.JoinPath(c.BaseURL, buildTransactionsPath)
+	if c.isHTTPError(ctx, resp) {
+		return nil, c.logHTTPError(ctx, resp)
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+	defer utils.DeferredClose(ctx, resp.Body, "closing response body")
+
+	var buildTxResponse types.BuildTransactionsResponse
+	err = json.Unmarshal(respBody, &buildTxResponse)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshalling response body: %w", err)
+	}
+
+	return &buildTxResponse, nil
+}
+
+func (c *Client) request(ctx context.Context, method, path string, bodyObj any) (*http.Response, error) {
+	reqBody, err := json.Marshal(bodyObj)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling request body: %w", err)
+	}
+
+	u, err := url.JoinPath(c.BaseURL, path)
 	if err != nil {
 		return nil, fmt.Errorf("joining path: %w", err)
 	}
 
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewBuffer(reqBody))
+	request, err := http.NewRequestWithContext(ctx, method, u, bytes.NewBuffer(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
@@ -61,21 +87,23 @@ func (c *Client) BuildTransactions(ctx context.Context, transactions ...types.Tr
 		return nil, fmt.Errorf("sending request: %w", err)
 	}
 
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response body: %w", err)
-	}
-	defer utils.DeferredClose(ctx, resp.Body, "closing response body")
+	return resp, nil
+}
 
-	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("unexpected statusCode=%d, body=%s", resp.StatusCode, string(respBody))
+func (c *Client) isHTTPError(ctx context.Context, resp *http.Response) bool {
+	return resp.StatusCode >= 400
+}
+
+func (c *Client) logHTTPError(ctx context.Context, resp *http.Response) error {
+	if c.isHTTPError(ctx, resp) {
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("reading response body to log error when statusCode=%d: %w", resp.StatusCode, err)
+		}
+		defer utils.DeferredClose(ctx, resp.Body, "closing response body")
+
+		return fmt.Errorf("unexpected statusCode=%d, body=%v", resp.StatusCode, string(respBody))
 	}
 
-	var buildTxResponse types.BuildTransactionsResponse
-	err = json.Unmarshal(respBody, &buildTxResponse)
-	if err != nil {
-		return nil, fmt.Errorf("unmarshalling response body: %w", err)
-	}
-
-	return &buildTxResponse, nil
+	return nil
 }

--- a/pkg/wbclient/types/types.go
+++ b/pkg/wbclient/types/types.go
@@ -12,3 +12,12 @@ type BuildTransactionsRequest struct {
 type BuildTransactionsResponse struct {
 	TransactionXDRs []string `json:"transaction_xdrs"`
 }
+
+type CreateFeeBumpTransactionRequest struct {
+	Transaction string `json:"transaction" validate:"required"`
+}
+
+type TransactionEnvelopeResponse struct {
+	Transaction       string `json:"transaction"`
+	NetworkPassphrase string `json:"networkPassphrase"`
+}

--- a/scripts/exclude_from_coverage.sh
+++ b/scripts/exclude_from_coverage.sh
@@ -17,4 +17,5 @@ EOF
 # Usage
 exclude_terms "mock" "c.out"
 exclude_terms "mocks" "c.out"
+exclude_terms "internal/integrationtests" "c.out"
 exclude_terms "fixtures.go" "c.out"


### PR DESCRIPTION
### What

Update integration tests to include a call to the fee bump endpoint.

Also, assert that the buildTx and the feeBumpTx endpoints have the correct source account and signer.

### Why

As part of #149 

### Known limitations

The steps to be added are:
- [x] buildTx (`POST /tss/transactions/build`)
- [x] feeBumpTx (`POST /tx/create-fee-bump`)
- [ ] submitTx
- [ ] Poll the tx status from the Stellar network
- [ ] Poll the tx status from the wallet-backend (`GET /transactions/{transactionhash}`)
- [ ] Expand the number of operations being tested
- [ ] (future) webhooks

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
