### PR TITLE
validators: allow `POST /accounts{address}` to accept Contract addresses

### DIFF
--- a/internal/validators/validate.go
+++ b/internal/validators/validate.go
@@ -24,8 +24,11 @@ func NewValidator() (*validator.Validate, error) {
 }
 
 func publicKeyValidation(fl validator.FieldLevel) bool {
-	addr := fl.Field().String()
-	return addr == "" || strkey.IsValidEd25519PublicKey(addr) || strkey.IsValidMuxedAccountEd25519PublicKey(addr)
+	addr := strings.TrimSpace(fl.Field().String())
+	return addr == "" ||
+		strkey.IsValidEd25519PublicKey(addr) ||
+		strkey.IsValidMuxedAccountEd25519PublicKey(addr) ||
+		strkey.IsValidContractAddress(addr)
 }
 
 func ParseValidationError(errors validator.ValidationErrors) map[string]interface{} {

--- a/internal/validators/validate_test.go
+++ b/internal/validators/validate_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/go-playground/validator/v10"
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,7 +49,7 @@ func TestParseValidationError(t *testing.T) {
 					RequiredField:      "foo",
 					RequiredArrayField: []string{"bar", ""},
 					EnumField:          "bar",
-					PublicKeyField:     keypair.MustRandom().Address(),
+					PublicKeyField:     "GABJI7HL7SUQNXALMFMY35GHVXIZICQYONETFCW53CQ5QB6WX2T6GLIT",
 					UnknownTagField:    2,
 				},
 				expectedFieldErrors: map[string]interface{}{
@@ -62,7 +61,7 @@ func TestParseValidationError(t *testing.T) {
 					RequiredField:      "foo",
 					RequiredArrayField: []string{"bar"},
 					EnumField:          "bar",
-					PublicKeyField:     keypair.MustRandom().Address(),
+					PublicKeyField:     "MABJI7HL7SUQNXALMFMY35GHVXIZICQYONETFCW53CQ5QB6WX2T6GAAAAAAAAAPCIDPLU",
 					UnknownTagField:    1,
 				},
 				expectedFieldErrors: map[string]interface{}{
@@ -74,7 +73,7 @@ func TestParseValidationError(t *testing.T) {
 					RequiredField:      "foo",
 					RequiredArrayField: []string{"bar"},
 					EnumField:          "bar",
-					PublicKeyField:     keypair.MustRandom().Address(),
+					PublicKeyField:     "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
 					UnknownTagField:    2,
 					NestedField: []testStructNested{
 						{


### PR DESCRIPTION
### What

Allow `POST /accounts{address}` to accept Contract addresses

### Why

SO we can support C-accounts

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
