### PR TITLE
Use a composite key as primary key for state changes

### DIFF
--- a/internal/db/migrations/2025-06-10.4-create_indexer_table_state_changes.sql
+++ b/internal/db/migrations/2025-06-10.4-create_indexer_table_state_changes.sql
@@ -2,7 +2,8 @@
 
 -- Table: state_changes
 CREATE TABLE state_changes (
-    id TEXT PRIMARY KEY,
+    to_id BIGINT NOT NULL,
+    state_change_order BIGINT NOT NULL,
     state_change_category TEXT NOT NULL,
     state_change_reason TEXT,
     ingested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -23,7 +24,8 @@ CREATE TABLE state_changes (
     spender_account_id TEXT,
     sponsored_account_id TEXT,
     sponsor_account_id TEXT,
-    thresholds JSONB
+    thresholds JSONB,
+    PRIMARY KEY (to_id, state_change_order)
 );
 
 CREATE INDEX idx_state_changes_account_id ON state_changes(account_id);

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -21,6 +21,7 @@ type IndexerBufferInterface interface {
 	GetNumberOfTransactions() int
 	GetAllTransactions() []types.Transaction
 	GetAllStateChanges() []types.StateChange
+	CalculateStateChangeOrder()
 }
 
 type TokenTransferProcessorInterface interface {
@@ -96,6 +97,9 @@ func (i *Indexer) ProcessTransaction(ctx context.Context, transaction ingest.Led
 		return fmt.Errorf("processing token transfer state changes: %w", err)
 	}
 	i.Buffer.PushStateChanges(tokenTransferStateChanges)
+
+	// Generate IDs for state changes
+	i.Buffer.CalculateStateChangeOrder()
 
 	return nil
 }

--- a/internal/indexer/indexer_buffer.go
+++ b/internal/indexer/indexer_buffer.go
@@ -1,12 +1,11 @@
 package indexer
 
 import (
-	"encoding/binary"
-	"hash/fnv"
 	"sort"
 	"sync"
 
 	set "github.com/deckarep/golang-set/v2"
+
 	"github.com/stellar/wallet-backend/internal/indexer/types"
 )
 
@@ -179,20 +178,4 @@ func (b *IndexerBuffer) GetAllStateChanges() []types.StateChange {
 	stateChangesCopy := make([]types.StateChange, len(b.stateChanges))
 	copy(stateChangesCopy, b.stateChanges)
 	return stateChangesCopy
-}
-
-func makeStateChangeID(groupKey int64, idx int) int64 {
-	h := fnv.New64a()
-
-	var buf [8]byte
-	// Mix the group key (operation ID or TxID) into the hash
-	binary.LittleEndian.PutUint64(buf[:], uint64(groupKey))
-	_, _ = h.Write(buf[:])
-
-	// Mix the per-group index into the hash
-	binary.LittleEndian.PutUint64(buf[:], uint64(idx))
-	_, _ = h.Write(buf[:])
-
-	// Return a non-negative BIGINT from the 64-bit hash
-	return int64(h.Sum64() & 0x7fffffffffffffff)
 }

--- a/internal/indexer/indexer_buffer.go
+++ b/internal/indexer/indexer_buffer.go
@@ -1,10 +1,12 @@
 package indexer
 
 import (
+	"encoding/binary"
+	"hash/fnv"
+	"sort"
 	"sync"
 
 	set "github.com/deckarep/golang-set/v2"
-
 	"github.com/stellar/wallet-backend/internal/indexer/types"
 )
 
@@ -146,6 +148,29 @@ func (b *IndexerBuffer) PushStateChanges(stateChanges []types.StateChange) {
 	}
 }
 
