### PR TITLE
Skip creating state changes for claimable balance IDs

### DIFF
--- a/internal/indexer/processors/token_transfer.go
+++ b/internal/indexer/processors/token_transfer.go
@@ -246,6 +246,11 @@ func (p *TokenTransferProcessor) handleTransfer(transfer *ttp.Transfer, contract
 		return nil
 
 	default:
+		// Skip transfers involving claimable balances (like LP to CB during trustline revocation)
+		if isClaimableBalance(transfer.GetFrom()) || isClaimableBalance(transfer.GetTo()) {
+			return nil
+		}
+
 		if isLiquidityPool(transfer.GetFrom()) || isLiquidityPool(transfer.GetTo()) {
 			return p.handleTransfersWithLiquidityPool(transfer, contractAddress, asset, builder)
 		}
@@ -297,8 +302,8 @@ func (p *TokenTransferProcessor) handleMint(mint *ttp.Mint, contractAddress stri
 		changes = append(changes, mintChange)
 	}
 
-	// Create credit state change for the receiving account. Skip mints to liquidity pools since we dont track LP accounts
-	if !isLiquidityPool(mint.GetTo()) {
+	// Create credit state change for the receiving account. Skip mints to liquidity pools or claimable balances since we dont track them as accounts
+	if !isLiquidityPool(mint.GetTo()) && !isClaimableBalance(mint.GetTo()) {
 		creditChange := p.createStateChange(types.StateChangeCategoryBalance, types.StateChangeReasonCredit, mint.GetTo(), mint.GetAmount(), contractAddress, asset, builder)
 		changes = append(changes, creditChange)
 	}
@@ -350,8 +355,8 @@ func (p *TokenTransferProcessor) handleDefaultBurnOrClawback(from string, amount
 		changes = append(changes, burnChange)
 	}
 
-	// Always record debit from the account losing the tokens. Skip burns from LP accounts since we dont track LP accounts
-	if !isLiquidityPool(from) {
+	// Always record debit from the account losing the tokens. Skip burns from LP or claimable balance since we dont track them as accounts
+	if !isLiquidityPool(from) && !isClaimableBalance(from) {
 		debitChange := p.createStateChange(types.StateChangeCategoryBalance, types.StateChangeReasonDebit, from, amount, contractAddress, asset, builder)
 		changes = append(changes, debitChange)
 	}

--- a/internal/indexer/processors/utils.go
+++ b/internal/indexer/processors/utils.go
@@ -47,6 +47,15 @@ func isLiquidityPool(accountID string) bool {
 	return versionByte == strkey.VersionByteLiquidityPool
 }
 
+// isClaimableBalance checks if the given ID is a claimable balance
+func isClaimableBalance(id string) bool {
+	versionByte, _, err := strkey.DecodeAny(id)
+	if err != nil {
+		return false
+	}
+	return versionByte == strkey.VersionByteClaimableBalance
+}
+
 // operationSourceAccount returns the source account for an operation,
 // falling back to the transaction source account if the operation doesn't have one
 func operationSourceAccount(tx ingest.LedgerTransaction, op xdr.Operation) string {

--- a/internal/indexer/processors/utils_test.go
+++ b/internal/indexer/processors/utils_test.go
@@ -106,3 +106,44 @@ func Test_ConvertOperation(t *testing.T) {
 	}
 	assert.Equal(t, wantDataOp, gotDataOp)
 }
+
+func Test_isClaimableBalance(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       string
+		expected bool
+	}{
+		{
+			name:     "valid claimable balance ID",
+			id:       "BAAFK3PZYCD4YKOLFNOCJVG2JIHWOBE5NHU5FHY3ESAHMAO3C5RIYGTBDI",
+			expected: true,
+		},
+		{
+			name:     "regular account ID starting with G",
+			id:       "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+			expected: false,
+		},
+		{
+			name:     "liquidity pool ID starting with P",
+			id:       "PAQKWTDZ3PQLV6OB5HZRLJ6BPZAXUZWBQNC6FDZF3EOJF5LNXKN7C5TJ",
+			expected: false,
+		},
+		{
+			name:     "invalid string",
+			id:       "invalid-id",
+			expected: false,
+		},
+		{
+			name:     "empty string",
+			id:       "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isClaimableBalance(tt.id)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/integrationtests/data_validation_test.go
+++ b/internal/integrationtests/data_validation_test.go
@@ -1205,6 +1205,16 @@ func (suite *DataValidationTestSuite) validateCreateClaimableBalanceStateChanges
 		suite.Require().NoError(err, "failed to marshal state change")
 		fmt.Printf("%s\n", string(jsonBytes))
 		validateStateChangeBase(suite, edge.Node, ledgerNumber)
+
+		// Validate that no state changes have claimable balance IDs as accounts
+		accountID := edge.Node.GetAccountID()
+		suite.Require().NotEmpty(accountID, "account ID should not be empty")
+
+		// Decode the account ID to check its version byte
+		versionByte, _, err := strkey.DecodeAny(accountID)
+		suite.Require().NoError(err, "account ID should be a valid strkey: %s", accountID)
+		suite.Require().NotEqual(strkey.VersionByteClaimableBalance, versionByte,
+			"state change should not have claimable balance ID as account: %s", accountID)
 	}
 	fmt.Printf("primary account: %s\n", primaryAccount)
 	fmt.Printf("secondary account: %s\n", secondaryAccount)


### PR DESCRIPTION
### What

When handling mint events from ttp, skip events with claimable balance IDs as the recipient.

### Why

For `CREATE_CLAIMABLE_BALANCE` operations we were wrongly creating a state change with the claimable balance ID as the account ID. This happens because when an issuer creates a claimable balance, TTP creates a mint event to the CBID and we were not skipping it.

### Known limitations

N/A

### Issue that this PR addresses
