### PR TITLE
Refactor: Move `TransactionService` under `/services`

### DIFF
--- a/internal/serve/graphql/resolvers/mutations.resolvers.go
+++ b/internal/serve/graphql/resolvers/mutations.resolvers.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stellar/wallet-backend/internal/services"
 	"github.com/stellar/wallet-backend/internal/signing"
 	"github.com/stellar/wallet-backend/internal/signing/store"
-	transactionservices "github.com/stellar/wallet-backend/internal/transactions/services"
 	transactionsUtils "github.com/stellar/wallet-backend/internal/transactions/utils"
 	"github.com/stellar/wallet-backend/pkg/sorobanauth"
 )
@@ -142,49 +141,49 @@ func (r *mutationResolver) BuildTransaction(ctx context.Context, input graphql1.
 	tx, err := r.transactionService.BuildAndSignTransactionWithChannelAccount(ctx, ops, int64(transaction.Timeout), simulationResult)
 	if err != nil {
 		switch {
-		case errors.Is(err, transactionservices.ErrInvalidTimeout):
+		case errors.Is(err, services.ErrInvalidTimeout):
 			return nil, &gqlerror.Error{
 				Message: err.Error(),
 				Extensions: map[string]interface{}{
 					"code": "INVALID_TIMEOUT",
 				},
 			}
-		case errors.Is(err, transactionservices.ErrInvalidOperationChannelAccount):
+		case errors.Is(err, services.ErrInvalidOperationChannelAccount):
 			return nil, &gqlerror.Error{
 				Message: err.Error(),
 				Extensions: map[string]interface{}{
 					"code": "INVALID_OPERATION_CHANNEL_ACCOUNT",
 				},
 			}
-		case errors.Is(err, transactionservices.ErrInvalidOperationMissingSource):
+		case errors.Is(err, services.ErrInvalidOperationMissingSource):
 			return nil, &gqlerror.Error{
 				Message: err.Error(),
 				Extensions: map[string]interface{}{
 					"code": "INVALID_OPERATION_MISSING_SOURCE",
 				},
 			}
-		case errors.Is(err, transactionservices.ErrInvalidSorobanOperationCount):
+		case errors.Is(err, services.ErrInvalidSorobanOperationCount):
 			return nil, &gqlerror.Error{
 				Message: err.Error(),
 				Extensions: map[string]interface{}{
 					"code": "INVALID_SOROBAN_OPERATION_COUNT",
 				},
 			}
-		case errors.Is(err, transactionservices.ErrInvalidSorobanSimulationEmpty):
+		case errors.Is(err, services.ErrInvalidSorobanSimulationEmpty):
 			return nil, &gqlerror.Error{
 				Message: err.Error(),
 				Extensions: map[string]interface{}{
 					"code": "INVALID_SOROBAN_SIMULATION_EMPTY",
 				},
 			}
-		case errors.Is(err, transactionservices.ErrInvalidSorobanSimulationFailed):
+		case errors.Is(err, services.ErrInvalidSorobanSimulationFailed):
 			return nil, &gqlerror.Error{
 				Message: err.Error(),
 				Extensions: map[string]interface{}{
 					"code": "INVALID_SOROBAN_SIMULATION_FAILED",
 				},
 			}
-		case errors.Is(err, transactionservices.ErrInvalidSorobanOperationType):
+		case errors.Is(err, services.ErrInvalidSorobanOperationType):
 			return nil, &gqlerror.Error{
 				Message: err.Error(),
 				Extensions: map[string]interface{}{

--- a/internal/serve/graphql/resolvers/resolver.go
+++ b/internal/serve/graphql/resolvers/resolver.go
@@ -11,8 +11,6 @@ import (
 	"github.com/stellar/wallet-backend/internal/data"
 	"github.com/stellar/wallet-backend/internal/services"
 
-	// TODO: Move TransactionService under /services
-	txservices "github.com/stellar/wallet-backend/internal/transactions/services"
 )
 
 // Resolver is the main resolver struct for gqlgen
@@ -25,7 +23,7 @@ type Resolver struct {
 	// accountService provides account management operations
 	accountService services.AccountService
 	// transactionService provides transaction building and signing operations
-	transactionService txservices.TransactionService
+	transactionService services.TransactionService
 	// feeBumpService provides fee-bump transaction wrapping operations
 	feeBumpService services.FeeBumpService
 }
@@ -33,7 +31,7 @@ type Resolver struct {
 // NewResolver creates a new resolver instance with required dependencies
 // This constructor is called during server startup to initialize the resolver
 // Dependencies are injected here and available to all resolver functions.
-func NewResolver(models *data.Models, accountService services.AccountService, transactionService txservices.TransactionService, feeBumpService services.FeeBumpService) *Resolver {
+func NewResolver(models *data.Models, accountService services.AccountService, transactionService services.TransactionService, feeBumpService services.FeeBumpService) *Resolver {
 	return &Resolver{
 		models:             models,
 		accountService:     accountService,

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stellar/wallet-backend/internal/signing"
 	"github.com/stellar/wallet-backend/internal/signing/store"
 	signingutils "github.com/stellar/wallet-backend/internal/signing/utils"
-	txservices "github.com/stellar/wallet-backend/internal/transactions/services"
 	"github.com/stellar/wallet-backend/pkg/wbclient/auth"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -79,7 +78,7 @@ type handlerDeps struct {
 	AccountService     services.AccountService
 	FeeBumpService     services.FeeBumpService
 	MetricsService     metrics.MetricsService
-	TransactionService txservices.TransactionService
+	TransactionService services.TransactionService
 	RPCService         services.RPCService
 	// Error Tracker
 	AppTracker apptracker.AppTracker
@@ -152,7 +151,7 @@ func initHandlerDeps(ctx context.Context, cfg Configs) (handlerDeps, error) {
 		return handlerDeps{}, fmt.Errorf("instantiating fee bump service: %w", err)
 	}
 
-	txService, err := txservices.NewTransactionService(txservices.TransactionServiceOptions{
+	txService, err := services.NewTransactionService(services.TransactionServiceOptions{
 		DB:                                 dbConnectionPool,
 		DistributionAccountSignatureClient: cfg.DistributionAccountSignatureClient,
 		ChannelAccountSignatureClient:      cfg.ChannelAccountSignatureClient,

--- a/internal/services/transaction_service.go
+++ b/internal/services/transaction_service.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/stellar/wallet-backend/internal/db"
 	"github.com/stellar/wallet-backend/internal/entities"
-	"github.com/stellar/wallet-backend/internal/services"
 	"github.com/stellar/wallet-backend/internal/signing"
 	"github.com/stellar/wallet-backend/internal/signing/store"
 	"github.com/stellar/wallet-backend/internal/utils"
@@ -45,7 +44,7 @@ type transactionService struct {
 	DistributionAccountSignatureClient signing.SignatureClient
 	ChannelAccountSignatureClient      signing.SignatureClient
 	ChannelAccountStore                store.ChannelAccountStore
-	RPCService                         services.RPCService
+	RPCService                         RPCService
 	BaseFee                            int64
 }
 
@@ -56,7 +55,7 @@ type TransactionServiceOptions struct {
 	DistributionAccountSignatureClient signing.SignatureClient
 	ChannelAccountSignatureClient      signing.SignatureClient
 	ChannelAccountStore                store.ChannelAccountStore
-	RPCService                         services.RPCService
+	RPCService                         RPCService
 	BaseFee                            int64
 }
 

--- a/internal/services/transaction_service_test.go
+++ b/internal/services/transaction_service_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stellar/wallet-backend/internal/db"
 	"github.com/stellar/wallet-backend/internal/db/dbtest"
 	"github.com/stellar/wallet-backend/internal/entities"
-	"github.com/stellar/wallet-backend/internal/services"
 	"github.com/stellar/wallet-backend/internal/signing"
 	"github.com/stellar/wallet-backend/internal/signing/store"
 	"github.com/stellar/wallet-backend/internal/transactions/utils"
@@ -150,7 +149,7 @@ func TestValidateOptions(t *testing.T) {
 			DistributionAccountSignatureClient: nil,
 			ChannelAccountSignatureClient:      &signing.SignatureClientMock{},
 			ChannelAccountStore:                &store.ChannelAccountStoreMock{},
-			RPCService:                         &services.RPCServiceMock{},
+			RPCService:                         &RPCServiceMock{},
 			BaseFee:                            114,
 		}
 		err := opts.ValidateOptions()
@@ -162,7 +161,7 @@ func TestValidateOptions(t *testing.T) {
 			DistributionAccountSignatureClient: nil,
 			ChannelAccountSignatureClient:      &signing.SignatureClientMock{},
 			ChannelAccountStore:                &store.ChannelAccountStoreMock{},
-			RPCService:                         &services.RPCServiceMock{},
+			RPCService:                         &RPCServiceMock{},
 			BaseFee:                            114,
 		}
 		err := opts.ValidateOptions()
@@ -175,7 +174,7 @@ func TestValidateOptions(t *testing.T) {
 			DistributionAccountSignatureClient: &signing.SignatureClientMock{},
 			ChannelAccountSignatureClient:      nil,
 			ChannelAccountStore:                &store.ChannelAccountStoreMock{},
-			RPCService:                         &services.RPCServiceMock{},
+			RPCService:                         &RPCServiceMock{},
 			BaseFee:                            114,
 		}
 		err := opts.ValidateOptions()
@@ -188,7 +187,7 @@ func TestValidateOptions(t *testing.T) {
 			DistributionAccountSignatureClient: &signing.SignatureClientMock{},
 			ChannelAccountSignatureClient:      &signing.SignatureClientMock{},
 			ChannelAccountStore:                nil,
-			RPCService:                         &services.RPCServiceMock{},
+			RPCService:                         &RPCServiceMock{},
 			BaseFee:                            114,
 		}
 		err := opts.ValidateOptions()
@@ -214,7 +213,7 @@ func TestValidateOptions(t *testing.T) {
 			DistributionAccountSignatureClient: &signing.SignatureClientMock{},
 			ChannelAccountSignatureClient:      &signing.SignatureClientMock{},
 			ChannelAccountStore:                &store.ChannelAccountStoreMock{},
-			RPCService:                         &services.RPCServiceMock{},
+			RPCService:                         &RPCServiceMock{},
 			BaseFee:                            txnbuild.MinBaseFee - 10,
 		}
 		err := opts.ValidateOptions()
@@ -232,7 +231,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 	mDistributionAccountSignatureClient := signing.SignatureClientMock{}
 	mChannelAccountSignatureClient := signing.SignatureClientMock{}
 	mChannelAccountStore := store.ChannelAccountStoreMock{}
-	mRPCService := services.RPCServiceMock{}
+	mRPCService := RPCServiceMock{}
 	txService, outerErr := NewTransactionService(TransactionServiceOptions{
 		DB:                                 dbConnectionPool,
 		DistributionAccountSignatureClient: &mDistributionAccountSignatureClient,


### PR DESCRIPTION
### What

Moves `TransactionService` from `/transactions/services` to `/services`.

### Why

For consistency with the other services.

### Known limitations

N/A

### Issue that this PR addresses

https://github.com/stellar/wallet-backend/issues/280

### Checklist

#### PR Structure

- [ ] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.
- [ ] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.
- [ ] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [ ] This is not a breaking change.
- [ ] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
