### PR TITLE
fix(internal): Mitigate GraphQL worker pool exhaustion

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -36,6 +36,9 @@ func (c *serveCmd) Command() *cobra.Command {
 		utils.GraphQLComplexityLimitOption(&cfg.GraphQLComplexityLimit),
 		utils.MaxAccountsPerBalancesQueryOption(&cfg.MaxAccountsPerBalancesQuery),
 		utils.MaxGraphQLWorkerPoolSizeOption(&cfg.MaxGraphQLWorkerPoolSize),
+		utils.GraphQLRateLimitPerSecondOption(&cfg.GraphQLRateLimitPerSecond),
+		utils.GraphQLRateLimitBurstOption(&cfg.GraphQLRateLimitBurst),
+		utils.GraphQLMaxConcurrencyPerRequestOption(&cfg.GraphQLMaxConcurrencyPerReq),
 		{
 			Name:        "port",
 			Usage:       "Port to listen and serve on",

--- a/cmd/utils/global_options.go
+++ b/cmd/utils/global_options.go
@@ -262,6 +262,39 @@ func MaxGraphQLWorkerPoolSizeOption(configKey *int) *config.ConfigOption {
 	}
 }
 
+func GraphQLMaxConcurrencyPerRequestOption(configKey *int) *config.ConfigOption {
+	return &config.ConfigOption{
+		Name:        "graphql-max-concurrency-per-request",
+		Usage:       "Maximum number of concurrent worker goroutines per GraphQL request. Limits how much of the worker pool a single request can consume.",
+		OptType:     types.Int,
+		ConfigKey:   configKey,
+		FlagDefault: 30,
+		Required:    false,
+	}
+}
+
+func GraphQLRateLimitPerSecondOption(configKey *int) *config.ConfigOption {
+	return &config.ConfigOption{
+		Name:        "graphql-rate-limit-per-second",
+		Usage:       "Maximum GraphQL requests per second per IP address. Set to 0 to disable rate limiting.",
+		OptType:     types.Int,
+		ConfigKey:   configKey,
+		FlagDefault: 10,
+		Required:    false,
+	}
+}
+
+func GraphQLRateLimitBurstOption(configKey *int) *config.ConfigOption {
+	return &config.ConfigOption{
+		Name:        "graphql-rate-limit-burst",
+		Usage:       "Maximum burst of GraphQL requests allowed per IP address. Defaults to the per-second rate if not set.",
+		OptType:     types.Int,
+		ConfigKey:   configKey,
+		FlagDefault: 20,
+		Required:    false,
+	}
+}
+
 func DistributionAccountSignatureProviderOption(scOpts *SignatureClientOptions) config.ConfigOptions {
 	opts := config.ConfigOptions{}
 	opts = append(opts, DistributionAccountPublicKeyOption(&scOpts.DistributionAccountPublicKey))

--- a/cmd/utils/global_options.go
+++ b/cmd/utils/global_options.go
@@ -287,10 +287,10 @@ func GraphQLRateLimitPerSecondOption(configKey *int) *config.ConfigOption {
 func GraphQLRateLimitBurstOption(configKey *int) *config.ConfigOption {
 	return &config.ConfigOption{
 		Name:        "graphql-rate-limit-burst",
-		Usage:       "Maximum burst of GraphQL requests allowed per IP address. Defaults to the per-second rate if not set.",
+		Usage:       "Maximum burst of GraphQL requests allowed per IP address. Set to 0 to use the per-second rate as the burst value.",
 		OptType:     types.Int,
 		ConfigKey:   configKey,
-		FlagDefault: 20,
+		FlagDefault: 0,
 		Required:    false,
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/vikstrous/dataloadgen v0.0.9
 	golang.org/x/term v0.33.0
 	golang.org/x/text v0.27.0
+	golang.org/x/time v0.8.0
 )
 
 require (
@@ -184,7 +185,6 @@ require (
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
-	golang.org/x/time v0.8.0 // indirect
 	google.golang.org/api v0.215.0 // indirect
 	google.golang.org/genproto v0.0.0-20241118233622-e639e219e697 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250728155136-f173205681a0 // indirect

--- a/internal/integrationtests/account_balances_test.go
+++ b/internal/integrationtests/account_balances_test.go
@@ -248,8 +248,10 @@ func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_MultiAccoun
 // TestCheckpoint_MultiAccount_ExceedsMaxLimitReturnsError verifies that exceeding the maximum
 // number of addresses returns an appropriate error.
 func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_MultiAccount_ExceedsMaxLimitReturnsError() {
-	// Create 101 addresses to exceed the typical max limit
-	addresses := make([]string, 101)
+	// Create 21 addresses to exceed the default max limit of 20.
+	// We use a small excess (not 101) to stay under the GraphQL complexity
+	// limit, which now scales with the number of addresses.
+	addresses := make([]string, 21)
 	for i := range addresses {
 		addresses[i] = suite.testEnv.BalanceTestAccount1KP.Address()
 	}

--- a/internal/integrationtests/infrastructure/containers.go
+++ b/internal/integrationtests/infrastructure/containers.go
@@ -452,6 +452,7 @@ func createWalletBackendAPIContainer(ctx context.Context, name string, imageName
 			"NUMBER_CHANNEL_ACCOUNTS":                 "15",
 			"CHANNEL_ACCOUNT_ENCRYPTION_PASSPHRASE":   "GB3SKOV2DTOAZVYUXFAM4ELPQDLCF3LTGB4IEODUKQ7NDRZOOESSMNU7",
 			"STELLAR_ENVIRONMENT":                     "integration-test",
+			"GRAPHQL_RATE_LIMIT_PER_SECOND":           "0",
 		},
 		Networks:   []string{testNetwork.Name},
 		WaitingFor: wait.ForHTTP("/health").WithPort(walletBackendContainerAPIPort + "/tcp"),

--- a/internal/serve/graphql/resolvers/account_balances_test.go
+++ b/internal/serve/graphql/resolvers/account_balances_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stellar/wallet-backend/internal/data"
 	"github.com/stellar/wallet-backend/internal/indexer/types"
 	graphql1 "github.com/stellar/wallet-backend/internal/serve/graphql/generated"
+	"github.com/stellar/wallet-backend/internal/serve/middleware"
 	"github.com/stellar/wallet-backend/internal/services"
 )
 
@@ -1100,5 +1101,43 @@ func TestQueryResolver_BalancesByAccountAddresses(t *testing.T) {
 		assert.Nil(t, results[1].Error)
 		require.Len(t, results[1].Balances, 1)
 		assert.IsType(t, &graphql1.SEP41Balance{}, results[1].Balances[0])
+	})
+
+	t.Run("uses per-request pool from context when available", func(t *testing.T) {
+		mockTrustlineBalanceModel := data.NewTrustlineBalanceModelMock(t)
+		mockNativeBalanceModel := data.NewNativeBalanceModelMock(t)
+		mockAccountContractTokens := data.NewAccountContractTokensModelMock(t)
+		mockRPCService := services.NewRPCServiceMock(t)
+
+		// Inject a request-scoped pool into the context
+		requestPool := pond.NewPool(5)
+		defer requestPool.StopAndWait()
+		ctx := middleware.WithRequestPool(context.Background(), requestPool)
+
+		mockNativeBalanceModel.On("GetByAccount", ctx, testAccountAddress).Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 10000000000}, nil)
+		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress).Return([]data.TrustlineBalance{}, nil)
+		mockAccountContractTokens.On("GetByAccount", ctx, testAccountAddress).Return([]*data.Contract{}, nil)
+		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
+
+		resolver := &queryResolver{
+			&Resolver{
+				balanceReader:              NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
+				accountContractTokensModel: mockAccountContractTokens,
+				rpcService:                 mockRPCService,
+				pool:                       pond.NewPool(0),
+				config:                     ResolverConfig{MaxAccountsPerBalancesQuery: 10, MaxWorkerPoolSize: 10},
+			},
+		}
+
+		results, err := resolver.BalancesByAccountAddresses(ctx, []string{testAccountAddress})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, testAccountAddress, results[0].Address)
+		assert.Nil(t, results[0].Error)
+		require.Len(t, results[0].Balances, 1)
+
+		// Verify the request pool was used (it has tasks submitted)
+		assert.Greater(t, requestPool.CompletedTasks(), uint64(0),
+			"request pool should have been used instead of the shared pool")
 	})
 }

