### PR TITLE
services: complete the channel account service so it can create/delete any number of accounts

### DIFF
--- a/cmd/channel_account.go
+++ b/cmd/channel_account.go
@@ -76,7 +76,7 @@ func (c *channelAccountCmd) Command(cmdService ChAccCmdServiceInterface) *cobra.
 
 	ensureCmd := &cobra.Command{
 		Use:   "ensure {amount}",
-		Short: "Ensures that the number of channel accounts is at least the [amount] provided",
+		Short: "Ensures that the number of channel accounts is at exactly the [amount] provided",
 		Args:  cobra.ExactArgs(1),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := cfgOpts.RequireE(); err != nil {

--- a/cmd/channel_account.go
+++ b/cmd/channel_account.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stellar/wallet-backend/internal/db"
 	"github.com/stellar/wallet-backend/internal/metrics"
 	"github.com/stellar/wallet-backend/internal/services"
+	"github.com/stellar/wallet-backend/internal/signing"
 	"github.com/stellar/wallet-backend/internal/signing/store"
 	signingutils "github.com/stellar/wallet-backend/internal/signing/utils"
 	internalUtils "github.com/stellar/wallet-backend/internal/utils"
@@ -98,6 +99,16 @@ func (c *channelAccountCmd) Command(cmdService ChAccCmdServiceInterface) *cobra.
 				return fmt.Errorf("resolving distribution account signature client: %w", err)
 			}
 
+			chAccSigClient, err := utils.SignatureClientResolver(&utils.SignatureClientOptions{
+				Type:                 signing.ChannelAccountSignatureClientType,
+				NetworkPassphrase:    cfg.NetworkPassphrase,
+				EncryptionPassphrase: cfg.EncryptionPassphrase,
+				DBConnectionPool:     dbConnectionPool,
+			})
+			if err != nil {
+				return fmt.Errorf("resolving channel account signature client: %w", err)
+			}
+
 			db, err := dbConnectionPool.SqlxDB(ctx)
 			if err != nil {
 				return fmt.Errorf("getting sqlx db: %w", err)
@@ -115,6 +126,7 @@ func (c *channelAccountCmd) Command(cmdService ChAccCmdServiceInterface) *cobra.
 				DB:                                 dbConnectionPool,
 				BaseFee:                            int64(cfg.BaseFee),
 				DistributionAccountSignatureClient: distAccSigClient,
+				ChannelAccountSignatureClient:      chAccSigClient,
 				ChannelAccountStore:                &channelAccountModel,
 				PrivateKeyEncrypter:                &privateKeyEncrypter,
 				EncryptionPassphrase:               cfg.EncryptionPassphrase,

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -172,6 +172,7 @@ func initHandlerDeps(ctx context.Context, cfg Configs) (handlerDeps, error) {
 		RPCService:                         rpcService,
 		BaseFee:                            int64(cfg.BaseFee),
 		DistributionAccountSignatureClient: cfg.DistributionAccountSignatureClient,
+		ChannelAccountSignatureClient:      cfg.ChannelAccountSignatureClient,
 		ChannelAccountStore:                store.NewChannelAccountModel(dbConnectionPool),
 		PrivateKeyEncrypter:                &signingutils.DefaultPrivateKeyEncrypter{},
 		EncryptionPassphrase:               cfg.EncryptionPassphrase,
@@ -209,7 +210,7 @@ func ensureChannelAccounts(ctx context.Context, channelAccountService services.C
 		log.Ctx(ctx).Errorf("error ensuring the number of channel accounts: %s", err.Error())
 		return
 	}
-	log.Ctx(ctx).Infof("Ensured that at least %d channel accounts exist in the database", numberOfChannelAccounts)
+	log.Ctx(ctx).Infof("Ensured that exactly %d channel accounts exist in the database", numberOfChannelAccounts)
 }
 
 func handler(deps handlerDeps) http.Handler {

--- a/internal/services/channel_account_service.go
+++ b/internal/services/channel_account_service.go
@@ -53,7 +53,7 @@ func (s *channelAccountService) EnsureChannelAccounts(ctx context.Context, numbe
 	log.Ctx(ctx).Infof("🔍 Channel accounts amounts: {desired:%d, existing:%d}", number, currentChannelAccountNumber)
 
 	if currentChannelAccountNumber == number {
-		log.Ctx(ctx).Infof("✅ There are exactly %d channel accounts currently. Exiting...", number)
+		log.Ctx(ctx).Infof("✅ There are exactly %d channel accounts currently. Skipping...", number)
 		return nil
 	} else if currentChannelAccountNumber > number {
 		// Delete excess accounts

--- a/internal/services/channel_account_service.go
+++ b/internal/services/channel_account_service.go
@@ -156,7 +156,7 @@ func (s *channelAccountService) deleteChannelAccountsInBatches(ctx context.Conte
 		log.Ctx(ctx).Debugf("batch size: %d", batchSize)
 		err := s.deleteChannelAccounts(ctx, batchSize)
 		if err != nil {
-			return fmt.Errorf("creating channel accounts in batch: %w", err)
+			return fmt.Errorf("deleting channel accounts in batch: %w", err)
 		}
 		amount -= batchSize
 	}
@@ -207,6 +207,7 @@ func (s *channelAccountService) deleteChannelAccounts(ctx context.Context, numAc
 				return tx, nil
 			}
 
+			log.Ctx(ctx).Infof("⛓️ Will merge accounts on chain: %v", publicKeys)
 			err = s.submitChannelAccountsTxOnChain(ctx, distAccPublicKey, ops, chAccSigner)
 			if err != nil {
 				return fmt.Errorf("submitting delete account transaction: %w", err)
@@ -327,7 +328,7 @@ func parseResultXDR(resultXDR string) string {
 	var xdrResult xdr.TransactionResult
 	err := xdr.SafeUnmarshalBase64(resultXDR, &xdrResult)
 	if err != nil {
-		log.Errorf("unmarshalling transaction result=%v", err)
+		log.Errorf("error unmarshalling transaction result: %v", err)
 		return resultXDR
 	}
 	return fmt.Sprintf("%+v", xdrResult)

--- a/internal/signing/store/channel_accounts_model.go
+++ b/internal/signing/store/channel_accounts_model.go
@@ -128,6 +128,10 @@ func (ca *ChannelAccountModel) BatchInsert(ctx context.Context, sqlExec db.SQLEx
 		return nil
 	}
 
+	if sqlExec == nil {
+		sqlExec = ca.DB
+	}
+
 	publicKeys := make([]string, len(channelAccounts))
 	encryptedPrivateKeys := make([]string, len(channelAccounts))
 	for i, ca := range channelAccounts {
@@ -158,10 +162,15 @@ func (ca *ChannelAccountModel) BatchInsert(ctx context.Context, sqlExec db.SQLEx
 }
 
 func (ca *ChannelAccountModel) GetAll(ctx context.Context, sqlExec db.SQLExecuter, limit int) ([]*ChannelAccount, error) {
+	if sqlExec == nil {
+		sqlExec = ca.DB
+	}
+
 	query := `
 		SELECT * FROM channel_accounts
 		ORDER BY created_at ASC
 		LIMIT $1
+		FOR UPDATE SKIP LOCKED
 	`
 
 	var channelAccounts []*ChannelAccount
@@ -174,6 +183,10 @@ func (ca *ChannelAccountModel) GetAll(ctx context.Context, sqlExec db.SQLExecute
 }
 
 func (ca *ChannelAccountModel) Delete(ctx context.Context, sqlExec db.SQLExecuter, publicKeys ...string) (int64, error) {
+	if sqlExec == nil {
+		sqlExec = ca.DB
+	}
+
 	query := `DELETE FROM channel_accounts WHERE public_key = ANY($1)`
 
 	result, err := sqlExec.ExecContext(ctx, query, pq.Array(publicKeys))

--- a/internal/signing/store/mocks.go
+++ b/internal/signing/store/mocks.go
@@ -66,9 +66,13 @@ func (s *ChannelAccountStoreMock) GetAll(ctx context.Context, sqlExec db.SQLExec
 	return args.Get(0).([]*ChannelAccount), args.Error(1)
 }
 
-func (s *ChannelAccountStoreMock) Delete(ctx context.Context, sqlExec db.SQLExecuter, publicKey string) error {
-	args := s.Called(ctx, sqlExec, publicKey)
-	return args.Error(0)
+func (s *ChannelAccountStoreMock) Delete(ctx context.Context, sqlExec db.SQLExecuter, publicKeys ...string) (int64, error) {
+	_ca := []any{ctx, sqlExec}
+	for _, publicKey := range publicKeys {
+		_ca = append(_ca, publicKey)
+	}
+	args := s.Called(_ca...)
+	return args.Get(0).(int64), args.Error(1)
 }
 
 func (s *ChannelAccountStoreMock) Count(ctx context.Context) (int64, error) {

--- a/internal/signing/store/mocks.go
+++ b/internal/signing/store/mocks.go
@@ -58,6 +58,19 @@ func (s *ChannelAccountStoreMock) BatchInsert(ctx context.Context, sqlExec db.SQ
 	return args.Error(0)
 }
 
+func (s *ChannelAccountStoreMock) GetAll(ctx context.Context, sqlExec db.SQLExecuter, limit int) ([]*ChannelAccount, error) {
+	args := s.Called(ctx, sqlExec, limit)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*ChannelAccount), args.Error(1)
+}
+
+func (s *ChannelAccountStoreMock) Delete(ctx context.Context, sqlExec db.SQLExecuter, publicKey string) error {
+	args := s.Called(ctx, sqlExec, publicKey)
+	return args.Error(0)
+}
+
 func (s *ChannelAccountStoreMock) Count(ctx context.Context) (int64, error) {
 	args := s.Called(ctx)
 	return int64(args.Int(0)), args.Error(1)

--- a/internal/signing/store/mocks.go
+++ b/internal/signing/store/mocks.go
@@ -67,11 +67,7 @@ func (s *ChannelAccountStoreMock) GetAll(ctx context.Context, sqlExec db.SQLExec
 }
 
 func (s *ChannelAccountStoreMock) Delete(ctx context.Context, sqlExec db.SQLExecuter, publicKeys ...string) (int64, error) {
-	_ca := []any{ctx, sqlExec}
-	for _, publicKey := range publicKeys {
-		_ca = append(_ca, publicKey)
-	}
-	args := s.Called(_ca...)
+	args := s.Called(ctx, sqlExec, publicKeys)
 	return args.Get(0).(int64), args.Error(1)
 }
 

--- a/internal/signing/store/types.go
+++ b/internal/signing/store/types.go
@@ -21,10 +21,12 @@ type ChannelAccount struct {
 type ChannelAccountStore interface {
 	GetAndLockIdleChannelAccount(ctx context.Context, lockedUntil time.Duration) (*ChannelAccount, error)
 	Get(ctx context.Context, sqlExec db.SQLExecuter, publicKey string) (*ChannelAccount, error)
+	GetAll(ctx context.Context, sqlExec db.SQLExecuter, limit int) ([]*ChannelAccount, error)
 	GetAllByPublicKey(ctx context.Context, sqlExec db.SQLExecuter, publicKeys ...string) ([]*ChannelAccount, error)
 	AssignTxToChannelAccount(ctx context.Context, publicKey string, txHash string) error
 	UnassignTxAndUnlockChannelAccounts(ctx context.Context, sqlExec db.SQLExecuter, txHashes ...string) (int64, error)
 	BatchInsert(ctx context.Context, sqlExec db.SQLExecuter, channelAccounts []*ChannelAccount) error
+	Delete(ctx context.Context, sqlExec db.SQLExecuter, publicKey string) error
 	Count(ctx context.Context) (int64, error)
 }
 

--- a/internal/signing/store/types.go
+++ b/internal/signing/store/types.go
@@ -26,7 +26,7 @@ type ChannelAccountStore interface {
 	AssignTxToChannelAccount(ctx context.Context, publicKey string, txHash string) error
 	UnassignTxAndUnlockChannelAccounts(ctx context.Context, sqlExec db.SQLExecuter, txHashes ...string) (int64, error)
 	BatchInsert(ctx context.Context, sqlExec db.SQLExecuter, channelAccounts []*ChannelAccount) error
-	Delete(ctx context.Context, sqlExec db.SQLExecuter, publicKey string) error
+	Delete(ctx context.Context, sqlExec db.SQLExecuter, publicKeys ...string) (int64, error)
 	Count(ctx context.Context) (int64, error)
 }
 


### PR DESCRIPTION
### What

Complete the channel account service, so it can create/delete any number of accounts.

### Why

Before this change, it wouldn't be able to delete any accounts and would only be able to create at most 19 accounts. Such behavior is not enough for a prod-ready application.

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
