### PR TITLE
{ingestor, store}: eagerly unlock channel accounts when their txHash is ingested

### DIFF
--- a/cmd/channel_account.go
+++ b/cmd/channel_account.go
@@ -104,7 +104,7 @@ func (c *channelAccountCmd) Command(cmdService ChAccCmdServiceInterface) *cobra.
 			}
 			metricsService := metrics.NewMetricsService(db)
 			httpClient := http.Client{Timeout: time.Duration(30 * time.Second)}
-			rpcService, err := services.NewRPCService(cfg.RPCURL, &httpClient, metricsService)
+			rpcService, err := services.NewRPCService(cfg.RPCURL, cfg.NetworkPassphrase, &httpClient, metricsService)
 			if err != nil {
 				return fmt.Errorf("instantiating rpc service: %w", err)
 			}

--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -35,6 +35,7 @@ func (c *ingestCmd) Command() *cobra.Command {
 		utils.WebhookHandlerChannelMaxWorkersOptions(&cfg.WebhookChannelMaxWorkers),
 		utils.WebhookHandlerChannelMaxRetriesOption(&cfg.WebhookChannelMaxRetries),
 		utils.WebhookHandlerChannelMinWaitBtwnRetriesMSOption(&cfg.WebhookChannelWaitBtwnTriesMS),
+		utils.NetworkPassphraseOption(&cfg.NetworkPassphrase),
 		{
 			Name:        "ledger-cursor-name",
 			Usage:       "Name of last synced ledger cursor, used to keep track of the last ledger ingested by the service. When starting up, ingestion will resume from the ledger number stored in this record. It should be an unique name per container as different containers would overwrite the cursor value of its peers when using the same cursor name.",

--- a/cmd/integrationtests.go
+++ b/cmd/integrationtests.go
@@ -109,7 +109,7 @@ func (c *integrationTestsCmd) Command() *cobra.Command {
 			metricsService := metrics.NewMetricsService(db)
 
 			httpClient := http.Client{Timeout: time.Duration(30 * time.Second)}
-			rpcService, err := services.NewRPCService(cfg.RPCURL, &httpClient, metricsService)
+			rpcService, err := services.NewRPCService(cfg.RPCURL, cfg.NetworkPassphrase, &httpClient, metricsService)
 			if err != nil {
 				return fmt.Errorf("instantiating rpc service: %w", err)
 			}

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stellar/wallet-backend/internal/db"
 	"github.com/stellar/wallet-backend/internal/metrics"
 	"github.com/stellar/wallet-backend/internal/services"
+	"github.com/stellar/wallet-backend/internal/signing/store"
 	"github.com/stellar/wallet-backend/internal/tss"
 	tssrouter "github.com/stellar/wallet-backend/internal/tss/router"
 	tssstore "github.com/stellar/wallet-backend/internal/tss/store"
@@ -74,6 +75,7 @@ func setupDeps(cfg Configs) (services.IngestService, error) {
 	if err != nil {
 		return nil, fmt.Errorf("instantiating tss store: %w", err)
 	}
+	chAccStore := store.NewChannelAccountModel(dbConnectionPool)
 	tssRouterConfig := tssrouter.RouterConfigs{
 		WebhookChannel: cfg.WebhookChannel,
 	}
@@ -81,7 +83,7 @@ func setupDeps(cfg Configs) (services.IngestService, error) {
 	router := tssrouter.NewRouter(tssRouterConfig)
 
 	ingestService, err := services.NewIngestService(
-		models, cfg.LedgerCursorName, cfg.AppTracker, rpcService, router, tssStore, metricsService)
+		models, cfg.LedgerCursorName, cfg.AppTracker, rpcService, router, tssStore, chAccStore, metricsService)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating ingest service: %w", err)
 	}

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -28,6 +28,7 @@ type Configs struct {
 	LogLevel                      logrus.Level
 	AppTracker                    apptracker.AppTracker
 	RPCURL                        string
+	NetworkPassphrase             string
 	WebhookChannelMaxBufferSize   int
 	WebhookChannelMaxWorkers      int
 	WebhookChannelMaxRetries      int
@@ -65,7 +66,7 @@ func setupDeps(cfg Configs) (services.IngestService, error) {
 		return nil, fmt.Errorf("creating models: %w", err)
 	}
 	httpClient := &http.Client{Timeout: 30 * time.Second}
-	rpcService, err := services.NewRPCService(cfg.RPCURL, httpClient, metricsService)
+	rpcService, err := services.NewRPCService(cfg.RPCURL, cfg.NetworkPassphrase, httpClient, metricsService)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating rpc service: %w", err)
 	}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -151,7 +151,7 @@ func initHandlerDeps(ctx context.Context, cfg Configs) (handlerDeps, error) {
 	requestAuthVerifier := auth.NewHTTPRequestVerifier(jwtTokenParser, auth.DefaultMaxBodySize)
 
 	httpClient := http.Client{Timeout: time.Duration(30 * time.Second)}
-	rpcService, err := services.NewRPCService(cfg.RPCURL, &httpClient, metricsService)
+	rpcService, err := services.NewRPCService(cfg.RPCURL, cfg.NetworkPassphrase, &httpClient, metricsService)
 	if err != nil {
 		return handlerDeps{}, fmt.Errorf("instantiating rpc service: %w", err)
 	}

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -298,11 +298,12 @@ func (m *ingestService) processTSSTransactions(ctx context.Context, ledgerTransa
 		if err != nil {
 			return fmt.Errorf("extracting inner tx hash: %w", err)
 		}
-		err = m.chAccStore.UnassignTxAndUnlockChannelAccounts(ctx, innerTxHash)
+		rowsAffected, err := m.chAccStore.UnassignTxAndUnlockChannelAccounts(ctx, innerTxHash)
 		if err != nil {
 			return fmt.Errorf("unlocking channel account with txHash %s: %w", innerTxHash, err)
+		} else if rowsAffected > 0 {
+			log.Ctx(ctx).Infof("unlocked channel account with txHash %s", innerTxHash)
 		}
-		log.Ctx(ctx).Infof("unlocked channel account with txHash %s", innerTxHash)
 		if !tx.FeeBump {
 			// because all transactions submitted by TSS are fee bump transactions
 			continue

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -141,23 +141,34 @@ func (m *ingestService) Run(ctx context.Context, startLedger uint32, endLedger u
 			startTime := time.Now()
 			err = m.ingestPayments(ctx, ledgerTransactions)
 			if err != nil {
-				return fmt.Errorf("error ingesting payments: %w", err)
+				return fmt.Errorf("ingesting payments: %w", err)
 			}
 			m.metricsService.ObserveIngestionDuration(paymentPrometheusLabel, time.Since(startTime).Seconds())
 
 			startTime = time.Now()
+
+			// eagerly unlock channel accounts from txs
+			err = m.unlockChannelAccounts(ctx, ledgerTransactions)
+			if err != nil {
+				return fmt.Errorf("unlocking channel account from tx: %w", err)
+			}
+
+			// process tss transactions
 			err = m.processTSSTransactions(ctx, ledgerTransactions)
 			if err != nil {
-				return fmt.Errorf("error processing tss transactions: %w", err)
+				return fmt.Errorf("processing tss transactions: %w", err)
 			}
 			m.metricsService.ObserveIngestionDuration(tssPrometheusLabel, time.Since(startTime).Seconds())
 
+			// update cursor
 			err = m.models.Payments.UpdateLatestLedgerSynced(ctx, m.ledgerCursorName, ingestLedger)
 			if err != nil {
-				return fmt.Errorf("error updating latest synced ledger: %w", err)
+				return fmt.Errorf("updating latest synced ledger: %w", err)
 			}
 			m.metricsService.SetLatestLedgerIngested(float64(ingestLedger))
 			m.metricsService.ObserveIngestionDuration(totalIngestionPrometheusLabel, time.Since(start).Seconds())
+
+			// immediately trigger the next ingestion the wallet-backend is behind the RPC's latest ledger
 			if resp.LatestLedger-ingestLedger > 1 {
 				manualTriggerChannel <- true
 			}
@@ -267,10 +278,6 @@ func (m *ingestService) processTSSTransactions(ctx context.Context, ledgerTransa
 	statusCounts := make(map[string]float64)
 
 	for _, tx := range ledgerTransactions {
-		err := m.unlockChannelAccountFromTx(ctx, tx.EnvelopeXDR)
-		if err != nil {
-			return fmt.Errorf("error unlocking channel account from tx: %w", err)
-		}
 		if !tx.FeeBump {
 			// because all transactions submitted by TSS are fee bump transactions
 			continue
@@ -338,31 +345,41 @@ func (m *ingestService) processTSSTransactions(ctx context.Context, ledgerTransa
 	return nil
 }
 
-// unlockChannelAccountFromTx unlocks the channel account associated with the given transaction XDR.
-func (m *ingestService) unlockChannelAccountFromTx(ctx context.Context, txXDR string) error {
-	innerTxHash, err := m.extractInnerTxHash(txXDR)
-	if err != nil {
-		return fmt.Errorf("extracting inner tx hash: %w", err)
+// unlockChannelAccounts unlocks the channel accounts associated with the given transaction XDRs.
+func (m *ingestService) unlockChannelAccounts(ctx context.Context, ledgerTransactions []entities.Transaction) error {
+	if len(ledgerTransactions) == 0 {
+		log.Ctx(ctx).Debug("no transactions to unlock channel accounts from")
+		return nil
 	}
 
-	if rowsAffected, err := m.chAccStore.UnassignTxAndUnlockChannelAccounts(ctx, innerTxHash); err != nil {
-		return fmt.Errorf("unlocking channel account with txHash %s: %w", innerTxHash, err)
-	} else if rowsAffected > 0 {
-		log.Ctx(ctx).Infof("unlocked channel account with txHash %s", innerTxHash)
+	innerTxHashes := make([]string, 0, len(ledgerTransactions))
+	for _, tx := range ledgerTransactions {
+		if innerTxHash, err := m.extractInnerTxHash(tx.EnvelopeXDR); err != nil {
+			return fmt.Errorf("extracting inner tx hash: %w", err)
+		} else {
+			innerTxHashes = append(innerTxHashes, innerTxHash)
+		}
+	}
+
+	if affectedRows, err := m.chAccStore.UnassignTxAndUnlockChannelAccounts(ctx, innerTxHashes...); err != nil {
+		return fmt.Errorf("unlocking channel accounts with txHashes %v: %w", innerTxHashes, err)
+	} else if affectedRows > 0 {
+		log.Ctx(ctx).Infof("unlocked %d channel accounts", affectedRows)
 	}
 
 	return nil
 }
 
-// extractInnerTxHash receives a transaction XDR, either feeBump or regular, and returns the hash of the inner transaction.
+// extractInnerTxHash takes a transaction XDR string and returns the hash of its inner transaction.
+// For fee bump transactions, it returns the hash of the inner transaction.
+// For regular transactions, it returns the hash of the transaction itself.
 func (m *ingestService) extractInnerTxHash(txXDR string) (string, error) {
 	genericTx, err := txnbuild.TransactionFromXDR(txXDR)
 	if err != nil {
-		return "", fmt.Errorf("deserializing envelope xdr: %w", err)
+		return "", fmt.Errorf("deserializing envelope xdr %q: %w", txXDR, err)
 	}
 
 	var innerTx *txnbuild.Transaction
-
 	feeBumpTx, ok := genericTx.FeeBump()
 	if ok {
 		innerTx = feeBumpTx.InnerTransaction()
@@ -375,7 +392,7 @@ func (m *ingestService) extractInnerTxHash(txXDR string) (string, error) {
 
 	innerTxHash, err := innerTx.HashHex(m.rpcService.NetworkPassphrase())
 	if err != nil {
-		return "", fmt.Errorf("generating hashHex: %w", err)
+		return "", fmt.Errorf("generating hash hex: %w", err)
 	}
 
 	return innerTxHash, nil

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -88,6 +88,7 @@ func NewIngestService(
 	}, nil
 }
 
+// extractInnerTxHash receives a transaction XDR, either feeBump or regular, and returns the hash of the inner transaction.
 func (m *ingestService) extractInnerTxHash(txXDR string) (string, error) {
 	genericTx, err := txnbuild.TransactionFromXDR(txXDR)
 	if err != nil {

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -171,7 +171,7 @@ func TestProcessTSSTransactions(t *testing.T) {
 		mockMetricsService.On("SetNumTssTransactionsIngestedPerLedger", "SUCCESS", float64(1)).Once()
 		defer mockMetricsService.AssertExpectations(t)
 
-		mockChAccStore.On("UnassignTxAndUnlockChannelAccounts", mock.Anything, testInnerTxHash).Return(nil).Once()
+		mockChAccStore.On("UnassignTxAndUnlockChannelAccounts", mock.Anything, testInnerTxHash).Return(int64(1), nil).Once()
 
 		transactions := []entities.Transaction{
 			{
@@ -198,7 +198,7 @@ func TestProcessTSSTransactions(t *testing.T) {
 			Return(nil).
 			Once()
 
-		err := ingestService.processTSSTransactions(context.Background(), transactions)
+		err = ingestService.processTSSTransactions(context.Background(), transactions)
 		assert.NoError(t, err)
 
 		updatedTX, err := tssStore.GetTransaction(context.Background(), testInnerTxHash)
@@ -504,7 +504,7 @@ func TestIngest_LatestSyncedLedgerBehindRPC(t *testing.T) {
 	require.NoError(t, err)
 	txHash, err := transaction.HashHex(network.TestNetworkPassphrase)
 	require.NoError(t, err)
-	mockChAccStore.On("UnassignTxAndUnlockChannelAccounts", mock.Anything, txHash).Return(nil).Once()
+	mockChAccStore.On("UnassignTxAndUnlockChannelAccounts", mock.Anything, txHash).Return(int64(1), nil).Once()
 	txEnvXDR, err := transaction.Base64()
 	require.NoError(t, err)
 
@@ -574,7 +574,7 @@ func TestIngest_LatestSyncedLedgerAheadOfRPC(t *testing.T) {
 		On("NetworkPassphrase").Return(network.TestNetworkPassphrase)
 	mockRouter := tssrouter.MockRouter{}
 	mockChAccStore := &store.ChannelAccountStoreMock{}
-	mockChAccStore.On("UnassignTxAndUnlockChannelAccounts", mock.Anything, testInnerTxHash).Return(nil).Twice()
+	mockChAccStore.On("UnassignTxAndUnlockChannelAccounts", mock.Anything, testInnerTxHash).Return(int64(1), nil).Twice()
 	tssStore, err := tssstore.NewStore(dbConnectionPool, mockMetricsService)
 	require.NoError(t, err)
 

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -662,7 +662,7 @@ func TestIngest_LatestSyncedLedgerAheadOfRPC(t *testing.T) {
 	mockRPCService.AssertExpectations(t)
 }
 
-func Test_ingestSvc_extractInnerTxHash(t *testing.T) {
+func Test_ingestService_extractInnerTxHash(t *testing.T) {
 	networkPassphrase := network.TestNetworkPassphrase
 	sourceAccountKP := keypair.MustRandom()
 	destAccountKP := keypair.MustRandom()

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -22,9 +22,17 @@ import (
 	"github.com/stellar/wallet-backend/internal/db/dbtest"
 	"github.com/stellar/wallet-backend/internal/entities"
 	"github.com/stellar/wallet-backend/internal/metrics"
+	"github.com/stellar/wallet-backend/internal/signing/store"
 	"github.com/stellar/wallet-backend/internal/tss"
 	tssrouter "github.com/stellar/wallet-backend/internal/tss/router"
 	tssstore "github.com/stellar/wallet-backend/internal/tss/store"
+)
+
+const (
+	testInnerTxHash   = "2ba55208f8ccc21e67c3c515ee8e793bfebb5ff20e3a14264c0890897560e368"
+	testInnerTxXDR    = "AAAAAgAAAAC//CoiAsv/SQfZHUYwg1/5F127eo+Rv6b9lf6GbIJNygAAAGQAAAAAAAAAAgAAAAEAAAAAAAAAAAAAAABoI7JqAAAAAAAAAAEAAAAAAAAAAAAAAADcrhjQMMeoVosXGSgLrC4WhXYLHl1HcUniEWKOGTyPEAAAAAAAmJaAAAAAAAAAAAFsgk3KAAAAQEYaesICeGfKcUiMEYoZZrKptMmMcW8636peWLpChKukfqTxSujQilalxe6ab+en9Bhf8iGMF8jb5JqIIYlYjQs="
+	testFeeBumpTxHash = "b99e17610372fd66968cc3124c4d29a9dd856c2b8ffa1c446f6aefc5657f5a82"
+	testFeeBumpTxXDR  = "AAAABQAAAACRDhlb19H9O6EVQnLPSBX5kH4+ycO03nl6OOK1drSinwAAAAAAAAGQAAAAAgAAAAC//CoiAsv/SQfZHUYwg1/5F127eo+Rv6b9lf6GbIJNygAAAGQAAAAAAAAAAgAAAAEAAAAAAAAAAAAAAABoI7JqAAAAAAAAAAEAAAAAAAAAAAAAAADcrhjQMMeoVosXGSgLrC4WhXYLHl1HcUniEWKOGTyPEAAAAAAAmJaAAAAAAAAAAAFsgk3KAAAAQEYaesICeGfKcUiMEYoZZrKptMmMcW8636peWLpChKukfqTxSujQilalxe6ab+en9Bhf8iGMF8jb5JqIIYlYjQsAAAAAAAAAAXa0op8AAABADjCsmF/xr9jXwNStUM7YqXEd49qfbvGZPJPplANW7aiErkHWxEj6C2RVOyPyK8KBr1fjCleBSmDZjD1X0kkJCQ=="
 )
 
 func TestGetLedgerTransactions(t *testing.T) {
@@ -41,9 +49,10 @@ func TestGetLedgerTransactions(t *testing.T) {
 	mockAppTracker := apptracker.MockAppTracker{}
 	mockRPCService := RPCServiceMock{}
 	mockRouter := tssrouter.MockRouter{}
+	mockChAccStore := &store.ChannelAccountStoreMock{}
 	tssStore, err := tssstore.NewStore(dbConnectionPool, mockMetricsService)
 	require.NoError(t, err)
-	ingestService, err := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, &mockRouter, tssStore, mockMetricsService)
+	ingestService, err := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, &mockRouter, tssStore, mockChAccStore, mockMetricsService)
 	require.NoError(t, err)
 	t.Run("all_ledger_transactions_in_single_gettransactions_call", func(t *testing.T) {
 		defer mockMetricsService.AssertExpectations(t)
@@ -140,10 +149,12 @@ func TestProcessTSSTransactions(t *testing.T) {
 	require.NoError(t, err)
 	mockAppTracker := apptracker.MockAppTracker{}
 	mockRPCService := RPCServiceMock{}
+	mockRPCService.On("NetworkPassphrase").Return(network.TestNetworkPassphrase)
 	mockRouter := tssrouter.MockRouter{}
+	mockChAccStore := &store.ChannelAccountStoreMock{}
 	tssStore, err := tssstore.NewStore(dbConnectionPool, mockMetricsService)
 	require.NoError(t, err)
-	ingestService, err := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, &mockRouter, tssStore, mockMetricsService)
+	ingestService, err := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, &mockRouter, tssStore, mockChAccStore, mockMetricsService)
 	require.NoError(t, err)
 
 	t.Run("routes_to_tss_router", func(t *testing.T) {
@@ -160,13 +171,15 @@ func TestProcessTSSTransactions(t *testing.T) {
 		mockMetricsService.On("SetNumTssTransactionsIngestedPerLedger", "SUCCESS", float64(1)).Once()
 		defer mockMetricsService.AssertExpectations(t)
 
+		mockChAccStore.On("UnassignTxAndUnlockChannelAccounts", mock.Anything, testInnerTxHash).Return(nil).Once()
+
 		transactions := []entities.Transaction{
 			{
 				Status:              entities.SuccessStatus,
-				Hash:                "feebumphash",
+				Hash:                testFeeBumpTxHash,
 				ApplicationOrder:    1,
 				FeeBump:             true,
-				EnvelopeXDR:         "feebumpxdr",
+				EnvelopeXDR:         testFeeBumpTxXDR,
 				ResultXDR:           "AAAAAAAAAMj////9AAAAAA==",
 				ResultMetaXDR:       "meta",
 				Ledger:              123456,
@@ -175,9 +188,9 @@ func TestProcessTSSTransactions(t *testing.T) {
 			},
 		}
 
-		err = tssStore.UpsertTransaction(context.Background(), "localhost:8000/webhook", "hash", "xdr", tss.RPCTXStatus{OtherStatus: tss.NewStatus})
+		err = tssStore.UpsertTransaction(context.Background(), "localhost:8000/webhook", testInnerTxHash, testFeeBumpTxXDR, tss.RPCTXStatus{OtherStatus: tss.NewStatus})
 		require.NoError(t, err)
-		err = tssStore.UpsertTry(context.Background(), "hash", "feebumphash", "feebumpxdr", tss.RPCTXStatus{OtherStatus: tss.NewStatus}, tss.RPCTXCode{OtherCodes: tss.NewCode}, "")
+		err = tssStore.UpsertTry(context.Background(), testInnerTxHash, testFeeBumpTxHash, testFeeBumpTxXDR, tss.RPCTXStatus{OtherStatus: tss.NewStatus}, tss.RPCTXCode{OtherCodes: tss.NewCode}, "")
 		require.NoError(t, err)
 
 		mockRouter.
@@ -188,10 +201,10 @@ func TestProcessTSSTransactions(t *testing.T) {
 		err := ingestService.processTSSTransactions(context.Background(), transactions)
 		assert.NoError(t, err)
 
-		updatedTX, err := tssStore.GetTransaction(context.Background(), "hash")
+		updatedTX, err := tssStore.GetTransaction(context.Background(), testInnerTxHash)
 		require.NoError(t, err)
 		assert.Equal(t, string(entities.SuccessStatus), updatedTX.Status)
-		updatedTry, err := tssStore.GetTry(context.Background(), "feebumphash")
+		updatedTry, err := tssStore.GetTry(context.Background(), testFeeBumpTxHash)
 		require.NoError(t, err)
 		assert.Equal(t, "AAAAAAAAAMj////9AAAAAA==", updatedTry.ResultXDR)
 		assert.Equal(t, int32(xdr.TransactionResultCodeTxTooLate), updatedTry.Code)
@@ -212,9 +225,10 @@ func TestIngestPayments(t *testing.T) {
 	mockAppTracker := apptracker.MockAppTracker{}
 	mockRPCService := RPCServiceMock{}
 	mockRouter := tssrouter.MockRouter{}
+	mockChAccStore := &store.ChannelAccountStoreMock{}
 	tssStore, err := tssstore.NewStore(dbConnectionPool, mockMetricsService)
 	require.NoError(t, err)
-	ingestService, err := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, &mockRouter, tssStore, mockMetricsService)
+	ingestService, err := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, &mockRouter, tssStore, mockChAccStore, mockMetricsService)
 	require.NoError(t, err)
 	srcAccount := keypair.MustRandom().Address()
 	destAccount := keypair.MustRandom().Address()
@@ -460,38 +474,44 @@ func TestIngest_LatestSyncedLedgerBehindRPC(t *testing.T) {
 	require.NoError(t, err)
 	mockAppTracker := apptracker.MockAppTracker{}
 	mockRPCService := RPCServiceMock{}
-	mockRPCService.On("TrackRPCServiceHealth", ctx, mock.Anything).Once()
+	mockRPCService.
+		On("TrackRPCServiceHealth", ctx, mock.Anything).Once().
+		On("NetworkPassphrase").Return(network.TestNetworkPassphrase)
 	mockRouter := tssrouter.MockRouter{}
+	mockChAccStore := &store.ChannelAccountStoreMock{}
 
 	tssStore, err := tssstore.NewStore(dbConnectionPool, mockMetricsService)
 	require.NoError(t, err)
 
-	ingestService, err := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, &mockRouter, tssStore, mockMetricsService)
+	ingestService, err := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, &mockRouter, tssStore, mockChAccStore, mockMetricsService)
 	require.NoError(t, err)
 
 	srcAccount := keypair.MustRandom().Address()
 	destAccount := keypair.MustRandom().Address()
 
-	paymentOp := txnbuild.Payment{
-		SourceAccount: srcAccount,
-		Destination:   destAccount,
-		Amount:        "10",
-		Asset:         txnbuild.NativeAsset{},
-	}
 	transaction, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &txnbuild.SimpleAccount{
 			AccountID: keypair.MustRandom().Address(),
 		},
-		Operations:    []txnbuild.Operation{&paymentOp},
+		Operations: []txnbuild.Operation{&txnbuild.Payment{
+			SourceAccount: srcAccount,
+			Destination:   destAccount,
+			Amount:        "10",
+			Asset:         txnbuild.NativeAsset{},
+		}},
 		Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(10)},
 	})
 	require.NoError(t, err)
+	txHash, err := transaction.HashHex(network.TestNetworkPassphrase)
+	require.NoError(t, err)
+	mockChAccStore.On("UnassignTxAndUnlockChannelAccounts", mock.Anything, txHash).Return(nil).Once()
 	txEnvXDR, err := transaction.Base64()
 	require.NoError(t, err)
+
 	mockResult := entities.RPCGetTransactionsResult{
 		Transactions: []entities.Transaction{{
 			Status:           entities.SuccessStatus,
-			Hash:             "abcd",
+			Hash:             txHash,
 			ApplicationOrder: 1,
 			FeeBump:          false,
 			EnvelopeXDR:      txEnvXDR,
@@ -499,7 +519,7 @@ func TestIngest_LatestSyncedLedgerBehindRPC(t *testing.T) {
 			Ledger:           50,
 		}, {
 			Status:           entities.SuccessStatus,
-			Hash:             "abcd",
+			Hash:             "some-other-tx-hash",
 			ApplicationOrder: 1,
 			FeeBump:          false,
 			EnvelopeXDR:      txEnvXDR,
@@ -549,13 +569,16 @@ func TestIngest_LatestSyncedLedgerAheadOfRPC(t *testing.T) {
 	require.NoError(t, err)
 	mockAppTracker := apptracker.MockAppTracker{}
 	mockRPCService := RPCServiceMock{}
-	mockRPCService.On("TrackRPCServiceHealth", ctx, mock.Anything).Once()
+	mockRPCService.
+		On("TrackRPCServiceHealth", ctx, mock.Anything).Once().
+		On("NetworkPassphrase").Return(network.TestNetworkPassphrase)
 	mockRouter := tssrouter.MockRouter{}
-
+	mockChAccStore := &store.ChannelAccountStoreMock{}
+	mockChAccStore.On("UnassignTxAndUnlockChannelAccounts", mock.Anything, testInnerTxHash).Return(nil).Twice()
 	tssStore, err := tssstore.NewStore(dbConnectionPool, mockMetricsService)
 	require.NoError(t, err)
 
-	ingestService, err := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, &mockRouter, tssStore, mockMetricsService)
+	ingestService, err := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, &mockRouter, tssStore, mockChAccStore, mockMetricsService)
 	require.NoError(t, err)
 
 	mockMetricsService.On("ObserveDBQueryDuration", "INSERT", "ingest_store", mock.AnythingOfType("float64")).Once()
@@ -596,22 +619,21 @@ func TestIngest_LatestSyncedLedgerAheadOfRPC(t *testing.T) {
 	log.DefaultLogger.SetOutput(&logBuffer)
 	log.SetLevel(log.DebugLevel)
 
-	txEnvXDR := "AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAACgAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAArqN6LeOagjxMaUP96Bzfs9e0corNZXzBWJkFoK7kvkwAAAAAO5rKAAAAAAAAAAABVvwF9wAAAEAKZ7IPj/46PuWU6ZOtyMosctNAkXRNX9WCAI5RnfRk+AyxDLoDZP/9l3NvsxQtWj9juQOuoBlFLnWu8intgxQA"
 	mockResult := entities.RPCGetTransactionsResult{
 		Transactions: []entities.Transaction{{
 			Status:           entities.SuccessStatus,
-			Hash:             "abcd",
+			Hash:             testInnerTxHash,
 			ApplicationOrder: 1,
 			FeeBump:          false,
-			EnvelopeXDR:      txEnvXDR,
+			EnvelopeXDR:      testInnerTxXDR,
 			ResultXDR:        "AAAAAAAAAMj////9AAAAAA==",
 			Ledger:           100,
 		}, {
 			Status:           entities.SuccessStatus,
-			Hash:             "abcd",
+			Hash:             testFeeBumpTxHash,
 			ApplicationOrder: 1,
 			FeeBump:          false,
-			EnvelopeXDR:      txEnvXDR,
+			EnvelopeXDR:      testFeeBumpTxXDR,
 			ResultXDR:        "AAAAAAAAAMj////9AAAAAA==",
 			Ledger:           101,
 		}},

--- a/internal/services/mocks.go
+++ b/internal/services/mocks.go
@@ -60,6 +60,11 @@ func (r *RPCServiceMock) SimulateTransaction(transactionXDR string, resourceConf
 	return args.Get(0).(entities.RPCSimulateTransactionResult), args.Error(1)
 }
 
+func (r *RPCServiceMock) NetworkPassphrase() string {
+	args := r.Called()
+	return args.String(0)
+}
+
 // NewRPCServiceMock creates a new instance of RPCServiceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewRPCServiceMock(t interface {

--- a/internal/services/rpc_service.go
+++ b/internal/services/rpc_service.go
@@ -308,7 +308,7 @@ func (r *rpcService) sendRPCRequest(method string, params entities.RPCParams) (j
 	err = json.Unmarshal(body, &res)
 	if err != nil {
 		r.metricsService.IncRPCEndpointFailure(method)
-		return nil, fmt.Errorf("parsing RPC response %s: %w", string(body), err)
+		return nil, fmt.Errorf("parsing RPC response JSON: %w", err)
 	}
 
 	if res.Result == nil {

--- a/internal/services/rpc_service.go
+++ b/internal/services/rpc_service.go
@@ -308,7 +308,7 @@ func (r *rpcService) sendRPCRequest(method string, params entities.RPCParams) (j
 	err = json.Unmarshal(body, &res)
 	if err != nil {
 		r.metricsService.IncRPCEndpointFailure(method)
-		return nil, fmt.Errorf("parsing RPC response JSON: %w", err)
+		return nil, fmt.Errorf("parsing RPC response %s: %w", string(body), err)
 	}
 
 	if res.Result == nil {

--- a/internal/services/rpc_service_test.go
+++ b/internal/services/rpc_service_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stellar/go/network"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
@@ -45,7 +46,7 @@ func TestSendRPCRequest(t *testing.T) {
 	mockMetricsService := metrics.NewMockMetricsService()
 	mockHTTPClient := utils.MockHTTPClient{}
 	rpcURL := "http://api.vibrantapp.com/soroban/rpc"
-	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient, mockMetricsService)
+	rpcService, err := NewRPCService(rpcURL, network.TestNetworkPassphrase, &mockHTTPClient, mockMetricsService)
 	require.NoError(t, err)
 
 	t.Run("successful", func(t *testing.T) {
@@ -173,7 +174,7 @@ func TestSendTransaction(t *testing.T) {
 	mockMetricsService := metrics.NewMockMetricsService()
 	mockHTTPClient := utils.MockHTTPClient{}
 	rpcURL := "http://api.vibrantapp.com/soroban/rpc"
-	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient, mockMetricsService)
+	rpcService, err := NewRPCService(rpcURL, network.TestNetworkPassphrase, &mockHTTPClient, mockMetricsService)
 	require.NoError(t, err)
 
 	t.Run("successful", func(t *testing.T) {
@@ -408,7 +409,7 @@ func Test_rpcService_SimulateTransaction(t *testing.T) {
 				Once()
 
 			// Simulate Transaction
-			rpcService, err := NewRPCService(rpcURL, &mHTTPClient, mMetricsService)
+			rpcService, err := NewRPCService(rpcURL, network.TestNetworkPassphrase, &mHTTPClient, mMetricsService)
 			require.NoError(t, err)
 			simulateTransactionResult, err := rpcService.SimulateTransaction(transactionXDR, entities.RPCResourceConfig{})
 
@@ -437,7 +438,7 @@ func TestGetTransaction(t *testing.T) {
 	mockMetricsService := metrics.NewMockMetricsService()
 	mockHTTPClient := utils.MockHTTPClient{}
 	rpcURL := "http://api.vibrantapp.com/soroban/rpc"
-	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient, mockMetricsService)
+	rpcService, err := NewRPCService(rpcURL, network.TestNetworkPassphrase, &mockHTTPClient, mockMetricsService)
 	require.NoError(t, err)
 
 	t.Run("successful", func(t *testing.T) {
@@ -532,7 +533,7 @@ func TestGetTransactions(t *testing.T) {
 	mockMetricsService := metrics.NewMockMetricsService()
 	mockHTTPClient := utils.MockHTTPClient{}
 	rpcURL := "http://api.vibrantapp.com/soroban/rpc"
-	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient, mockMetricsService)
+	rpcService, err := NewRPCService(rpcURL, network.TestNetworkPassphrase, &mockHTTPClient, mockMetricsService)
 	require.NoError(t, err)
 
 	t.Run("rpc_request_fails", func(t *testing.T) {
@@ -614,7 +615,7 @@ func TestSendGetHealth(t *testing.T) {
 	mockMetricsService := metrics.NewMockMetricsService()
 	mockHTTPClient := utils.MockHTTPClient{}
 	rpcURL := "http://api.vibrantapp.com/soroban/rpc"
-	rpcService, err := NewRPCService(rpcURL, &mockHTTPClient, mockMetricsService)
+	rpcService, err := NewRPCService(rpcURL, network.TestNetworkPassphrase, &mockHTTPClient, mockMetricsService)
 	require.NoError(t, err)
 
 	t.Run("successful", func(t *testing.T) {
@@ -688,7 +689,7 @@ func TestTrackRPCServiceHealth_HealthyService(t *testing.T) {
 
 	mockHTTPClient := &utils.MockHTTPClient{}
 	rpcURL := "http://test-url-track-rpc-service-health"
-	rpcService, err := NewRPCService(rpcURL, mockHTTPClient, mockMetricsService)
+	rpcService, err := NewRPCService(rpcURL, network.TestNetworkPassphrase, mockHTTPClient, mockMetricsService)
 	require.NoError(t, err)
 
 	healthResult := entities.RPCGetHealthResult{
@@ -758,7 +759,7 @@ func TestTrackRPCServiceHealth_UnhealthyService(t *testing.T) {
 	mockHTTPClient := &utils.MockHTTPClient{}
 	defer mockHTTPClient.AssertExpectations(t)
 	rpcURL := "http://test-url-track-rpc-service-health"
-	rpcService, err := NewRPCService(rpcURL, mockHTTPClient, mockMetricsService)
+	rpcService, err := NewRPCService(rpcURL, network.TestNetworkPassphrase, mockHTTPClient, mockMetricsService)
 	require.NoError(t, err)
 	rpcService.healthCheckTickInterval = healthCheckTickInterval
 	rpcService.healthCheckWarningInterval = healthCheckWarningInterval
@@ -809,7 +810,7 @@ func TestTrackRPCService_ContextCancelled(t *testing.T) {
 	mockMetricsService := metrics.NewMockMetricsService()
 	mockHTTPClient := &utils.MockHTTPClient{}
 	rpcURL := "http://test-url-track-rpc-service-health"
-	rpcService, err := NewRPCService(rpcURL, mockHTTPClient, mockMetricsService)
+	rpcService, err := NewRPCService(rpcURL, network.TestNetworkPassphrase, mockHTTPClient, mockMetricsService)
 	require.NoError(t, err)
 
 	rpcService.TrackRPCServiceHealth(ctx, nil)

--- a/internal/services/rpc_service_test.go
+++ b/internal/services/rpc_service_test.go
@@ -139,7 +139,7 @@ func TestSendRPCRequest(t *testing.T) {
 		resp, err := rpcService.sendRPCRequest("sendTransaction", entities.RPCParams{})
 
 		assert.Nil(t, resp)
-		assert.Equal(t, "parsing RPC response JSON: invalid character 'i' looking for beginning of object key string", err.Error())
+		assert.ErrorContains(t, err, "parsing RPC response {invalid-json: invalid character 'i' looking for beginning of object key string")
 	})
 
 	t.Run("response_has_no_result_field", func(t *testing.T) {

--- a/internal/services/rpc_service_test.go
+++ b/internal/services/rpc_service_test.go
@@ -139,7 +139,7 @@ func TestSendRPCRequest(t *testing.T) {
 		resp, err := rpcService.sendRPCRequest("sendTransaction", entities.RPCParams{})
 
 		assert.Nil(t, resp)
-		assert.ErrorContains(t, err, "parsing RPC response {invalid-json: invalid character 'i' looking for beginning of object key string")
+		assert.ErrorContains(t, err, "parsing RPC response JSON: invalid character 'i' looking for beginning of object key string")
 	})
 
 	t.Run("response_has_no_result_field", func(t *testing.T) {

--- a/internal/signing/store/channel_accounts_model_test.go
+++ b/internal/signing/store/channel_accounts_model_test.go
@@ -251,6 +251,8 @@ func Test_ChannelAccountModel_UnassignTxAndUnlockChannelAccounts(t *testing.T) {
 				chAccFromDB, err := m.Get(ctx, dbConnectionPool, fixture.Address())
 				require.NoError(t, err)
 				require.True(t, chAccFromDB.LockedTxHash.Valid)
+				require.True(t, chAccFromDB.LockedAt.Valid)
+				require.True(t, chAccFromDB.LockedUntil.Valid)
 			}
 
 			rowsAffected, err := m.UnassignTxAndUnlockChannelAccounts(ctx, tc.txHashes(fixtures)...)

--- a/internal/signing/store/channel_accounts_model_test.go
+++ b/internal/signing/store/channel_accounts_model_test.go
@@ -170,7 +170,7 @@ func TestAssignTxToChannelAccount(t *testing.T) {
 	assert.Equal(t, "txhash", channelAccountFromDB.LockedTxHash.String)
 }
 
-func TestUnlockChannelAccountFromTx(t *testing.T) {
+func Test_ChannelAccountModel_UnassignTxAndUnlockChannelAccounts(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()
 	dbConnectionPool, outerErr := db.OpenDBConnectionPool(dbt.DSN)
@@ -253,12 +253,12 @@ func TestUnlockChannelAccountFromTx(t *testing.T) {
 				require.True(t, chAccFromDB.LockedTxHash.Valid)
 			}
 
-			err := m.UnassignTxAndUnlockChannelAccounts(ctx, tc.txHashes(fixtures)...)
+			rowsAffected, err := m.UnassignTxAndUnlockChannelAccounts(ctx, tc.txHashes(fixtures)...)
 			if tc.expectedErrContains != "" {
 				require.ErrorContains(t, err, tc.expectedErrContains)
 			} else {
 				require.NoError(t, err)
-
+				require.Equal(t, int64(tc.numberOfFixtures), rowsAffected)
 				// 🔓 Channel accounts get unlocked
 				for _, fixture := range fixtures {
 					chAccFromDB, err := m.Get(ctx, dbConnectionPool, fixture.Address())

--- a/internal/signing/store/mocks.go
+++ b/internal/signing/store/mocks.go
@@ -44,8 +44,12 @@ func (s *ChannelAccountStoreMock) AssignTxToChannelAccount(ctx context.Context, 
 	return args.Error(0)
 }
 
-func (s *ChannelAccountStoreMock) UnassignTxAndUnlockChannelAccount(ctx context.Context, txHash string) error {
-	args := s.Called(ctx, txHash)
+func (s *ChannelAccountStoreMock) UnassignTxAndUnlockChannelAccounts(ctx context.Context, txHashes ...string) error {
+	_ca := []any{ctx}
+	for _, txHash := range txHashes {
+		_ca = append(_ca, txHash)
+	}
+	args := s.Called(_ca...)
 	return args.Error(0)
 }
 

--- a/internal/signing/store/mocks.go
+++ b/internal/signing/store/mocks.go
@@ -44,13 +44,13 @@ func (s *ChannelAccountStoreMock) AssignTxToChannelAccount(ctx context.Context, 
 	return args.Error(0)
 }
 
-func (s *ChannelAccountStoreMock) UnassignTxAndUnlockChannelAccounts(ctx context.Context, txHashes ...string) error {
+func (s *ChannelAccountStoreMock) UnassignTxAndUnlockChannelAccounts(ctx context.Context, txHashes ...string) (int64, error) {
 	_ca := []any{ctx}
 	for _, txHash := range txHashes {
 		_ca = append(_ca, txHash)
 	}
 	args := s.Called(_ca...)
-	return args.Error(0)
+	return args.Get(0).(int64), args.Error(1)
 }
 
 func (s *ChannelAccountStoreMock) BatchInsert(ctx context.Context, sqlExec db.SQLExecuter, channelAccounts []*ChannelAccount) error {

--- a/internal/signing/store/types.go
+++ b/internal/signing/store/types.go
@@ -23,7 +23,7 @@ type ChannelAccountStore interface {
 	Get(ctx context.Context, sqlExec db.SQLExecuter, publicKey string) (*ChannelAccount, error)
 	GetAllByPublicKey(ctx context.Context, sqlExec db.SQLExecuter, publicKeys ...string) ([]*ChannelAccount, error)
 	AssignTxToChannelAccount(ctx context.Context, publicKey string, txHash string) error
-	UnassignTxAndUnlockChannelAccounts(ctx context.Context, txHashes ...string) error
+	UnassignTxAndUnlockChannelAccounts(ctx context.Context, txHashes ...string) (int64, error)
 	BatchInsert(ctx context.Context, sqlExec db.SQLExecuter, channelAccounts []*ChannelAccount) error
 	Count(ctx context.Context) (int64, error)
 }

--- a/internal/signing/store/types.go
+++ b/internal/signing/store/types.go
@@ -23,7 +23,7 @@ type ChannelAccountStore interface {
 	Get(ctx context.Context, sqlExec db.SQLExecuter, publicKey string) (*ChannelAccount, error)
 	GetAllByPublicKey(ctx context.Context, sqlExec db.SQLExecuter, publicKeys ...string) ([]*ChannelAccount, error)
 	AssignTxToChannelAccount(ctx context.Context, publicKey string, txHash string) error
-	UnassignTxAndUnlockChannelAccount(ctx context.Context, txHash string) error
+	UnassignTxAndUnlockChannelAccounts(ctx context.Context, txHashes ...string) error
 	BatchInsert(ctx context.Context, sqlExec db.SQLExecuter, channelAccounts []*ChannelAccount) error
 	Count(ctx context.Context) (int64, error)
 }

--- a/internal/tss/channels/webhook_channel.go
+++ b/internal/tss/channels/webhook_channel.go
@@ -135,7 +135,7 @@ func (p *webhookPool) UnlockChannelAccount(ctx context.Context, txXDR string) er
 	if err != nil {
 		return fmt.Errorf("unable to hashhex transaction: %w", err)
 	}
-	err = p.ChannelAccountStore.UnassignTxAndUnlockChannelAccount(ctx, txHash)
+	err = p.ChannelAccountStore.UnassignTxAndUnlockChannelAccounts(ctx, txHash)
 	if err != nil {
 		return fmt.Errorf("unable to unlock channel account associated with transaction: %w", err)
 	}

--- a/internal/tss/channels/webhook_channel_test.go
+++ b/internal/tss/channels/webhook_channel_test.go
@@ -4,14 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
-	"github.com/stellar/go/keypair"
-	"github.com/stellar/go/txnbuild"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -93,100 +90,4 @@ func TestWebhookHandlerServiceChannel(t *testing.T) {
 	tx, err := store.GetTransaction(context.Background(), payload.TransactionHash)
 	assert.Equal(t, string(tss.SentStatus), tx.Status)
 	assert.NoError(t, err)
-}
-
-func TestUnlockChannelAccount(t *testing.T) {
-	dbt := dbtest.Open(t)
-	defer dbt.Close()
-	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
-	require.NoError(t, err)
-	defer dbConnectionPool.Close()
-
-	mockMetricsService := metrics.NewMockMetricsService()
-	store, err := store.NewStore(dbConnectionPool, mockMetricsService)
-	require.NoError(t, err)
-	channelAccountStore := channelAccountStore.ChannelAccountStoreMock{}
-	mockHTTPClient := utils.MockHTTPClient{}
-	cfg := WebhookChannelConfigs{
-		HTTPClient:           &mockHTTPClient,
-		Store:                store,
-		ChannelAccountStore:  &channelAccountStore,
-		MaxBufferSize:        1,
-		MaxWorkers:           1,
-		MaxRetries:           3,
-		MinWaitBtwnRetriesMS: 5,
-		NetworkPassphrase:    "networkpassphrase",
-		MetricsService:       mockMetricsService,
-	}
-
-	mockMetricsService.On("RegisterPoolMetrics", WebhookChannelName, mock.AnythingOfType("*pond.WorkerPool")).Once()
-	defer mockMetricsService.AssertExpectations(t)
-
-	channel := NewWebhookChannel(cfg)
-	account := keypair.MustRandom()
-	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
-		SourceAccount:        &txnbuild.SimpleAccount{AccountID: account.Address()},
-		IncrementSequenceNum: true,
-		Operations: []txnbuild.Operation{
-			&txnbuild.Payment{
-				Destination: keypair.MustRandom().Address(),
-				Amount:      "10",
-				Asset:       txnbuild.NativeAsset{},
-			},
-		},
-		BaseFee:       txnbuild.MinBaseFee,
-		Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(30)},
-	})
-	require.NoError(t, err)
-
-	distributionAccount := keypair.MustRandom()
-
-	feeBumpTx, err := txnbuild.NewFeeBumpTransaction(txnbuild.FeeBumpTransactionParams{
-		Inner:      tx,
-		FeeAccount: distributionAccount.Address(),
-		BaseFee:    txnbuild.MinBaseFee,
-	})
-	require.NoError(t, err)
-
-	t.Run("simple_tx", func(t *testing.T) {
-		txXDR, err := tx.Base64()
-		assert.NoError(t, err)
-		txHash, err := tx.HashHex(cfg.NetworkPassphrase)
-		assert.NoError(t, err)
-		channelAccountStore.
-			On("UnassignTxAndUnlockChannelAccounts", context.Background(), txHash).
-			Return(int64(1), nil).
-			Once()
-
-		err = channel.UnlockChannelAccount(context.Background(), txXDR)
-		assert.NoError(t, err)
-	})
-
-	t.Run("feebump_tx", func(t *testing.T) {
-		txXDR, err := feeBumpTx.Base64()
-		assert.NoError(t, err)
-		txHash, err := tx.HashHex(cfg.NetworkPassphrase)
-		assert.NoError(t, err)
-		channelAccountStore.
-			On("UnassignTxAndUnlockChannelAccounts", context.Background(), txHash).
-			Return(int64(1), nil).
-			Once()
-
-		err = channel.UnlockChannelAccount(context.Background(), txXDR)
-		assert.NoError(t, err)
-	})
-
-	t.Run("unlock_channel_account_from_tx_returns_error", func(t *testing.T) {
-		txXDR, err := tx.Base64()
-		assert.NoError(t, err)
-		txHash, err := tx.HashHex(cfg.NetworkPassphrase)
-		assert.NoError(t, err)
-		channelAccountStore.
-			On("UnassignTxAndUnlockChannelAccounts", context.Background(), txHash).
-			Return(int64(0), errors.New("unabe to unlock channel account")).
-			Once()
-
-		err = channel.UnlockChannelAccount(context.Background(), txXDR)
-		assert.Equal(t, "unable to unlock channel account associated with transaction: unabe to unlock channel account", err.Error())
-	})
 }

--- a/internal/tss/channels/webhook_channel_test.go
+++ b/internal/tss/channels/webhook_channel_test.go
@@ -155,7 +155,7 @@ func TestUnlockChannelAccount(t *testing.T) {
 		assert.NoError(t, err)
 		channelAccountStore.
 			On("UnassignTxAndUnlockChannelAccounts", context.Background(), txHash).
-			Return(nil).
+			Return(int64(1), nil).
 			Once()
 
 		err = channel.UnlockChannelAccount(context.Background(), txXDR)
@@ -169,7 +169,7 @@ func TestUnlockChannelAccount(t *testing.T) {
 		assert.NoError(t, err)
 		channelAccountStore.
 			On("UnassignTxAndUnlockChannelAccounts", context.Background(), txHash).
-			Return(nil).
+			Return(int64(1), nil).
 			Once()
 
 		err = channel.UnlockChannelAccount(context.Background(), txXDR)
@@ -183,7 +183,7 @@ func TestUnlockChannelAccount(t *testing.T) {
 		assert.NoError(t, err)
 		channelAccountStore.
 			On("UnassignTxAndUnlockChannelAccounts", context.Background(), txHash).
-			Return(errors.New("unabe to unlock channel account")).
+			Return(int64(0), errors.New("unabe to unlock channel account")).
 			Once()
 
 		err = channel.UnlockChannelAccount(context.Background(), txXDR)

--- a/internal/tss/channels/webhook_channel_test.go
+++ b/internal/tss/channels/webhook_channel_test.go
@@ -154,7 +154,7 @@ func TestUnlockChannelAccount(t *testing.T) {
 		txHash, err := tx.HashHex(cfg.NetworkPassphrase)
 		assert.NoError(t, err)
 		channelAccountStore.
-			On("UnassignTxAndUnlockChannelAccount", context.Background(), txHash).
+			On("UnassignTxAndUnlockChannelAccounts", context.Background(), txHash).
 			Return(nil).
 			Once()
 
@@ -168,7 +168,7 @@ func TestUnlockChannelAccount(t *testing.T) {
 		txHash, err := tx.HashHex(cfg.NetworkPassphrase)
 		assert.NoError(t, err)
 		channelAccountStore.
-			On("UnassignTxAndUnlockChannelAccount", context.Background(), txHash).
+			On("UnassignTxAndUnlockChannelAccounts", context.Background(), txHash).
 			Return(nil).
 			Once()
 
@@ -182,7 +182,7 @@ func TestUnlockChannelAccount(t *testing.T) {
 		txHash, err := tx.HashHex(cfg.NetworkPassphrase)
 		assert.NoError(t, err)
 		channelAccountStore.
-			On("UnassignTxAndUnlockChannelAccount", context.Background(), txHash).
+			On("UnassignTxAndUnlockChannelAccounts", context.Background(), txHash).
 			Return(errors.New("unabe to unlock channel account")).
 			Once()
 

--- a/internal/utils/sql.go
+++ b/internal/utils/sql.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"database/sql"
+	"time"
+)
+
+func SQLNullString(s string) sql.NullString {
+	return sql.NullString{
+		String: s,
+		Valid:  s != "",
+	}
+}
+
+func SQLNullTime(t time.Time) sql.NullTime {
+	return sql.NullTime{
+		Time:  t,
+		Valid: !t.IsZero(),
+	}
+}

--- a/internal/utils/sql_test.go
+++ b/internal/utils/sql_test.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_SQLNullString(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want sql.NullString
+	}{
+		{
+			name: "empty string",
+			arg:  "",
+			want: sql.NullString{String: "", Valid: false},
+		},
+		{
+			name: "non-empty string",
+			arg:  "hello",
+			want: sql.NullString{String: "hello", Valid: true},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SQLNullString(tc.arg)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func Test_SQLNullTime(t *testing.T) {
+	wantTime := time.Date(2000, 1, 2, 3, 4, 5, 6, time.UTC)
+	tests := []struct {
+		name string
+		arg  time.Time
+		want sql.NullTime
+	}{
+		{
+			name: "zero time",
+			arg:  time.Time{},
+			want: sql.NullTime{Time: time.Time{}, Valid: false},
+		},
+		{
+			name: "non-zero time",
+			arg:  wantTime,
+			want: sql.NullTime{Time: wantTime, Valid: true},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SQLNullTime(tc.arg)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
### What

Eagerly unlock channel accounts when their txHash is ingested.

### Why

So channel accounts became available sooner.

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
