### PR TITLE
fix: test was failing intermittently due to a timeout that was too short

### DIFF
--- a/internal/services/rpc_service.go
+++ b/internal/services/rpc_service.go
@@ -288,7 +288,7 @@ func (r *rpcService) TrackRPCServiceHealth(ctx context.Context, immediateHealthC
 	for {
 		select {
 		case <-ctx.Done():
-			log.Ctx(ctx).Info("RPC health tracking stopped due to context cancellation")
+			log.Ctx(ctx).Infof("RPC health tracking stopped due to context cancellation: %v", ctx.Err())
 			return
 
 		case sig := <-signalChan:

--- a/internal/services/rpc_service_test.go
+++ b/internal/services/rpc_service_test.go
@@ -878,7 +878,7 @@ func TestTrackRPCServiceHealth_HealthyService(t *testing.T) {
 	}
 
 	// Mock the HTTP response for GetHealth
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), rpcService.HealthCheckTickInterval()*2)
 	defer cancel()
 	mockResponse := &http.Response{
 		Body: io.NopCloser(bytes.NewBuffer([]byte(`{


### PR DESCRIPTION
### What

Fix test that was failing intermittently due to a timeout that was too short.

### Why

The test had a context with timeout of 5 seconds, exactly the same timeout as the one used in the RPC health checker.

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
