### PR TITLE
[FEATURE] [internal ]adds metrics for rpc queries

### DIFF
--- a/internal/metrics/mocks.go
+++ b/internal/metrics/mocks.go
@@ -77,10 +77,6 @@ func (m *MockMetricsService) IncRPCMethodErrors(method, errorType string) {
 	m.Called(method, errorType)
 }
 
-func (m *MockMetricsService) ObserveRPCResponseSize(method string, sizeBytes int) {
-	m.Called(method, sizeBytes)
-}
-
 func (m *MockMetricsService) IncNumRequests(endpoint, method string, statusCode int) {
 	m.Called(endpoint, method, statusCode)
 }

--- a/internal/services/rpc_service.go
+++ b/internal/services/rpc_service.go
@@ -105,8 +105,6 @@ func (r *rpcService) GetTransaction(transactionHash string) (entities.RPCGetTran
 		return entities.RPCGetTransactionResult{}, fmt.Errorf("sending getTransaction request: %w", err)
 	}
 
-	r.metricsService.ObserveRPCResponseSize("GetTransaction", len(resultBytes))
-
 	var result entities.RPCGetTransactionResult
 	err = json.Unmarshal(resultBytes, &result)
 	if err != nil {
@@ -142,8 +140,6 @@ func (r *rpcService) GetTransactions(startLedger int64, startCursor string, limi
 		return entities.RPCGetTransactionsResult{}, fmt.Errorf("sending getTransactions request: %w", err)
 	}
 
-	r.metricsService.ObserveRPCResponseSize("GetTransactions", len(resultBytes))
-
 	var result entities.RPCGetTransactionsResult
 	err = json.Unmarshal(resultBytes, &result)
 	if err != nil {
@@ -166,8 +162,6 @@ func (r *rpcService) GetHealth() (entities.RPCGetHealthResult, error) {
 		r.metricsService.IncRPCMethodErrors("GetHealth", "rpc_error")
 		return entities.RPCGetHealthResult{}, fmt.Errorf("sending getHealth request: %w", err)
 	}
-
-	r.metricsService.ObserveRPCResponseSize("GetHealth", len(resultBytes))
 
 	var result entities.RPCGetHealthResult
 	err = json.Unmarshal(resultBytes, &result)
@@ -200,8 +194,6 @@ func (r *rpcService) GetLedgers(startLedger uint32, limit uint32) (GetLedgersRes
 		return GetLedgersResponse{}, fmt.Errorf("sending getLedgers request: %w", err)
 	}
 
-	r.metricsService.ObserveRPCResponseSize("GetLedgers", len(resultBytes))
-
 	var result GetLedgersResponse
 	err = json.Unmarshal(resultBytes, &result)
 	if err != nil {
@@ -228,8 +220,6 @@ func (r *rpcService) GetLedgerEntries(keys []string) (entities.RPCGetLedgerEntri
 		return entities.RPCGetLedgerEntriesResult{}, fmt.Errorf("sending getLedgerEntries request: %w", err)
 	}
 
-	r.metricsService.ObserveRPCResponseSize("GetLedgerEntries", len(resultBytes))
-
 	var result entities.RPCGetLedgerEntriesResult
 	err = json.Unmarshal(resultBytes, &result)
 	if err != nil {
@@ -252,8 +242,6 @@ func (r *rpcService) SendTransaction(transactionXDR string) (entities.RPCSendTra
 		r.metricsService.IncRPCMethodErrors("SendTransaction", "rpc_error")
 		return entities.RPCSendTransactionResult{}, fmt.Errorf("sending sendTransaction request: %w", err)
 	}
-
-	r.metricsService.ObserveRPCResponseSize("SendTransaction", len(resultBytes))
 
 	var result entities.RPCSendTransactionResult
 	err = json.Unmarshal(resultBytes, &result)
@@ -278,8 +266,6 @@ func (r *rpcService) SimulateTransaction(transactionXDR string, resourceConfig e
 		r.metricsService.IncRPCMethodErrors("SimulateTransaction", "rpc_error")
 		return entities.RPCSimulateTransactionResult{}, fmt.Errorf("sending simulateTransaction request: %w", err)
 	}
-
-	r.metricsService.ObserveRPCResponseSize("SimulateTransaction", len(resultBytes))
 
 	var result entities.RPCSimulateTransactionResult
 	err = json.Unmarshal(resultBytes, &result)

--- a/internal/services/rpc_service_test.go
+++ b/internal/services/rpc_service_test.go
@@ -253,7 +253,6 @@ func TestSendTransaction(t *testing.T) {
 		mockMetricsService.On("IncRPCRequests", "sendTransaction").Once()
 		mockMetricsService.On("IncRPCEndpointSuccess", "sendTransaction").Once()
 		mockMetricsService.On("ObserveRPCRequestDuration", "sendTransaction", mock.AnythingOfType("float64")).Once()
-		mockMetricsService.On("ObserveRPCResponseSize", "SendTransaction", mock.AnythingOfType("int")).Once()
 		defer mockMetricsService.AssertExpectations(t)
 
 		transactionXDR := "AAAAAgAAAABYJgX6SmA2tGVDv3GXfOWbkeL869ahE0e5DG9HnXQw/QAAAGQAAjpnAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAACxaDFEbbssZfrbRgFxTYIygITSQxsUpDmneN2gAZBEFQAAAAAAAAAABfXhAAAAAAAAAAAA"
@@ -463,7 +462,6 @@ func Test_rpcService_SimulateTransaction(t *testing.T) {
 				On("ObserveRPCRequestDuration", "simulateTransaction", mock.AnythingOfType("float64")).Once()
 			if tc.httpResponseErr == nil {
 				mMetricsService.On("IncRPCEndpointSuccess", "simulateTransaction").Once()
-				mMetricsService.On("ObserveRPCResponseSize", "SimulateTransaction", mock.AnythingOfType("int")).Once()
 			} else {
 				mMetricsService.On("IncRPCEndpointFailure", "simulateTransaction").Once()
 				mMetricsService.On("IncRPCMethodErrors", "SimulateTransaction", "rpc_error").Once()
@@ -527,7 +525,6 @@ func TestGetTransaction(t *testing.T) {
 		mockMetricsService.On("IncRPCRequests", "getTransaction").Once()
 		mockMetricsService.On("IncRPCEndpointSuccess", "getTransaction").Once()
 		mockMetricsService.On("ObserveRPCRequestDuration", "getTransaction", mock.AnythingOfType("float64")).Once()
-		mockMetricsService.On("ObserveRPCResponseSize", "GetTransaction", mock.AnythingOfType("int")).Once()
 		defer mockMetricsService.AssertExpectations(t)
 
 		transactionHash := "6bc97bddc21811c626839baf4ab574f4f9f7ddbebb44d286ae504396d4e752da"
@@ -649,7 +646,6 @@ func TestGetTransactions(t *testing.T) {
 		mockMetricsService.On("IncRPCRequests", "getTransactions").Once()
 		mockMetricsService.On("IncRPCEndpointSuccess", "getTransactions").Once()
 		mockMetricsService.On("ObserveRPCRequestDuration", "getTransactions", mock.AnythingOfType("float64")).Once()
-		mockMetricsService.On("ObserveRPCResponseSize", "GetTransactions", mock.AnythingOfType("int")).Once()
 		defer mockMetricsService.AssertExpectations(t)
 
 		params := entities.RPCParams{StartLedger: 10, Pagination: entities.RPCPagination{Limit: 5}}
@@ -716,7 +712,6 @@ func TestSendGetHealth(t *testing.T) {
 		mockMetricsService.On("IncRPCRequests", "getHealth").Once()
 		mockMetricsService.On("IncRPCEndpointSuccess", "getHealth").Once()
 		mockMetricsService.On("ObserveRPCRequestDuration", "getHealth", mock.AnythingOfType("float64")).Once()
-		mockMetricsService.On("ObserveRPCResponseSize", "GetHealth", mock.AnythingOfType("int")).Once()
 		defer mockMetricsService.AssertExpectations(t)
 
 		payload := map[string]interface{}{
@@ -785,8 +780,7 @@ func Test_rpcService_GetLedgers(t *testing.T) {
 			On("ObserveRPCMethodDuration", "GetLedgers", mock.AnythingOfType("float64")).Once().
 			On("IncRPCRequests", "getLedgers").Once().
 			On("IncRPCEndpointSuccess", "getLedgers").Once().
-			On("ObserveRPCRequestDuration", "getLedgers", mock.AnythingOfType("float64")).Once().
-			On("ObserveRPCResponseSize", "GetLedgers", mock.AnythingOfType("int")).Once()
+			On("ObserveRPCRequestDuration", "getLedgers", mock.AnythingOfType("float64")).Once()
 		defer mockMetricsService.AssertExpectations(t)
 
 		payload := map[string]any{
@@ -897,7 +891,6 @@ func TestTrackRPCServiceHealth_HealthyService(t *testing.T) {
 	mockMetricsService.On("IncRPCRequests", "getHealth").Once()
 	mockMetricsService.On("IncRPCEndpointSuccess", "getHealth").Once()
 	mockMetricsService.On("ObserveRPCRequestDuration", "getHealth", mock.AnythingOfType("float64")).Once()
-	mockMetricsService.On("ObserveRPCResponseSize", "GetHealth", mock.AnythingOfType("int")).Once()
 	mockMetricsService.On("SetRPCServiceHealth", true).Once()
 	mockMetricsService.On("SetRPCLatestLedger", int64(100)).Once()
 	defer mockMetricsService.AssertExpectations(t)
@@ -1067,7 +1060,6 @@ func TestTrackRPCService_DeadlockPrevention(t *testing.T) {
 	mockMetricsService.On("IncRPCRequests", "getHealth").Maybe()
 	mockMetricsService.On("IncRPCEndpointSuccess", "getHealth").Maybe()
 	mockMetricsService.On("ObserveRPCRequestDuration", "getHealth", mock.AnythingOfType("float64")).Maybe()
-	mockMetricsService.On("ObserveRPCResponseSize", "GetHealth", mock.AnythingOfType("int")).Maybe()
 	mockMetricsService.On("SetRPCServiceHealth", true).Maybe()
 	mockMetricsService.On("SetRPCLatestLedger", mock.AnythingOfType("int64")).Maybe()
 	defer mockMetricsService.AssertExpectations(t)


### PR DESCRIPTION
Closes #338 

### What
Adds metric collection for rpc interactions

### Why
To support initial deployment and monitoring

### Known limitations
N/a

### Issue that this PR addresses
https://github.com/stellar/wallet-backend/issues/338

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
