### PR TITLE
indexer: bulk state change processor

### DIFF
--- a/internal/indexer/bulk_operation_processor.go
+++ b/internal/indexer/bulk_operation_processor.go
@@ -1,0 +1,49 @@
+package indexer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	operation_processor "github.com/stellar/go/processors/operation"
+
+	"github.com/stellar/wallet-backend/internal/indexer/processors"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+)
+
+// BulkOperationProcessor combines multiple OperationProcessorInterface instances
+// and processes operations through all of them, collecting their results.
+type BulkOperationProcessor struct {
+	processors []OperationStateChangeProcessorInterface
+}
+
+// NewBulkOperationProcessor creates a new bulk processor with the given processors.
+func NewBulkOperationProcessor(processors ...OperationStateChangeProcessorInterface) *BulkOperationProcessor {
+	return &BulkOperationProcessor{
+		processors: processors,
+	}
+}
+
+// ProcessOperation processes the operation through all child processors and combines their results.
+func (b *BulkOperationProcessor) ProcessOperation(ctx context.Context, opWrapper *operation_processor.TransactionOperationWrapper) ([]types.StateChange, error) {
+	stateChangesMap := map[string]types.StateChange{}
+
+	for _, processor := range b.processors {
+		stateChanges, err := processor.ProcessOperation(ctx, opWrapper)
+		if err != nil && !errors.Is(err, processors.ErrInvalidOpType) {
+			return nil, fmt.Errorf("processor %T failed: %w", processor, err)
+		} else if err != nil {
+			continue
+		}
+
+		for _, stateChange := range stateChanges {
+			stateChangesMap[stateChange.ID] = stateChange
+		}
+	}
+
+	stateChanges := make([]types.StateChange, 0, len(stateChangesMap))
+	for _, stateChange := range stateChangesMap {
+		stateChanges = append(stateChanges, stateChange)
+	}
+	return stateChanges, nil
+}

--- a/internal/indexer/bulk_operation_processor_test.go
+++ b/internal/indexer/bulk_operation_processor_test.go
@@ -1,0 +1,165 @@
+package indexer
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stellar/go/network"
+	operation_processor "github.com/stellar/go/processors/operation"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/indexer/processors"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+)
+
+func Test_BulkOperationProcessor_ProcessOperation(t *testing.T) {
+	ctx := context.Background()
+	testOp := &operation_processor.TransactionOperationWrapper{
+		Network:      network.TestNetworkPassphrase,
+		LedgerClosed: time.Now(),
+		Operation: xdr.Operation{
+			Body: xdr.OperationBody{Type: xdr.OperationTypePayment},
+		},
+	}
+
+	type testCase struct {
+		name            string
+		numProcessors   int
+		prepareMocks    func(t *testing.T, processors []OperationStateChangeProcessorInterface)
+		wantErrContains string
+		wantResult      []types.StateChange
+	}
+
+	testCases := []testCase{
+		{
+			name:          "🟢successful_processing_with_multiple_processors",
+			numProcessors: 2,
+			prepareMocks: func(t *testing.T, procs []OperationStateChangeProcessorInterface) {
+				mock1 := procs[0].(*MockOperationStateChangeProcessor)
+				mock2 := procs[1].(*MockOperationStateChangeProcessor)
+
+				stateChanges1 := []types.StateChange{{ID: "sc1"}}
+				stateChanges2 := []types.StateChange{{ID: "sc2"}}
+
+				mock1.On("ProcessOperation", ctx, testOp).Return(stateChanges1, nil)
+				mock2.On("ProcessOperation", ctx, testOp).Return(stateChanges2, nil)
+			},
+			wantResult: []types.StateChange{{ID: "sc1"}, {ID: "sc2"}},
+		},
+		{
+			name:          "🟢successful_processing_with_empty_results",
+			numProcessors: 2,
+			prepareMocks: func(t *testing.T, procs []OperationStateChangeProcessorInterface) {
+				mock1 := procs[0].(*MockOperationStateChangeProcessor)
+				mock2 := procs[1].(*MockOperationStateChangeProcessor)
+
+				mock1.On("ProcessOperation", ctx, testOp).Return([]types.StateChange{}, nil)
+				mock2.On("ProcessOperation", ctx, testOp).Return([]types.StateChange{}, nil)
+			},
+			wantResult: []types.StateChange{},
+		},
+		{
+			name:          "🟢ignores_err_invalid_op_type_errors",
+			numProcessors: 2,
+			prepareMocks: func(t *testing.T, procs []OperationStateChangeProcessorInterface) {
+				mock1 := procs[0].(*MockOperationStateChangeProcessor)
+				mock2 := procs[1].(*MockOperationStateChangeProcessor)
+
+				stateChanges1 := []types.StateChange{{ID: "sc1"}}
+				stateChanges2 := []types.StateChange{{ID: "sc2"}}
+
+				mock1.On("ProcessOperation", ctx, testOp).Return(stateChanges1, processors.ErrInvalidOpType)
+				mock2.On("ProcessOperation", ctx, testOp).Return(stateChanges2, nil)
+			},
+			wantResult: []types.StateChange{{ID: "sc2"}},
+		},
+		{
+			name:          "🔴returns_first_error_from_processor_with_proper_wrapping",
+			numProcessors: 1,
+			prepareMocks: func(t *testing.T, procs []OperationStateChangeProcessorInterface) {
+				mock := procs[0].(*MockOperationStateChangeProcessor)
+
+				stateChanges := []types.StateChange{{ID: "sc1"}}
+				expectedError := errors.New("processor error")
+
+				mock.On("ProcessOperation", ctx, testOp).Return(stateChanges, expectedError)
+			},
+			wantErrContains: "processor *indexer.MockOperationStateChangeProcessor failed:",
+			wantResult:      nil,
+		},
+		{
+			name:          "🔴returns_first_error_when_multiple_processors_would_fail",
+			numProcessors: 1,
+			prepareMocks: func(t *testing.T, procs []OperationStateChangeProcessorInterface) {
+				mock := procs[0].(*MockOperationStateChangeProcessor)
+
+				stateChanges := []types.StateChange{{ID: "sc1"}}
+				resErr := errors.New("first error")
+
+				mock.On("ProcessOperation", ctx, testOp).Return(stateChanges, resErr)
+			},
+			wantErrContains: "first error",
+			wantResult:      nil,
+		},
+		{
+			name:          "🟢deduplicates_state_changes_by_id",
+			numProcessors: 2,
+			prepareMocks: func(t *testing.T, procs []OperationStateChangeProcessorInterface) {
+				mock1 := procs[0].(*MockOperationStateChangeProcessor)
+				mock2 := procs[1].(*MockOperationStateChangeProcessor)
+
+				stateChanges1 := []types.StateChange{{ID: "sc1", StateChangeCategory: types.StateChangeCategoryDebit}}
+				stateChanges2 := []types.StateChange{{ID: "sc1", StateChangeCategory: types.StateChangeCategoryDebit}}
+
+				mock1.On("ProcessOperation", ctx, testOp).Return(stateChanges1, nil)
+				mock2.On("ProcessOperation", ctx, testOp).Return(stateChanges2, nil)
+			},
+			wantResult: []types.StateChange{{ID: "sc1", StateChangeCategory: types.StateChangeCategoryDebit}},
+		},
+		{
+			name:          "🟢works_with_no_processors",
+			numProcessors: 0,
+			prepareMocks:  func(t *testing.T, procs []OperationStateChangeProcessorInterface) {},
+			wantResult:    []types.StateChange{},
+		},
+		{
+			name:          "🟢works_with_single_processor",
+			numProcessors: 1,
+			prepareMocks: func(t *testing.T, procs []OperationStateChangeProcessorInterface) {
+				mock := procs[0].(*MockOperationStateChangeProcessor)
+				stateChanges := []types.StateChange{{ID: "sc1"}}
+
+				mock.On("ProcessOperation", ctx, testOp).Return(stateChanges, nil)
+			},
+			wantResult: []types.StateChange{{ID: "sc1"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			processors := []OperationStateChangeProcessorInterface{}
+			for range tc.numProcessors {
+				newProcessor := &MockOperationStateChangeProcessor{}
+				defer newProcessor.AssertExpectations(t)
+				processors = append(processors, newProcessor)
+			}
+			tc.prepareMocks(t, processors)
+
+			bulkProcessor := NewBulkOperationProcessor(processors...)
+			result, err := bulkProcessor.ProcessOperation(ctx, testOp)
+
+			if tc.wantErrContains != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tc.wantErrContains)
+				assert.Empty(t, result)
+			} else {
+				require.NoError(t, err)
+				assert.ElementsMatch(t, tc.wantResult, result)
+			}
+		})
+	}
+}

