### PR TITLE
integrationtests: submit tx to RPC and poll from RPC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.2
 
 require (
 	github.com/alitto/pond v1.9.2
+	github.com/avast/retry-go/v4 v4.6.1
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/dlmiddlecote/sqlstats v1.0.2
 	github.com/getsentry/sentry-go v0.29.1
@@ -20,7 +21,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/stellar/go v0.0.0-20241113194904-713725358e05
 	github.com/stellar/go-xdr v0.0.0-20231122183749-b53fb00bcac2
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.10.0
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/term v0.30.0
 )

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/avast/retry-go/v4 v4.6.1 h1:VkOLRubHdisGrHnTu89g08aQEWEgRU7LVEop3GbIcMk=
+github.com/avast/retry-go/v4 v4.6.1/go.mod h1:V6oF8njAwxJ5gRo1Q7Cxab24xs5NCWZBeaHHBklR8mA=
 github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
 github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -220,8 +222,9 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/internal/integrationtests/fixtures.go
+++ b/internal/integrationtests/fixtures.go
@@ -1,0 +1,35 @@
+package integrationtests
+
+import (
+	"fmt"
+
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/txnbuild"
+
+	"github.com/stellar/wallet-backend/pkg/utils"
+)
+
+type Fixtures struct {
+	SourceAccountKP *keypair.Full
+}
+
+// prepareClassicOps prepares a slice of strings, each representing a payment operation XDR. Currently only returns one operation (payment).
+func (f *Fixtures) prepareClassicOps() ([]string, error) {
+	paymentOp := &txnbuild.Payment{
+		SourceAccount: f.SourceAccountKP.Address(),
+		Destination:   f.SourceAccountKP.Address(),
+		Amount:        "10",
+		Asset:         txnbuild.NativeAsset{},
+	}
+
+	paymentOpXDR, err := paymentOp.BuildXDR()
+	if err != nil {
+		return nil, fmt.Errorf("building payment operation XDR: %w", err)
+	}
+	b64OpXDR, err := utils.OperationXDRToBase64(paymentOpXDR)
+	if err != nil {
+		return nil, fmt.Errorf("encoding payment operation XDR to base64: %w", err)
+	}
+
+	return []string{b64OpXDR}, nil
+}

--- a/internal/integrationtests/helpers.go
+++ b/internal/integrationtests/helpers.go
@@ -31,3 +31,27 @@ func parseFeeBumpTxXDR(txXDR string) (*txnbuild.FeeBumpTransaction, error) {
 	}
 	return feeBumpTx, nil
 }
+
+// txString returns a string representation of a transaction given its XDR.
+func txString(txXDR string) (string, error) {
+	genericTx, err := txnbuild.TransactionFromXDR(txXDR)
+	if err != nil {
+		return "", fmt.Errorf("building transaction from XDR: %w", err)
+	}
+
+	opsSliceStr := func(ops []txnbuild.Operation) []string {
+		var opsStr []string
+		for _, op := range ops {
+			opsStr = append(opsStr, fmt.Sprintf("\n\t\t%#v", op))
+		}
+		return opsStr
+	}
+
+	if tx, ok := genericTx.Transaction(); ok {
+		return fmt.Sprintf("\n\ttx=%#v, \n\tops=%+v", tx, opsSliceStr(tx.Operations())), nil
+	} else if feeBumpTx, ok := genericTx.FeeBump(); ok {
+		return fmt.Sprintf("\n\tfeeBump=%#v, \n\ttx=%#v, \n\tops=%+v", feeBumpTx, feeBumpTx.InnerTransaction(), opsSliceStr(feeBumpTx.InnerTransaction().Operations())), nil
+	}
+
+	return fmt.Sprintf("%+v", genericTx), nil
+}

