### PR TITLE
services: eagerly unlock channel accounts when their txHash is observed

### DIFF
--- a/internal/indexer/indexer_buffer.go
+++ b/internal/indexer/indexer_buffer.go
@@ -59,3 +59,15 @@ func (b *IndexerBuffer) GetParticipantTransactions(participant string) []types.T
 
 	return txs
 }
+
+func (b *IndexerBuffer) GetAllTransactions() []types.Transaction {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	txs := make([]types.Transaction, 0, len(b.txByHash))
+	for _, tx := range b.txByHash {
+		txs = append(txs, tx)
+	}
+
+	return txs
+}

--- a/internal/indexer/indexer_buffer_test.go
+++ b/internal/indexer/indexer_buffer_test.go
@@ -44,6 +44,9 @@ func Test_IndexerBuffer_PushParticipantTransaction_and_Getters(t *testing.T) {
 
 		// Assert GetNumberOfTransactions
 		assert.Equal(t, 2, indexerBuffer.GetNumberOfTransactions())
+
+		// Assert GetAllTransactions
+		assert.ElementsMatch(t, []types.Transaction{tx1, tx2}, indexerBuffer.GetAllTransactions())
 	})
 
 	t.Run("🟢concurrent_calls", func(t *testing.T) {
@@ -75,7 +78,7 @@ func Test_IndexerBuffer_PushParticipantTransaction_and_Getters(t *testing.T) {
 
 		// Concurrent getter operations
 		wg = sync.WaitGroup{}
-		wg.Add(4)
+		wg.Add(5)
 
 		// GetParticipantTransactions
 		go func() {
@@ -96,6 +99,12 @@ func Test_IndexerBuffer_PushParticipantTransaction_and_Getters(t *testing.T) {
 		// Assert Participants
 		go func() {
 			assert.Equal(t, set.NewSet("alice", "bob"), indexerBuffer.Participants)
+			wg.Done()
+		}()
+
+		// Assert GetAllTransactions
+		go func() {
+			assert.ElementsMatch(t, []types.Transaction{tx1, tx2}, indexerBuffer.GetAllTransactions())
 			wg.Done()
 		}()
 

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -535,7 +535,7 @@ func (m *ingestService) unlockChannelAccounts(ctx context.Context, ledgerTransac
 		}
 	}
 
-	if affectedRows, err := m.chAccStore.UnassignTxAndUnlockChannelAccounts(ctx, innerTxHashes...); err != nil {
+	if affectedRows, err := m.chAccStore.UnassignTxAndUnlockChannelAccounts(ctx, nil, innerTxHashes...); err != nil {
 		return fmt.Errorf("unlocking channel accounts with txHashes %v: %w", innerTxHashes, err)
 	} else if affectedRows > 0 {
 		log.Ctx(ctx).Infof("unlocked %d channel accounts", affectedRows)

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -156,7 +156,7 @@ func (m *ingestService) DeprecatedRun(ctx context.Context, startLedger uint32, e
 			m.metricsService.ObserveIngestionDuration(paymentPrometheusLabel, time.Since(startTime).Seconds())
 
 			// eagerly unlock channel accounts from txs
-			err = m.unlockChannelAccounts(ctx, ledgerTransactions)
+			err = m.unlockChannelAccountsDeprecated(ctx, ledgerTransactions)
 			if err != nil {
 				return fmt.Errorf("unlocking channel account from tx: %w", err)
 			}
@@ -414,12 +414,41 @@ func (m *ingestService) ingestProcessedData(ctx context.Context, ledgerIndexer *
 
 		log.Ctx(ctx).Infof("✅ inserted %d transactions with hashes %v", len(insertedHashes), insertedHashes)
 
-		// 3. TODO: Unlock channel accounts.
+		// 3. Unlock channel accounts.
+		err = m.unlockChannelAccounts(ctx, ledgerIndexer)
+		if err != nil {
+			return fmt.Errorf("unlocking channel accounts: %w", err)
+		}
 
 		return nil
 	})
 	if dbTxErr != nil {
 		return fmt.Errorf("ingesting processed data: %w", dbTxErr)
+	}
+
+	return nil
+}
+
+// unlockChannelAccounts unlocks the channel accounts associated with the given transaction XDRs.
+func (m *ingestService) unlockChannelAccounts(ctx context.Context, ledgerIndexer *indexer.Indexer) error {
+	txs := ledgerIndexer.GetAllTransactions()
+	if len(txs) == 0 {
+		return nil
+	}
+
+	innerTxHashes := make([]string, 0, len(txs))
+	for _, tx := range txs {
+		innerTxHash, err := m.extractInnerTxHash(tx.EnvelopeXDR)
+		if err != nil {
+			return fmt.Errorf("extracting inner tx hash: %w", err)
+		}
+		innerTxHashes = append(innerTxHashes, innerTxHash)
+	}
+
+	if affectedRows, err := m.chAccStore.UnassignTxAndUnlockChannelAccounts(ctx, nil, innerTxHashes...); err != nil {
+		return fmt.Errorf("unlocking channel accounts with txHashes %v: %w", innerTxHashes, err)
+	} else if affectedRows > 0 {
+		log.Ctx(ctx).Infof("🔓 unlocked %d channel accounts", affectedRows)
 	}
 
 	return nil
@@ -519,8 +548,8 @@ func (m *ingestService) ingestPayments(ctx context.Context, ledgerTransactions [
 	return nil
 }
 
-// unlockChannelAccounts unlocks the channel accounts associated with the given transaction XDRs.
-func (m *ingestService) unlockChannelAccounts(ctx context.Context, ledgerTransactions []entities.Transaction) error {
+// unlockChannelAccountsDeprecated unlocks the channel accounts associated with the given transaction XDRs.
+func (m *ingestService) unlockChannelAccountsDeprecated(ctx context.Context, ledgerTransactions []entities.Transaction) error {
 	if len(ledgerTransactions) == 0 {
 		log.Ctx(ctx).Debug("no transactions to unlock channel accounts from")
 		return nil
@@ -584,12 +613,12 @@ func trackIngestServiceHealth(ctx context.Context, heartbeat chan any, tracker a
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			warn := fmt.Sprintf("ingestion service stale for over %s", ingestHealthCheckMaxWaitTime)
-			log.Warn(warn)
+			warn := fmt.Sprintf("🐌 ingestion service stale for over %s 🐢", ingestHealthCheckMaxWaitTime)
+			log.Ctx(ctx).Warn(warn)
 			if tracker != nil {
 				tracker.CaptureMessage(warn)
 			} else {
-				log.Warn("App Tracker is nil")
+				log.Ctx(ctx).Warnf("[NIL TRACKER] %s", warn)
 			}
 			ticker.Reset(ingestHealthCheckMaxWaitTime)
 		case <-heartbeat:

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -489,7 +489,7 @@ func TestIngest_LatestSyncedLedgerBehindRPC(t *testing.T) {
 	require.NoError(t, err)
 	txHash, err := transaction.HashHex(network.TestNetworkPassphrase)
 	require.NoError(t, err)
-	mockChAccStore.On("UnassignTxAndUnlockChannelAccounts", mock.Anything, txHash).Return(int64(1), nil).Once()
+	mockChAccStore.On("UnassignTxAndUnlockChannelAccounts", mock.Anything, mock.Anything, txHash).Return(int64(1), nil).Once()
 	txEnvXDR, err := transaction.Base64()
 	require.NoError(t, err)
 
@@ -558,7 +558,7 @@ func TestIngest_LatestSyncedLedgerAheadOfRPC(t *testing.T) {
 		On("TrackRPCServiceHealth", ctx, mock.Anything).Once().
 		On("NetworkPassphrase").Return(network.TestNetworkPassphrase)
 	mockChAccStore := &store.ChannelAccountStoreMock{}
-	mockChAccStore.On("UnassignTxAndUnlockChannelAccounts", mock.Anything, testInnerTxHash).Return(int64(1), nil).Twice()
+	mockChAccStore.On("UnassignTxAndUnlockChannelAccounts", mock.Anything, mock.Anything, testInnerTxHash).Return(int64(1), nil).Twice()
 	mockContractStore := &cache.MockTokenContractStore{}
 	ingestService, err := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, mockChAccStore, mockContractStore, mockMetricsService)
 	require.NoError(t, err)

--- a/internal/signing/store/channel_accounts_model.go
+++ b/internal/signing/store/channel_accounts_model.go
@@ -93,7 +93,11 @@ func (ca *ChannelAccountModel) AssignTxToChannelAccount(ctx context.Context, pub
 	return nil
 }
 
-func (ca *ChannelAccountModel) UnassignTxAndUnlockChannelAccounts(ctx context.Context, txHashes ...string) (int64, error) {
+func (ca *ChannelAccountModel) UnassignTxAndUnlockChannelAccounts(ctx context.Context, sqlExec db.SQLExecuter, txHashes ...string) (int64, error) {
+	if sqlExec == nil {
+		sqlExec = ca.DB
+	}
+
 	if len(txHashes) == 0 {
 		return 0, errors.New("txHashes cannot be empty")
 	}
@@ -107,7 +111,7 @@ func (ca *ChannelAccountModel) UnassignTxAndUnlockChannelAccounts(ctx context.Co
 		WHERE
 			locked_tx_hash = ANY($1)
 	`
-	res, err := ca.DB.ExecContext(ctx, query, pq.Array(txHashes))
+	res, err := sqlExec.ExecContext(ctx, query, pq.Array(txHashes))
 	if err != nil {
 		return 0, fmt.Errorf("unlocking channel accounts %v: %w", txHashes, err)
 	}

--- a/internal/signing/store/channel_accounts_model_test.go
+++ b/internal/signing/store/channel_accounts_model_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stellar/wallet-backend/internal/utils"
 )
 
-func createChannelAccountFixture(t *testing.T, ctx context.Context, dbConnectionPool db.ConnectionPool, channelAccounts ...ChannelAccount) {
+func createChannelAccountFixture(t *testing.T, ctx context.Context, sqlExec db.SQLExecuter, channelAccounts ...ChannelAccount) {
 	t.Helper()
 	if len(channelAccounts) == 0 {
 		return
@@ -26,7 +26,7 @@ func createChannelAccountFixture(t *testing.T, ctx context.Context, dbConnection
 		VALUES
 			(:public_key, :encrypted_private_key, :locked_tx_hash, :locked_at, :locked_until)
 	`
-	_, err := dbConnectionPool.NamedExecContext(ctx, q, channelAccounts)
+	_, err := sqlExec.NamedExecContext(ctx, q, channelAccounts)
 	require.NoError(t, err)
 }
 
@@ -182,6 +182,7 @@ func Test_ChannelAccountModel_UnassignTxAndUnlockChannelAccounts(t *testing.T) {
 
 	testCases := []struct {
 		name                string
+		useDBTx             bool
 		numberOfFixtures    int
 		txHashes            func(fixtures []*keypair.Full) []string
 		expectedErrContains string
@@ -203,6 +204,14 @@ func Test_ChannelAccountModel_UnassignTxAndUnlockChannelAccounts(t *testing.T) {
 		},
 		{
 			name:             "🟢single_tx_hash_found",
+			numberOfFixtures: 1,
+			txHashes: func(fixtures []*keypair.Full) []string {
+				return []string{"txhash_" + fixtures[0].Address()}
+			},
+		},
+		{
+			name:             "🟢single_tx_hash_found_with_db_tx",
+			useDBTx:          true,
 			numberOfFixtures: 1,
 			txHashes: func(fixtures []*keypair.Full) []string {
 				return []string{"txhash_" + fixtures[0].Address()}
@@ -231,12 +240,20 @@ func Test_ChannelAccountModel_UnassignTxAndUnlockChannelAccounts(t *testing.T) {
 				require.NoError(t, err)
 			}()
 
+			var sqlExec db.SQLExecuter = dbConnectionPool
+			if tc.useDBTx {
+				dbTx, err := dbConnectionPool.BeginTxx(ctx, nil)
+				require.NoError(t, err)
+				defer dbTx.Rollback()
+				sqlExec = dbTx
+			}
+
 			// Create fixtures for this test case
 			fixtures := make([]*keypair.Full, tc.numberOfFixtures)
 			now := time.Now()
 			for i := range fixtures {
 				channelAccount := keypair.MustRandom()
-				createChannelAccountFixture(t, ctx, dbConnectionPool, ChannelAccount{
+				createChannelAccountFixture(t, ctx, sqlExec, ChannelAccount{
 					PublicKey:           channelAccount.Address(),
 					EncryptedPrivateKey: channelAccount.Seed(),
 					LockedTxHash:        utils.SQLNullString("txhash_" + channelAccount.Address()),
@@ -248,14 +265,14 @@ func Test_ChannelAccountModel_UnassignTxAndUnlockChannelAccounts(t *testing.T) {
 
 			// 🔒 Channel accounts start locked
 			for _, fixture := range fixtures {
-				chAccFromDB, err := m.Get(ctx, dbConnectionPool, fixture.Address())
+				chAccFromDB, err := m.Get(ctx, sqlExec, fixture.Address())
 				require.NoError(t, err)
 				require.True(t, chAccFromDB.LockedTxHash.Valid)
 				require.True(t, chAccFromDB.LockedAt.Valid)
 				require.True(t, chAccFromDB.LockedUntil.Valid)
 			}
 
-			rowsAffected, err := m.UnassignTxAndUnlockChannelAccounts(ctx, tc.txHashes(fixtures)...)
+			rowsAffected, err := m.UnassignTxAndUnlockChannelAccounts(ctx, sqlExec, tc.txHashes(fixtures)...)
 			if tc.expectedErrContains != "" {
 				require.ErrorContains(t, err, tc.expectedErrContains)
 			} else {
@@ -263,7 +280,7 @@ func Test_ChannelAccountModel_UnassignTxAndUnlockChannelAccounts(t *testing.T) {
 				require.Equal(t, int64(tc.numberOfFixtures), rowsAffected)
 				// 🔓 Channel accounts get unlocked
 				for _, fixture := range fixtures {
-					chAccFromDB, err := m.Get(ctx, dbConnectionPool, fixture.Address())
+					chAccFromDB, err := m.Get(ctx, sqlExec, fixture.Address())
 					require.NoError(t, err)
 					require.False(t, chAccFromDB.LockedTxHash.Valid)
 					require.False(t, chAccFromDB.LockedAt.Valid)

--- a/internal/signing/store/mocks.go
+++ b/internal/signing/store/mocks.go
@@ -44,8 +44,8 @@ func (s *ChannelAccountStoreMock) AssignTxToChannelAccount(ctx context.Context, 
 	return args.Error(0)
 }
 
-func (s *ChannelAccountStoreMock) UnassignTxAndUnlockChannelAccounts(ctx context.Context, txHashes ...string) (int64, error) {
-	_ca := []any{ctx}
+func (s *ChannelAccountStoreMock) UnassignTxAndUnlockChannelAccounts(ctx context.Context, sqlExec db.SQLExecuter, txHashes ...string) (int64, error) {
+	_ca := []any{ctx, sqlExec}
 	for _, txHash := range txHashes {
 		_ca = append(_ca, txHash)
 	}

--- a/internal/signing/store/types.go
+++ b/internal/signing/store/types.go
@@ -23,7 +23,7 @@ type ChannelAccountStore interface {
 	Get(ctx context.Context, sqlExec db.SQLExecuter, publicKey string) (*ChannelAccount, error)
 	GetAllByPublicKey(ctx context.Context, sqlExec db.SQLExecuter, publicKeys ...string) ([]*ChannelAccount, error)
 	AssignTxToChannelAccount(ctx context.Context, publicKey string, txHash string) error
-	UnassignTxAndUnlockChannelAccounts(ctx context.Context, txHashes ...string) (int64, error)
+	UnassignTxAndUnlockChannelAccounts(ctx context.Context, sqlExec db.SQLExecuter, txHashes ...string) (int64, error)
 	BatchInsert(ctx context.Context, sqlExec db.SQLExecuter, channelAccounts []*ChannelAccount) error
 	Count(ctx context.Context) (int64, error)
 }


### PR DESCRIPTION
### What

Eagerly unlock channel accounts when their txHash is observed.

### Why

We're replaying #180 now that the ingestor is being reimplemented to index & ingest state changes

### Issue that this PR addresses

Closes #216 

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
