### PR TITLE
Unlock channelAccounts if /build fails

### DIFF
--- a/internal/serve/httphandler/transactions_handler.go
+++ b/internal/serve/httphandler/transactions_handler.go
@@ -2,7 +2,6 @@ package httphandler
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/stellar/go/support/render/httpjson"
@@ -13,7 +12,6 @@ import (
 	"github.com/stellar/wallet-backend/internal/signing"
 	"github.com/stellar/wallet-backend/internal/signing/store"
 	transactionservices "github.com/stellar/wallet-backend/internal/transactions/services"
-	transactionsUtils "github.com/stellar/wallet-backend/internal/transactions/utils"
 	"github.com/stellar/wallet-backend/pkg/sorobanauth"
 	"github.com/stellar/wallet-backend/pkg/wbclient/types"
 )
@@ -28,43 +26,26 @@ type TransactionsHandler struct {
 func (t *TransactionsHandler) BuildTransactions(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	var reqParams types.BuildTransactionsRequest
-	httpErr := DecodeJSONAndValidate(ctx, r, &reqParams, t.AppTracker)
-	if httpErr != nil {
+	if httpErr := DecodeJSONAndValidate(ctx, r, &reqParams, t.AppTracker); httpErr != nil {
 		httpErr.Render(w)
 		return
 	}
-	var transactionXDRs []string
-	for i, transaction := range reqParams.Transactions {
-		ops, err := transactionsUtils.BuildOperations(transaction.Operations)
-		if err != nil {
-			httperror.BadRequest("", map[string]any{
-				fmt.Sprintf("transactions[%d].operations", i): err.Error(),
-			}).Render(w)
+
+	txXDRs, err := t.TransactionService.BuildAndSignTransactionsWithChannelAccounts(ctx, reqParams.Transactions...)
+	if err != nil {
+		if errors.Is(err, transactionservices.ErrInvalidArguments) ||
+			errors.Is(err, signing.ErrUnavailableChannelAccounts) ||
+			errors.Is(err, sorobanauth.ErrForbiddenSigner) {
+			httperror.BadRequest(err.Error(), nil).Render(w)
 			return
 		}
-		tx, err := t.TransactionService.BuildAndSignTransactionWithChannelAccount(ctx, ops, transaction.Timeout, transaction.SimulationResult)
-		if err != nil {
-			if errors.Is(err, transactionservices.ErrInvalidArguments) ||
-				errors.Is(err, signing.ErrUnavailableChannelAccounts) ||
-				errors.Is(err, sorobanauth.ErrForbiddenSigner) {
-				httperror.BadRequest(err.Error(), nil).Render(w)
-				return
-			}
-			if errors.Is(err, store.ErrNoIdleChannelAccountAvailable) {
-				httperror.InternalServerError(ctx, err.Error(), err, nil, t.AppTracker).Render(w)
-				return
-			}
-			httperror.InternalServerError(ctx, "unable to build transaction", err, nil, t.AppTracker).Render(w)
+		if errors.Is(err, store.ErrNoIdleChannelAccountAvailable) {
+			httperror.InternalServerError(ctx, err.Error(), err, nil, t.AppTracker).Render(w)
 			return
 		}
-		txXdrStr, err := tx.Base64()
-		if err != nil {
-			httperror.InternalServerError(ctx, "unable to base64 transaction", err, nil, t.AppTracker).Render(w)
-			return
-		}
-		transactionXDRs = append(transactionXDRs, txXdrStr)
+		httperror.InternalServerError(ctx, "unable to build transaction", err, nil, t.AppTracker).Render(w)
+		return
 	}
-	httpjson.Render(w, types.BuildTransactionsResponse{
-		TransactionXDRs: transactionXDRs,
-	}, httpjson.JSON)
+
+	httpjson.Render(w, types.BuildTransactionsResponse{TransactionXDRs: txXDRs}, httpjson.JSON)
 }

--- a/internal/signing/store/mocks.go
+++ b/internal/signing/store/mocks.go
@@ -23,6 +23,14 @@ func (s *ChannelAccountStoreMock) GetAndLockIdleChannelAccount(ctx context.Conte
 	return args.Get(0).(*ChannelAccount), args.Error(1)
 }
 
+func (s *ChannelAccountStoreMock) Unlock(ctx context.Context, publicKeys ...string) ([]ChannelAccount, error) {
+	args := s.Called(ctx, publicKeys)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]ChannelAccount), args.Error(1)
+}
+
 func (s *ChannelAccountStoreMock) Get(ctx context.Context, sqlExec db.SQLExecuter, publicKey string) (*ChannelAccount, error) {
 	args := s.Called(ctx, sqlExec, publicKey)
 	if args.Get(0) == nil {

--- a/internal/signing/store/mocks.go
+++ b/internal/signing/store/mocks.go
@@ -24,7 +24,11 @@ func (s *ChannelAccountStoreMock) GetAndLockIdleChannelAccount(ctx context.Conte
 }
 
 func (s *ChannelAccountStoreMock) Unlock(ctx context.Context, publicKeys ...string) ([]ChannelAccount, error) {
-	args := s.Called(ctx, publicKeys)
+	_args := []any{ctx}
+	for _, publicKey := range publicKeys {
+		_args = append(_args, publicKey)
+	}
+	args := s.Called(_args...)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -71,6 +75,20 @@ func (s *ChannelAccountStoreMock) Count(ctx context.Context) (int64, error) {
 	return int64(args.Int(0)), args.Error(1)
 }
 
+// NewChannelAccountStoreMock creates a new instance of ChannelAccountStoreMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewChannelAccountStoreMock(t interface {
+	mock.TestingT
+	Cleanup(func())
+}) *ChannelAccountStoreMock {
+	mock := &ChannelAccountStoreMock{}
+	mock.Mock.Test(t)
+
+	t.Cleanup(func() { mock.AssertExpectations(t) })
+
+	return mock
+}
+
 type KeypairStoreMock struct {
 	mock.Mock
 }
@@ -88,18 +106,4 @@ func (s *KeypairStoreMock) GetByPublicKey(ctx context.Context, publicKey string)
 func (s *KeypairStoreMock) Insert(ctx context.Context, publicKey string, encryptedPrivateKey []byte) error {
 	args := s.Called(ctx, publicKey, encryptedPrivateKey)
 	return args.Error(0)
-}
-
-// NewChannelAccountStoreMock creates a new instance of ChannelAccountStoreMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-// The first argument is typically a *testing.T value.
-func NewChannelAccountStoreMock(t interface {
-	mock.TestingT
-	Cleanup(func())
-}) *ChannelAccountStoreMock {
-	mock := &ChannelAccountStoreMock{}
-	mock.Mock.Test(t)
-
-	t.Cleanup(func() { mock.AssertExpectations(t) })
-
-	return mock
 }

--- a/internal/signing/store/types.go
+++ b/internal/signing/store/types.go
@@ -20,6 +20,8 @@ type ChannelAccount struct {
 
 type ChannelAccountStore interface {
 	GetAndLockIdleChannelAccount(ctx context.Context, lockedUntil time.Duration) (*ChannelAccount, error)
+	// Unlock unlocks the channel accounts with the given public keys and returns the unlocked channel accounts.
+	Unlock(ctx context.Context, publicKeys ...string) ([]ChannelAccount, error)
 	Get(ctx context.Context, sqlExec db.SQLExecuter, publicKey string) (*ChannelAccount, error)
 	GetAllByPublicKey(ctx context.Context, sqlExec db.SQLExecuter, publicKeys ...string) ([]*ChannelAccount, error)
 	AssignTxToChannelAccount(ctx context.Context, publicKey string, txHash string) error

--- a/internal/transactions/services/mocks.go
+++ b/internal/transactions/services/mocks.go
@@ -4,10 +4,10 @@ import (
 	"context"
 
 	"github.com/stellar/go/txnbuild"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/stellar/wallet-backend/internal/entities"
-
-	"github.com/stretchr/testify/mock"
+	"github.com/stellar/wallet-backend/pkg/wbclient/types"
 )
 
 type TransactionServiceMock struct {
@@ -19,6 +19,14 @@ var _ TransactionService = (*TransactionServiceMock)(nil)
 func (t *TransactionServiceMock) NetworkPassphrase() string {
 	args := t.Called()
 	return args.String(0)
+}
+
+func (t *TransactionServiceMock) BuildAndSignTransactionsWithChannelAccounts(ctx context.Context, transactions []types.Transaction) (txXDRs []string, err error) {
+	args := t.Called(ctx, transactions)
+	if result := args.Get(0); result != nil {
+		return result.([]string), args.Error(1)
+	}
+	return nil, args.Error(1)
 }
 
 func (t *TransactionServiceMock) BuildAndSignTransactionWithChannelAccount(ctx context.Context, operations []txnbuild.Operation, timeoutInSecs int64, simulationResult entities.RPCSimulateTransactionResult) (*txnbuild.Transaction, error) {

--- a/internal/transactions/services/mocks.go
+++ b/internal/transactions/services/mocks.go
@@ -3,10 +3,8 @@ package services
 import (
 	"context"
 
-	"github.com/stellar/go/txnbuild"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/stellar/wallet-backend/internal/entities"
 	"github.com/stellar/wallet-backend/pkg/wbclient/types"
 )
 
@@ -21,18 +19,14 @@ func (t *TransactionServiceMock) NetworkPassphrase() string {
 	return args.String(0)
 }
 
-func (t *TransactionServiceMock) BuildAndSignTransactionsWithChannelAccounts(ctx context.Context, transactions []types.Transaction) (txXDRs []string, err error) {
-	args := t.Called(ctx, transactions)
+func (t *TransactionServiceMock) BuildAndSignTransactionsWithChannelAccounts(ctx context.Context, transactions ...types.Transaction) (txXDRs []string, err error) {
+	_args := []any{ctx}
+	for _, transaction := range transactions {
+		_args = append(_args, transaction)
+	}
+	args := t.Called(_args...)
 	if result := args.Get(0); result != nil {
 		return result.([]string), args.Error(1)
-	}
-	return nil, args.Error(1)
-}
-
-func (t *TransactionServiceMock) BuildAndSignTransactionWithChannelAccount(ctx context.Context, operations []txnbuild.Operation, timeoutInSecs int64, simulationResult entities.RPCSimulateTransactionResult) (*txnbuild.Transaction, error) {
-	args := t.Called(ctx, operations, timeoutInSecs, simulationResult)
-	if result := args.Get(0); result != nil {
-		return result.(*txnbuild.Transaction), args.Error(1)
 	}
 	return nil, args.Error(1)
 }

--- a/internal/transactions/services/transaction_service.go
+++ b/internal/transactions/services/transaction_service.go
@@ -116,7 +116,8 @@ func (t *transactionService) BuildAndSignTransactionsWithChannelAccounts(ctx con
 		}
 
 		// build txnbuild operations:
-		ops, err := transactionsUtils.BuildOperations(transaction.Operations)
+		var ops []txnbuild.Operation
+		ops, err = transactionsUtils.BuildOperations(transaction.Operations)
 		if err != nil {
 			return nil, fmt.Errorf("building txnbuildoperations for transaction[%d]: %w", i, err)
 		}

--- a/internal/transactions/services/transaction_service.go
+++ b/internal/transactions/services/transaction_service.go
@@ -155,6 +155,8 @@ func (t *transactionService) BuildAndSignTransactionsWithChannelAccounts(ctx con
 	return txXDRs, nil
 }
 
+// buildAndSignTransactionWithChannelAccount will build a transaction with a channel account and sign it with that channel account.
+// If any error occurs after the channel account has been retrieved, the channel account public key will be returned.
 func (t *transactionService) buildAndSignTransactionWithChannelAccount(ctx context.Context, operations []txnbuild.Operation, timeoutInSecs int64, simulationResponse entities.RPCSimulateTransactionResult) (tx *txnbuild.Transaction, chAccPubKey string, err error) {
 	// validate and sanitize transactions timeouts:
 	if timeoutInSecs > MaxTimeoutInSeconds {

--- a/internal/transactions/services/transaction_service_test.go
+++ b/internal/transactions/services/transaction_service_test.go
@@ -244,7 +244,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 	require.NoError(t, outerErr)
 
 	t.Run("🔴timeout_must_be_smaller_than_max_timeout", func(t *testing.T) {
-		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{}, MaxTimeoutInSeconds+1, entities.RPCSimulateTransactionResult{})
+		tx, err := txService.buildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{}, MaxTimeoutInSeconds+1, entities.RPCSimulateTransactionResult{})
 		assert.Empty(t, tx)
 		assert.ErrorContains(t, err, fmt.Sprintf("cannot be greater than %d seconds", MaxTimeoutInSeconds))
 	})
@@ -255,7 +255,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 			Return("", errors.New("channel accounts unavailable")).
 			Once()
 
-		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{}, 30, entities.RPCSimulateTransactionResult{})
+		tx, err := txService.buildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{}, 30, entities.RPCSimulateTransactionResult{})
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
 		assert.Empty(t, tx)
@@ -269,7 +269,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 			Return(channelAccount.Address(), nil).
 			Once()
 
-		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{&txnbuild.AccountMerge{
+		tx, err := txService.buildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{&txnbuild.AccountMerge{
 			Destination:   keypair.MustRandom().Address(),
 			SourceAccount: channelAccount.Address(),
 		}}, 30, entities.RPCSimulateTransactionResult{})
@@ -286,7 +286,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 			Return(channelAccount.Address(), nil).
 			Once()
 
-		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{&txnbuild.AccountMerge{
+		tx, err := txService.buildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{&txnbuild.AccountMerge{
 			Destination: keypair.MustRandom().Address(),
 		}}, 30, entities.RPCSimulateTransactionResult{})
 
@@ -307,7 +307,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 			Return(int64(0), errors.New("rpc service down")).
 			Once()
 
-		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{}, 30, entities.RPCSimulateTransactionResult{})
+		tx, err := txService.buildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{}, 30, entities.RPCSimulateTransactionResult{})
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
 		mRPCService.AssertExpectations(t)
@@ -328,7 +328,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 			Return(int64(1), nil).
 			Once()
 
-		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{}, 30, entities.RPCSimulateTransactionResult{})
+		tx, err := txService.buildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{}, 30, entities.RPCSimulateTransactionResult{})
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
 		mRPCService.AssertExpectations(t)
@@ -356,7 +356,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 			Return(int64(1), nil).
 			Once()
 
-		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{buildPaymentOp(t)}, 30, entities.RPCSimulateTransactionResult{})
+		tx, err := txService.buildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{buildPaymentOp(t)}, 30, entities.RPCSimulateTransactionResult{})
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
 		mChannelAccountStore.AssertExpectations(t)
@@ -388,7 +388,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 			Return(int64(1), nil).
 			Once()
 
-		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{buildPaymentOp(t)}, 30, entities.RPCSimulateTransactionResult{})
+		tx, err := txService.buildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{buildPaymentOp(t)}, 30, entities.RPCSimulateTransactionResult{})
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
 		mChannelAccountStore.AssertExpectations(t)
@@ -449,7 +449,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 					Return(int64(1), nil).
 					Once()
 
-				tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{buildPaymentOp(t)}, int64(tc.inputTimeout), entities.RPCSimulateTransactionResult{})
+				tx, err := txService.buildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{buildPaymentOp(t)}, int64(tc.inputTimeout), entities.RPCSimulateTransactionResult{})
 
 				mChannelAccountSignatureClient.AssertExpectations(t)
 				mChannelAccountStore.AssertExpectations(t)
@@ -491,7 +491,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		require.Equal(t, xdr.Int64(133301), sorobanTxData.ResourceFee)
 
 		simulationResponse := buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeAccount, keypair.MustRandom().Address())
-		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{buildInvokeContractOp(t)}, 30, simulationResponse)
+		tx, err := txService.buildAndSignTransactionWithChannelAccount(context.Background(), []txnbuild.Operation{buildInvokeContractOp(t)}, 30, simulationResponse)
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
 		mChannelAccountStore.AssertExpectations(t)


### PR DESCRIPTION
### What

Unlock channelAccounts if `/build` fails

### Why

Address @aristidesstaffieri [comment](https://github.com/stellar/wallet-backend/pull/184#discussion_r2098198111):
<img width="786" alt="Screenshot 2025-05-28 at 3 02 04 PM" src="https://github.com/user-attachments/assets/73f1eec7-4a73-43f8-a00b-286913f0096a" />

### Checklist

#### PR Structure

- [ ] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