--- a/internal/indexer/mocks.go
+++ b/internal/indexer/mocks.go
@@ -36,11 +36,11 @@ func (m *MockTokenTransferProcessor) ProcessTransaction(ctx context.Context, tx 
 	return args.Get(0).([]types.StateChange), args.Error(1)
 }
 
-type MockOperationProcessor struct {
+type MockOperationStateChangeProcessor struct {
 	mock.Mock
 }
 
-func (m *MockOperationProcessor) ProcessOperation(ctx context.Context, opWrapper *operation_processor.TransactionOperationWrapper) ([]types.StateChange, error) {
+func (m *MockOperationStateChangeProcessor) ProcessOperation(ctx context.Context, opWrapper *operation_processor.TransactionOperationWrapper) ([]types.StateChange, error) {
 	args := m.Called(ctx, opWrapper)
 	return args.Get(0).([]types.StateChange), args.Error(1)
 }
@@ -92,8 +92,8 @@ func (m *MockIndexerBuffer) GetAllStateChanges() []types.StateChange {
 }
 
 var (
-	_ IndexerBufferInterface          = &MockIndexerBuffer{}
-	_ ParticipantsProcessorInterface  = &MockParticipantsProcessor{}
-	_ TokenTransferProcessorInterface = &MockTokenTransferProcessor{}
-	_ OperationProcessorInterface     = &MockOperationProcessor{}
+	_ IndexerBufferInterface                 = &MockIndexerBuffer{}
+	_ ParticipantsProcessorInterface         = &MockParticipantsProcessor{}
+	_ TokenTransferProcessorInterface        = &MockTokenTransferProcessor{}
+	_ OperationStateChangeProcessorInterface = &MockOperationStateChangeProcessor{}
 )


### PR DESCRIPTION
### What

Implement a bulk state change processor, so we can easily add extra/custom state change processors for specific contracts.

### Why

So we can expand contracts indexing

### Issue that this PR addresses

[TODO: Attach the link to the GitHub issue or task. Include the priority of the task here in addition to the link.]

### Checklist

#### PR Structure

- [ ] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.
- [ ] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.
- [ ] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [ ] This is not a breaking change.
- [ ] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
