### PR TITLE
services: ingest transactions pertaining to at least one of our watched account(s)

### DIFF
--- a/internal/data/accounts.go
+++ b/internal/data/accounts.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/lib/pq"
-
 	"github.com/stellar/wallet-backend/internal/db"
 	"github.com/stellar/wallet-backend/internal/metrics"
 )
@@ -41,26 +39,6 @@ func (m *AccountModel) Delete(ctx context.Context, address string) error {
 	}
 	m.MetricsService.IncDBQuery("DELETE", "accounts")
 	return nil
-}
-
-// GetExisting returns only the addresses from the input list that exist in the database.
-func (m *AccountModel) GetExisting(ctx context.Context, dbTx db.Transaction, stellarAddresses []string) ([]string, error) {
-	var sqlExecuter db.SQLExecuter = dbTx
-	if sqlExecuter == nil {
-		sqlExecuter = m.DB
-	}
-
-	const query = "SELECT stellar_address FROM accounts WHERE stellar_address = ANY($1) FOR UPDATE"
-	var existingAddresses []string
-	start := time.Now()
-	err := sqlExecuter.SelectContext(ctx, &existingAddresses, query, pq.Array(stellarAddresses))
-	duration := time.Since(start).Seconds()
-	m.MetricsService.ObserveDBQueryDuration("SELECT", "accounts", duration)
-	if err != nil {
-		return nil, fmt.Errorf("getting existing addresses: %w", err)
-	}
-	m.MetricsService.IncDBQuery("SELECT", "accounts")
-	return existingAddresses, nil
 }
 
 // IsAccountFeeBumpEligible checks whether an account is eligible to have its transaction fee-bumped. Channel Accounts should be