--- a/internal/serve/graphql/resolvers/queries.resolvers.go
+++ b/internal/serve/graphql/resolvers/queries.resolvers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stellar/wallet-backend/internal/entities"
 	"github.com/stellar/wallet-backend/internal/indexer/types"
 	graphql1 "github.com/stellar/wallet-backend/internal/serve/graphql/generated"
+	"github.com/stellar/wallet-backend/internal/serve/middleware"
 	"github.com/stellar/wallet-backend/internal/utils"
 )
 
@@ -331,9 +332,19 @@ func (r *queryResolver) BalancesByAccountAddresses(ctx context.Context, addresse
 		}
 	}
 
+	// Use the per-request pool (bounded concurrency) if available, otherwise
+	// fall back to the shared pool. The per-request pool is injected by
+	// RequestPoolMiddleware and limits the total worker goroutines a single
+	// HTTP request can consume, preventing one request from monopolising the
+	// shared pool via aliased queries.
+	pool := middleware.RequestPoolFromContext(ctx)
+	if pool == nil {
+		pool = r.pool
+	}
+
 	// Phase 1: Parallel collection of trustlines/contracts for each account
 	accountInfos := make([]*accountKeyInfo, len(addresses))
-	group := r.pool.NewGroupContext(ctx)
+	group := pool.NewGroupContext(ctx)
 
 	for idx, addr := range addresses {
 		index := idx
@@ -443,7 +454,7 @@ func (r *queryResolver) BalancesByAccountAddresses(ctx context.Context, addresse
 	// Phase 2: Parallel processing of results per account
 	networkPassphrase := r.rpcService.NetworkPassphrase()
 	results := make([]*graphql1.AccountBalances, len(addresses))
-	group = r.pool.NewGroupContext(ctx)
+	group = pool.NewGroupContext(ctx)
 	var resultsMu sync.Mutex
 
 	for idx, info := range accountInfos {
@@ -476,7 +487,7 @@ func (r *queryResolver) BalancesByAccountAddresses(ctx context.Context, addresse
 			}
 
 			// Parse ledger entries for this account
-			balances, parseErr := parseAccountBalances(ctx, info, r.contractMetadataService, networkPassphrase, r.pool)
+			balances, parseErr := parseAccountBalances(ctx, info, r.contractMetadataService, networkPassphrase, pool)
 			if parseErr != nil {
 				errStr := fmt.Sprintf("parsing account balances: %v", parseErr)
 				result.Error = &errStr

--- a/internal/serve/middleware/rate_limiter.go
+++ b/internal/serve/middleware/rate_limiter.go
@@ -1,0 +1,103 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// ipLimiter tracks per-IP rate limiters with periodic cleanup of stale entries.
+type ipLimiter struct {
+	mu       sync.Mutex
+	limiters map[string]*visitorEntry
+	rate     rate.Limit
+	burst    int
+}
+
+type visitorEntry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+func newIPLimiter(r rate.Limit, burst int) *ipLimiter {
+	ipl := &ipLimiter{
+		limiters: make(map[string]*visitorEntry),
+		rate:     r,
+		burst:    burst,
+	}
+	go ipl.cleanup()
+	return ipl
+}
+
+func (ipl *ipLimiter) getLimiter(ip string) *rate.Limiter {
+	ipl.mu.Lock()
+	defer ipl.mu.Unlock()
+
+	v, exists := ipl.limiters[ip]
+	if !exists {
+		limiter := rate.NewLimiter(ipl.rate, ipl.burst)
+		ipl.limiters[ip] = &visitorEntry{limiter: limiter, lastSeen: time.Now()}
+		return limiter
+	}
+	v.lastSeen = time.Now()
+	return v.limiter
+}
+
+// cleanup removes entries not seen in the last 5 minutes, runs every minute.
+func (ipl *ipLimiter) cleanup() {
+	for {
+		time.Sleep(time.Minute)
+		ipl.mu.Lock()
+		for ip, v := range ipl.limiters {
+			if time.Since(v.lastSeen) > 5*time.Minute {
+				delete(ipl.limiters, ip)
+			}
+		}
+		ipl.mu.Unlock()
+	}
+}
+
+// RateLimiter returns HTTP middleware that limits requests per IP address.
+// requestsPerSecond controls the steady-state rate; burst controls the maximum
+// number of requests allowed in a single burst.
+func RateLimiter(requestsPerSecond float64, burst int) func(http.Handler) http.Handler {
+	limiter := newIPLimiter(rate.Limit(requestsPerSecond), burst)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ip := extractIP(r)
+			if !limiter.getLimiter(ip).Allow() {
+				http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// extractIP returns the client IP for rate-limiting purposes.
+//
+// Header trust order:
+//  1. X-Real-IP — set by the NGINX ingress controller to the real client IP
+//     (derived from $remote_addr, which is trustworthy because the AWS NLB
+//     preserves the client IP at L4). NGINX overwrites any client-supplied
+//     X-Real-IP, so this value cannot be spoofed.
+//  2. RemoteAddr — direct connection peer; useful when there is no reverse proxy.
+//
+// X-Forwarded-For is intentionally NOT used. With use-forwarded-headers: "true",
+// NGINX appends the real IP but preserves attacker-controlled leftmost values.
+// An attacker can rotate the first XFF entry per request to bypass per-IP limits.
+func extractIP(r *http.Request) string {
+	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		return xri
+	}
+
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return ip
+}

--- a/internal/serve/middleware/rate_limiter.go
+++ b/internal/serve/middleware/rate_limiter.go
@@ -9,12 +9,15 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// ipLimiter tracks per-IP rate limiters with periodic cleanup of stale entries.
+const staleEntryTTL = 5 * time.Minute
+
+// ipLimiter tracks per-IP rate limiters with opportunistic cleanup of stale entries.
 type ipLimiter struct {
-	mu       sync.Mutex
-	limiters map[string]*visitorEntry
-	rate     rate.Limit
-	burst    int
+	mu          sync.Mutex
+	limiters    map[string]*visitorEntry
+	rate        rate.Limit
+	burst       int
+	lastCleanup time.Time
 }
 
 type visitorEntry struct {
@@ -23,41 +26,38 @@ type visitorEntry struct {
 }
 
 func newIPLimiter(r rate.Limit, burst int) *ipLimiter {
-	ipl := &ipLimiter{
-		limiters: make(map[string]*visitorEntry),
-		rate:     r,
-		burst:    burst,
+	return &ipLimiter{
+		limiters:    make(map[string]*visitorEntry),
+		rate:        r,
+		burst:       burst,
+		lastCleanup: time.Now(),
 	}
-	go ipl.cleanup()
-	return ipl
 }
 
 func (ipl *ipLimiter) getLimiter(ip string) *rate.Limiter {
 	ipl.mu.Lock()
 	defer ipl.mu.Unlock()
 
+	now := time.Now()
+
+	// Opportunistic cleanup: run at most once per minute while holding the lock.
+	if now.Sub(ipl.lastCleanup) > time.Minute {
+		for k, v := range ipl.limiters {
+			if now.Sub(v.lastSeen) > staleEntryTTL {
+				delete(ipl.limiters, k)
+			}
+		}
+		ipl.lastCleanup = now
+	}
+
 	v, exists := ipl.limiters[ip]
 	if !exists {
 		limiter := rate.NewLimiter(ipl.rate, ipl.burst)
-		ipl.limiters[ip] = &visitorEntry{limiter: limiter, lastSeen: time.Now()}
+		ipl.limiters[ip] = &visitorEntry{limiter: limiter, lastSeen: now}
 		return limiter
 	}
-	v.lastSeen = time.Now()
+	v.lastSeen = now
 	return v.limiter
-}
-
-// cleanup removes entries not seen in the last 5 minutes, runs every minute.
-func (ipl *ipLimiter) cleanup() {
-	for {
-		time.Sleep(time.Minute)
-		ipl.mu.Lock()
-		for ip, v := range ipl.limiters {
-			if time.Since(v.lastSeen) > 5*time.Minute {
-				delete(ipl.limiters, ip)
-			}
-		}
-		ipl.mu.Unlock()
-	}
 }
 
 // RateLimiter returns HTTP middleware that limits requests per IP address.
@@ -79,20 +79,11 @@ func RateLimiter(requestsPerSecond float64, burst int) func(http.Handler) http.H
 }
 
 // extractIP returns the client IP for rate-limiting purposes.
-//
-// Header trust order:
-//  1. X-Real-IP — set by the NGINX ingress controller to the real client IP
-//     (derived from $remote_addr, which is trustworthy because the AWS NLB
-//     preserves the client IP at L4). NGINX overwrites any client-supplied
-//     X-Real-IP, so this value cannot be spoofed.
-//  2. RemoteAddr — direct connection peer; useful when there is no reverse proxy.
-//
-// X-Forwarded-For is intentionally NOT used. With use-forwarded-headers: "true",
-// NGINX appends the real IP but preserves attacker-controlled leftmost values.
-// An attacker can rotate the first XFF entry per request to bypass per-IP limits.
 func extractIP(r *http.Request) string {
 	if xri := r.Header.Get("X-Real-IP"); xri != "" {
-		return xri
+		if net.ParseIP(xri) != nil {
+			return xri
+		}
 	}
 
 	ip, _, err := net.SplitHostPort(r.RemoteAddr)

--- a/internal/serve/middleware/rate_limiter_test.go
+++ b/internal/serve/middleware/rate_limiter_test.go
@@ -1,0 +1,126 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRateLimiter(t *testing.T) {
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("allows requests within limit", func(t *testing.T) {
+		handler := RateLimiter(10, 5)(okHandler)
+
+		for i := 0; i < 5; i++ {
+			req := httptest.NewRequest(http.MethodPost, "/graphql/query", nil)
+			req.RemoteAddr = "192.168.1.1:12345"
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			assert.Equal(t, http.StatusOK, rr.Code, "request %d should succeed", i)
+		}
+	})
+
+	t.Run("rejects requests exceeding burst", func(t *testing.T) {
+		handler := RateLimiter(1, 2)(okHandler)
+
+		// First 2 should succeed (burst)
+		for i := 0; i < 2; i++ {
+			req := httptest.NewRequest(http.MethodPost, "/graphql/query", nil)
+			req.RemoteAddr = "10.0.0.1:12345"
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			assert.Equal(t, http.StatusOK, rr.Code, "burst request %d should succeed", i)
+		}
+
+		// Third should be rate limited
+		req := httptest.NewRequest(http.MethodPost, "/graphql/query", nil)
+		req.RemoteAddr = "10.0.0.1:12345"
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusTooManyRequests, rr.Code)
+	})
+
+	t.Run("tracks IPs independently", func(t *testing.T) {
+		handler := RateLimiter(1, 1)(okHandler)
+
+		// Exhaust limit for IP A
+		req := httptest.NewRequest(http.MethodPost, "/graphql/query", nil)
+		req.RemoteAddr = "10.0.0.1:12345"
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		// IP A should be limited
+		rr = httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusTooManyRequests, rr.Code)
+
+		// IP B should still work
+		req2 := httptest.NewRequest(http.MethodPost, "/graphql/query", nil)
+		req2.RemoteAddr = "10.0.0.2:12345"
+		rr2 := httptest.NewRecorder()
+		handler.ServeHTTP(rr2, req2)
+		assert.Equal(t, http.StatusOK, rr2.Code)
+	})
+}
+
+func TestExtractIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		xForwarded string
+		xRealIP    string
+		expected   string
+	}{
+		{
+			name:       "prefers X-Real-IP over RemoteAddr",
+			remoteAddr: "10.0.0.1:1234",
+			xRealIP:    "203.0.113.50",
+			expected:   "203.0.113.50",
+		},
+		{
+			name:       "ignores X-Forwarded-For (spoofable)",
+			remoteAddr: "10.0.0.1:1234",
+			xForwarded: "203.0.113.50, 70.41.3.18",
+			expected:   "10.0.0.1",
+		},
+		{
+			name:       "X-Real-IP takes priority over X-Forwarded-For",
+			remoteAddr: "10.0.0.1:1234",
+			xForwarded: "1.2.3.4",
+			xRealIP:    "203.0.113.50",
+			expected:   "203.0.113.50",
+		},
+		{
+			name:       "falls back to RemoteAddr",
+			remoteAddr: "10.0.0.1:1234",
+			expected:   "10.0.0.1",
+		},
+		{
+			name:       "handles RemoteAddr without port",
+			remoteAddr: "10.0.0.1",
+			expected:   "10.0.0.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if tt.xForwarded != "" {
+				req.Header.Set("X-Forwarded-For", tt.xForwarded)
+			}
+			if tt.xRealIP != "" {
+				req.Header.Set("X-Real-IP", tt.xRealIP)
+			}
+			got := extractIP(req)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/internal/serve/middleware/rate_limiter_test.go
+++ b/internal/serve/middleware/rate_limiter_test.go
@@ -107,6 +107,12 @@ func TestExtractIP(t *testing.T) {
 			remoteAddr: "10.0.0.1",
 			expected:   "10.0.0.1",
 		},
+		{
+			name:       "ignores invalid X-Real-IP and falls back to RemoteAddr",
+			remoteAddr: "10.0.0.1:1234",
+			xRealIP:    "not-an-ip",
+			expected:   "10.0.0.1",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/serve/middleware/request_pool.go
+++ b/internal/serve/middleware/request_pool.go
@@ -18,6 +18,12 @@ func RequestPoolFromContext(ctx context.Context) pond.Pool {
 	return pool
 }
 
+// WithRequestPool returns a new context with the given pool set. This is useful
+// in tests to inject a request-scoped pool without the HTTP middleware.
+func WithRequestPool(ctx context.Context, pool pond.Pool) context.Context {
+	return context.WithValue(ctx, requestPoolKey, pool)
+}
+
 // RequestPoolMiddleware creates a bounded worker pool for each HTTP request and
 // injects it into the request context. All GraphQL field resolutions within the
 // same request share this pool, which caps the total number of concurrent worker

--- a/internal/serve/middleware/request_pool.go
+++ b/internal/serve/middleware/request_pool.go
@@ -1,0 +1,35 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/alitto/pond/v2"
+)
+
+type contextKey string
+
+const requestPoolKey contextKey = "requestPool"
+
+// RequestPoolFromContext returns the per-request worker pool from the context.
+// Returns nil if no pool was set (e.g., in tests without the middleware).
+func RequestPoolFromContext(ctx context.Context) pond.Pool {
+	pool, _ := ctx.Value(requestPoolKey).(pond.Pool)
+	return pool
+}
+
+// RequestPoolMiddleware creates a bounded worker pool for each HTTP request and
+// injects it into the request context. All GraphQL field resolutions within the
+// same request share this pool, which caps the total number of concurrent worker
+// goroutines a single request can consume. The pool is stopped and drained when
+// the HTTP handler returns.
+func RequestPoolMiddleware(maxConcurrency int) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			pool := pond.NewPool(maxConcurrency)
+			ctx := context.WithValue(r.Context(), requestPoolKey, pool)
+			next.ServeHTTP(w, r.WithContext(ctx))
+			pool.StopAndWait()
+		})
+	}
+}

--- a/internal/serve/middleware/request_pool_test.go
+++ b/internal/serve/middleware/request_pool_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alitto/pond/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -70,36 +71,23 @@ func TestRequestPoolMiddleware(t *testing.T) {
 	})
 
 	t.Run("pool is stopped after handler returns", func(t *testing.T) {
-		var capturedStopped bool
+		var capturedPool pond.Pool
 		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			pool := RequestPoolFromContext(r.Context())
-			require.NotNil(t, pool)
+			capturedPool = RequestPoolFromContext(r.Context())
+			require.NotNil(t, capturedPool)
 			// Submit a task to ensure pool is running
-			task := pool.Submit(func() {})
+			task := capturedPool.Submit(func() {})
 			task.Wait()
-			assert.False(t, pool.Stopped(), "pool should not be stopped during handler")
+			assert.False(t, capturedPool.Stopped(), "pool should not be stopped during handler")
 		})
 
