### PR TITLE
services: channel accounts are now created using sponsored reserves and balance=0

### DIFF
--- a/internal/services/mocks.go
+++ b/internal/services/mocks.go
@@ -60,6 +60,20 @@ func (r *RPCServiceMock) SimulateTransaction(transactionXDR string, resourceConf
 	return args.Get(0).(entities.RPCSimulateTransactionResult), args.Error(1)
 }
 
+// NewRPCServiceMock creates a new instance of RPCServiceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewRPCServiceMock(t interface {
+	mock.TestingT
+	Cleanup(func())
+}) *RPCServiceMock {
+	mock := &RPCServiceMock{}
+	mock.Mock.Test(t)
+
+	t.Cleanup(func() { mock.AssertExpectations(t) })
+
+	return mock
+}
+
 type AccountSponsorshipServiceMock struct {
 	mock.Mock
 }

--- a/internal/signing/mocks.go
+++ b/internal/signing/mocks.go
@@ -42,3 +42,17 @@ func (s *SignatureClientMock) SignStellarFeeBumpTransaction(ctx context.Context,
 	}
 	return args.Get(0).(*txnbuild.FeeBumpTransaction), args.Error(1)
 }
+
+// NewSignatureClientMock creates a new instance of SignatureClientMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewSignatureClientMock(t interface {
+	mock.TestingT
+	Cleanup(func())
+}) *SignatureClientMock {
+	mock := &SignatureClientMock{}
+	mock.Mock.Test(t)
+
+	t.Cleanup(func() { mock.AssertExpectations(t) })
+
+	return mock
+}

--- a/internal/signing/store/mocks.go
+++ b/internal/signing/store/mocks.go
@@ -77,3 +77,17 @@ func (s *KeypairStoreMock) Insert(ctx context.Context, publicKey string, encrypt
 	args := s.Called(ctx, publicKey, encryptedPrivateKey)
 	return args.Error(0)
 }
+
+// NewChannelAccountStoreMock creates a new instance of ChannelAccountStoreMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewChannelAccountStoreMock(t interface {
+	mock.TestingT
+	Cleanup(func())
+}) *ChannelAccountStoreMock {
+	mock := &ChannelAccountStoreMock{}
+	mock.Mock.Test(t)
+
+	t.Cleanup(func() { mock.AssertExpectations(t) })
+
+	return mock
+}


### PR DESCRIPTION
### What

Channel accounts are now created with sponsored reserves.

### Why

Channel accounts should have zero balance.

### Issue that this PR addresses

Closes #175 

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