--- a/internal/data/accounts_test.go
+++ b/internal/data/accounts_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/lib/pq"
 	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -77,102 +76,6 @@ func TestAccountModelDelete(t *testing.T) {
 	var dbAddress sql.NullString
 	err = m.DB.GetContext(ctx, &dbAddress, "SELECT stellar_address FROM accounts LIMIT 1")
 	assert.ErrorIs(t, err, sql.ErrNoRows)
-}
-
-func Test_AccountModel_GetExisting(t *testing.T) {
-	dbt := dbtest.Open(t)
-	defer dbt.Close()
-	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
-	require.NoError(t, err)
-	defer dbConnectionPool.Close()
-
-	ctx := context.Background()
-	existingAddress1 := keypair.MustRandom().Address()
-	existingAddress2 := keypair.MustRandom().Address()
-	existingAddresses := []string{existingAddress1, existingAddress2}
-	nonExistingAddress := keypair.MustRandom().Address()
-
-	// Insert addresses to test against
-	_, err = dbConnectionPool.ExecContext(ctx, "INSERT INTO accounts (stellar_address) SELECT unnest($1::text[])", pq.Array(existingAddresses))
-	require.NoError(t, err)
-
-	testCases := []struct {
-		name            string
-		inputValues     []string
-		useDBTx         bool
-		wantResults     []string
-		wantErrContains string
-	}{
-		{
-			name:            "🟢all_addresses_found",
-			inputValues:     existingAddresses,
-			useDBTx:         false,
-			wantResults:     existingAddresses,
-			wantErrContains: "",
-		},
-		{
-			name:            "🟢all_addresses_found_with_db_transaction",
-			inputValues:     existingAddresses,
-			useDBTx:         true,
-			wantResults:     existingAddresses,
-			wantErrContains: "",
-		},
-		{
-			name:            "🟢no_addresses_found",
-			inputValues:     []string{nonExistingAddress},
-			useDBTx:         false,
-			wantResults:     nil,
-			wantErrContains: "",
-		},
-		{
-			name:            "🟢mixed_addresses",
-			inputValues:     []string{existingAddress1, existingAddress2, nonExistingAddress},
-			useDBTx:         false,
-			wantResults:     []string{existingAddress1, existingAddress2},
-			wantErrContains: "",
-		},
-		{
-			name:            "🟢empty_input",
-			inputValues:     []string{},
-			useDBTx:         false,
-			wantResults:     nil,
-			wantErrContains: "",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Create fresh mock for each test case
-			mockMetricsService := metrics.NewMockMetricsService()
-			mockMetricsService.
-				On("ObserveDBQueryDuration", "SELECT", "accounts", mock.Anything).Return().
-				On("IncDBQuery", "SELECT", "accounts").Return()
-			defer mockMetricsService.AssertExpectations(t)
-
-			m := &AccountModel{
-				DB:             dbConnectionPool,
-				MetricsService: mockMetricsService,
-			}
-
-			var dbTx db.Transaction
-			if tc.useDBTx {
-				dbTx, err = dbConnectionPool.BeginTxx(ctx, nil)
-				require.NoError(t, err)
-				defer dbTx.Rollback()
-			}
-
-			got, err := m.GetExisting(ctx, dbTx, tc.inputValues)
-
-			if tc.wantErrContains != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tc.wantErrContains)
-				assert.Nil(t, got)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tc.wantResults, got)
-			}
-		})
-	}
 }
 
 func TestAccountModelIsAccountFeeBumpEligible(t *testing.T) {

--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -8,11 +8,12 @@ import (
 )
 
 type Models struct {
-	DB          db.ConnectionPool
-	Account     *AccountModel
-	Contract    *ContractModel
-	IngestStore *IngestStoreModel
-	Payments    *PaymentModel
+	DB           db.ConnectionPool
+	Account      *AccountModel
+	Contract     *ContractModel
+	IngestStore  *IngestStoreModel
+	Payments     *PaymentModel
+	Transactions *TransactionModel
 }
 
 func NewModels(db db.ConnectionPool, metricsService metrics.MetricsService) (*Models, error) {
@@ -21,10 +22,11 @@ func NewModels(db db.ConnectionPool, metricsService metrics.MetricsService) (*Mo
 	}
 
 	return &Models{
-		DB:          db,
-		Account:     &AccountModel{DB: db, MetricsService: metricsService},
-		Contract:    &ContractModel{DB: db, MetricsService: metricsService},
-		IngestStore: &IngestStoreModel{DB: db, MetricsService: metricsService},
-		Payments:    &PaymentModel{DB: db, MetricsService: metricsService},
+		DB:           db,
+		Account:      &AccountModel{DB: db, MetricsService: metricsService},
+		Contract:     &ContractModel{DB: db, MetricsService: metricsService},
+		IngestStore:  &IngestStoreModel{DB: db, MetricsService: metricsService},
+		Payments:     &PaymentModel{DB: db, MetricsService: metricsService},
+		Transactions: &TransactionModel{DB: db, MetricsService: metricsService},
 	}, nil
 }

--- a/internal/data/transactions.go
+++ b/internal/data/transactions.go
@@ -1,0 +1,120 @@
+package data
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/lib/pq"
+
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+)
+
+type TransactionModel struct {
+	DB             db.ConnectionPool
+	MetricsService metrics.MetricsService
+}
+
+func (m *TransactionModel) BatchInsert(
+	ctx context.Context,
+	dbTx db.SQLExecuter,
+	txs []types.Transaction,
+	stellarAddressesByTxHash map[string][]string,
+) error {
+	now := time.Now()
+	var sqlExecuter db.SQLExecuter = dbTx
+	if sqlExecuter == nil {
+		sqlExecuter = m.DB
+	}
+
+	// 1. Flatten the transactions into parallel slices
+	hashes := make([]string, len(txs))
+	toIDs := make([]int64, len(txs))
+	envelopeXDRs := make([]string, len(txs))
+	resultXDRs := make([]string, len(txs))
+	metaXDRs := make([]string, len(txs))
+	ledgerNumbers := make([]int, len(txs))
+	ledgerCreatedAts := make([]time.Time, len(txs))
+	ingestedAts := make([]time.Time, len(txs))
+
+	for i, t := range txs {
+		hashes[i] = t.Hash
+		toIDs[i] = t.ToID
+		envelopeXDRs[i] = t.EnvelopeXDR
+		resultXDRs[i] = t.ResultXDR
+		metaXDRs[i] = t.MetaXDR
+		ledgerNumbers[i] = int(t.LedgerNumber)
+		ledgerCreatedAts[i] = t.LedgerCreatedAt
+		ingestedAts[i] = now
+	}
+
+	// 2. Batch insert the transactions into the database
+	const insertTxsQuery = `
+    INSERT INTO transactions
+      (hash, to_id, envelope_xdr, result_xdr, meta_xdr, ledger_number, ledger_created_at, ingested_at)
+    SELECT
+      UNNEST($1::text[]),
+      UNNEST($2::bigint[]),
+      UNNEST($3::text[]),
+      UNNEST($4::text[]),
+      UNNEST($5::text[]),
+      UNNEST($6::bigint[]),
+      UNNEST($7::timestamptz[]),
+      UNNEST($8::timestamptz[])
+    ON CONFLICT (hash) DO NOTHING;
+    `
+
+	start := time.Now()
+	_, err := sqlExecuter.ExecContext(ctx, insertTxsQuery,
+		pq.Array(hashes),
+		pq.Array(toIDs),
+		pq.Array(envelopeXDRs),
+		pq.Array(resultXDRs),
+		pq.Array(metaXDRs),
+		pq.Array(ledgerNumbers),
+		pq.Array(ledgerCreatedAts),
+		pq.Array(ingestedAts),
+	)
+	duration := time.Since(start).Seconds()
+	m.MetricsService.ObserveDBQueryDuration("INSERT", "transactions", duration)
+	if err != nil {
+		return fmt.Errorf("batch inserting transactions: %w", err)
+	}
+	m.MetricsService.IncDBQuery("INSERT", "transactions")
+
+	// 3. Flatten the stellarAddressesByTxHash into parallel slices
+	var (
+		txHashes   []string
+		accountIDs []string
+	)
+	for txHash, addrs := range stellarAddressesByTxHash {
+		for _, acct := range addrs {
+			txHashes = append(txHashes, txHash)
+			accountIDs = append(accountIDs, acct)
+		}
+	}
+
+	// 4. Batch insert the transactions_accounts into the database
+	const insertLinks = `
+    INSERT INTO transactions_accounts (tx_hash, account_id)
+    SELECT
+      UNNEST($1::text[]),
+      UNNEST($2::text[])
+    ON CONFLICT DO NOTHING;
+    `
+	start = time.Now()
+	_, err = sqlExecuter.ExecContext(ctx, insertLinks,
+		pq.Array(txHashes),
+		pq.Array(accountIDs),
+	)
+	duration = time.Since(start).Seconds()
+	m.MetricsService.ObserveDBQueryDuration("INSERT", "transactions_accounts", duration)
+	if err != nil {
+		return fmt.Errorf("batch insert transactions_accounts: %w", err)
+	}
+	m.MetricsService.IncDBQuery("INSERT", "transactions_accounts")
+
+	return nil
+}

