### PR TITLE
Bugfix: race condition caused by processing taking too long

### DIFF
--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -176,7 +176,7 @@ func (m *ingestService) DeprecatedRun(ctx context.Context, startLedger uint32, e
 			m.metricsService.ObserveIngestionDuration(totalIngestionPrometheusLabel, time.Since(start).Seconds())
 
 			// immediately trigger the next ingestion the wallet-backend is behind the RPC's latest ledger
-			if resp.LatestLedger-ingestLedger > 1 {
+			if resp.LatestLedger-ingestLedger > 1 && len(manualTriggerChannel) == 0 {
 				manualTriggerChannel <- true
 			}
 
@@ -258,7 +258,7 @@ func (m *ingestService) Run(ctx context.Context, startLedger uint32, endLedger u
 		m.metricsService.SetLatestLedgerIngested(float64(getLedgersResponse.LatestLedger))
 		m.metricsService.ObserveIngestionDuration(totalIngestionPrometheusLabel, time.Since(totalIngestionStart).Seconds())
 
-		if len(getLedgersResponse.Ledgers) == m.getLedgersLimit {
+		if len(getLedgersResponse.Ledgers) == m.getLedgersLimit && len(manualTriggerChan) == 0 {
 			manualTriggerChan <- nil
 		}
 	}

--- a/internal/utils/mocks.go
+++ b/internal/utils/mocks.go
@@ -13,8 +13,19 @@ type MockHTTPClient struct {
 
 func (s *MockHTTPClient) Post(url, contentType string, body io.Reader) (resp *http.Response, err error) {
 	args := s.Called(url, contentType, body)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
+
+	// Handle function return values (like Mockery does)
+	if args.Get(0) != nil {
+		if returnFunc, ok := args.Get(0).(func(string, string, io.Reader) *http.Response); ok {
+			resp = returnFunc(url, contentType, body)
+		} else {
+			resp = args.Get(0).(*http.Response)
+		}
 	}
-	return args.Get(0).(*http.Response), args.Error(1)
+
+	if args.Error(1) != nil {
+		err = args.Error(1)
+	}
+
+	return resp, err
 }


### PR DESCRIPTION
### What

Only call the ingestor's manualTriggerChannel if it's empty

### Why

When the processing time takes longer than 5s, which is common in production, since even downloading the ledgers from the RPC takes ~5s for 10 ledgers, the code was entering a deadlock.

Considering the processing time is 11s, here's the sequence of events that lead to a deadlock:

- [**T=0s**] RPC Health Check: channel now contains 1 health update
https://github.com/stellar/wallet-backend/blob/8a12000c478e72169413ef2b47085415b5c1fdb7/internal/services/rpc_service.go#L284
- [**T=0s**] Ingestion Loop Starts. Channel will be emptied and the processing step will take 11s
https://github.com/stellar/wallet-backend/blob/8a12000c478e72169413ef2b47085415b5c1fdb7/internal/services/ingest.go#L226
- [**T=5s**] RPC Health Check (BLOCKS!): RPC health goroutine STOPS executing since it gets blocked until `r.heartbeatChannel` is consumed.
https://github.com/stellar/wallet-backend/blob/8a12000c478e72169413ef2b47085415b5c1fdb7/internal/services/rpc_service.go#L284
- [**T=11s**]: Ingestion Loop Finishes (BLOCKS!): the manual trigger is called, but since the RPC health check is already halted, this will make the ingestor halt as well, resulting in a deadlock.

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
