### PR TITLE
services: fix ingestor not catching-up

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -69,7 +69,6 @@ func setupDeps(cfg Configs) (services.IngestService, error) {
 	if err != nil {
 		return nil, fmt.Errorf("instantiating rpc service: %w", err)
 	}
-	go rpcService.TrackRPCServiceHealth(context.Background())
 	tssStore, err := tssstore.NewStore(dbConnectionPool, metricsService)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating tss store: %w", err)

--- a/internal/integrationtests/integrationtests.go
+++ b/internal/integrationtests/integrationtests.go
@@ -313,7 +313,7 @@ func NewIntegrationTests(ctx context.Context, opts IntegrationTestsOptions) (*In
 		return nil, fmt.Errorf("validating integration tests options: %w", err)
 	}
 
-	go opts.RPCService.TrackRPCServiceHealth(ctx)
+	go opts.RPCService.TrackRPCServiceHealth(ctx, nil)
 
 	fixtures := Fixtures{
 		NetworkPassphrase:  opts.NetworkPassphrase,

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -155,7 +155,7 @@ func initHandlerDeps(ctx context.Context, cfg Configs) (handlerDeps, error) {
 	if err != nil {
 		return handlerDeps{}, fmt.Errorf("instantiating rpc service: %w", err)
 	}
-	go rpcService.TrackRPCServiceHealth(ctx)
+	go rpcService.TrackRPCServiceHealth(ctx, nil)
 
 	channelAccountStore := store.NewChannelAccountModel(dbConnectionPool)
 

--- a/internal/services/channel_account_service.go
+++ b/internal/services/channel_account_service.go
@@ -250,7 +250,7 @@ func NewChannelAccountService(ctx context.Context, opts ChannelAccountServiceOpt
 		return nil, fmt.Errorf("validating channel account service options: %w", err)
 	}
 
-	go opts.RPCService.TrackRPCServiceHealth(ctx)
+	go opts.RPCService.TrackRPCServiceHealth(ctx, nil)
 
 	return &channelAccountService{
 		DB:                                 opts.DB,

--- a/internal/services/channel_account_service_test.go
+++ b/internal/services/channel_account_service_test.go
@@ -31,7 +31,7 @@ func TestChannelAccountServiceEnsureChannelAccounts(t *testing.T) {
 	ctx := context.Background()
 	heartbeatChan := make(chan entities.RPCGetHealthResult, 1)
 	mockRPCService := RPCServiceMock{}
-	mockRPCService.On("TrackRPCServiceHealth", ctx).Return()
+	mockRPCService.On("TrackRPCServiceHealth", ctx, mock.Anything).Return()
 	signatureClient := signing.SignatureClientMock{}
 	channelAccountStore := store.ChannelAccountStoreMock{}
 	privateKeyEncrypter := signingutils.DefaultPrivateKeyEncrypter{}
@@ -303,7 +303,7 @@ func TestSubmitTransaction(t *testing.T) {
 
 	ctx := context.Background()
 	mockRPCService := RPCServiceMock{}
-	mockRPCService.On("TrackRPCServiceHealth", ctx).Return()
+	mockRPCService.On("TrackRPCServiceHealth", ctx, mock.Anything).Return()
 	defer mockRPCService.AssertExpectations(t)
 	signatureClient := signing.SignatureClientMock{}
 	channelAccountStore := store.ChannelAccountStoreMock{}
@@ -360,7 +360,7 @@ func TestWaitForTransactionConfirmation(t *testing.T) {
 	ctx := context.Background()
 	mockRPCService := RPCServiceMock{}
 	defer mockRPCService.AssertExpectations(t)
-	mockRPCService.On("TrackRPCServiceHealth", ctx).Return()
+	mockRPCService.On("TrackRPCServiceHealth", ctx, mock.Anything).Return()
 	signatureClient := signing.SignatureClientMock{}
 	channelAccountStore := store.ChannelAccountStoreMock{}
 	privateKeyEncrypter := signingutils.DefaultPrivateKeyEncrypter{}

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -89,6 +89,8 @@ func NewIngestService(
 }
 
 func (m *ingestService) Run(ctx context.Context, startLedger uint32, endLedger uint32) error {
+	manualTriggerChannel := make(chan any, 1)
+	go m.rpcService.TrackRPCServiceHealth(ctx, manualTriggerChannel)
 	ingestHeartbeatChannel := make(chan any, 1)
 	rpcHeartbeatChannel := m.rpcService.GetHeartbeatChannel()
 	go trackIngestServiceHealth(ctx, ingestHeartbeatChannel, m.appTracker)
@@ -149,6 +151,7 @@ func (m *ingestService) Run(ctx context.Context, startLedger uint32, endLedger u
 			}
 			m.metricsService.SetLatestLedgerIngested(float64(ingestLedger))
 			m.metricsService.ObserveIngestionDuration(totalIngestionPrometheusLabel, time.Since(start).Seconds())
+			manualTriggerChannel <- true
 
 			ingestLedger++
 		}

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -122,7 +122,7 @@ func (m *ingestService) Run(ctx context.Context, startLedger uint32, endLedger u
 				time.Sleep(5 * time.Second)
 				continue
 			}
-			log.Ctx(ctx).Infof("ingesting ledger: %d", ingestLedger)
+			log.Ctx(ctx).Infof("ingesting ledger: %d, oldest: %d, latest: %d", ingestLedger, resp.OldestLedger, resp.LatestLedger)
 
 			start := time.Now()
 			ledgerTransactions, err := m.GetLedgerTransactions(int64(ingestLedger))
@@ -151,7 +151,9 @@ func (m *ingestService) Run(ctx context.Context, startLedger uint32, endLedger u
 			}
 			m.metricsService.SetLatestLedgerIngested(float64(ingestLedger))
 			m.metricsService.ObserveIngestionDuration(totalIngestionPrometheusLabel, time.Since(start).Seconds())
-			manualTriggerChannel <- true
+			if resp.LatestLedger-ingestLedger > 1 {
+				manualTriggerChannel <- true
+			}
 
 			ingestLedger++
 		}

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -460,6 +460,7 @@ func TestIngest_LatestSyncedLedgerBehindRPC(t *testing.T) {
 	require.NoError(t, err)
 	mockAppTracker := apptracker.MockAppTracker{}
 	mockRPCService := RPCServiceMock{}
+	mockRPCService.On("TrackRPCServiceHealth", ctx, mock.Anything).Once()
 	mockRouter := tssrouter.MockRouter{}
 
 	tssStore, err := tssstore.NewStore(dbConnectionPool, mockMetricsService)
@@ -548,6 +549,7 @@ func TestIngest_LatestSyncedLedgerAheadOfRPC(t *testing.T) {
 	require.NoError(t, err)
 	mockAppTracker := apptracker.MockAppTracker{}
 	mockRPCService := RPCServiceMock{}
+	mockRPCService.On("TrackRPCServiceHealth", ctx, mock.Anything).Once()
 	mockRouter := tssrouter.MockRouter{}
 
 	tssStore, err := tssstore.NewStore(dbConnectionPool, mockMetricsService)

--- a/internal/services/mocks.go
+++ b/internal/services/mocks.go
@@ -16,8 +16,8 @@ type RPCServiceMock struct {
 
 var _ RPCService = (*RPCServiceMock)(nil)
 
-func (r *RPCServiceMock) TrackRPCServiceHealth(ctx context.Context) {
-	r.Called(ctx)
+func (r *RPCServiceMock) TrackRPCServiceHealth(ctx context.Context, triggerHeartbeat chan any) {
+	r.Called(ctx, triggerHeartbeat)
 }
 
 func (r *RPCServiceMock) GetHeartbeatChannel() chan entities.RPCGetHealthResult {

--- a/internal/services/rpc_service.go
+++ b/internal/services/rpc_service.go
@@ -31,6 +31,11 @@ type RPCService interface {
 	GetLedgerEntries(keys []string) (entities.RPCGetLedgerEntriesResult, error)
 	GetAccountLedgerSequence(address string) (int64, error)
 	GetHeartbeatChannel() chan entities.RPCGetHealthResult
+	// TrackRPCServiceHealth monitors the health of the RPC service.
+	//
+	// The `triggerHeartbeat` parameter is a channel that can be used to force the
+	// health check to run. This is useful when the ingestor is behind the RPC and
+	// needs to catch up.
 	TrackRPCServiceHealth(ctx context.Context, triggerHeartbeat chan any)
 	SimulateTransaction(transactionXDR string, resourceConfig entities.RPCResourceConfig) (entities.RPCSimulateTransactionResult, error)
 }
@@ -242,6 +247,7 @@ func (r *rpcService) TrackRPCServiceHealth(ctx context.Context, triggerHeartbeat
 			warningTicker.Reset(r.HealthCheckWarningInterval())
 		case <-healthCheckTicker.C:
 			executeHealthCheck()
+		// If triggerHeartbeat is nil, this case will never trigger.
 		case <-triggerHeartbeat:
 			healthCheckTicker.Reset(r.HealthCheckTickInterval())
 			executeHealthCheck()

--- a/internal/services/rpc_service_test.go
+++ b/internal/services/rpc_service_test.go
@@ -788,7 +788,7 @@ func TestTrackRPCServiceHealth_UnhealthyService(t *testing.T) {
 	logMessages := []string{}
 	for _, entry := range entries {
 		logMessages = append(logMessages, entry.Message)
-		if strings.Contains(entry.Message, "rpc service unhealthy for over "+healthCheckWarningInterval.String()) {
+		if strings.Contains(entry.Message, "RPC service unhealthy for over "+healthCheckWarningInterval.String()) {
 			testSucceeded = true
 			break
 		}

--- a/internal/services/rpc_service_test.go
+++ b/internal/services/rpc_service_test.go
@@ -716,7 +716,7 @@ func TestTrackRPCServiceHealth_HealthyService(t *testing.T) {
 	mockHTTPClient.On("Post", rpcURL, "application/json", mock.Anything).Return(mockResponse, nil).Run(func(args mock.Arguments) {
 		cancel()
 	})
-	rpcService.TrackRPCServiceHealth(ctx)
+	rpcService.TrackRPCServiceHealth(ctx, nil)
 
 	// Get result from heartbeat channel
 	select {
@@ -781,7 +781,7 @@ func TestTrackRPCServiceHealth_UnhealthyService(t *testing.T) {
 		Return(mockResponse, nil)
 
 	// The ctx will timeout after {contextTimeout}, which is enough for the warning to trigger
-	rpcService.TrackRPCServiceHealth(ctx)
+	rpcService.TrackRPCServiceHealth(ctx, nil)
 
 	entries := getLogs()
 	testSucceeded := false
@@ -812,7 +812,7 @@ func TestTrackRPCService_ContextCancelled(t *testing.T) {
 	rpcService, err := NewRPCService(rpcURL, mockHTTPClient, mockMetricsService)
 	require.NoError(t, err)
 
-	rpcService.TrackRPCServiceHealth(ctx)
+	rpcService.TrackRPCServiceHealth(ctx, nil)
 
 	// Verify channel is closed after context cancellation
 	time.Sleep(100 * time.Millisecond)

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -63,34 +63,37 @@ func TestIsEmpty(t *testing.T) {
 	// Define test cases
 	testCases := []testCase{
 		// String
-		{name: "String empty", isEmptyFn: func() bool { return IsEmpty[string]("") }, expected: true},
-		{name: "String non-empty", isEmptyFn: func() bool { return IsEmpty[string]("not empty") }, expected: false},
+		{name: "*String nil", isEmptyFn: func() bool { return IsEmpty[*string](nil) }, expected: true},
+		{name: "String empty", isEmptyFn: func() bool { return IsEmpty("") }, expected: true},
+		{name: "String non-empty", isEmptyFn: func() bool { return IsEmpty("not empty") }, expected: false},
 		// Int
-		{name: "Int zero", isEmptyFn: func() bool { return IsEmpty[int](0) }, expected: true},
-		{name: "Int non-zero", isEmptyFn: func() bool { return IsEmpty[int](1) }, expected: false},
+		{name: "*Int nil", isEmptyFn: func() bool { return IsEmpty[*int](nil) }, expected: true},
+		{name: "Int zero", isEmptyFn: func() bool { return IsEmpty(0) }, expected: true},
+		{name: "Int non-zero", isEmptyFn: func() bool { return IsEmpty(1) }, expected: false},
 		// Slice:
 		{name: "Slice nil", isEmptyFn: func() bool { return IsEmpty[[]string](nil) }, expected: true},
-		{name: "Slice empty", isEmptyFn: func() bool { return IsEmpty[[]string]([]string{}) }, expected: false},
-		{name: "Slice non-empty", isEmptyFn: func() bool { return IsEmpty[[]string]([]string{"not empty"}) }, expected: false},
+		{name: "Slice empty", isEmptyFn: func() bool { return IsEmpty([]string{}) }, expected: false},
+		{name: "Slice non-empty", isEmptyFn: func() bool { return IsEmpty([]string{"not empty"}) }, expected: false},
 		// Struct:
-		{name: "Struct zero", isEmptyFn: func() bool { return IsEmpty[testStruct](testStruct{}) }, expected: true},
-		{name: "Struct non-zero", isEmptyFn: func() bool { return IsEmpty[testStruct](testStruct{Name: "not empty"}) }, expected: false},
+		{name: "*Struct nil", isEmptyFn: func() bool { return IsEmpty[*testStruct](nil) }, expected: true},
+		{name: "Struct zero", isEmptyFn: func() bool { return IsEmpty(testStruct{}) }, expected: true},
+		{name: "Struct non-zero", isEmptyFn: func() bool { return IsEmpty(testStruct{Name: "not empty"}) }, expected: false},
 		// Pointer:
 		{name: "Pointer nil", isEmptyFn: func() bool { return IsEmpty[*string](nil) }, expected: true},
-		{name: "Pointer non-nil", isEmptyFn: func() bool { return IsEmpty[*string](new(string)) }, expected: false},
+		{name: "Pointer non-nil", isEmptyFn: func() bool { return IsEmpty(new(string)) }, expected: false},
 		// Function:
 		{name: "Function nil", isEmptyFn: func() bool { return IsEmpty[func() string](nil) }, expected: true},
-		{name: "Function non-nil", isEmptyFn: func() bool { return IsEmpty[func() string](func() string { return "not empty" }) }, expected: false},
-		// Interface:
-		{name: "Interface nil", isEmptyFn: func() bool { return IsEmpty[interface{}](nil) }, expected: true},
-		{name: "Interface non-nil", isEmptyFn: func() bool { return IsEmpty[interface{}](new(string)) }, expected: false},
+		{name: "Function non-nil", isEmptyFn: func() bool { return IsEmpty(func() string { return "not empty" }) }, expected: false},
+		// Any/interface{}:
+		{name: "Any/interface{} nil", isEmptyFn: func() bool { return IsEmpty[any](nil) }, expected: true},
+		{name: "Any/interface{} non-nil", isEmptyFn: func() bool { return IsEmpty[any](new(string)) }, expected: false},
 		// Map:
 		{name: "Map nil", isEmptyFn: func() bool { return IsEmpty[map[string]string](nil) }, expected: true},
-		{name: "Map empty", isEmptyFn: func() bool { return IsEmpty[map[string]string](map[string]string{}) }, expected: false},
-		{name: "Map non-empty", isEmptyFn: func() bool { return IsEmpty[map[string]string](map[string]string{"not empty": "not empty"}) }, expected: false},
+		{name: "Map empty", isEmptyFn: func() bool { return IsEmpty(map[string]string{}) }, expected: false},
+		{name: "Map non-empty", isEmptyFn: func() bool { return IsEmpty(map[string]string{"not empty": "not empty"}) }, expected: false},
 		// Channel:
 		{name: "Channel nil", isEmptyFn: func() bool { return IsEmpty[chan string](nil) }, expected: true},
-		{name: "Channel non-nil", isEmptyFn: func() bool { return IsEmpty[chan string](make(chan string)) }, expected: false},
+		{name: "Channel non-nil", isEmptyFn: func() bool { return IsEmpty(make(chan string)) }, expected: false},
 	}
 
 	// Run test cases


### PR DESCRIPTION
### What

Upgrade the ingestor triggers, so it can catch up to the latest ledger, if outdated.

### Why

The ingestor was depending oin the health check, that happens every ~5s, which is about the same period of the consensus. This means that if the service got downtime, it would never catch up to the latest ledger.

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