--- a/internal/data/transactions.go
+++ b/internal/data/transactions.go
@@ -138,13 +138,11 @@ func (m *TransactionModel) BatchInsert(
 		pq.Array(stellarAddresses),
 	)
 	duration := time.Since(start).Seconds()
-	m.MetricsService.ObserveDBQueryDuration("INSERT", "transactions", duration)
-	m.MetricsService.ObserveDBQueryDuration("INSERT", "transactions_accounts", duration)
+	m.MetricsService.ObserveDBQueryDuration("INSERT", "transactions,transactions_accounts", duration)
 	if err != nil {
 		return nil, fmt.Errorf("batch inserting transactions and accounts: %w", err)
 	}
-	m.MetricsService.IncDBQuery("INSERT", "transactions")
-	m.MetricsService.IncDBQuery("INSERT", "transactions_accounts")
+	m.MetricsService.IncDBQuery("INSERT", "transactions,transactions_accounts")
 
 	return insertedHashes, nil
 }

--- a/internal/data/transactions_test.go
+++ b/internal/data/transactions_test.go
@@ -147,7 +147,7 @@ func Test_TransactionModel_BatchInsert(t *testing.T) {
 				sqlExecuter = tx
 			}
 
-			err := m.BatchInsert(ctx, sqlExecuter, tc.txs, tc.stellarAddressesByHash)
+			gotInsertedHashes, err := m.BatchInsert(ctx, sqlExecuter, tc.txs, tc.stellarAddressesByHash)
 
 			if tc.wantErrContains != "" {
 				require.Error(t, err)
@@ -157,10 +157,11 @@ func Test_TransactionModel_BatchInsert(t *testing.T) {
 
 			// Verify the results
 			require.NoError(t, err)
-			var insertedHashes []string
-			err = sqlExecuter.SelectContext(ctx, &insertedHashes, "SELECT hash FROM transactions ORDER BY hash")
+			var dbInsertedHashes []string
+			err = sqlExecuter.SelectContext(ctx, &dbInsertedHashes, "SELECT hash FROM transactions")
 			require.NoError(t, err)
-			assert.Equal(t, tc.wantHashes, insertedHashes)
+			assert.ElementsMatch(t, tc.wantHashes, dbInsertedHashes)
+			assert.ElementsMatch(t, tc.wantHashes, gotInsertedHashes)
 
 			// Verify the account links
 			if len(tc.stellarAddressesByHash) > 0 {

--- a/internal/data/transactions_test.go
+++ b/internal/data/transactions_test.go
@@ -1,0 +1,168 @@
+package data
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stellar/go/keypair"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+)
+
+func Test_TransactionModel_BatchInsert(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	ctx := context.Background()
+	now := time.Now()
+
+	// Create test data
+	kp1 := keypair.MustRandom()
+	kp2 := keypair.MustRandom()
+	const q = "INSERT INTO accounts (stellar_address) SELECT UNNEST(ARRAY[$1, $2])"
+	_, err = dbConnectionPool.ExecContext(ctx, q, kp1.Address(), kp2.Address())
+	require.NoError(t, err)
+
+	tx1 := types.Transaction{
+		Hash:            "tx1",
+		EnvelopeXDR:     "envelope1",
+		ResultXDR:       "result1",
+		MetaXDR:         "meta1",
+		LedgerNumber:    1,
+		LedgerCreatedAt: now,
+	}
+	tx2 := types.Transaction{
+		Hash:            "tx2",
+		EnvelopeXDR:     "envelope2",
+		ResultXDR:       "result2",
+		MetaXDR:         "meta2",
+		LedgerNumber:    2,
+		LedgerCreatedAt: now,
+	}
+
+	testCases := []struct {
+		name                   string
+		useDBTx                bool
+		txs                    []types.Transaction
+		stellarAddressesByHash map[string][]string
+		wantErrContains        string
+		wantResults            []string
+	}{
+		{
+			name:                   "🟢successful_insert_without_transaction",
+			useDBTx:                false,
+			txs:                    []types.Transaction{tx1, tx2},
+			stellarAddressesByHash: map[string][]string{tx1.Hash: {kp1.Address()}, tx2.Hash: {kp2.Address()}},
+			wantErrContains:        "",
+			wantResults:            []string{tx1.Hash, tx2.Hash},
+		},
+		{
+			name:                   "🟢successful_insert_with_transaction",
+			useDBTx:                true,
+			txs:                    []types.Transaction{tx1},
+			stellarAddressesByHash: map[string][]string{tx1.Hash: {kp1.Address()}},
+			wantErrContains:        "",
+			wantResults:            []string{tx1.Hash},
+		},
+		{
+			name:                   "🟢empty_input",
+			useDBTx:                false,
+			txs:                    []types.Transaction{},
+			stellarAddressesByHash: map[string][]string{},
+			wantErrContains:        "",
+			wantResults:            nil,
+		},
+		{
+			name:                   "🟡duplicate_transaction",
+			useDBTx:                false,
+			txs:                    []types.Transaction{tx1, tx1},
+			stellarAddressesByHash: map[string][]string{tx1.Hash: {kp1.Address()}},
+			wantErrContains:        "",
+			wantResults:            []string{tx1.Hash},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Clear the database before each test
+			_, err = dbConnectionPool.ExecContext(ctx, "TRUNCATE transactions, transactions_accounts CASCADE")
+			require.NoError(t, err)
+
+			// Create fresh mock for each test case
+			mockMetricsService := metrics.NewMockMetricsService()
+			mockMetricsService.
+				On("ObserveDBQueryDuration", "INSERT", "transactions", mock.Anything).Return().
+				On("IncDBQuery", "INSERT", "transactions").Return().
+				On("ObserveDBQueryDuration", "INSERT", "transactions_accounts", mock.Anything).Return().
+				On("IncDBQuery", "INSERT", "transactions_accounts").Return()
+			defer mockMetricsService.AssertExpectations(t)
+
+			m := &TransactionModel{
+				DB:             dbConnectionPool,
+				MetricsService: mockMetricsService,
+			}
+
+			var sqlExecuter db.SQLExecuter = dbConnectionPool
+			if tc.useDBTx {
+				tx, err := dbConnectionPool.BeginTxx(ctx, nil)
+				require.NoError(t, err)
+				defer tx.Rollback()
+				sqlExecuter = tx
+			}
+
+			err := m.BatchInsert(ctx, sqlExecuter, tc.txs, tc.stellarAddressesByHash)
+
+			if tc.wantErrContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErrContains)
+				return
+			}
+
+			// Verify the results
+			require.NoError(t, err)
+			var insertedHashes []string
+			err = sqlExecuter.SelectContext(ctx, &insertedHashes, "SELECT hash FROM transactions ORDER BY hash")
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantResults, insertedHashes)
+
+			// Verify the account links
+			if len(tc.stellarAddressesByHash) > 0 {
+				var accountLinks []struct {
+					TxHash    string `db:"tx_hash"`
+					AccountID string `db:"account_id"`
+				}
+				err = sqlExecuter.SelectContext(ctx, &accountLinks, "SELECT tx_hash, account_id FROM transactions_accounts ORDER BY tx_hash, account_id")
+				require.NoError(t, err)
+
+				// Create a map of tx_hash -> set of account_ids for O(1) lookups
+				accountLinksMap := make(map[string]map[string]struct{})
+				for _, link := range accountLinks {
+					if _, exists := accountLinksMap[link.TxHash]; !exists {
+						accountLinksMap[link.TxHash] = make(map[string]struct{})
+					}
+					accountLinksMap[link.TxHash][link.AccountID] = struct{}{}
+				}
+
+				// Verify each transaction has its expected account links
+				for txHash, expectedAccounts := range tc.stellarAddressesByHash {
+					accounts, exists := accountLinksMap[txHash]
+					require.True(t, exists, "Transaction %s not found in account links", txHash)
+					for _, expectedAccount := range expectedAccounts {
+						_, found := accounts[expectedAccount]
+						assert.True(t, found, "Expected account link not found: tx=%s, account=%s", txHash, expectedAccount)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/data/transactions_test.go
+++ b/internal/data/transactions_test.go
@@ -128,10 +128,8 @@ func Test_TransactionModel_BatchInsert(t *testing.T) {
 			// Create fresh mock for each test case
 			mockMetricsService := metrics.NewMockMetricsService()
 			mockMetricsService.
-				On("ObserveDBQueryDuration", "INSERT", "transactions", mock.Anything).Return().
-				On("IncDBQuery", "INSERT", "transactions").Return().
-				On("ObserveDBQueryDuration", "INSERT", "transactions_accounts", mock.Anything).Return().
-				On("IncDBQuery", "INSERT", "transactions_accounts").Return()
+				On("ObserveDBQueryDuration", "INSERT", "transactions,transactions_accounts", mock.Anything).Return().Once().
+				On("IncDBQuery", "INSERT", "transactions,transactions_accounts").Return().Once()
 			defer mockMetricsService.AssertExpectations(t)
 
 			m := &TransactionModel{

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -223,6 +223,7 @@ func (m *ingestService) Run(ctx context.Context, startLedger uint32, endLedger u
 		case <-ctx.Done():
 			return fmt.Errorf("ingestor stopped due to context cancellation: %w", ctx.Err())
 		case rpcHealth = <-rpcHeartbeatChannel:
+			ingestHeartbeatChannel <- true // ⬅️ indicate that it's still running
 			// this will fallthrough to execute the code below ⬇️
 		}
 

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -398,7 +398,7 @@ func (m *ingestService) ingestProcessedData(ctx context.Context, ledgerIndexer *
 			}
 
 			// 1.2. TODO: Identify which operations should be ingested.
-			// 1.3. TODO: Identify which channel accounts should be unlocked.
+			// 1.3. TODO: Identify which state changes should be ingested.
 		}
 
 		// 2. Insert queries


### PR DESCRIPTION
### What

Persist in the database the indexed transactions that pertain to at least one of our watched account(s).

### Why

Closes #202 

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