+func (b *IndexerBuffer) CalculateStateChangeOrder() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	sort.Slice(b.stateChanges, func(i, j int) bool {
+		return b.stateChanges[i].SortKey < b.stateChanges[j].SortKey
+	})
+
+	perOpIdx := make(map[int64]int)
+	for i := range b.stateChanges {
+		sc := &b.stateChanges[i]
+
+		// State changes are 1-indexed within an operation.
+		if sc.OperationID != 0 {
+			perOpIdx[sc.OperationID]++
+			sc.StateChangeOrder = int64(perOpIdx[sc.OperationID])
+		} else {
+			// Fee state changes are 0-indexed.
+			sc.StateChangeOrder = 0
+		}
+	}
+}
+
 func (b *IndexerBuffer) GetAllStateChanges() []types.StateChange {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
@@ -154,4 +179,20 @@ func (b *IndexerBuffer) GetAllStateChanges() []types.StateChange {
 	stateChangesCopy := make([]types.StateChange, len(b.stateChanges))
 	copy(stateChangesCopy, b.stateChanges)
 	return stateChangesCopy
+}
+
+func makeStateChangeID(groupKey int64, idx int) int64 {
+	h := fnv.New64a()
+
+	var buf [8]byte
+	// Mix the group key (operation ID or TxID) into the hash
+	binary.LittleEndian.PutUint64(buf[:], uint64(groupKey))
+	_, _ = h.Write(buf[:])
+
+	// Mix the per-group index into the hash
+	binary.LittleEndian.PutUint64(buf[:], uint64(idx))
+	_, _ = h.Write(buf[:])
+
+	// Return a non-negative BIGINT from the 64-bit hash
+	return int64(h.Sum64() & 0x7fffffffffffffff)
 }

--- a/internal/indexer/indexer_buffer.go
+++ b/internal/indexer/indexer_buffer.go
@@ -159,13 +159,12 @@ func (b *IndexerBuffer) CalculateStateChangeOrder() {
 	for i := range b.stateChanges {
 		sc := &b.stateChanges[i]
 
-		// State changes are 1-indexed within an operation.
+		// State changes are 1-indexed within an operation/transaction.
 		if sc.OperationID != 0 {
 			perOpIdx[sc.OperationID]++
 			sc.StateChangeOrder = int64(perOpIdx[sc.OperationID])
 		} else {
-			// Fee state changes are 0-indexed.
-			sc.StateChangeOrder = 0
+			sc.StateChangeOrder = 1
 		}
 	}
 }

--- a/internal/indexer/indexer_buffer_test.go
+++ b/internal/indexer/indexer_buffer_test.go
@@ -317,7 +317,7 @@ func Test_IndexerBuffer_StateChanges(t *testing.T) {
 		assert.Equal(t, int64(1), allStateChanges[1].StateChangeOrder)
 		assert.Equal(t, int64(1), allStateChanges[2].StateChangeOrder)
 
-		// For state changes with same operation ID, the order is calculated using the 
+		// For state changes with same operation ID, the order is calculated using the
 		// sort key and the credit state change comes before the debit one.
 		assert.Equal(t, int64(1), allStateChanges[3].StateChangeOrder)
 		assert.Equal(t, types.StateChangeCategoryCredit, allStateChanges[3].StateChangeCategory)

--- a/internal/indexer/indexer_buffer_test.go
+++ b/internal/indexer/indexer_buffer_test.go
@@ -215,9 +215,9 @@ func Test_IndexerBuffer_StateChanges(t *testing.T) {
 	t.Run("🟢sequential_calls", func(t *testing.T) {
 		indexerBuffer := NewIndexerBuffer()
 
-		sc1 := types.StateChange{ID: "sc1"}
-		sc2 := types.StateChange{ID: "sc2"}
-		sc3 := types.StateChange{ID: "sc3"}
+		sc1 := types.StateChange{ToID: 1, StateChangeOrder: 1}
+		sc2 := types.StateChange{ToID: 2, StateChangeOrder: 1}
+		sc3 := types.StateChange{ToID: 3, StateChangeOrder: 1}
 
 		indexerBuffer.PushStateChanges([]types.StateChange{sc1})
 		indexerBuffer.PushStateChanges([]types.StateChange{sc2, sc3})
@@ -229,9 +229,9 @@ func Test_IndexerBuffer_StateChanges(t *testing.T) {
 	t.Run("🟢concurrent_calls", func(t *testing.T) {
 		indexerBuffer := NewIndexerBuffer()
 
-		sc1 := types.StateChange{ID: "sc1"}
-		sc2 := types.StateChange{ID: "sc2"}
-		sc3 := types.StateChange{ID: "sc3"}
+		sc1 := types.StateChange{ToID: 1, StateChangeOrder: 1}
+		sc2 := types.StateChange{ToID: 2, StateChangeOrder: 1}
+		sc3 := types.StateChange{ToID: 3, StateChangeOrder: 1}
 
 		wg := sync.WaitGroup{}
 		wg.Add(2)
@@ -263,9 +263,9 @@ func Test_IndexerBuffer_StateChanges(t *testing.T) {
 		indexerBuffer.PushParticipantOperation("someone", op1, tx1)
 		indexerBuffer.PushParticipantOperation("someone", op2, tx2)
 
-		sc1 := types.StateChange{ID: "sc1", TxHash: tx1.Hash, OperationID: op1.ID, AccountID: "alice"}
-		sc2 := types.StateChange{ID: "sc2", TxHash: tx2.Hash, OperationID: op2.ID, AccountID: "alice"}
-		sc3 := types.StateChange{ID: "sc3", TxHash: tx2.Hash, OperationID: op2.ID, AccountID: "bob"}
+		sc1 := types.StateChange{ToID: 1, StateChangeOrder: 1, TxHash: tx1.Hash, OperationID: op1.ID, AccountID: "alice"}
+		sc2 := types.StateChange{ToID: 2, StateChangeOrder: 1, TxHash: tx2.Hash, OperationID: op2.ID, AccountID: "alice"}
+		sc3 := types.StateChange{ToID: 3, StateChangeOrder: 1, TxHash: tx2.Hash, OperationID: op2.ID, AccountID: "bob"}
 
 		indexerBuffer.PushStateChanges([]types.StateChange{sc1})
 		indexerBuffer.PushStateChanges([]types.StateChange{sc2, sc3})

--- a/internal/indexer/mocks.go
+++ b/internal/indexer/mocks.go
@@ -95,6 +95,10 @@ func (m *MockIndexerBuffer) GetAllStateChanges() []types.StateChange {
 	return args.Get(0).([]types.StateChange)
 }
 
+func (m *MockIndexerBuffer) CalculateStateChangeOrder() {
+	m.Called()
+}
+
 var (
 	_ IndexerBufferInterface          = &MockIndexerBuffer{}
 	_ ParticipantsProcessorInterface  = &MockParticipantsProcessor{}

--- a/internal/indexer/processors/effects.go
+++ b/internal/indexer/processors/effects.go
@@ -76,6 +76,7 @@ func (p *EffectsProcessor) ProcessOperation(ctx context.Context, opWrapper *oper
 	ledgerCloseTime := opWrapper.Transaction.Ledger.LedgerCloseTime()
 	ledgerNumber := opWrapper.Transaction.Ledger.LedgerSequence()
 	txHash := opWrapper.Transaction.Result.TransactionHash.HexString()
+	txID := opWrapper.Transaction.ID()
 
 	// Extract effects from the operation using Stellar SDK
 	effectOutputs, err := effects.Effects(opWrapper)
@@ -90,7 +91,7 @@ func (p *EffectsProcessor) ProcessOperation(ctx context.Context, opWrapper *oper
 	}
 
 	var stateChanges []types.StateChange
-	masterBuilder := NewStateChangeBuilder(ledgerNumber, ledgerCloseTime, txHash).WithOperationID(opWrapper.ID())
+	masterBuilder := NewStateChangeBuilder(ledgerNumber, ledgerCloseTime, txHash, txID).WithOperationID(opWrapper.ID())
 	// Process each effect and convert to our internal state change representation
 	for _, effect := range effectOutputs {
 		changeBuilder := masterBuilder.Clone().WithAccount(effect.Address)

--- a/internal/indexer/processors/processors_test_utils.go
+++ b/internal/indexer/processors/processors_test_utils.go
@@ -6,7 +6,6 @@ package processors
 import (
 	"context"
 	"encoding/hex"
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -813,7 +812,6 @@ func assertStateChangeBase(t *testing.T, change types.StateChange, category type
 	require.Equal(t, category, change.StateChangeCategory)
 	require.Equal(t, expectedAccount, change.AccountID)
 	require.Equal(t, utils.SQLNullString(expectedAmount), change.Amount)
-	require.Equal(t, fmt.Sprintf("%d-%s", change.OperationID, expectedAccount), change.ID)
 	require.Equal(t, utils.SQLNullString(expectedToken), change.TokenID)
 }
 

--- a/internal/indexer/processors/processors_test_utils.go
+++ b/internal/indexer/processors/processors_test_utils.go
@@ -813,12 +813,16 @@ func assertStateChangeBase(t *testing.T, change types.StateChange, category type
 	require.Equal(t, expectedAccount, change.AccountID)
 	require.Equal(t, utils.SQLNullString(expectedAmount), change.Amount)
 	require.Equal(t, utils.SQLNullString(expectedToken), change.TokenID)
+	if change.OperationID != 0 {
+		require.Equal(t, change.OperationID, change.ToID)
+	}
 }
 
 // Assertion helpers for common patterns
 func assertFeeEvent(t *testing.T, change types.StateChange, expectedAmount string) {
 	t.Helper()
 	assertStateChangeBase(t, change, types.StateChangeCategoryDebit, someTxAccount.ToAccountId().Address(), expectedAmount, nativeContractAddress)
+	assert.Equal(t, change.TxID, change.ToID)
 }
 
 func assertDebitEvent(t *testing.T, change types.StateChange, expectedAccount string, expectedAmount string, expectedToken string) {

--- a/internal/indexer/processors/state_change_builder.go
+++ b/internal/indexer/processors/state_change_builder.go
@@ -132,11 +132,23 @@ func (b *StateChangeBuilder) generateSortKey() string {
 		reason = string(*b.base.StateChangeReason)
 	}
 
-	// For JSON fields, marshal to get a canonical string. Errors are ignored as this is for internal sorting.
-	signerWeights, _ := json.Marshal(b.base.SignerWeights)
-	thresholds, _ := json.Marshal(b.base.Thresholds)
-	flags, _ := json.Marshal(b.base.Flags)
-	keyValue, _ := json.Marshal(b.base.KeyValue)
+	// For JSON fields, marshal to get a canonical string
+	signerWeights, err := json.Marshal(b.base.SignerWeights)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal signer weights: %v", err))
+	}
+	thresholds, err := json.Marshal(b.base.Thresholds)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal thresholds: %v", err))
+	}
+	flags, err := json.Marshal(b.base.Flags)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal flags: %v", err))
+	}
+	keyValue, err := json.Marshal(b.base.KeyValue)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal key value: %v", err))
+	}
 
 	return fmt.Sprintf(
 		"%d:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s",

--- a/internal/indexer/processors/token_transfer.go
+++ b/internal/indexer/processors/token_transfer.go
@@ -38,6 +38,7 @@ func (p *TokenTransferProcessor) ProcessTransaction(ctx context.Context, tx inge
 	ledgerCloseTime := tx.Ledger.LedgerCloseTime()
 	ledgerNumber := tx.Ledger.LedgerSequence()
 	txHash := tx.Result.TransactionHash.HexString()
+	txID := tx.ID()
 
 	// Extract token transfer events from the transaction using Stellar SDK
 	txEvents, err := p.eventsProcessor.EventsFromTransaction(tx)
@@ -46,7 +47,7 @@ func (p *TokenTransferProcessor) ProcessTransaction(ctx context.Context, tx inge
 	}
 
 	stateChanges := make([]types.StateChange, 0, len(txEvents.OperationEvents)+1)
-	builder := NewStateChangeBuilder(ledgerNumber, ledgerCloseTime, txHash)
+	builder := NewStateChangeBuilder(ledgerNumber, ledgerCloseTime, txHash, txID)
 
 	// Process fee events
 	feeChange, err := p.processFeeEvents(builder.Clone(), txEvents.FeeEvents)

--- a/internal/indexer/types/types.go
+++ b/internal/indexer/types/types.go
@@ -185,7 +185,7 @@ type StateChange struct {
 	Transaction *Transaction `json:"transaction,omitempty" db:"transaction"`
 	// Internal IDs used for sorting state changes within an operation.
 	SortKey string `json:"-"`
-	TxID   int64  `json:"-"`
+	TxID    int64  `json:"-"`
 }
 
 type NullableJSONB map[string]any

--- a/internal/indexer/types/types.go
+++ b/internal/indexer/types/types.go
@@ -182,6 +182,9 @@ type StateChange struct {
 	Operation   *Operation   `json:"operation,omitempty" db:"operation"`
 	TxHash      string       `json:"txHash,omitempty" db:"tx_hash"`
 	Transaction *Transaction `json:"transaction,omitempty" db:"transaction"`
+	// Internal IDs used for sorting state changes within an operation.
+	SortID string `json:"-"`
+	TxID   int64  `json:"-"`
 }
 
 type NullableJSONB map[string]any

--- a/internal/indexer/types/types.go
+++ b/internal/indexer/types/types.go
@@ -154,7 +154,8 @@ const (
 )
 
 type StateChange struct {
-	ID                  string              `json:"id,omitempty" db:"id"`
+	ToID                int64               `json:"toId,omitempty" db:"to_id"`
+	StateChangeOrder    int64               `json:"stateChangeOrder,omitempty" db:"state_change_order"`
 	StateChangeCategory StateChangeCategory `json:"stateChangeCategory,omitempty" db:"state_change_category"`
 	StateChangeReason   *StateChangeReason  `json:"stateChangeReason,omitempty" db:"state_change_reason"`
 	IngestedAt          time.Time           `json:"ingestedAt,omitempty" db:"ingested_at"`
@@ -183,7 +184,7 @@ type StateChange struct {
 	TxHash      string       `json:"txHash,omitempty" db:"tx_hash"`
 	Transaction *Transaction `json:"transaction,omitempty" db:"transaction"`
 	// Internal IDs used for sorting state changes within an operation.
-	SortID string `json:"-"`
+	SortKey string `json:"-"`
 	TxID   int64  `json:"-"`
 }
 


### PR DESCRIPTION
### What

Use a composite key tuple of transaction/operation order (toid) and the state change order within an operation as the primary key for a state change.

- Adds a new db column:`toID` which represents the operationID if not a fee state change otherwise its a transactionID. This is because fee state changes are not associated with an operation but a tx. The [toID](https://pkg.go.dev/github.com/stellar/go/toid) is an ID that represents the ledger, a transaction's order within that ledger and an operation's order within that tx
- Adds a new column: `StateChangeOrder` which represents the order of a state change within an operation.
- Establishes a deterministic order of state changes within an operation based on a sort key: `toID > category > reason > account ID > .....`.
- Add the primary key for state changes table:  `(to_id, state_change_order)`
- Update unit tests to account for the change

### Why

We need a way to uniquely identify a state change and this new composite key of toID and the state change's order within an operation helps us do this. The sort order makes sure that the order value we calculate will always be deterministic and produce the same result if we do reprocessing/backfilling.

The `state_change_order` is also helpful for pagination queries for state changes where we can use the tuple (`to_id`, `state_change_order`) as a cursor.

### Known limitations

N/A

### Issue that this PR addresses

#269 

### Checklist

#### PR Structure

- [ ] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.
- [ ] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.
- [ ] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [ ] This is not a breaking change.
- [ ] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