-		var afterHandlerPool bool
-		wrappedMiddleware := func(next http.Handler) http.Handler {
-			return RequestPoolMiddleware(5)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				next.ServeHTTP(w, r)
-				// After inner handler returns but before middleware returns,
-				// the pool should still be accessible
-				pool := RequestPoolFromContext(r.Context())
-				afterHandlerPool = pool != nil
-				// Note: pool.Stopped() may or may not be true here since
-				// StopAndWait happens after ServeHTTP returns in the middleware
-			}))
-		}
-
-		handler := wrappedMiddleware(inner)
+		handler := RequestPoolMiddleware(5)(inner)
 		req := httptest.NewRequest(http.MethodPost, "/graphql/query", nil)
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)
 
-		_ = capturedStopped
-		assert.True(t, afterHandlerPool, "pool should be in context")
+		require.NotNil(t, capturedPool)
+		assert.True(t, capturedPool.Stopped(), "pool should be stopped after middleware returns")
 	})
 }
 

--- a/internal/serve/middleware/request_pool_test.go
+++ b/internal/serve/middleware/request_pool_test.go
@@ -77,7 +77,7 @@ func TestRequestPoolMiddleware(t *testing.T) {
 			require.NotNil(t, capturedPool)
 			// Submit a task to ensure pool is running
 			task := capturedPool.Submit(func() {})
-			task.Wait()
+			require.NoError(t, task.Wait())
 			assert.False(t, capturedPool.Stopped(), "pool should not be stopped during handler")
 		})
 

