### PR TITLE
Continue ingestion process if there is error getting ledgers from RPC

### DIFF
--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -306,6 +306,7 @@ func (m *ingestService) Run(ctx context.Context, startLedger uint32, endLedger u
 			if updateErr := m.models.IngestStore.UpdateLatestLedgerSynced(ctx, dbTx, m.ledgerCursorName, lastLedger); updateErr != nil {
 				return fmt.Errorf("updating latest synced ledger: %w", updateErr)
 			}
+			m.metricsService.SetLatestLedgerIngested(float64(lastLedger))
 			checkpointLedger := m.accountTokenService.GetCheckpointLedger()
 			if lastLedger > checkpointLedger {
 				if updateErr := m.models.IngestStore.UpdateLatestLedgerSynced(ctx, dbTx, m.accountTokensCursorName, lastLedger); updateErr != nil {
@@ -322,7 +323,6 @@ func (m *ingestService) Run(ctx context.Context, startLedger uint32, endLedger u
 		m.metricsService.ObserveIngestionPhaseDuration("cursor_update", cursorDuration.Seconds())
 
 		totalDuration := time.Since(totalIngestionStart)
-		m.metricsService.SetLatestLedgerIngested(float64(getLedgersResponse.LatestLedger))
 		m.metricsService.ObserveIngestionDuration(totalDuration.Seconds())
 		m.metricsService.IncIngestionLedgersProcessed(len(getLedgersResponse.Ledgers))
 


### PR DESCRIPTION
Currently, the ingestion process exits if the getLedgers fetch fails. We want to keep continuing the loop and retry to get the ledgers