### PR TITLE
Add a /health endpoint to the ingest server

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -29,6 +29,8 @@ func (c *ingestCmd) Command() *cobra.Command {
 		utils.StartLedgerOption(&cfg.StartLedger),
 		utils.EndLedgerOption(&cfg.EndLedger),
 		utils.NetworkPassphraseOption(&cfg.NetworkPassphrase),
+		utils.IngestHealthCheckPortOption(&cfg.HealthCheckPort),
+		utils.IngestMetricsPortOption(&cfg.MetricsPort),
 		{
 			Name:        "ledger-cursor-name",
 			Usage:       "Name of last synced ledger cursor, used to keep track of the last ledger ingested by the service. When starting up, ingestion will resume from the ledger number stored in this record. It should be an unique name per container as different containers would overwrite the cursor value of its peers when using the same cursor name.",

--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -29,8 +29,7 @@ func (c *ingestCmd) Command() *cobra.Command {
 		utils.StartLedgerOption(&cfg.StartLedger),
 		utils.EndLedgerOption(&cfg.EndLedger),
 		utils.NetworkPassphraseOption(&cfg.NetworkPassphrase),
-		utils.IngestHealthCheckPortOption(&cfg.HealthCheckPort),
-		utils.IngestMetricsPortOption(&cfg.MetricsPort),
+		utils.IngestServerPortOption(&cfg.ServerPort),
 		{
 			Name:        "ledger-cursor-name",
 			Usage:       "Name of last synced ledger cursor, used to keep track of the last ledger ingested by the service. When starting up, ingestion will resume from the ledger number stored in this record. It should be an unique name per container as different containers would overwrite the cursor value of its peers when using the same cursor name.",

--- a/cmd/utils/global_options.go
+++ b/cmd/utils/global_options.go
@@ -10,24 +10,13 @@ import (
 	"github.com/stellar/wallet-backend/internal/signing"
 )
 
-func IngestHealthCheckPortOption(configKey *int) *config.ConfigOption {
+func IngestServerPortOption(configKey *int) *config.ConfigOption {
 	return &config.ConfigOption{
-		Name:        "ingest-health-check-port",
-		Usage:       "The port for the ingest health check server.",
+		Name:        "ingest-server-port",
+		Usage:       "The port for the ingest server.",
 		OptType:     types.Int,
 		ConfigKey:   configKey,
-		FlagDefault: 8002,
-		Required:    true,
-	}
-}
-
-func IngestMetricsPortOption(configKey *int) *config.ConfigOption {
-	return &config.ConfigOption{
-		Name:        "ingest-metrics-port",
-		Usage:       "The port for the ingest metrics server.",
-		OptType:     types.Int,
-		ConfigKey:   configKey,
-		FlagDefault: 8003,
+		FlagDefault: 8001,
 		Required:    true,
 	}
 }

--- a/cmd/utils/global_options.go
+++ b/cmd/utils/global_options.go
@@ -10,6 +10,28 @@ import (
 	"github.com/stellar/wallet-backend/internal/signing"
 )
 
+func IngestHealthCheckPortOption(configKey *int) *config.ConfigOption {
+	return &config.ConfigOption{
+		Name:        "ingest-health-check-port",
+		Usage:       "The port for the ingest health check server.",
+		OptType:     types.Int,
+		ConfigKey:   configKey,
+		FlagDefault: 8002,
+		Required:    true,
+	}
+}
+
+func IngestMetricsPortOption(configKey *int) *config.ConfigOption {
+	return &config.ConfigOption{
+		Name:        "ingest-metrics-port",
+		Usage:       "The port for the ingest metrics server.",
+		OptType:     types.Int,
+		ConfigKey:   configKey,
+		FlagDefault: 8003,
+		Required:    true,
+	}
+}
+
 func DatabaseURLOption(configKey *string) *config.ConfigOption {
 	return &config.ConfigOption{
 		Name:        "database-url",

--- a/internal/serve/httphandler/health.go
+++ b/internal/serve/httphandler/health.go
@@ -1,0 +1,54 @@
+package httphandler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/stellar/go/support/render/httpjson"
+
+	"github.com/stellar/wallet-backend/internal/apptracker"
+	"github.com/stellar/wallet-backend/internal/data"
+	"github.com/stellar/wallet-backend/internal/serve/httperror"
+	"github.com/stellar/wallet-backend/internal/services"
+)
+
+type HealthHandler struct {
+	Models     *data.Models
+	RPCService services.RPCService
+	AppTracker apptracker.AppTracker
+}
+
+var (
+	ledgerCursorName      = "live_ingest_cursor"
+	ledgerHealthThreshold = uint32(5)
+)
+
+func (h HealthHandler) GetHealth(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	rpcHealth, err := h.RPCService.GetHealth()
+	if err != nil {
+		httperror.InternalServerError(ctx, "", err, nil, h.AppTracker).Render(w)
+		return
+	}
+	if rpcHealth.Status != "healthy" {
+		httperror.InternalServerError(ctx, "", errors.New("RPC is not healthy"), nil, h.AppTracker).Render(w)
+		return
+	}
+
+	backendLatestLedger, err := h.Models.IngestStore.GetLatestLedgerSynced(ctx, ledgerCursorName)
+	if err != nil {
+		httperror.InternalServerError(ctx, "", err, nil, h.AppTracker).Render(w)
+		return
+	}
+	if rpcHealth.LatestLedger-backendLatestLedger > ledgerHealthThreshold {
+		httperror.InternalServerError(ctx, "", errors.New("wallet backend is not in sync with the RPC"), nil, h.AppTracker).Render(w)
+		return
+	}
+
+	httpjson.Render(w, map[string]interface{}{
+		"status":                "ok",
+		"rpc_latest_ledger":     rpcHealth.LatestLedger,
+		"backend_latest_ledger": backendLatestLedger,
+	}, httpjson.JSON)
+}

--- a/internal/serve/httphandler/health_test.go
+++ b/internal/serve/httphandler/health_test.go
@@ -165,4 +165,3 @@ func TestHealthHandler_GetHealth(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/serve/httphandler/health_test.go
+++ b/internal/serve/httphandler/health_test.go
@@ -1,0 +1,168 @@
+// Health handler tests for wallet backend health check endpoint
+package httphandler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/apptracker"
+	"github.com/stellar/wallet-backend/internal/data"
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/entities"
+	"github.com/stellar/wallet-backend/internal/metrics"
+	"github.com/stellar/wallet-backend/internal/services"
+)
+
+func TestHealthHandler_GetHealth(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	dbConnectionPool, err := db.OpenDBConnectionPool(dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	mockMetricsService := metrics.NewMockMetricsService()
+	mockMetricsService.On("ObserveDBQueryDuration", "SELECT", "ingest_store", mock.AnythingOfType("float64")).Return()
+	mockMetricsService.On("IncDBQuery", "SELECT", "ingest_store").Return()
+	defer mockMetricsService.AssertExpectations(t)
+
+	models, err := data.NewModels(dbConnectionPool, mockMetricsService)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name                    string
+		rpcHealthResult         entities.RPCGetHealthResult
+		rpcHealthError          error
+		backendLatestLedger     uint32
+		hasCursorInDB           bool
+		expectedStatusCode      int
+		expectedResponseStatus  string
+		shouldCheckResponseBody bool
+	}{
+		{
+			name: "healthy - RPC and backend in sync",
+			rpcHealthResult: entities.RPCGetHealthResult{
+				Status:       "healthy",
+				LatestLedger: 100,
+			},
+			rpcHealthError:          nil,
+			backendLatestLedger:     98,
+			hasCursorInDB:           true,
+			expectedStatusCode:      http.StatusOK,
+			expectedResponseStatus:  "ok",
+			shouldCheckResponseBody: true,
+		},
+		{
+			name: "healthy - at threshold boundary (exactly 5 ledgers behind)",
+			rpcHealthResult: entities.RPCGetHealthResult{
+				Status:       "healthy",
+				LatestLedger: 105,
+			},
+			rpcHealthError:          nil,
+			backendLatestLedger:     100,
+			hasCursorInDB:           true,
+			expectedStatusCode:      http.StatusOK,
+			expectedResponseStatus:  "ok",
+			shouldCheckResponseBody: true,
+		},
+		{
+			name:                    "unhealthy - RPC service error",
+			rpcHealthResult:         entities.RPCGetHealthResult{},
+			rpcHealthError:          errors.New("RPC connection failed"),
+			backendLatestLedger:     0,
+			hasCursorInDB:           false,
+			expectedStatusCode:      http.StatusInternalServerError,
+			expectedResponseStatus:  "",
+			shouldCheckResponseBody: false,
+		},
+		{
+			name: "unhealthy - RPC status not healthy",
+			rpcHealthResult: entities.RPCGetHealthResult{
+				Status:       "unhealthy",
+				LatestLedger: 100,
+			},
+			rpcHealthError:          nil,
+			backendLatestLedger:     98,
+			hasCursorInDB:           true,
+			expectedStatusCode:      http.StatusInternalServerError,
+			expectedResponseStatus:  "",
+			shouldCheckResponseBody: false,
+		},
+		{
+			name: "unhealthy - backend significantly behind",
+			rpcHealthResult: entities.RPCGetHealthResult{
+				Status:       "healthy",
+				LatestLedger: 1000,
+			},
+			rpcHealthError:          nil,
+			backendLatestLedger:     900,
+			hasCursorInDB:           true,
+			expectedStatusCode:      http.StatusInternalServerError,
+			expectedResponseStatus:  "",
+			shouldCheckResponseBody: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup database state
+			ctx := context.Background()
+			_, err := dbConnectionPool.ExecContext(ctx, "DELETE FROM ingest_store WHERE key = 'live_ingest_cursor'")
+			require.NoError(t, err)
+
+			if tc.hasCursorInDB {
+				_, err = dbConnectionPool.ExecContext(ctx, "INSERT INTO ingest_store (key, value) VALUES ('live_ingest_cursor', $1)", tc.backendLatestLedger)
+				require.NoError(t, err)
+			}
+
+			// Setup mocks
+			mockRPCService := &services.RPCServiceMock{}
+			mockAppTracker := apptracker.NewMockAppTracker(t)
+			mockAppTracker.On("CaptureException", mock.Anything).Return().Maybe()
+			defer mockAppTracker.AssertExpectations(t)
+
+			handler := &HealthHandler{
+				Models:     models,
+				RPCService: mockRPCService,
+				AppTracker: mockAppTracker,
+			}
+
+			mockRPCService.On("GetHealth").Return(tc.rpcHealthResult, tc.rpcHealthError)
+			defer mockRPCService.AssertExpectations(t)
+
+			req := httptest.NewRequest(http.MethodGet, "/health", nil)
+			recorder := httptest.NewRecorder()
+			handler.GetHealth(recorder, req)
+			assert.Equal(t, tc.expectedStatusCode, recorder.Code)
+
+			if tc.shouldCheckResponseBody {
+				var response map[string]interface{}
+				err := json.Unmarshal(recorder.Body.Bytes(), &response)
+				require.NoError(t, err)
+
+				assert.Equal(t, tc.expectedResponseStatus, response["status"])
+				assert.Equal(t, float64(tc.rpcHealthResult.LatestLedger), response["rpc_latest_ledger"])
+
+				expectedBackendLedger := uint32(0)
+				if tc.hasCursorInDB {
+					expectedBackendLedger = tc.backendLatestLedger
+				}
+				assert.Equal(t, float64(expectedBackendLedger), response["backend_latest_ledger"])
+			}
+
+			// Clean up
+			_, cleanupErr := dbConnectionPool.ExecContext(ctx, "DELETE FROM ingest_store WHERE key = 'live_ingest_cursor'")
+			require.NoError(t, cleanupErr)
+		})
+	}
+}
+


### PR DESCRIPTION
### What

- Update the health check to also check for RPC health and the difference between the wallet-backend latest ledger and RPC latest ledger
- Add a health check endpoint to the ingest server.

### Why

We spin up the API and Ingest services separately in our kubernetes environment. The ingest service needs a health check endpoint so that the readiness probe for kube can be configured to check for ingest service health.

### Known limitations

N/A

### Checklist

#### PR Structure

- [ ] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.
- [ ] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.
- [ ] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [ ] This is not a breaking change.
- [ ] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