--- a/internal/serve/middleware/request_pool_test.go
+++ b/internal/serve/middleware/request_pool_test.go
@@ -1,0 +1,110 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestPoolMiddleware(t *testing.T) {
+	t.Run("injects pool into context", func(t *testing.T) {
+		var poolFound bool
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			pool := RequestPoolFromContext(r.Context())
+			poolFound = pool != nil
+		})
+
+		handler := RequestPoolMiddleware(10)(inner)
+		req := httptest.NewRequest(http.MethodPost, "/graphql/query", nil)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		assert.True(t, poolFound, "request pool should be present in context")
+	})
+
+	t.Run("limits concurrency", func(t *testing.T) {
+		const maxConcurrency = 5
+		var peakConcurrent atomic.Int64
+		var currentConcurrent atomic.Int64
+
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			pool := RequestPoolFromContext(r.Context())
+			require.NotNil(t, pool)
+
+			var wg sync.WaitGroup
+			// Submit more tasks than the concurrency limit
+			for i := 0; i < 20; i++ {
+				wg.Add(1)
+				pool.Submit(func() {
+					defer wg.Done()
+					cur := currentConcurrent.Add(1)
+					// Track peak concurrency
+					for {
+						peak := peakConcurrent.Load()
+						if cur <= peak || peakConcurrent.CompareAndSwap(peak, cur) {
+							break
+						}
+					}
+					time.Sleep(10 * time.Millisecond)
+					currentConcurrent.Add(-1)
+				})
+			}
+			wg.Wait()
+		})
+
+		handler := RequestPoolMiddleware(maxConcurrency)(inner)
+		req := httptest.NewRequest(http.MethodPost, "/graphql/query", nil)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		assert.LessOrEqual(t, peakConcurrent.Load(), int64(maxConcurrency),
+			"peak concurrency should not exceed pool limit")
+		assert.Greater(t, peakConcurrent.Load(), int64(0),
+			"at least some tasks should have run concurrently")
+	})
+
+	t.Run("pool is stopped after handler returns", func(t *testing.T) {
+		var capturedStopped bool
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			pool := RequestPoolFromContext(r.Context())
+			require.NotNil(t, pool)
+			// Submit a task to ensure pool is running
+			task := pool.Submit(func() {})
+			task.Wait()
+			assert.False(t, pool.Stopped(), "pool should not be stopped during handler")
+		})
+
+		var afterHandlerPool bool
+		wrappedMiddleware := func(next http.Handler) http.Handler {
+			return RequestPoolMiddleware(5)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				next.ServeHTTP(w, r)
+				// After inner handler returns but before middleware returns,
+				// the pool should still be accessible
+				pool := RequestPoolFromContext(r.Context())
+				afterHandlerPool = pool != nil
+				// Note: pool.Stopped() may or may not be true here since
+				// StopAndWait happens after ServeHTTP returns in the middleware
+			}))
+		}
+
+		handler := wrappedMiddleware(inner)
+		req := httptest.NewRequest(http.MethodPost, "/graphql/query", nil)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		_ = capturedStopped
+		assert.True(t, afterHandlerPool, "pool should be in context")
+	})
+}
+
+func TestRequestPoolFromContext_NoPool(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	pool := RequestPoolFromContext(req.Context())
+	assert.Nil(t, pool, "should return nil when no pool in context")
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -65,8 +65,8 @@ type Configs struct {
 	GraphQLComplexityLimit      int
 	MaxAccountsPerBalancesQuery int
 	MaxGraphQLWorkerPoolSize    int
-	GraphQLRateLimitPerSecond      int
-	GraphQLRateLimitBurst          int
+	GraphQLRateLimitPerSecond   int
+	GraphQLRateLimitBurst       int
 	GraphQLMaxConcurrencyPerReq int
 
 	// Error Tracker
@@ -122,8 +122,8 @@ type handlerDeps struct {
 	GraphQLComplexityLimit      int
 	MaxAccountsPerBalancesQuery int
 	MaxGraphQLWorkerPoolSize    int
-	GraphQLRateLimitPerSecond      int
-	GraphQLRateLimitBurst          int
+	GraphQLRateLimitPerSecond   int
+	GraphQLRateLimitBurst       int
 	GraphQLMaxConcurrencyPerReq int
 
 	// Error Tracker
@@ -240,8 +240,8 @@ func initHandlerDeps(ctx context.Context, cfg Configs) (handlerDeps, error) {
 		GraphQLComplexityLimit:      cfg.GraphQLComplexityLimit,
 		MaxAccountsPerBalancesQuery: cfg.MaxAccountsPerBalancesQuery,
 		MaxGraphQLWorkerPoolSize:    cfg.MaxGraphQLWorkerPoolSize,
-		GraphQLRateLimitPerSecond:      cfg.GraphQLRateLimitPerSecond,
-		GraphQLRateLimitBurst:          cfg.GraphQLRateLimitBurst,
+		GraphQLRateLimitPerSecond:   cfg.GraphQLRateLimitPerSecond,
+		GraphQLRateLimitBurst:       cfg.GraphQLRateLimitBurst,
 		GraphQLMaxConcurrencyPerReq: cfg.GraphQLMaxConcurrencyPerReq,
 	}, nil
 }

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -65,6 +65,9 @@ type Configs struct {
 	GraphQLComplexityLimit      int
 	MaxAccountsPerBalancesQuery int
 	MaxGraphQLWorkerPoolSize    int
+	GraphQLRateLimitPerSecond      int
+	GraphQLRateLimitBurst          int
+	GraphQLMaxConcurrencyPerReq int
 
 	// Error Tracker
 	AppTracker apptracker.AppTracker
@@ -119,6 +122,9 @@ type handlerDeps struct {
 	GraphQLComplexityLimit      int
 	MaxAccountsPerBalancesQuery int
 	MaxGraphQLWorkerPoolSize    int
+	GraphQLRateLimitPerSecond      int
+	GraphQLRateLimitBurst          int
+	GraphQLMaxConcurrencyPerReq int
 
 	// Error Tracker
 	AppTracker apptracker.AppTracker
@@ -234,6 +240,9 @@ func initHandlerDeps(ctx context.Context, cfg Configs) (handlerDeps, error) {
 		GraphQLComplexityLimit:      cfg.GraphQLComplexityLimit,
 		MaxAccountsPerBalancesQuery: cfg.MaxAccountsPerBalancesQuery,
 		MaxGraphQLWorkerPoolSize:    cfg.MaxGraphQLWorkerPoolSize,
+		GraphQLRateLimitPerSecond:      cfg.GraphQLRateLimitPerSecond,
+		GraphQLRateLimitBurst:          cfg.GraphQLRateLimitBurst,
+		GraphQLMaxConcurrencyPerReq: cfg.GraphQLMaxConcurrencyPerReq,
 	}, nil
 }
 
@@ -271,6 +280,16 @@ func handler(deps handlerDeps) http.Handler {
 		}
 
 		r.Route("/graphql", func(r chi.Router) {
+			if deps.GraphQLRateLimitPerSecond > 0 {
+				burst := deps.GraphQLRateLimitBurst
+				if burst <= 0 {
+					burst = deps.GraphQLRateLimitPerSecond
+				}
+				r.Use(middleware.RateLimiter(float64(deps.GraphQLRateLimitPerSecond), burst))
+			}
+			if deps.GraphQLMaxConcurrencyPerReq > 0 {
+				r.Use(middleware.RequestPoolMiddleware(deps.GraphQLMaxConcurrencyPerReq))
+			}
 			r.Use(middleware.DataloaderMiddleware(deps.Models))
 
 			resolver := resolvers.NewResolver(
@@ -382,4 +401,14 @@ func addComplexityCalculation(config *generated.Config) {
 	config.Complexity.Transaction.Operations = paginatedQueryComplexityFunc
 	config.Complexity.Transaction.StateChanges = paginatedQueryComplexityFunc
 	config.Complexity.Operation.StateChanges = paginatedQueryComplexityFunc
+
+	// BalancesByAccountAddresses spawns multiple parallel worker pool tasks per address,
+	// so its complexity must scale with the number of addresses requested.
+	config.Complexity.Query.BalancesByAccountAddresses = func(childComplexity int, addresses []string) int {
+		count := len(addresses)
+		if count == 0 {
+			count = 1
+		}
+		return childComplexity * count
+	}
 }


### PR DESCRIPTION
### What
Add defense against DoS through GraphQL query aliasing:

1. Complexity weight: balancesByAccountAddresses now scales complexity by address count, reducing max aliases from ~1000 to ~16 under the default complexity limit.

2. Per-IP rate limiting: new middleware on the `/graphql` route using `X-Real-IP` (set by ingress) with configurable requests-per-second and burst (defaults: 10/s, burst 20).

3. Per-request worker pool: each HTTP request gets its own bounded pond.Pool (default 30 workers) via context, preventing any single request from monopolising the shared pool. The resolver falls back to the shared pool when the middleware is absent (e.g. in tests).

```
  New config flags:
    --graphql-rate-limit-per-second (default 10, 0 to disable)
    --graphql-rate-limit-burst (default 20)
    --graphql-max-concurrency-per-request (default 30, 0 to disable)
```

### Why
Worker pool can be starved using `BalancesByAccountAddresses`

### Known limitations
N/A

### Issue that this PR addresses
N/A

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
