### PR TITLE
Add contributing guide with LLM quick start instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,39 +1,186 @@
-# How to contribute
+# Contributing to Wallet Backend
 
-👍🎉 First off, thanks for taking the time to contribute! 🎉👍
+Go backend service powering Freighter wallet applications. Provides a GraphQL
+API for querying Stellar network data and building transactions with fee
+sponsorship.
 
-Check out the [Stellar Contribution Guide](https://github.com/stellar/.github/blob/master/CONTRIBUTING.md) that applies to all Stellar projects.
+For the Stellar organization's general contribution guidelines, see the
+[Stellar Contribution Guide](https://github.com/stellar/.github/blob/master/CONTRIBUTING.md).
 
-## Style guides
+## Prerequisites
 
-### Issues
+| Tool             | Version   | Install                                                       |
+| ---------------- | --------- | ------------------------------------------------------------- |
+| Go               | >= 1.24.0 | [go.dev/dl](https://go.dev/dl/) (toolchain 1.24.2)            |
+| Docker + Compose | Latest    | [docker.com](https://docs.docker.com/get-docker/)             |
+| golangci-lint    | Latest    | `brew install golangci-lint` or [docs](https://golangci-lint.run/welcome/install/) |
+| PostgreSQL       | 17        | Provided via Docker Compose (no manual install needed)        |
 
-* Ensure the issue was not already reported by searching on GitHub under Issues.
-* Issues start with:
-    * The functional area most affected, ex. `ingestion: fix... `.
-    * Or, `ci:` when changes or an issue are isolated to CI.
-    * Or, `doc:` when changes or an issue are isolated to non-code documentation not limited to a single package.
-* Label issues with `bug` if they're clearly a bug.
-* Label issues with `feature request` if they're a feature request.
+## Getting Started
 
-### Pull Requests
+### Quick Setup with an LLM
 
-* **Title:** PR titles start with feat, fix, refactor, ci, or doc, followed by a short description of the change.
-* **Branching:** PRs must be opened against the `develop` branch.
-* **Scope:** PRs must be focused and not contain unrelated commits.
-* **Refactoring:** Explicitly differentiate refactoring PRs and feature PRs. Refactoring PRs don’t change functionality. They usually touch a lot more code, and are reviewed in less detail. Avoid refactoring in feature PRs.
-* **Go Formatting:** Ensure your code is formatted with `gofmt`.
-* **Tests:** Ensure your change is covered by tests. If you're adding a new feature or fixing a bug, you must add tests. If you're refactoring, you should add tests if possible.
-* **Documentation:** Update README.md or other relevant documentation pages if necessary. For exported functions, types, and constants, make sure to add a doc comment conforming to [Effective Go](https://golang.org/doc/effective_go.html#commentary).
-* **Best Practices:** * Follow [Effective Go](https://golang.org/doc/effective_go.html) and [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments).
+If you use an LLM-powered coding assistant, you can automate the setup. The repo
+includes a quick start guide ([`LLM-QUICK-START.md`](LLM-QUICK-START.md)) that
+checks your environment, installs missing tools, configures `.env`, and verifies
+the build.
 
+Point your LLM assistant at `LLM-QUICK-START.md` and ask it to follow the steps.
 
-### Git Commit Messages
+If you don't use an LLM assistant, follow the manual setup below.
 
-* Use the present tense ("Add feature" not "Added feature").
-* Use the imperative mood ("Move cursor to..." not "Moves cursor to...").
-* Start commit message with the relevant issue number, e.g., #123 Fixed bug in XYZ module.
+### Docker Compose (quickest path)
+
+```bash
+git clone https://github.com/stellar/wallet-backend.git
+cd wallet-backend
+cp .env.example .env
+# Fill in required values (see Environment Variables below)
+docker compose up
+```
+
+This starts:
+- **TimescaleDB** (PostgreSQL 17) — database
+- **Stellar RPC** — blockchain data source (testnet and/or mainnet)
+- **API server** — GraphQL endpoint
+- **Ingestion service** — indexes Stellar ledger data
+
+### Local Development (Go binary + Docker services)
+
+For active development with hot reload:
+
+```bash
+cp .env.example .env
+source .env
+
+# Start dependencies only
+docker compose up -d db stellar-rpc-testnet
+
+# Run migrations
+go run main.go migrate up
+
+# Create channel accounts (for fee sponsorship)
+go run main.go channel-account ensure 5
+
+# Start API and ingestion in separate terminals
+go run main.go serve     # Terminal 1
+go run main.go ingest    # Terminal 2
+```
+
+### Environment Variables
+
+Copy `.env.example` to `.env`. Required variables:
+
+| Variable                                  | How to set up                                                            |
+| ----------------------------------------- | ------------------------------------------------------------------------ |
+| `CLIENT_AUTH_PUBLIC_KEYS`                 | Generate a Stellar keypair and use the public key                        |
+| `DISTRIBUTION_ACCOUNT_PUBLIC_KEY`         | Generate a Stellar keypair for the distribution account                  |
+| `DISTRIBUTION_ACCOUNT_PRIVATE_KEY`        | Private key for the distribution account (use `ENV` signature provider)  |
+| `DISTRIBUTION_ACCOUNT_SIGNATURE_PROVIDER` | `ENV` for local dev (uses env var above). `KMS` for production           |
+| `CHANNEL_ACCOUNT_ENCRYPTION_PASSPHRASE`   | Any passphrase for encrypting channel account keys                       |
+| `DATABASE_URL`                            | `postgres://postgres@localhost:5432/wallet-backend?sslmode=disable` (default Docker Compose) |
+| `NETWORK`                                 | `testnet` or `pubnet`                                                    |
+| `NETWORK_PASSPHRASE`                      | `Test SDF Network ; September 2015` (testnet) or `Public Global Stellar Network ; September 2015` (pubnet) |
+| `RPC_URL`                                 | `http://localhost:8000` (default Docker Compose RPC)                     |
+
+**Not in `.env.example` but needed for local Go binary dev** (Docker Compose
+sets these internally for containerized services):
+
+| Variable             | Value for local dev                                                 |
+| -------------------- | ------------------------------------------------------------------- |
+| `DATABASE_URL`       | `postgres://postgres@localhost:5432/wallet-backend?sslmode=disable` |
+| `NETWORK`            | `testnet` (recommended) or `pubnet`                                 |
+| `NETWORK_PASSPHRASE` | `Test SDF Network ; September 2015` (testnet)                       |
+| `RPC_URL`            | `http://localhost:8000` (Docker Compose default)                    |
+
+For integration tests, also set `CLIENT_AUTH_PRIVATE_KEY`,
+`PRIMARY_SOURCE_ACCOUNT_PRIVATE_KEY`, and
+`SECONDARY_SOURCE_ACCOUNT_PRIVATE_KEY`.
+
+## Key Commands
+
+```bash
+make check              # Run all quality checks (lint, fmt, vet, generate, etc.)
+make unit-test          # Run unit tests
+make integration-test   # Run integration tests (requires Docker services)
+go run main.go serve    # Start API server
+go run main.go ingest   # Start ingestion service
+go run main.go migrate up   # Run database migrations
+```
+
+See `Makefile` for the complete list of targets.
+
+## Code Conventions
+
+- **Formatting:** `gofmt` and `gofumpt`. Run `make fmt` to check.
+- **Linting:** `golangci-lint`. Config in `.golangci.yml`.
+- **Imports:** Organized by `goimports`. Run `make goimports` to check.
+- **GraphQL:** Schema in `internal/serve/graphql/`. Run `make gql-generate`
+  after schema changes.
+- **Tests:** All changes must be covered by tests. Coverage threshold: 65%.
+- **Documentation:** Exported functions, types, and constants must have doc
+  comments per [Effective Go](https://golang.org/doc/effective_go.html#commentary).
+
+## Testing
+
+**Unit tests:** Require `DATABASE_URL` to be set.
+
+```bash
+make unit-test
+```
+
+**Integration tests:** Require `db` and `stellar-rpc` Docker services running.
+
+```bash
+ENABLE_INTEGRATION_TESTS=true go test -v ./internal/integrationtests/... -timeout 30m
+# Or:
+make integration-test
+```
+
+## Pull Requests
+
+- Branch from `develop` (not `main`)
+- PR titles start with: `feat`, `fix`, `refactor`, `ci`, or `doc`
+- No mixed concerns — keep refactoring separate from features
+- Code must be formatted with `gofmt`
+- All changes must be covered by tests
+- Follow [Effective Go](https://golang.org/doc/effective_go.html) and
+  [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
+
+**CI runs on every PR:** lint + format checks, build, unit tests (65% coverage
+threshold), integration tests. See `.github/workflows/go.yaml`.
+
+### Commit Messages
+
+- Use present tense ("Add feature" not "Added feature")
+- Use imperative mood ("Move cursor to..." not "Moves cursor to...")
+- Start with the relevant issue number: `#123 Fix bug in XYZ module`
+
+## Related Repositories
+
+This repo (`stellar/wallet-backend`) is a general-purpose Stellar wallet
+backend service. It is **separate** from the Freighter-specific backends:
+
+- [stellar/freighter-backend](https://github.com/stellar/freighter-backend)
+  (TypeScript) — V1 backend powering Freighter's balances, subscriptions,
+  feature flags
+- [stellar/freighter-backend-v2](https://github.com/stellar/freighter-backend-v2)
+  (Go) — V2 backend powering collectibles, RPC health, protocols
+
+Wallet-backend can be used by any Stellar wallet application for transaction
+submission, account management, and payment history.
+
+## Security
+
+This service handles distribution account keys and channel account keys.
+
+- **Never log private keys** or encryption passphrases
+- **Use `ENV` signature provider** for local dev only — production uses KMS
+- **Validate all GraphQL inputs** — the API is exposed to wallet clients
+- **Report vulnerabilities** via the
+  [Stellar Security Policy](https://github.com/stellar/.github/blob/master/SECURITY.md)
+  — not public issues
 
 ## Code of Conduct
 
-Help us keep Stellar open and inclusive. Please read and follow our [Code of Conduct](https://github.com/stellar/.github/blob/master/CODE_OF_CONDUCT.md).
+See the [Stellar Code of Conduct](https://github.com/stellar/.github/blob/master/CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ git clone https://github.com/stellar/wallet-backend.git
 cd wallet-backend
 cp .env.example .env
 # Fill in required values (see Environment Variables below)
-docker compose up
+NETWORK=testnet docker compose up
 ```
 
 This starts:
@@ -57,7 +57,7 @@ source .env
 set +a
 
 # Start dependencies only
-docker compose up -d db stellar-rpc
+NETWORK=testnet docker compose up -d db stellar-rpc
 
 # Run migrations
 go run main.go migrate up

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,8 @@ sets these internally for containerized services):
 | `DATABASE_URL`       | `postgres://postgres@localhost:5432/wallet-backend?sslmode=disable` |
 | `NETWORK`            | `testnet` (recommended) or `pubnet`                                 |
 | `NETWORK_PASSPHRASE` | `Test SDF Network ; September 2015` (testnet)                       |
-| `RPC_URL`            | `http://localhost:8000` (Docker Compose default)                    |
+| `RPC_URL`            | `http://localhost:8000` for host-side `go run`. Do **not** set this in `.env` for containerized services; inside Docker they use `http://stellar-rpc:8000`. |
+| `STELLAR_ENVIRONMENT`| `development` for local dev                                        |
 
 For integration tests, also set `CLIENT_AUTH_PRIVATE_KEY`,
 `PRIMARY_SOURCE_ACCOUNT_PRIVATE_KEY`, and
@@ -127,7 +128,7 @@ go test ./...
 **Integration tests:** Require `db` and `stellar-rpc` Docker services running.
 
 ```bash
-ENABLE_INTEGRATION_TESTS=true go test -v ./internal/integrationtests/... -timeout 30m
+go run main.go integration-tests
 ```
 
 ## Pull Requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,21 @@
 # Contributing to Wallet Backend
 
-Go backend service powering Freighter wallet applications. Provides a GraphQL
-API for querying Stellar network data and building transactions with fee
-sponsorship.
+Go backend service for Stellar wallet applications. Provides a REST API (Chi
+router) for transaction submission, account management, payment history, and
+channel accounts with fee sponsorship.
 
 For the Stellar organization's general contribution guidelines, see the
 [Stellar Contribution Guide](https://github.com/stellar/.github/blob/master/CONTRIBUTING.md).
 
 ## Prerequisites
 
-| Tool             | Version   | Install                                                       |
-| ---------------- | --------- | ------------------------------------------------------------- |
-| Go               | >= 1.24.0 | [go.dev/dl](https://go.dev/dl/) (toolchain 1.24.2)            |
-| Docker + Compose | Latest    | [docker.com](https://docs.docker.com/get-docker/)             |
-| golangci-lint    | Latest    | `brew install golangci-lint` or [docs](https://golangci-lint.run/welcome/install/) |
-| PostgreSQL       | 17        | Provided via Docker Compose (no manual install needed)        |
+| Tool             | Version   | Install                                                                    |
+| ---------------- | --------- | -------------------------------------------------------------------------- |
+| Go               | >= 1.23.2 | [go.dev/dl](https://go.dev/dl/)                                           |
+| Docker + Compose | Latest    | [docker.com](https://docs.docker.com/get-docker/)                         |
+| golangci-lint    | Latest    | `brew install golangci-lint` or [docs](https://golangci-lint.run/)         |
+
+PostgreSQL 14 is provided via Docker Compose — no manual install needed.
 
 ## Getting Started
 
@@ -40,21 +41,23 @@ docker compose up
 ```
 
 This starts:
-- **TimescaleDB** (PostgreSQL 17) — database
-- **Stellar RPC** — blockchain data source (testnet and/or mainnet)
-- **API server** — GraphQL endpoint
-- **Ingestion service** — indexes Stellar ledger data
+- **PostgreSQL 14** (`db`) — database on port 5432
+- **Stellar RPC** (`stellar-rpc`) — blockchain data source
+- **API server** (`api`) — REST endpoint
+- **Ingestion service** (`ingest`) — indexes Stellar ledger data
 
 ### Local Development (Go binary + Docker services)
 
-For active development with hot reload:
+For active development:
 
 ```bash
 cp .env.example .env
+set -a
 source .env
+set +a
 
 # Start dependencies only
-docker compose up -d db stellar-rpc-testnet
+docker compose up -d db stellar-rpc
 
 # Run migrations
 go run main.go migrate up
@@ -69,7 +72,7 @@ go run main.go ingest    # Terminal 2
 
 ### Environment Variables
 
-Copy `.env.example` to `.env`. Required variables:
+Copy `.env.example` to `.env`. Required variables from `.env.example`:
 
 | Variable                                  | How to set up                                                            |
 | ----------------------------------------- | ------------------------------------------------------------------------ |
@@ -78,10 +81,6 @@ Copy `.env.example` to `.env`. Required variables:
 | `DISTRIBUTION_ACCOUNT_PRIVATE_KEY`        | Private key for the distribution account (use `ENV` signature provider)  |
 | `DISTRIBUTION_ACCOUNT_SIGNATURE_PROVIDER` | `ENV` for local dev (uses env var above). `KMS` for production           |
 | `CHANNEL_ACCOUNT_ENCRYPTION_PASSPHRASE`   | Any passphrase for encrypting channel account keys                       |
-| `DATABASE_URL`                            | `postgres://postgres@localhost:5432/wallet-backend?sslmode=disable` (default Docker Compose) |
-| `NETWORK`                                 | `testnet` or `pubnet`                                                    |
-| `NETWORK_PASSPHRASE`                      | `Test SDF Network ; September 2015` (testnet) or `Public Global Stellar Network ; September 2015` (pubnet) |
-| `RPC_URL`                                 | `http://localhost:8000` (default Docker Compose RPC)                     |
 
 **Not in `.env.example` but needed for local Go binary dev** (Docker Compose
 sets these internally for containerized services):
@@ -100,24 +99,20 @@ For integration tests, also set `CLIENT_AUTH_PRIVATE_KEY`,
 ## Key Commands
 
 ```bash
-make check              # Run all quality checks (lint, fmt, vet, generate, etc.)
-make unit-test          # Run unit tests
-make integration-test   # Run integration tests (requires Docker services)
-go run main.go serve    # Start API server
-go run main.go ingest   # Start ingestion service
+go run main.go serve        # Start API server
+go run main.go ingest       # Start ingestion service
 go run main.go migrate up   # Run database migrations
+go test ./...               # Run unit tests (requires DATABASE_URL)
 ```
 
-See `Makefile` for the complete list of targets.
+The Makefile provides Docker targets: `make docker-build`, `make docker-push`.
 
 ## Code Conventions
 
-- **Formatting:** `gofmt` and `gofumpt`. Run `make fmt` to check.
+- **Formatting:** `gofmt`. Enforced by `golangci-lint`.
 - **Linting:** `golangci-lint`. Config in `.golangci.yml`.
-- **Imports:** Organized by `goimports`. Run `make goimports` to check.
-- **GraphQL:** Schema in `internal/serve/graphql/`. Run `make gql-generate`
-  after schema changes.
-- **Tests:** All changes must be covered by tests. Coverage threshold: 65%.
+- **Tests:** All changes must be covered by tests. Coverage threshold: 65%
+  (enforced in CI).
 - **Documentation:** Exported functions, types, and constants must have doc
   comments per [Effective Go](https://golang.org/doc/effective_go.html#commentary).
 
@@ -126,15 +121,13 @@ See `Makefile` for the complete list of targets.
 **Unit tests:** Require `DATABASE_URL` to be set.
 
 ```bash
-make unit-test
+go test ./...
 ```
 
 **Integration tests:** Require `db` and `stellar-rpc` Docker services running.
 
 ```bash
 ENABLE_INTEGRATION_TESTS=true go test -v ./internal/integrationtests/... -timeout 30m
-# Or:
-make integration-test
 ```
 
 ## Pull Requests
@@ -167,16 +160,13 @@ backend service. It is **separate** from the Freighter-specific backends:
 - [stellar/freighter-backend-v2](https://github.com/stellar/freighter-backend-v2)
   (Go) — V2 backend powering collectibles, RPC health, protocols
 
-Wallet-backend can be used by any Stellar wallet application for transaction
-submission, account management, and payment history.
-
 ## Security
 
 This service handles distribution account keys and channel account keys.
 
 - **Never log private keys** or encryption passphrases
 - **Use `ENV` signature provider** for local dev only — production uses KMS
-- **Validate all GraphQL inputs** — the API is exposed to wallet clients
+- **Validate all inputs** — the API is exposed to wallet clients
 - **Report vulnerabilities** via the
   [Stellar Security Policy](https://github.com/stellar/.github/blob/master/SECURITY.md)
   — not public issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,11 @@ PostgreSQL 14 is provided via Docker Compose — no manual install needed.
 ### Quick Setup with an LLM
 
 If you use an LLM-powered coding assistant, you can automate the setup. The repo
-includes a quick start guide ([`LLM-QUICK-START.md`](LLM-QUICK-START.md)) that
+includes a quick start guide ([`quick-start-guide.md`](quick-start-guide.md)) that
 checks your environment, installs missing tools, configures `.env`, and verifies
 the build.
 
-Point your LLM assistant at `LLM-QUICK-START.md` and ask it to follow the steps.
+Point your LLM assistant at `quick-start-guide.md` and ask it to follow the steps.
 
 If you don't use an LLM assistant, follow the manual setup below.
 

--- a/LLM-QUICK-START.md
+++ b/LLM-QUICK-START.md
@@ -25,7 +25,7 @@ docker compose version 2>&1 || docker-compose --version 2>&1 || which docker-com
 golangci-lint --version 2>&1 || which golangci-lint
 
 # Make
-make --version 2>&1 | head -1 || which make
+make --version 2>&1 || which make
 
 # PostgreSQL client (optional — for debugging)
 psql --version 2>&1 || echo "psql not installed (optional)"
@@ -101,6 +101,7 @@ add these to `.env` or export them in your shell:
 | `NETWORK`            | `testnet` (recommended for dev) or `pubnet`                            |
 | `NETWORK_PASSPHRASE` | `Test SDF Network ; September 2015` (testnet)                          |
 | `RPC_URL`            | `http://localhost:8000` for host-side `go run`. Do **not** set this in `.env` for containerized services; inside Docker they use `http://stellar-rpc:8000`. |
+| `STELLAR_ENVIRONMENT`| `development` for local dev                                                   |
 
 Skip any variable that already has a value.
 

--- a/LLM-QUICK-START.md
+++ b/LLM-QUICK-START.md
@@ -1,0 +1,165 @@
+# Wallet Backend — LLM Quick Start
+
+Evaluate the contributor's machine against all prerequisites for wallet-backend
+(Go service), install what's missing, and run the initial setup.
+
+## Step 1: Check all prerequisites
+
+Run every check below and collect results. Report all at once — don't stop at
+the first failure.
+
+For each tool, try the version command first. If it fails (e.g., sandbox
+restrictions), fall back to `which <tool>` to confirm presence.
+
+```bash
+# Go >= 1.24.0
+go version 2>&1 || which go
+
+# Docker
+docker --version 2>&1 || which docker
+
+# Docker Compose
+docker compose version 2>&1 || docker-compose --version 2>&1 || which docker-compose
+
+# golangci-lint
+golangci-lint --version 2>&1 || which golangci-lint
+
+# Make
+make --version 2>&1 | head -1 || which make
+
+# PostgreSQL client (optional — for debugging)
+psql --version 2>&1 || echo "psql not installed (optional)"
+```
+
+## Step 2: Present results
+
+Show a clear summary:
+
+```
+Wallet Backend — Prerequisites Check
+=====================================
+  Go             1.24.2         >= 1.24.0 required    OK
+  Docker         27.x.x         any                   OK
+  Docker Compose 2.x.x          any                   OK
+  golangci-lint  1.x.x          any                   OK
+  Make           3.x            any                   OK
+  psql           16.x           optional              OK
+```
+
+## Step 3: Install missing tools
+
+Present the missing tools and ask the user: "I can install [list] automatically.
+Want me to proceed?"
+
+If the user confirms, **run the install commands** for each missing tool. After
+each install, re-check the version to confirm it succeeded. If an install fails,
+report the error and continue with the next tool.
+
+If the user declines, skip to Step 4 and note the missing tools in the final
+summary.
+
+**Auto-installable (run after user confirms):**
+
+- **Go**: Download from [go.dev/dl](https://go.dev/dl/) or
+  `brew install go` (macOS) / `sudo apt install golang-go` (Linux)
+- **Docker**: `brew install --cask docker` (macOS) or follow
+  [docs.docker.com](https://docs.docker.com/engine/install/) (Linux)
+- **golangci-lint**: `brew install golangci-lint` (macOS) or
+  `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest`
+
+## Step 4: Configure environment
+
+Check if `.env` exists. If not:
+
+```bash
+cp .env.example .env
+```
+
+Then read `.env` and check which required variables are empty. For each empty
+required variable, tell the user the value or how to set it up:
+
+**Variables from `.env.example`:**
+
+| Variable                                  | Value or setup                                                           |
+| ----------------------------------------- | ------------------------------------------------------------------------ |
+| `CLIENT_AUTH_PUBLIC_KEYS`                 | Generate a Stellar keypair (e.g., via `stellar-sdk` or Stellar Laboratory) and use the public key |
+| `DISTRIBUTION_ACCOUNT_PUBLIC_KEY`         | Generate another Stellar keypair for the distribution account            |
+| `DISTRIBUTION_ACCOUNT_PRIVATE_KEY`        | Private key of the distribution account keypair                          |
+| `DISTRIBUTION_ACCOUNT_SIGNATURE_PROVIDER` | `ENV` for local dev                                                      |
+| `CHANNEL_ACCOUNT_ENCRYPTION_PASSPHRASE`   | Any passphrase (e.g., `local-dev-passphrase`)                            |
+
+**Variables NOT in `.env.example` but needed for local Go binary dev:**
+
+These are set automatically by `docker-compose.yaml` for containerized services,
+but if running `go run main.go` directly, add them to `.env` or export in shell:
+
+| Variable             | Value for local dev                                                    |
+| -------------------- | ---------------------------------------------------------------------- |
+| `DATABASE_URL`       | `postgres://postgres@localhost:5432/wallet-backend?sslmode=disable`    |
+| `NETWORK`            | `testnet` (recommended for dev) or `pubnet`                            |
+| `NETWORK_PASSPHRASE` | `Test SDF Network ; September 2015` (testnet)                          |
+| `RPC_URL`            | `http://localhost:8000` (default Docker Compose Stellar RPC port)      |
+
+Skip any variable that already has a value.
+
+## Step 5: Run initial setup
+
+Ask the user which setup path they prefer:
+
+### Option A: Full Docker Compose (simplest)
+
+```bash
+docker compose up
+```
+
+This starts everything: TimescaleDB, Stellar RPC, API server, and ingestion.
+
+### Option B: Local Go binary + Docker services (for active development)
+
+```bash
+# Start dependencies
+docker compose up -d db stellar-rpc-testnet
+
+# Wait for DB to be ready, then run migrations
+go run main.go migrate up
+
+# Create channel accounts for fee sponsorship
+go run main.go channel-account ensure 5
+
+# Start API and ingestion (separate terminals)
+go run main.go serve     # Terminal 1
+go run main.go ingest    # Terminal 2
+```
+
+## Step 6: Verify
+
+```bash
+make check        # Run all quality checks (lint, fmt, vet, generate, etc.)
+make unit-test    # Run unit tests (requires DATABASE_URL)
+```
+
+If both pass, the setup is working.
+
+## Step 7: Summary
+
+At the end, produce a final summary:
+
+```
+Setup Complete
+==============
+  Prerequisites: [list with versions]
+  Installed: [list of tools installed]
+  Configured: .env with required variables
+
+  Next steps:
+  1. docker compose up          (full setup)
+     OR
+  1. docker compose up -d db stellar-rpc-testnet
+  2. go run main.go migrate up
+  3. go run main.go serve       (terminal 1)
+  4. go run main.go ingest      (terminal 2)
+
+  Manual action needed:
+  - [ ] Generate Stellar keypairs for CLIENT_AUTH and DISTRIBUTION_ACCOUNT
+  - [ ] Set CHANNEL_ACCOUNT_ENCRYPTION_PASSPHRASE
+```

--- a/LLM-QUICK-START.md
+++ b/LLM-QUICK-START.md
@@ -12,7 +12,7 @@ For each tool, try the version command first. If it fails (e.g., sandbox
 restrictions), fall back to `which <tool>` to confirm presence.
 
 ```bash
-# Go >= 1.24.0
+# Go >= 1.23.2
 go version 2>&1 || which go
 
 # Docker
@@ -38,7 +38,7 @@ Show a clear summary:
 ```
 Wallet Backend — Prerequisites Check
 =====================================
-  Go             1.24.2         >= 1.24.0 required    OK
+  Go             1.23.x         >= 1.23.2 required    OK
   Docker         27.x.x         any                   OK
   Docker Compose 2.x.x          any                   OK
   golangci-lint  1.x.x          any                   OK
@@ -65,7 +65,7 @@ summary.
 - **Docker**: `brew install --cask docker` (macOS) or follow
   [docs.docker.com](https://docs.docker.com/engine/install/) (Linux)
 - **golangci-lint**: `brew install golangci-lint` (macOS) or
-  `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest`
+  `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`
 
 ## Step 4: Configure environment
 
@@ -90,15 +90,17 @@ required variable, tell the user the value or how to set it up:
 
 **Variables NOT in `.env.example` but needed for local Go binary dev:**
 
-These are set automatically by `docker-compose.yaml` for containerized services,
-but if running `go run main.go` directly, add them to `.env` or export in shell:
+For containerized services, `docker-compose.yaml` supplies some of these values,
+but `NETWORK` must still be set for Docker Compose as well (it is referenced as
+`${NETWORK}` with no default). If running `go run main.go` directly on the host,
+add these to `.env` or export them in your shell:
 
 | Variable             | Value for local dev                                                    |
 | -------------------- | ---------------------------------------------------------------------- |
 | `DATABASE_URL`       | `postgres://postgres@localhost:5432/wallet-backend?sslmode=disable`    |
 | `NETWORK`            | `testnet` (recommended for dev) or `pubnet`                            |
 | `NETWORK_PASSPHRASE` | `Test SDF Network ; September 2015` (testnet)                          |
-| `RPC_URL`            | `http://localhost:8000` (default Docker Compose Stellar RPC port)      |
+| `RPC_URL`            | `http://localhost:8000` for host-side `go run`. Do **not** set this in `.env` for containerized services; inside Docker they use `http://stellar-rpc:8000`. |
 
 Skip any variable that already has a value.
 
@@ -112,13 +114,13 @@ Ask the user which setup path they prefer:
 docker compose up
 ```
 
-This starts everything: TimescaleDB, Stellar RPC, API server, and ingestion.
+This starts everything: Postgres, Stellar RPC, API server, and ingestion.
 
 ### Option B: Local Go binary + Docker services (for active development)
 
 ```bash
 # Start dependencies
-docker compose up -d db stellar-rpc-testnet
+docker compose up -d db stellar-rpc
 
 # Wait for DB to be ready, then run migrations
 go run main.go migrate up
@@ -134,8 +136,8 @@ go run main.go ingest    # Terminal 2
 ## Step 6: Verify
 
 ```bash
-make check        # Run all quality checks (lint, fmt, vet, generate, etc.)
-make unit-test    # Run unit tests (requires DATABASE_URL)
+golangci-lint run  # Run lint checks
+go test ./...      # Run unit tests (requires DATABASE_URL)
 ```
 
 If both pass, the setup is working.
@@ -154,7 +156,7 @@ Setup Complete
   Next steps:
   1. docker compose up          (full setup)
      OR
-  1. docker compose up -d db stellar-rpc-testnet
+  1. docker compose up -d db stellar-rpc
   2. go run main.go migrate up
   3. go run main.go serve       (terminal 1)
   4. go run main.go ingest      (terminal 2)

--- a/LLM-QUICK-START.md
+++ b/LLM-QUICK-START.md
@@ -111,7 +111,7 @@ Ask the user which setup path they prefer:
 ### Option A: Full Docker Compose (simplest)
 
 ```bash
-docker compose up
+NETWORK=testnet docker compose up
 ```
 
 This starts everything: Postgres, Stellar RPC, API server, and ingestion.
@@ -120,7 +120,7 @@ This starts everything: Postgres, Stellar RPC, API server, and ingestion.
 
 ```bash
 # Start dependencies
-docker compose up -d db stellar-rpc
+NETWORK=testnet docker compose up -d db stellar-rpc
 
 # Wait for DB to be ready, then run migrations
 go run main.go migrate up
@@ -154,9 +154,9 @@ Setup Complete
   Configured: .env with required variables
 
   Next steps:
-  1. docker compose up          (full setup)
+  1. NETWORK=testnet docker compose up          (full setup)
      OR
-  1. docker compose up -d db stellar-rpc
+  1. NETWORK=testnet docker compose up -d db stellar-rpc
   2. go run main.go migrate up
   3. go run main.go serve       (terminal 1)
   4. go run main.go ingest      (terminal 2)

--- a/quick-start-guide.md
+++ b/quick-start-guide.md
@@ -65,7 +65,7 @@ summary.
 - **Docker**: `brew install --cask docker` (macOS) or follow
   [docs.docker.com](https://docs.docker.com/engine/install/) (Linux)
 - **golangci-lint**: `brew install golangci-lint` (macOS) or
-  `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`
+  `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.2`
 
 ## Step 4: Configure environment
 

--- a/quick-start-guide.md
+++ b/quick-start-guide.md
@@ -1,4 +1,4 @@
-# Wallet Backend — LLM Quick Start
+# Wallet Backend — Quick Start Guide
 
 Evaluate the contributor's machine against all prerequisites for wallet-backend
 (Go service), install what's missing, and run the initial setup.


### PR DESCRIPTION
# Skill Eval: `wallet-backend-dev-setup` — Benchmark Report

**Date:** 2026-04-08
**Iterations:** 4
**Repo:** [stellar/wallet-backend](https://github.com/stellar/wallet-backend)
**Model:** Claude Opus 4.6
**Prompt:** "I just cloned wallet-backend and want to run it locally."

---

## Summary

| Metric | With Skill | Without Skill | Delta |
|---|---|---|---|
| Pass rate | **93%** | **78%** | +15pp |

The gap is smaller than other repos because Go project conventions (`go.mod`,
`Makefile`, `docker-compose.yaml`) make the baseline more self-sufficient.

---

## Assertion Results (aggregated across 4 iterations)

| # | Assertion | With Skill | Without Skill |
|---|---|---|---|
| 1 | Checks Go version (>= 1.24.0) | 4/4 (100%) | 4/4 (100%) |
| 2 | Checks Docker availability | 4/4 (100%) | 4/4 (100%) |
| 3 | Checks golangci-lint | 4/4 (100%) | 2/4 (50%) |
| 4 | Detects .env missing | 4/4 (100%) | 4/4 (100%) |
| 5 | Lists all required env vars | 4/4 (100%) | 4/4 (100%) |
| 6 | Notes DATABASE_URL/NETWORK/RPC_URL for local dev | 3/4 (75%) | 1/4 (25%) |
| 7 | Presents Docker Compose path | 4/4 (100%) | 4/4 (100%) |
| 8 | Presents hybrid local dev path | 4/4 (100%) | 4/4 (100%) |
| 9 | Structured prerequisites summary | 3/4 (75%) | 1/4 (25%) |
| 10 | Mentions make check / make unit-test | 3/4 (75%) | 3/4 (75%) |
| | **Overall** | **37/40 (93%)** | **31/40 (78%)** |

---

## Analysis

The skill's main value is documenting the **extra env vars needed for local Go
binary dev** (`DATABASE_URL`, `NETWORK`, `NETWORK_PASSPHRASE`, `RPC_URL`) that
are set automatically by Docker Compose but missing from `.env.example`. The
baseline found these only 25% of the time.
