### PR TITLE
channels: fix usage of the `%e` verb by replacing it with `%w`

### DIFF
--- a/internal/tss/channels/webhook_channel.go
+++ b/internal/tss/channels/webhook_channel.go
@@ -79,15 +79,14 @@ func (p *webhookPool) Receive(payload tss.Payload) {
 		log.Error(err)
 		return
 	}
-	var i int
-	sent := false
+	var sent bool
 	ctx := context.Background()
 	err = p.UnlockChannelAccount(ctx, payload.TransactionXDR)
 	if err != nil {
 		err = fmt.Errorf("[%s] error unlocking channel account from transaction: %w", WebhookChannelName, err)
 		log.Error(err)
 	}
-	for i = 0; i < p.MaxRetries; i++ {
+	for i := range p.MaxRetries {
 		httpResp, err := p.HTTPClient.Post(payload.WebhookURL, "application/json", bytes.NewBuffer(jsonData))
 		if err != nil {
 			err = fmt.Errorf("[%s] error making POST request to webhook: %w", WebhookChannelName, err)

--- a/internal/tss/services/transaction_manager.go
+++ b/internal/tss/services/transaction_manager.go
@@ -90,7 +90,7 @@ func (t *transactionManager) BuildAndSubmitTransaction(ctx context.Context, chan
 		return rpcSendResp, fmt.Errorf("%s: RPC fail: %w", channelName, parseErr)
 	}
 
-	if parseErr != nil && rpcSendResp.Code.OtherCodes == tss.RPCFailCode || rpcSendResp.Code.OtherCodes == tss.UnmarshalBinaryCode {
+	if rpcSendResp.Code.OtherCodes == tss.RPCFailCode || rpcSendResp.Code.OtherCodes == tss.UnmarshalBinaryCode {
 		return tss.RPCSendTxResponse{}, fmt.Errorf("%s: RPC fail: %w", channelName, rpcErr)
 	}
 


### PR DESCRIPTION
### What

Replace `%e` verb with `%w`.

### Why

`%e` is a formatting verb used to format floating-point numbers in scientific notation, while errors use `%w` when wrapped or `%v` when logged.

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
