### PR TITLE
cmd: allow hosts to configure the limit for the `getLedgers` call

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -30,6 +30,7 @@ func (c *ingestCmd) Command() *cobra.Command {
 		utils.EndLedgerOption(&cfg.EndLedger),
 		utils.NetworkPassphraseOption(&cfg.NetworkPassphrase),
 		utils.IngestServerPortOption(&cfg.ServerPort),
+		utils.GetLedgersLimitOption(&cfg.GetLedgersLimit),
 		{
 			Name:        "ledger-cursor-name",
 			Usage:       "Name of last synced ledger cursor, used to keep track of the last ledger ingested by the service. When starting up, ingestion will resume from the ledger number stored in this record. It should be an unique name per container as different containers would overwrite the cursor value of its peers when using the same cursor name.",

--- a/cmd/utils/global_options.go
+++ b/cmd/utils/global_options.go
@@ -174,6 +174,16 @@ func EndLedgerOption(configKey *int) *config.ConfigOption {
 	}
 }
 
+func GetLedgersLimitOption(configKey *int) *config.ConfigOption {
+	return &config.ConfigOption{
+		Name:        "get-ledgers-limit",
+		Usage:       `The limit for the number of ledgers to get from the RPC when calling "getLedgers"`,
+		OptType:     types.Int,
+		ConfigKey:   configKey,
+		FlagDefault: 10,
+	}
+}
+
 func AWSOptions(awsRegionConfigKey *string, kmsKeyARN *string, required bool) config.ConfigOptions {
 	awsOpts := config.ConfigOptions{
 		{

--- a/cmd/utils/global_options.go
+++ b/cmd/utils/global_options.go
@@ -177,7 +177,7 @@ func EndLedgerOption(configKey *int) *config.ConfigOption {
 func GetLedgersLimitOption(configKey *int) *config.ConfigOption {
 	return &config.ConfigOption{
 		Name:        "get-ledgers-limit",
-		Usage:       `The limit for the number of ledgers to get from the RPC when calling "getLedgers"`,
+		Usage:       `The limit for the number of ledgers to fetch from the RPC in a single "getLedgers" call. In production, don't go above 10 if unless your RPC instance has the MAX_GET_LEDGERS_EXECUTION_DURATION >= 5s.`,
 		OptType:     types.Int,
 		ConfigKey:   configKey,
 		FlagDefault: 10,

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -37,6 +37,7 @@ type Configs struct {
 	AppTracker        apptracker.AppTracker
 	RPCURL            string
 	NetworkPassphrase string
+	GetLedgersLimit   int
 }
 
 func Ingest(cfg Configs) error {
@@ -80,7 +81,7 @@ func setupDeps(cfg Configs) (services.IngestService, error) {
 	}
 
 	ingestService, err := services.NewIngestService(
-		models, cfg.LedgerCursorName, cfg.AppTracker, rpcService, chAccStore, contractStore, metricsService)
+		models, cfg.LedgerCursorName, cfg.AppTracker, rpcService, chAccStore, contractStore, metricsService, cfg.GetLedgersLimit)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating ingest service: %w", err)
 	}

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -94,7 +94,7 @@ func NewIngestService(
 	if metricsService == nil {
 		return nil, errors.New("metricsService cannot be nil")
 	}
-	if getLedgersLimit < 0 {
+	if getLedgersLimit <= 0 {
 		return nil, errors.New("getLedgersLimit must be greater than 0")
 	}
 

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -38,7 +38,6 @@ var ErrAlreadyInSync = errors.New("ingestion is already in sync")
 const (
 	advisoryLockID                          = int(3747555612780983)
 	ingestHealthCheckMaxWaitTime            = 90 * time.Second
-	getLedgersLimit                         = 50 // NOTE: cannot be larger than 200
 	ledgerProcessorsCount                   = 16
 	paymentPrometheusLabel                  = "payment"
 	pathPaymentStrictSendPrometheusLabel    = "path_payment_strict_send"
@@ -61,6 +60,7 @@ type ingestService struct {
 	contractStore     cache.TokenContractStore
 	metricsService    metrics.MetricsService
 	networkPassphrase string
+	getLedgersLimit   int
 }
 
 func NewIngestService(
@@ -71,6 +71,7 @@ func NewIngestService(
 	chAccStore store.ChannelAccountStore,
 	contractStore cache.TokenContractStore,
 	metricsService metrics.MetricsService,
+	getLedgersLimit int,
 ) (*ingestService, error) {
 	if models == nil {
 		return nil, errors.New("models cannot be nil")
@@ -93,6 +94,9 @@ func NewIngestService(
 	if metricsService == nil {
 		return nil, errors.New("metricsService cannot be nil")
 	}
+	if getLedgersLimit < 0 {
+		return nil, errors.New("getLedgersLimit must be greater than 0")
+	}
 
 	return &ingestService{
 		models:            models,
@@ -103,6 +107,7 @@ func NewIngestService(
 		contractStore:     contractStore,
 		metricsService:    metricsService,
 		networkPassphrase: rpcService.NetworkPassphrase(),
+		getLedgersLimit:   getLedgersLimit,
 	}, nil
 }
 
@@ -253,7 +258,7 @@ func (m *ingestService) Run(ctx context.Context, startLedger uint32, endLedger u
 		m.metricsService.SetLatestLedgerIngested(float64(getLedgersResponse.LatestLedger))
 		m.metricsService.ObserveIngestionDuration(totalIngestionPrometheusLabel, time.Since(totalIngestionStart).Seconds())
 
-		if len(getLedgersResponse.Ledgers) == getLedgersLimit {
+		if len(getLedgersResponse.Ledgers) == m.getLedgersLimit {
 			manualTriggerChan <- nil
 		}
 	}
@@ -261,7 +266,7 @@ func (m *ingestService) Run(ctx context.Context, startLedger uint32, endLedger u
 
 // fetchNextLedgersBatch fetches the next batch of ledgers from the RPC service.
 func (m *ingestService) fetchNextLedgersBatch(ctx context.Context, rpcHealth entities.RPCGetHealthResult, startLedger uint32) (GetLedgersResponse, error) {
-	ledgerSeqRange, inSync := getLedgerSeqRange(rpcHealth.OldestLedger, rpcHealth.LatestLedger, startLedger)
+	ledgerSeqRange, inSync := m.getLedgerSeqRange(rpcHealth.OldestLedger, rpcHealth.LatestLedger, startLedger)
 	log.Ctx(ctx).Debugf("ledgerSeqRange: %+v", ledgerSeqRange)
 	if inSync {
 		return GetLedgersResponse{}, ErrAlreadyInSync
@@ -286,12 +291,12 @@ type LedgerSeqRange struct {
 // - the max ledger window to ingest.
 //
 // The returned ledger sequence range is inclusive of the start and end ledgers.
-func getLedgerSeqRange(rpcOldestLedger, rpcNewestLedger, latestLedgerSynced uint32) (ledgerRange LedgerSeqRange, inSync bool) {
+func (m *ingestService) getLedgerSeqRange(rpcOldestLedger, rpcNewestLedger, latestLedgerSynced uint32) (ledgerRange LedgerSeqRange, inSync bool) {
 	if latestLedgerSynced >= rpcNewestLedger {
 		return LedgerSeqRange{}, true
 	}
 	ledgerRange.StartLedger = max(latestLedgerSynced+1, rpcOldestLedger)
-	ledgerRange.Limit = getLedgersLimit
+	ledgerRange.Limit = uint32(m.getLedgersLimit)
 
 	return ledgerRange, false
 }

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -27,10 +27,11 @@ import (
 )
 
 const (
-	testInnerTxHash   = "2ba55208f8ccc21e67c3c515ee8e793bfebb5ff20e3a14264c0890897560e368"
-	testInnerTxXDR    = "AAAAAgAAAAC//CoiAsv/SQfZHUYwg1/5F127eo+Rv6b9lf6GbIJNygAAAGQAAAAAAAAAAgAAAAEAAAAAAAAAAAAAAABoI7JqAAAAAAAAAAEAAAAAAAAAAAAAAADcrhjQMMeoVosXGSgLrC4WhXYLHl1HcUniEWKOGTyPEAAAAAAAmJaAAAAAAAAAAAFsgk3KAAAAQEYaesICeGfKcUiMEYoZZrKptMmMcW8636peWLpChKukfqTxSujQilalxe6ab+en9Bhf8iGMF8jb5JqIIYlYjQs="
-	testFeeBumpTxHash = "b99e17610372fd66968cc3124c4d29a9dd856c2b8ffa1c446f6aefc5657f5a82"
-	testFeeBumpTxXDR  = "AAAABQAAAACRDhlb19H9O6EVQnLPSBX5kH4+ycO03nl6OOK1drSinwAAAAAAAAGQAAAAAgAAAAC//CoiAsv/SQfZHUYwg1/5F127eo+Rv6b9lf6GbIJNygAAAGQAAAAAAAAAAgAAAAEAAAAAAAAAAAAAAABoI7JqAAAAAAAAAAEAAAAAAAAAAAAAAADcrhjQMMeoVosXGSgLrC4WhXYLHl1HcUniEWKOGTyPEAAAAAAAmJaAAAAAAAAAAAFsgk3KAAAAQEYaesICeGfKcUiMEYoZZrKptMmMcW8636peWLpChKukfqTxSujQilalxe6ab+en9Bhf8iGMF8jb5JqIIYlYjQsAAAAAAAAAAXa0op8AAABADjCsmF/xr9jXwNStUM7YqXEd49qfbvGZPJPplANW7aiErkHWxEj6C2RVOyPyK8KBr1fjCleBSmDZjD1X0kkJCQ=="
+	testInnerTxHash        = "2ba55208f8ccc21e67c3c515ee8e793bfebb5ff20e3a14264c0890897560e368"
+	testInnerTxXDR         = "AAAAAgAAAAC//CoiAsv/SQfZHUYwg1/5F127eo+Rv6b9lf6GbIJNygAAAGQAAAAAAAAAAgAAAAEAAAAAAAAAAAAAAABoI7JqAAAAAAAAAAEAAAAAAAAAAAAAAADcrhjQMMeoVosXGSgLrC4WhXYLHl1HcUniEWKOGTyPEAAAAAAAmJaAAAAAAAAAAAFsgk3KAAAAQEYaesICeGfKcUiMEYoZZrKptMmMcW8636peWLpChKukfqTxSujQilalxe6ab+en9Bhf8iGMF8jb5JqIIYlYjQs="
+	testFeeBumpTxHash      = "b99e17610372fd66968cc3124c4d29a9dd856c2b8ffa1c446f6aefc5657f5a82"
+	testFeeBumpTxXDR       = "AAAABQAAAACRDhlb19H9O6EVQnLPSBX5kH4+ycO03nl6OOK1drSinwAAAAAAAAGQAAAAAgAAAAC//CoiAsv/SQfZHUYwg1/5F127eo+Rv6b9lf6GbIJNygAAAGQAAAAAAAAAAgAAAAEAAAAAAAAAAAAAAABoI7JqAAAAAAAAAAEAAAAAAAAAAAAAAADcrhjQMMeoVosXGSgLrC4WhXYLHl1HcUniEWKOGTyPEAAAAAAAmJaAAAAAAAAAAAFsgk3KAAAAQEYaesICeGfKcUiMEYoZZrKptMmMcW8636peWLpChKukfqTxSujQilalxe6ab+en9Bhf8iGMF8jb5JqIIYlYjQsAAAAAAAAAAXa0op8AAABADjCsmF/xr9jXwNStUM7YqXEd49qfbvGZPJPplANW7aiErkHWxEj6C2RVOyPyK8KBr1fjCleBSmDZjD1X0kkJCQ=="
+	defaultGetLedgersLimit = 50
 )
 
 func Test_getLedgerSeqRange(t *testing.T) {
@@ -120,7 +121,7 @@ func TestGetLedgerTransactions(t *testing.T) {
 	mockRPCService.On("NetworkPassphrase").Return(network.TestNetworkPassphrase)
 	mockChAccStore := &store.ChannelAccountStoreMock{}
 	mockContractStore := &cache.MockTokenContractStore{}
-	ingestService, err := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, mockChAccStore, mockContractStore, mockMetricsService, 50)
+	ingestService, err := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, mockChAccStore, mockContractStore, mockMetricsService, defaultGetLedgersLimit)
 	require.NoError(t, err)
 	t.Run("all_ledger_transactions_in_single_gettransactions_call", func(t *testing.T) {
 		defer mockMetricsService.AssertExpectations(t)
@@ -220,7 +221,7 @@ func TestIngestPayments(t *testing.T) {
 	mockRPCService.On("NetworkPassphrase").Return(network.TestNetworkPassphrase)
 	mockChAccStore := &store.ChannelAccountStoreMock{}
 	mockContractStore := &cache.MockTokenContractStore{}
-	ingestService, err := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, mockChAccStore, mockContractStore, mockMetricsService, 50)
+	ingestService, err := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, mockChAccStore, mockContractStore, mockMetricsService, defaultGetLedgersLimit)
 	require.NoError(t, err)
 	srcAccount := keypair.MustRandom().Address()
 	destAccount := keypair.MustRandom().Address()
@@ -470,7 +471,7 @@ func TestIngest_LatestSyncedLedgerBehindRPC(t *testing.T) {
 		On("NetworkPassphrase").Return(network.TestNetworkPassphrase)
 	mockChAccStore := &store.ChannelAccountStoreMock{}
 	mockContractStore := &cache.MockTokenContractStore{}
-	ingestService, err := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, mockChAccStore, mockContractStore, mockMetricsService, 50)
+	ingestService, err := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, mockChAccStore, mockContractStore, mockMetricsService, defaultGetLedgersLimit)
 	require.NoError(t, err)
 
 	srcAccount := keypair.MustRandom().Address()
@@ -562,7 +563,7 @@ func TestIngest_LatestSyncedLedgerAheadOfRPC(t *testing.T) {
 	mockChAccStore := &store.ChannelAccountStoreMock{}
 	mockChAccStore.On("UnassignTxAndUnlockChannelAccounts", mock.Anything, mock.Anything, testInnerTxHash).Return(int64(1), nil).Twice()
 	mockContractStore := &cache.MockTokenContractStore{}
-	ingestService, err := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, mockChAccStore, mockContractStore, mockMetricsService, 50)
+	ingestService, err := NewIngestService(models, "ingestionLedger", &mockAppTracker, &mockRPCService, mockChAccStore, mockContractStore, mockMetricsService, defaultGetLedgersLimit)
 	require.NoError(t, err)
 
 	mockMetricsService.On("ObserveDBQueryDuration", "INSERT", "ingest_store", mock.AnythingOfType("float64")).Once()
@@ -743,7 +744,7 @@ func Test_ingestService_getLedgerTransactions(t *testing.T) {
 			mockRPCService.On("NetworkPassphrase").Return(network.TestNetworkPassphrase)
 			mockChAccStore := &store.ChannelAccountStoreMock{}
 			mockContractStore := &cache.MockTokenContractStore{}
-			ingestService, err := NewIngestService(models, "testCursor", &mockAppTracker, &mockRPCService, mockChAccStore, mockContractStore, mockMetricsService, 50)
+			ingestService, err := NewIngestService(models, "testCursor", &mockAppTracker, &mockRPCService, mockChAccStore, mockContractStore, mockMetricsService, defaultGetLedgersLimit)
 			require.NoError(t, err)
 
 			var xdrLedgerCloseMeta xdr.LedgerCloseMeta


### PR DESCRIPTION
### What

Allow hosts to configure the limit for the `getLedgers` call

### Why

In production, limits above `10` will trigger a timeout on the RPC server if it's using the default RPC configuration of `MAX_GET_LEDGERS_EXECUTION_DURATION="5s"`

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