--- a/internal/integrationtests/integrationtests.go
+++ b/internal/integrationtests/integrationtests.go
@@ -117,6 +117,11 @@ func (it *IntegrationTests) Run(ctx context.Context) error {
 		if innerErr != nil {
 			return fmt.Errorf("parsing transaction from XDR: %w", innerErr)
 		}
+		innerTxHash, innerErr := tx.HashHex(it.NetworkPassphrase)
+		if innerErr != nil {
+			return fmt.Errorf("hashing transaction: %w", innerErr)
+		}
+		log.Ctx(ctx).Infof("=====> innerHash: %s", innerTxHash)
 		signedTx, innerErr := tx.Sign(it.NetworkPassphrase, it.SourceAccountKP)
 		if innerErr != nil {
 			return fmt.Errorf("signing transaction: %w", innerErr)

--- a/internal/integrationtests/integrationtests.go
+++ b/internal/integrationtests/integrationtests.go
@@ -100,9 +100,9 @@ func (it *IntegrationTests) Run(ctx context.Context) error {
 	}
 	log.Ctx(ctx).Infof("✅ builtTxResponse: %+v", builtTxResponse)
 	for i, txXDR := range builtTxResponse.TransactionXDRs {
-		txString, err := txString(txXDR)
-		if err != nil {
-			return fmt.Errorf("building transaction string: %w", err)
+		txString, innerErr := txString(txXDR)
+		if innerErr != nil {
+			return fmt.Errorf("building transaction string: %w", innerErr)
 		}
 		log.Ctx(ctx).Infof("builtTx[%d]: %s", i, txString)
 	}
@@ -113,17 +113,17 @@ func (it *IntegrationTests) Run(ctx context.Context) error {
 	log.Ctx(ctx).Info("===> 3️⃣ [Local] Signing transactions...")
 	signedTxXDRs := make([]string, len(builtTxResponse.TransactionXDRs))
 	for i, txXDR := range builtTxResponse.TransactionXDRs {
-		tx, err := parseTxXDR(txXDR)
-		if err != nil {
-			return fmt.Errorf("parsing transaction from XDR: %w", err)
+		tx, innerErr := parseTxXDR(txXDR)
+		if innerErr != nil {
+			return fmt.Errorf("parsing transaction from XDR: %w", innerErr)
 		}
-		signedTx, err := tx.Sign(it.NetworkPassphrase, it.SourceAccountKP)
-		if err != nil {
-			return fmt.Errorf("signing transaction: %w", err)
+		signedTx, innerErr := tx.Sign(it.NetworkPassphrase, it.SourceAccountKP)
+		if innerErr != nil {
+			return fmt.Errorf("signing transaction: %w", innerErr)
 		}
-		signedTxXDR, err := signedTx.Base64()
-		if err != nil {
-			return fmt.Errorf("encoding transaction to base64: %w", err)
+		signedTxXDR, innerErr := signedTx.Base64()
+		if innerErr != nil {
+			return fmt.Errorf("encoding transaction to base64: %w", innerErr)
 		}
 		signedTxXDRs[i] = signedTxXDR
 	}
@@ -133,16 +133,16 @@ func (it *IntegrationTests) Run(ctx context.Context) error {
 	log.Ctx(ctx).Info("===> 4️⃣ [WalletBackend] Creating fee bump transaction...")
 	feeBumpedTxs := make([]string, len(signedTxXDRs))
 	for i, txXDR := range signedTxXDRs {
-		feeBumpTxResponse, err := it.WBClient.FeeBumpTransaction(ctx, txXDR)
-		if err != nil {
-			return fmt.Errorf("calling feeBumpTransaction: %w", err)
+		feeBumpTxResponse, innerErr := it.WBClient.FeeBumpTransaction(ctx, txXDR)
+		if innerErr != nil {
+			return fmt.Errorf("calling feeBumpTransaction: %w", innerErr)
 		}
 		log.Ctx(ctx).Infof("✅ feeBumpTxResponse[%d]: %+v", i, feeBumpTxResponse)
 		feeBumpedTxs[i] = feeBumpTxResponse.Transaction
 
-		txString, err := txString(feeBumpedTxs[i])
-		if err != nil {
-			return fmt.Errorf("building transaction string: %w", err)
+		txString, innerErr := txString(feeBumpedTxs[i])
+		if innerErr != nil {
+			return fmt.Errorf("building transaction string: %w", innerErr)
 		}
 		log.Ctx(ctx).Infof("feeBumpedTx[%d]: %s", i, txString)
 

--- a/internal/integrationtests/integrationtests.go
+++ b/internal/integrationtests/integrationtests.go
@@ -220,6 +220,7 @@ func (it *IntegrationTests) prepareBuildTxRequest() (types.BuildTransactionsRequ
 
 	buildTxRequest.Transactions = append(buildTxRequest.Transactions, types.Transaction{
 		Operations: []string{b64OpXDR},
+		TimeBounds: 300,
 	})
 
 	return buildTxRequest, nil

--- a/internal/integrationtests/integrationtests.go
+++ b/internal/integrationtests/integrationtests.go
@@ -283,30 +283,6 @@ func assertOrFail(condition bool, format string, args ...any) {
 	}
 }
 
-// txString returns a string representation of a transaction given its XDR.
-func txString(txXDR string) (string, error) {
-	genericTx, err := txnbuild.TransactionFromXDR(txXDR)
-	if err != nil {
-		return "", fmt.Errorf("building transaction from XDR: %w", err)
-	}
-
-	opsSliceStr := func(ops []txnbuild.Operation) []string {
-		var opsStr []string
-		for _, op := range ops {
-			opsStr = append(opsStr, fmt.Sprintf("\n\t\t%#v", op))
-		}
-		return opsStr
-	}
-
-	if tx, ok := genericTx.Transaction(); ok {
-		return fmt.Sprintf("\n\ttx=%#v, \n\tops=%+v", tx, opsSliceStr(tx.Operations())), nil
-	} else if feeBumpTx, ok := genericTx.FeeBump(); ok {
-		return fmt.Sprintf("\n\tfeeBump=%#v, \n\ttx=%#v, \n\tops=%+v", feeBumpTx, feeBumpTx.InnerTransaction(), opsSliceStr(feeBumpTx.InnerTransaction().Operations())), nil
-	}
-
-	return fmt.Sprintf("%+v", genericTx), nil
-}
-
 func NewIntegrationTests(ctx context.Context, opts IntegrationTestsOptions) (*IntegrationTests, error) {
 	if err := opts.Validate(); err != nil {
 		return nil, fmt.Errorf("validating integration tests options: %w", err)

--- a/internal/integrationtests/integrationtests.go
+++ b/internal/integrationtests/integrationtests.go
@@ -159,7 +159,8 @@ func (it *IntegrationTests) Run(ctx context.Context) error {
 	log.Ctx(ctx).Info("===> 6️⃣ [RPC] Submitting transactions...")
 	hashes := make([]string, len(feeBumpedTxs))
 	for i, txXDR := range feeBumpedTxs {
-		res, err := it.RPCService.SendTransaction(txXDR)
+		var res entities.RPCSendTransactionResult
+		res, err = it.RPCService.SendTransaction(txXDR)
 		if err != nil {
 			return fmt.Errorf("sending transaction %d: %w", i, err)
 		}

--- a/internal/integrationtests/integrationtests.go
+++ b/internal/integrationtests/integrationtests.go
@@ -205,7 +205,7 @@ func (it *IntegrationTests) prepareBuildTxRequest() (types.BuildTransactionsRequ
 	paymentOp := &txnbuild.Payment{
 		SourceAccount: it.SourceAccountKP.Address(),
 		Destination:   it.SourceAccountKP.Address(),
-		Amount:        "10000000",
+		Amount:        "10",
 		Asset:         txnbuild.NativeAsset{},
 	}
 

--- a/internal/integrationtests/utils.go
+++ b/internal/integrationtests/utils.go
@@ -1,0 +1,57 @@
+package integrationtests
+
+import (
+	"fmt"
+
+	"github.com/stellar/go/txnbuild"
+)
+
+func parseTxXDR(txXDR string) (*txnbuild.Transaction, error) {
+	genericTx, err := txnbuild.TransactionFromXDR(txXDR)
+	if err != nil {
+		return nil, fmt.Errorf("building transaction from XDR: %w", err)
+	}
+
+	tx, ok := genericTx.Transaction()
+	if !ok {
+		return nil, fmt.Errorf("genericTx must be a transaction")
+	}
+	return tx, nil
+}
+
+func parseFeeBumpTxXDR(txXDR string) (*txnbuild.FeeBumpTransaction, error) {
+	genericTx, err := txnbuild.TransactionFromXDR(txXDR)
+	if err != nil {
+		return nil, fmt.Errorf("building transaction from XDR: %w", err)
+	}
+
+	feeBumpTx, ok := genericTx.FeeBump()
+	if !ok {
+		return nil, fmt.Errorf("genericTx must be a fee bump transaction")
+	}
+	return feeBumpTx, nil
+}
+
+// txString returns a string representation of a transaction given its XDR.
+func txString(txXDR string) (string, error) {
+	genericTx, err := txnbuild.TransactionFromXDR(txXDR)
+	if err != nil {
+		return "", fmt.Errorf("building transaction from XDR: %w", err)
+	}
+
+	opsSliceStr := func(ops []txnbuild.Operation) []string {
+		var opsStr []string
+		for _, op := range ops {
+			opsStr = append(opsStr, fmt.Sprintf("\n\t\t%#v", op))
+		}
+		return opsStr
+	}
+
+	if tx, ok := genericTx.Transaction(); ok {
+		return fmt.Sprintf("\n\ttx=%#v, \n\tops=%+v", tx, opsSliceStr(tx.Operations())), nil
+	} else if feeBumpTx, ok := genericTx.FeeBump(); ok {
+		return fmt.Sprintf("\n\tfeeBump=%#v, \n\ttx=%#v, \n\tops=%+v", feeBumpTx, feeBumpTx.InnerTransaction(), opsSliceStr(feeBumpTx.InnerTransaction().Operations())), nil
+	}
+
+	return fmt.Sprintf("%+v", genericTx), nil
+}

--- a/pkg/wbclient/client.go
+++ b/pkg/wbclient/client.go
@@ -8,10 +8,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
-	"github.com/stellar/wallet-backend/internal/tss"
 	"github.com/stellar/wallet-backend/internal/utils"
 	"github.com/stellar/wallet-backend/pkg/wbclient/types"
 )
@@ -19,7 +17,6 @@ import (
 const (
 	buildTransactionsPath        = "/tss/transactions/build"
 	createFeeBumpTransactionPath = "/tx/create-fee-bump"
-	getTransactionPath           = "/tss/transactions"
 )
 
 type Client struct {
@@ -90,27 +87,6 @@ func (c *Client) FeeBumpTransaction(ctx context.Context, transactionXDR string) 
 	}
 
 	return feeBumpTxResponse, nil
-}
-
-func (c *Client) GetTransaction(ctx context.Context, hash string) (*tss.TSSResponse, error) {
-	hash = strings.ToLower(strings.TrimSpace(hash))
-	path := fmt.Sprintf("%s/%s", getTransactionPath, hash)
-
-	resp, err := c.request(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, fmt.Errorf("calling client request: %w", err)
-	}
-
-	if c.isHTTPError(resp) {
-		return nil, c.logHTTPError(ctx, resp)
-	}
-
-	tssResponse, err := parseResponseBody[tss.TSSResponse](ctx, resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("parsing response body: %w", err)
-	}
-
-	return tssResponse, nil
 }
 
 func (c *Client) request(ctx context.Context, method, path string, bodyObj any) (*http.Response, error) {


### PR DESCRIPTION
### What

Update integration tests to submit the transaction to the RPC and poll the RPC waiting for a successful response.

### Why

As part of #149

### Known limitations

The steps to be added are:
- [x] buildTx (`POST /tss/transactions/build`)
- [x] feeBumpTx (`POST /tx/create-fee-bump`)
- [x] submitTx
- [x] Poll the tx status from the Stellar network
- [ ] Poll the tx status from the wallet-backend (`GET /transactions/{transactionhash}`)
- [ ] Expand the number of operations being tested
- [ ] (future) webhooks

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
