### PR TITLE
fix(internal): Refactor BuildTransaction to accept pre-simulated transaction XDR

### DIFF
--- a/internal/integrationtests/infrastructure/fixtures.go
+++ b/internal/integrationtests/infrastructure/fixtures.go
@@ -1192,7 +1192,8 @@ func (f *Fixtures) buildMultiOperationUseCase(
 	}, nil
 }
 
-// buildSorobanUseCase creates a UseCase for Soroban operations with simulation results.
+// buildSorobanUseCase creates a UseCase for Soroban operations with simulation data already
+// embedded in the transaction XDR (via the operation's Ext field).
 func (f *Fixtures) buildSorobanUseCase(
 	opXDR string,
 	txSigners *Set[*keypair.Full],
@@ -1200,7 +1201,7 @@ func (f *Fixtures) buildSorobanUseCase(
 	name string,
 	timeoutSeconds int64,
 ) (*UseCase, error) {
-	txXDR, err := f.buildTransactionXDR([]string{opXDR}, timeoutSeconds)
+	txXDR, err := f.buildSorobanTransactionXDR(opXDR, simulationResult.TransactionData, timeoutSeconds)
 	if err != nil {
 		return nil, fmt.Errorf("building transaction XDR for %s: %w", name, err)
 	}
@@ -1210,7 +1211,7 @@ func (f *Fixtures) buildSorobanUseCase(
 		category:             categorySoroban,
 		TxSigners:            txSigners,
 		DelayTime:            2 * time.Second,
-		RequestedTransaction: types.Transaction{TransactionXdr: txXDR, SimulationResult: simulationResult},
+		RequestedTransaction: types.Transaction{TransactionXdr: txXDR},
 	}, nil
 }
 
@@ -1455,6 +1456,60 @@ func (f *Fixtures) buildTransactionXDR(operationXDRs []string, timeoutSeconds in
 	}
 
 	// Convert to XDR string
+	txXDR, err := tx.Base64()
+	if err != nil {
+		return "", fmt.Errorf("encoding transaction to base64: %w", err)
+	}
+
+	return txXDR, nil
+}
+
+// buildSorobanTransactionXDR builds a transaction XDR for a Soroban operation with
+// SorobanTransactionData embedded in the operation's Ext field.
+func (f *Fixtures) buildSorobanTransactionXDR(opXDRStr string, sorobanData xdr.SorobanTransactionData, timeoutSeconds int64) (string, error) {
+	_ = timeoutSeconds // Reserved for future use; currently using NewInfiniteTimeout()
+
+	opXDR, err := utils.OperationXDRFromBase64(opXDRStr)
+	if err != nil {
+		return "", fmt.Errorf("converting operation XDR from base64: %w", err)
+	}
+	op, err := utils.OperationXDRToTxnBuildOp(opXDR)
+	if err != nil {
+		return "", fmt.Errorf("converting operation XDR to txnbuild operation: %w", err)
+	}
+
+	// Embed SorobanTransactionData in the operation's Ext field
+	txExt, err := xdr.NewTransactionExt(1, sorobanData)
+	if err != nil {
+		return "", fmt.Errorf("creating transaction ext: %w", err)
+	}
+	switch sorobanOp := op.(type) {
+	case *txnbuild.InvokeHostFunction:
+		sorobanOp.Ext = txExt
+	case *txnbuild.ExtendFootprintTtl:
+		sorobanOp.Ext = txExt
+	case *txnbuild.RestoreFootprint:
+		sorobanOp.Ext = txExt
+	default:
+		return "", fmt.Errorf("unsupported Soroban operation type: %T", op)
+	}
+
+	sourceAccKP := keypair.MustRandom()
+	sourceAcc := txnbuild.SimpleAccount{AccountID: sourceAccKP.Address(), Sequence: 0}
+
+	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount: &sourceAcc,
+		Operations:    []txnbuild.Operation{op},
+		BaseFee:       txnbuild.MinBaseFee,
+		Preconditions: txnbuild.Preconditions{
+			TimeBounds: txnbuild.NewInfiniteTimeout(),
+		},
+		IncrementSequenceNum: true,
+	})
+	if err != nil {
+		return "", fmt.Errorf("building transaction: %w", err)
+	}
+
 	txXDR, err := tx.Base64()
 	if err != nil {
 		return "", fmt.Errorf("encoding transaction to base64: %w", err)

--- a/internal/serve/graphql/generated/generated.go
+++ b/internal/serve/graphql/generated/generated.go
@@ -1852,7 +1852,6 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputAccountStateChangeFilterInput,
 		ec.unmarshalInputBuildTransactionInput,
 		ec.unmarshalInputCreateFeeBumpTransactionInput,
-		ec.unmarshalInputSimulationResultInput,
 	)
 	first := true
 
@@ -2174,17 +2173,6 @@ input CreateFeeBumpTransactionInput {
 # Input types for transaction mutations
 input BuildTransactionInput {
     transactionXdr: String!
-    simulationResult: SimulationResultInput
-}
-
-# Optional simulation result input for Soroban transactions
-input SimulationResultInput {
-    transactionData: String
-    events: [String!]
-    minResourceFee: String
-    results: [String!]
-    latestLedger: Int
-    error: String
 }
 
 
@@ -14690,7 +14678,7 @@ func (ec *executionContext) unmarshalInputBuildTransactionInput(ctx context.Cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"transactionXdr", "simulationResult"}
+	fieldsInOrder := [...]string{"transactionXdr"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -14704,13 +14692,6 @@ func (ec *executionContext) unmarshalInputBuildTransactionInput(ctx context.Cont
 				return it, err
 			}
 			it.TransactionXdr = data
-		case "simulationResult":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("simulationResult"))
-			data, err := ec.unmarshalOSimulationResultInput2ᚖgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐSimulationResultInput(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.SimulationResult = data
 		}
 	}
 
@@ -14738,68 +14719,6 @@ func (ec *executionContext) unmarshalInputCreateFeeBumpTransactionInput(ctx cont
 				return it, err
 			}
 			it.TransactionXdr = data
-		}
-	}
-
-	return it, nil
-}
-
-func (ec *executionContext) unmarshalInputSimulationResultInput(ctx context.Context, obj any) (SimulationResultInput, error) {
-	var it SimulationResultInput
-	asMap := map[string]any{}
-	for k, v := range obj.(map[string]any) {
-		asMap[k] = v
-	}
-
-	fieldsInOrder := [...]string{"transactionData", "events", "minResourceFee", "results", "latestLedger", "error"}
-	for _, k := range fieldsInOrder {
-		v, ok := asMap[k]
-		if !ok {
-			continue
-		}
-		switch k {
-		case "transactionData":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("transactionData"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.TransactionData = data
-		case "events":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("events"))
-			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Events = data
-		case "minResourceFee":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("minResourceFee"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.MinResourceFee = data
-		case "results":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("results"))
-			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Results = data
-		case "latestLedger":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("latestLedger"))
-			data, err := ec.unmarshalOInt2ᚖint32(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.LatestLedger = data
-		case "error":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("error"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Error = data
 		}
 	}
 
@@ -20400,14 +20319,6 @@ func (ec *executionContext) marshalOOperationEdge2ᚕᚖgithubᚗcomᚋstellar�
 	return ret
 }
 
-func (ec *executionContext) unmarshalOSimulationResultInput2ᚖgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐSimulationResultInput(ctx context.Context, v any) (*SimulationResultInput, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := ec.unmarshalInputSimulationResultInput(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
 func (ec *executionContext) marshalOStateChangeConnection2ᚖgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐStateChangeConnection(ctx context.Context, sel ast.SelectionSet, v *StateChangeConnection) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -20452,42 +20363,6 @@ func (ec *executionContext) marshalOStateChangeEdge2ᚕᚖgithubᚗcomᚋstellar
 
 	}
 	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
-}
-
-func (ec *executionContext) unmarshalOString2ᚕstringᚄ(ctx context.Context, v any) ([]string, error) {
-	if v == nil {
-		return nil, nil
-	}
-	var vSlice []any
-	vSlice = graphql.CoerceList(v)
-	var err error
-	res := make([]string, len(vSlice))
-	for i := range vSlice {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNString2string(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
-}
-
-func (ec *executionContext) marshalOString2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	for i := range v {
-		ret[i] = ec.marshalNString2string(ctx, sel, v[i])
-	}
 
 	for _, e := range ret {
 		if e == graphql.Null {

--- a/internal/serve/graphql/generated/models_gen.go
+++ b/internal/serve/graphql/generated/models_gen.go
@@ -54,8 +54,7 @@ type BalanceEdge struct {
 }
 
 type BuildTransactionInput struct {
-	TransactionXdr   string                 `json:"transactionXdr"`
-	SimulationResult *SimulationResultInput `json:"simulationResult,omitempty"`
+	TransactionXdr string `json:"transactionXdr"`
 }
 
 type BuildTransactionPayload struct {
@@ -140,15 +139,6 @@ func (SEP41Balance) IsBalance()                   {}
 func (this SEP41Balance) GetBalance() string      { return this.Balance }
 func (this SEP41Balance) GetTokenID() string      { return this.TokenID }
 func (this SEP41Balance) GetTokenType() TokenType { return this.TokenType }
-
-type SimulationResultInput struct {
-	TransactionData *string  `json:"transactionData,omitempty"`
-	Events          []string `json:"events,omitempty"`
-	MinResourceFee  *string  `json:"minResourceFee,omitempty"`
-	Results         []string `json:"results,omitempty"`
-	LatestLedger    *int32   `json:"latestLedger,omitempty"`
-	Error           *string  `json:"error,omitempty"`
-}
 
 type StateChangeConnection struct {
 	Edges    []*StateChangeEdge `json:"edges,omitempty"`

--- a/internal/serve/graphql/resolvers/mutations.resolvers.go
+++ b/internal/serve/graphql/resolvers/mutations.resolvers.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stellar/go-stellar-sdk/txnbuild"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
-	"github.com/stellar/wallet-backend/internal/entities"
 	graphql1 "github.com/stellar/wallet-backend/internal/serve/graphql/generated"
 	"github.com/stellar/wallet-backend/internal/services"
 	"github.com/stellar/wallet-backend/internal/signing"
@@ -32,23 +31,7 @@ func (r *mutationResolver) BuildTransaction(ctx context.Context, input graphql1.
 		}
 	}
 
-	// Convert simulation result if provided
-	var simulationResult *entities.RPCSimulateTransactionResult
-	if input.SimulationResult != nil {
-		convertedSimulationResult, err := convertSimulationResult(input.SimulationResult)
-		if err != nil {
-			return nil, &gqlerror.Error{
-				Message: err.Error(),
-				Extensions: map[string]any{
-					"code": "INVALID_SIMULATION_RESULT",
-				},
-			}
-		}
-		simulationResult = &convertedSimulationResult
-	}
-
-	// Build transaction from XDR with optional simulation result
-	tx, err := r.transactionService.BuildAndSignTransactionWithChannelAccount(ctx, genericTx, simulationResult)
+	tx, err := r.transactionService.BuildAndSignTransactionWithChannelAccount(ctx, genericTx)
 	if err != nil {
 		switch {
 		case errors.Is(err, services.ErrInvalidTimeout),
@@ -61,8 +44,7 @@ func (r *mutationResolver) BuildTransaction(ctx context.Context, input graphql1.
 				},
 			}
 		case errors.Is(err, services.ErrInvalidSorobanOperationCount),
-			errors.Is(err, services.ErrInvalidSorobanSimulationEmpty),
-			errors.Is(err, services.ErrInvalidSorobanSimulationFailed),
+			errors.Is(err, services.ErrMissingSorobanTransactionData),
 			errors.Is(err, services.ErrInvalidSorobanOperationType):
 			return nil, &gqlerror.Error{
 				Message: err.Error(),

--- a/internal/serve/graphql/resolvers/mutations_resolvers_test.go
+++ b/internal/serve/graphql/resolvers/mutations_resolvers_test.go
@@ -386,6 +386,52 @@ func TestMutationResolver_CreateFeeBumpTransaction(t *testing.T) {
 	})
 }
 
+func Test_convertSimulationResult(t *testing.T) {
+	t.Run("results are mapped through conversion", func(t *testing.T) {
+		// Use the same known auth entry XDR from sorobanauth tests
+		const authEntryXDR = "AAAAAQAAAAAAAAAAEG5rRhQ6188E3xuAkXVVe82tgIW2yZyDyH43k9/YHKVxxKYXs/ivgQAAAAAAAAABAAAAAAAAAAHXkotywnA8z+r365/0701QSlWouXn8m0UOoshCtNHOYQAAAAh0cmFuc2ZlcgAAAAMAAAASAAAAAAAAAAAQbmtGFDrXzwTfG4CRdVV7za2AhbbJnIPIfjeT39gcpQAAABIAAAAAAAAAABBua0YUOtfPBN8bgJF1VXvNrYCFtsmcg8h+N5Pf2BylAAAACgAAAAAAAAAAAAAAAAX14QAAAAAA"
+
+		xdrVal := xdr.ScVal{Type: xdr.ScValTypeScvBool, B: new(bool)}
+		*xdrVal.B = true
+		xdrBase64, err := xdr.MarshalBase64(xdrVal)
+		require.NoError(t, err)
+
+		resultJSON := `{"auth":["` + authEntryXDR + `"],"xdr":"` + xdrBase64 + `"}`
+
+		input := &graphql.SimulationResultInput{
+			Results: []string{resultJSON},
+		}
+
+		result, err := convertSimulationResult(input)
+		require.NoError(t, err)
+		require.Len(t, result.Results, 1)
+		require.Len(t, result.Results[0].Auth, 1)
+		assert.Equal(t, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, result.Results[0].Auth[0].Credentials.Type)
+
+		gotSigner, err := result.Results[0].Auth[0].Credentials.Address.Address.String()
+		require.NoError(t, err)
+		assert.Equal(t, "GAIG422GCQ5NPTYE34NYBELVKV543LMAQW3MTHEDZB7DPE673AOKLEXO", gotSigner)
+	})
+
+	t.Run("invalid results JSON returns error", func(t *testing.T) {
+		input := &graphql.SimulationResultInput{
+			Results: []string{"not-valid-json"},
+		}
+
+		_, err := convertSimulationResult(input)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "unmarshalling simulation result[0]")
+	})
+
+	t.Run("empty results stays empty", func(t *testing.T) {
+		input := &graphql.SimulationResultInput{}
+
+		result, err := convertSimulationResult(input)
+		require.NoError(t, err)
+		assert.Empty(t, result.Results)
+	})
+}
+
 func TestMutationResolver_BuildTransaction(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/serve/graphql/resolvers/mutations_resolvers_test.go
+++ b/internal/serve/graphql/resolvers/mutations_resolvers_test.go
@@ -7,14 +7,12 @@ import (
 
 	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/txnbuild"
-	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
 	"github.com/stellar/wallet-backend/internal/data"
-	"github.com/stellar/wallet-backend/internal/entities"
 	graphql "github.com/stellar/wallet-backend/internal/serve/graphql/generated"
 	"github.com/stellar/wallet-backend/internal/services"
 )
@@ -28,8 +26,8 @@ func (m *mockTransactionService) NetworkPassphrase() string {
 	return args.String(0)
 }
 
-func (m *mockTransactionService) BuildAndSignTransactionWithChannelAccount(ctx context.Context, genericTx *txnbuild.GenericTransaction, simulationResult *entities.RPCSimulateTransactionResult) (*txnbuild.Transaction, error) {
-	args := m.Called(ctx, genericTx, simulationResult)
+func (m *mockTransactionService) BuildAndSignTransactionWithChannelAccount(ctx context.Context, genericTx *txnbuild.GenericTransaction) (*txnbuild.Transaction, error) {
+	args := m.Called(ctx, genericTx)
 	return args.Get(0).(*txnbuild.Transaction), args.Error(1)
 }
 
@@ -386,52 +384,6 @@ func TestMutationResolver_CreateFeeBumpTransaction(t *testing.T) {
 	})
 }
 
-func Test_convertSimulationResult(t *testing.T) {
-	t.Run("results are mapped through conversion", func(t *testing.T) {
-		// Use the same known auth entry XDR from sorobanauth tests
-		const authEntryXDR = "AAAAAQAAAAAAAAAAEG5rRhQ6188E3xuAkXVVe82tgIW2yZyDyH43k9/YHKVxxKYXs/ivgQAAAAAAAAABAAAAAAAAAAHXkotywnA8z+r365/0701QSlWouXn8m0UOoshCtNHOYQAAAAh0cmFuc2ZlcgAAAAMAAAASAAAAAAAAAAAQbmtGFDrXzwTfG4CRdVV7za2AhbbJnIPIfjeT39gcpQAAABIAAAAAAAAAABBua0YUOtfPBN8bgJF1VXvNrYCFtsmcg8h+N5Pf2BylAAAACgAAAAAAAAAAAAAAAAX14QAAAAAA"
-
-		xdrVal := xdr.ScVal{Type: xdr.ScValTypeScvBool, B: new(bool)}
-		*xdrVal.B = true
-		xdrBase64, err := xdr.MarshalBase64(xdrVal)
-		require.NoError(t, err)
-
-		resultJSON := `{"auth":["` + authEntryXDR + `"],"xdr":"` + xdrBase64 + `"}`
-
-		input := &graphql.SimulationResultInput{
-			Results: []string{resultJSON},
-		}
-
-		result, err := convertSimulationResult(input)
-		require.NoError(t, err)
-		require.Len(t, result.Results, 1)
-		require.Len(t, result.Results[0].Auth, 1)
-		assert.Equal(t, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, result.Results[0].Auth[0].Credentials.Type)
-
-		gotSigner, err := result.Results[0].Auth[0].Credentials.Address.Address.String()
-		require.NoError(t, err)
-		assert.Equal(t, "GAIG422GCQ5NPTYE34NYBELVKV543LMAQW3MTHEDZB7DPE673AOKLEXO", gotSigner)
-	})
-
-	t.Run("invalid results JSON returns error", func(t *testing.T) {
-		input := &graphql.SimulationResultInput{
-			Results: []string{"not-valid-json"},
-		}
-
-		_, err := convertSimulationResult(input)
-		require.Error(t, err)
-		assert.ErrorContains(t, err, "unmarshalling simulation result[0]")
-	})
-
-	t.Run("empty results stays empty", func(t *testing.T) {
-		input := &graphql.SimulationResultInput{}
-
-		result, err := convertSimulationResult(input)
-		require.NoError(t, err)
-		assert.Empty(t, result.Results)
-	})
-}
-
 func TestMutationResolver_BuildTransaction(t *testing.T) {
 	ctx := context.Background()
 
@@ -470,7 +422,7 @@ func TestMutationResolver_BuildTransaction(t *testing.T) {
 			TransactionXdr: txXDR,
 		}
 
-		mockTransactionService.On("BuildAndSignTransactionWithChannelAccount", ctx, mock.AnythingOfType("*txnbuild.GenericTransaction"), (*entities.RPCSimulateTransactionResult)(nil)).Return(tx, nil)
+		mockTransactionService.On("BuildAndSignTransactionWithChannelAccount", ctx, mock.AnythingOfType("*txnbuild.GenericTransaction")).Return(tx, nil)
 
 		result, err := resolver.BuildTransaction(ctx, input)
 
@@ -538,7 +490,7 @@ func TestMutationResolver_BuildTransaction(t *testing.T) {
 			TransactionXdr: txXDR,
 		}
 
-		mockTransactionService.On("BuildAndSignTransactionWithChannelAccount", ctx, mock.AnythingOfType("*txnbuild.GenericTransaction"), (*entities.RPCSimulateTransactionResult)(nil)).Return((*txnbuild.Transaction)(nil), errors.New("transaction build failed"))
+		mockTransactionService.On("BuildAndSignTransactionWithChannelAccount", ctx, mock.AnythingOfType("*txnbuild.GenericTransaction")).Return((*txnbuild.Transaction)(nil), errors.New("transaction build failed"))
 
 		result, err := resolver.BuildTransaction(ctx, input)
 
@@ -547,216 +499,6 @@ func TestMutationResolver_BuildTransaction(t *testing.T) {
 		assert.ErrorContains(t, err, "transaction build failed")
 
 		mockTransactionService.AssertExpectations(t)
-	})
-
-	t.Run("with simulation result", func(t *testing.T) {
-		mockTransactionService := &mockTransactionService{}
-
-		resolver := &mutationResolver{
-			&Resolver{
-				transactionService: mockTransactionService,
-				models:             &data.Models{},
-			},
-		}
-
-		// Create a complete test transaction
-		sourceAccount := keypair.MustRandom()
-		tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
-			SourceAccount:        &txnbuild.SimpleAccount{AccountID: sourceAccount.Address()},
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					Destination: keypair.MustRandom().Address(),
-					Asset:       txnbuild.NativeAsset{},
-					Amount:      "10",
-				},
-			},
-			BaseFee:       txnbuild.MinBaseFee,
-			Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(30)},
-		})
-		require.NoError(t, err)
-
-		// Get the transaction XDR
-		txXDR, err := tx.Base64()
-		require.NoError(t, err)
-
-		// Create simulation result
-		latestLedger := int32(12345)
-		minResourceFee := "1000000"
-		errorMsg := "simulation error example"
-		events := []string{"event1", "event2"}
-
-		transactionData := (*string)(nil)
-
-		input := graphql.BuildTransactionInput{
-			TransactionXdr: txXDR,
-			SimulationResult: &graphql.SimulationResultInput{
-				LatestLedger:    &latestLedger,
-				MinResourceFee:  &minResourceFee,
-				Error:           &errorMsg,
-				Events:          events,
-				TransactionData: transactionData,
-			},
-		}
-
-		mockTransactionService.On("BuildAndSignTransactionWithChannelAccount",
-			ctx,
-			mock.AnythingOfType("*txnbuild.GenericTransaction"),
-			mock.MatchedBy(func(simResult *entities.RPCSimulateTransactionResult) bool {
-				// Verify all simulation result fields are properly converted
-				return simResult != nil &&
-					simResult.LatestLedger == int64(latestLedger) &&
-					simResult.MinResourceFee == minResourceFee &&
-					simResult.Error == errorMsg &&
-					len(simResult.Events) == 2 &&
-					simResult.Events[0] == "event1" &&
-					simResult.Events[1] == "event2"
-			})).Return(tx, nil)
-
-		result, err := resolver.BuildTransaction(ctx, input)
-
-		require.NoError(t, err)
-		assert.NotNil(t, result)
-		assert.True(t, result.Success)
-		assert.NotEmpty(t, result.TransactionXdr)
-
-		mockTransactionService.AssertExpectations(t)
-	})
-
-	t.Run("with valid transaction data", func(t *testing.T) {
-		mockTransactionService := &mockTransactionService{}
-
-		resolver := &mutationResolver{
-			&Resolver{
-				transactionService: mockTransactionService,
-				models:             &data.Models{},
-			},
-		}
-
-		// Create a complete test transaction
-		sourceAccount := keypair.MustRandom()
-		tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
-			SourceAccount:        &txnbuild.SimpleAccount{AccountID: sourceAccount.Address()},
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					Destination: keypair.MustRandom().Address(),
-					Asset:       txnbuild.NativeAsset{},
-					Amount:      "10",
-				},
-			},
-			BaseFee:       txnbuild.MinBaseFee,
-			Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(30)},
-		})
-		require.NoError(t, err)
-
-		// Get the transaction XDR
-		txXDR, err := tx.Base64()
-		require.NoError(t, err)
-
-		// Create a valid SorobanTransactionData
-		validTxData := xdr.SorobanTransactionData{
-			Ext: xdr.SorobanTransactionDataExt{
-				V: 0, // Version 0
-			},
-			Resources: xdr.SorobanResources{
-				Footprint: xdr.LedgerFootprint{
-					ReadOnly:  []xdr.LedgerKey{},
-					ReadWrite: []xdr.LedgerKey{},
-				},
-				Instructions:  1000000,
-				DiskReadBytes: 1000,
-				WriteBytes:    1000,
-			},
-			ResourceFee: 1000000,
-		}
-
-		validTxDataBase64, err := xdr.MarshalBase64(validTxData)
-		require.NoError(t, err)
-
-		input := graphql.BuildTransactionInput{
-			TransactionXdr: txXDR,
-			SimulationResult: &graphql.SimulationResultInput{
-				TransactionData: &validTxDataBase64,
-				Events:          []string{"test-event"},
-			},
-		}
-
-		mockTransactionService.On("BuildAndSignTransactionWithChannelAccount",
-			ctx,
-			mock.AnythingOfType("*txnbuild.GenericTransaction"),
-			mock.MatchedBy(func(simResult *entities.RPCSimulateTransactionResult) bool {
-				// Verify that TransactionData was successfully parsed and matches our original data
-				expectedTxDataBase64, marshalErr := xdr.MarshalBase64(simResult.TransactionData)
-				if marshalErr != nil {
-					return false
-				}
-				return simResult != nil &&
-					expectedTxDataBase64 == validTxDataBase64 &&
-					len(simResult.Events) == 1 &&
-					simResult.Events[0] == "test-event"
-			})).Return(tx, nil)
-
-		result, err := resolver.BuildTransaction(ctx, input)
-
-		require.NoError(t, err)
-		assert.NotNil(t, result)
-		assert.True(t, result.Success)
-		assert.NotEmpty(t, result.TransactionXdr)
-
-		mockTransactionService.AssertExpectations(t)
-	})
-
-	t.Run("invalid transaction data", func(t *testing.T) {
-		mockTransactionService := &mockTransactionService{}
-
-		resolver := &mutationResolver{
-			&Resolver{
-				transactionService: mockTransactionService,
-				models:             &data.Models{},
-			},
-		}
-
-		// Create a complete test transaction
-		sourceAccount := keypair.MustRandom()
-		tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
-			SourceAccount:        &txnbuild.SimpleAccount{AccountID: sourceAccount.Address()},
-			IncrementSequenceNum: true,
-			Operations: []txnbuild.Operation{
-				&txnbuild.Payment{
-					Destination: keypair.MustRandom().Address(),
-					Asset:       txnbuild.NativeAsset{},
-					Amount:      "10",
-				},
-			},
-			BaseFee:       txnbuild.MinBaseFee,
-			Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(30)},
-		})
-		require.NoError(t, err)
-
-		// Get the transaction XDR
-		txXDR, err := tx.Base64()
-		require.NoError(t, err)
-
-		invalidTransactionData := "invalid-transaction-data-xdr"
-
-		input := graphql.BuildTransactionInput{
-			TransactionXdr: txXDR,
-			SimulationResult: &graphql.SimulationResultInput{
-				TransactionData: &invalidTransactionData,
-			},
-		}
-
-		result, err := resolver.BuildTransaction(ctx, input)
-
-		require.Error(t, err)
-		assert.Nil(t, result)
-		assert.ErrorContains(t, err, "unmarshalling transaction data")
-
-		var gqlErr *gqlerror.Error
-		if errors.As(err, &gqlErr) {
-			assert.Equal(t, "INVALID_SIMULATION_RESULT", gqlErr.Extensions["code"])
-		}
 	})
 
 	t.Run("invalid operation structure error", func(t *testing.T) {
@@ -794,7 +536,7 @@ func TestMutationResolver_BuildTransaction(t *testing.T) {
 			TransactionXdr: txXDR,
 		}
 
-		mockTransactionService.On("BuildAndSignTransactionWithChannelAccount", ctx, mock.AnythingOfType("*txnbuild.GenericTransaction"), (*entities.RPCSimulateTransactionResult)(nil)).Return((*txnbuild.Transaction)(nil), services.ErrInvalidTimeout)
+		mockTransactionService.On("BuildAndSignTransactionWithChannelAccount", ctx, mock.AnythingOfType("*txnbuild.GenericTransaction")).Return((*txnbuild.Transaction)(nil), services.ErrInvalidTimeout)
 
 		result, err := resolver.BuildTransaction(ctx, input)
 
@@ -845,7 +587,7 @@ func TestMutationResolver_BuildTransaction(t *testing.T) {
 			TransactionXdr: txXDR,
 		}
 
-		mockTransactionService.On("BuildAndSignTransactionWithChannelAccount", ctx, mock.AnythingOfType("*txnbuild.GenericTransaction"), (*entities.RPCSimulateTransactionResult)(nil)).Return((*txnbuild.Transaction)(nil), services.ErrInvalidSorobanOperationCount)
+		mockTransactionService.On("BuildAndSignTransactionWithChannelAccount", ctx, mock.AnythingOfType("*txnbuild.GenericTransaction")).Return((*txnbuild.Transaction)(nil), services.ErrInvalidSorobanOperationCount)
 
 		result, err := resolver.BuildTransaction(ctx, input)
 

--- a/internal/serve/graphql/resolvers/resolver.go
+++ b/internal/serve/graphql/resolvers/resolver.go
@@ -193,6 +193,15 @@ func convertSimulationResult(simulationResultInput *graphql1.SimulationResultInp
 		simulationResult.LatestLedger = int64(*simulationResultInput.LatestLedger)
 	}
 
+	// Handle Results if provided
+	for i, resultJSON := range simulationResultInput.Results {
+		var result entities.RPCSimulateHostFunctionResult
+		if err := json.Unmarshal([]byte(resultJSON), &result); err != nil {
+			return entities.RPCSimulateTransactionResult{}, fmt.Errorf("unmarshalling simulation result[%d]: %w", i, err)
+		}
+		simulationResult.Results = append(simulationResult.Results, result)
+	}
+
 	// Handle TransactionData if provided
 	if simulationResultInput.TransactionData != nil {
 		var txData xdr.SorobanTransactionData

--- a/internal/serve/graphql/resolvers/resolver.go
+++ b/internal/serve/graphql/resolvers/resolver.go
@@ -16,14 +16,11 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/wallet-backend/internal/data"
-	"github.com/stellar/wallet-backend/internal/entities"
 	"github.com/stellar/wallet-backend/internal/indexer/types"
 	"github.com/stellar/wallet-backend/internal/metrics"
 	"github.com/stellar/wallet-backend/internal/serve/graphql/dataloaders"
-	graphql1 "github.com/stellar/wallet-backend/internal/serve/graphql/generated"
 	"github.com/stellar/wallet-backend/internal/serve/middleware"
 	"github.com/stellar/wallet-backend/internal/services"
 )
@@ -175,41 +172,4 @@ func (r *Resolver) resolveStateChangeTransaction(ctx context.Context, toID int64
 		return nil, fmt.Errorf("loading transaction for state change %s: %w", stateChangeKey, err)
 	}
 	return transaction, nil
-}
-
-// convertSimulationResult converts GraphQL SimulationResultInput to entities.RPCSimulateTransactionResult
-func convertSimulationResult(simulationResultInput *graphql1.SimulationResultInput) (entities.RPCSimulateTransactionResult, error) {
-	simulationResult := entities.RPCSimulateTransactionResult{
-		Events: simulationResultInput.Events,
-	}
-
-	if simulationResultInput.MinResourceFee != nil {
-		simulationResult.MinResourceFee = *simulationResultInput.MinResourceFee
-	}
-	if simulationResultInput.Error != nil {
-		simulationResult.Error = *simulationResultInput.Error
-	}
-	if simulationResultInput.LatestLedger != nil {
-		simulationResult.LatestLedger = int64(*simulationResultInput.LatestLedger)
-	}
-
-	// Handle Results if provided
-	for i, resultJSON := range simulationResultInput.Results {
-		var result entities.RPCSimulateHostFunctionResult
-		if err := json.Unmarshal([]byte(resultJSON), &result); err != nil {
-			return entities.RPCSimulateTransactionResult{}, fmt.Errorf("unmarshalling simulation result[%d]: %w", i, err)
-		}
-		simulationResult.Results = append(simulationResult.Results, result)
-	}
-
-	// Handle TransactionData if provided
-	if simulationResultInput.TransactionData != nil {
-		var txData xdr.SorobanTransactionData
-		if txDataErr := xdr.SafeUnmarshalBase64(*simulationResultInput.TransactionData, &txData); txDataErr != nil {
-			return entities.RPCSimulateTransactionResult{}, fmt.Errorf("unmarshalling transaction data: %w", txDataErr)
-		}
-		simulationResult.TransactionData = txData
-	}
-
-	return simulationResult, nil
 }

--- a/internal/serve/graphql/schema/mutations.graphqls
+++ b/internal/serve/graphql/schema/mutations.graphqls
@@ -13,17 +13,6 @@ input CreateFeeBumpTransactionInput {
 # Input types for transaction mutations
 input BuildTransactionInput {
     transactionXdr: String!
-    simulationResult: SimulationResultInput
-}
-
-# Optional simulation result input for Soroban transactions
-input SimulationResultInput {
-    transactionData: String
-    events: [String!]
-    minResourceFee: String
-    results: [String!]
-    latestLedger: Int
-    error: String
 }
 
 

--- a/internal/services/transaction_service.go
+++ b/internal/services/transaction_service.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stellar/wallet-backend/internal/entities"
 	"github.com/stellar/wallet-backend/internal/signing"
 	"github.com/stellar/wallet-backend/internal/signing/store"
-	"github.com/stellar/wallet-backend/internal/utils"
 	"github.com/stellar/wallet-backend/pkg/sorobanauth"
 	pkgUtils "github.com/stellar/wallet-backend/pkg/utils"
 )
@@ -37,15 +36,14 @@ var (
 	ErrInvalidOperationChannelAccount = errors.New("invalid operation: operation source account cannot be the channel account")
 	ErrInvalidOperationMissingSource  = errors.New("invalid operation: operation source account cannot be empty for non-Soroban operations")
 	ErrInvalidSorobanOperationCount   = errors.New("invalid Soroban transaction: must have exactly one operation")
-	ErrInvalidSorobanSimulationEmpty  = errors.New("invalid Soroban transaction: simulation response cannot be empty")
-	ErrInvalidSorobanSimulationFailed = errors.New("invalid Soroban transaction: simulation failed")
+	ErrMissingSorobanTransactionData  = errors.New("invalid Soroban transaction: missing SorobanTransactionData in operation Ext field")
 	ErrInvalidSorobanOperationType    = errors.New("invalid Soroban transaction: operation type not supported")
 	ErrSorobanResourceFeeExceedsBound = errors.New("invalid Soroban transaction: client-declared resource fee exceeds the allowed bound")
 )
 
 type TransactionService interface {
 	NetworkPassphrase() string
-	BuildAndSignTransactionWithChannelAccount(ctx context.Context, transaction *txnbuild.GenericTransaction, simulationResult *entities.RPCSimulateTransactionResult) (*txnbuild.Transaction, error)
+	BuildAndSignTransactionWithChannelAccount(ctx context.Context, transaction *txnbuild.GenericTransaction) (*txnbuild.Transaction, error)
 }
 
 type transactionService struct {
@@ -113,7 +111,7 @@ func (t *transactionService) NetworkPassphrase() string {
 	return t.DistributionAccountSignatureClient.NetworkPassphrase()
 }
 
-func (t *transactionService) BuildAndSignTransactionWithChannelAccount(ctx context.Context, transaction *txnbuild.GenericTransaction, simulationResponse *entities.RPCSimulateTransactionResult) (signedTx *txnbuild.Transaction, retErr error) {
+func (t *transactionService) BuildAndSignTransactionWithChannelAccount(ctx context.Context, transaction *txnbuild.GenericTransaction) (signedTx *txnbuild.Transaction, retErr error) {
 	timeoutInSecs := DefaultTimeoutInSeconds
 	channelAccountPublicKey, err := t.ChannelAccountSignatureClient.GetAccountPublicKey(ctx, timeoutInSecs)
 	if err != nil {
@@ -181,12 +179,11 @@ func (t *transactionService) BuildAndSignTransactionWithChannelAccount(ctx conte
 		IncrementSequenceNum: true,
 	}
 
-	// Adjust the transaction params with the soroban-related information (the `Ext` field):
-	if simulationResponse != nil {
-		buildTxParams, err = t.adjustParamsForSoroban(ctx, channelAccountPublicKey, buildTxParams, *simulationResponse)
-		if err != nil {
-			return nil, fmt.Errorf("handling soroban flows: %w", err)
-		}
+	// Adjust the transaction params for Soroban operations (validates auth entries, adjusts fees).
+	// This is a no-op for non-Soroban transactions.
+	buildTxParams, err = t.adjustParamsForSoroban(ctx, channelAccountPublicKey, buildTxParams)
+	if err != nil {
+		return nil, fmt.Errorf("handling soroban flows: %w", err)
 	}
 
 	tx, err := txnbuild.NewTransaction(buildTxParams)
@@ -240,14 +237,15 @@ func (t *transactionService) releaseChannelAccountLock(ctx context.Context, txHa
 	}
 }
 
-// adjustParamsForSoroban will use the `simulationResponse` to set the `Ext` field in the sorobanOp, in case the transaction
-// is a soroban transaction. The resulting `buildTxParams` will be later used by `txnbuild.NewTransaction` to:
+// adjustParamsForSoroban extracts SorobanTransactionData and auth entries from the Soroban operation
+// (already set by the client after simulation) and adjusts the transaction params accordingly.
+// The resulting `buildTxParams` will be later used by `txnbuild.NewTransaction` to:
 // - Calculate the total fee.
 // - Include the `Ext` information to the transaction envelope.
 //
 // Before the fee is accepted, this method re-simulates the transaction server-side and rejects any client-declared
 // `ResourceFee` that exceeds `min(serverMinResourceFee * sorobanResourceFeeSafetyFactor, t.BaseFee)`.
-func (t *transactionService) adjustParamsForSoroban(_ context.Context, channelAccountPublicKey string, buildTxParams txnbuild.TransactionParams, simulationResponse entities.RPCSimulateTransactionResult) (txnbuild.TransactionParams, error) {
+func (t *transactionService) adjustParamsForSoroban(_ context.Context, channelAccountPublicKey string, buildTxParams txnbuild.TransactionParams) (txnbuild.TransactionParams, error) {
 	// Ensure this is a soroban transaction.
 	operations := buildTxParams.Operations
 	isSoroban := slices.ContainsFunc(operations, func(op txnbuild.Operation) bool {
@@ -262,39 +260,44 @@ func (t *transactionService) adjustParamsForSoroban(_ context.Context, channelAc
 		return txnbuild.TransactionParams{}, fmt.Errorf("%w (%d provided)", ErrInvalidSorobanOperationCount, len(operations))
 	}
 
-	if utils.IsEmpty(simulationResponse) {
-		return txnbuild.TransactionParams{}, ErrInvalidSorobanSimulationEmpty
-	} else if simulationResponse.Error != "" {
-		return txnbuild.TransactionParams{}, fmt.Errorf("%w: %s", ErrInvalidSorobanSimulationFailed, simulationResponse.Error)
-	}
-
-	// Check if the channel account public key is used as a source account for any SourceAccount auth entry.
-	err := sorobanauth.CheckForForbiddenSigners(simulationResponse.Results, operations[0].GetSourceAccount(), channelAccountPublicKey)
-	if err != nil {
-		return txnbuild.TransactionParams{}, fmt.Errorf("ensuring the channel account is not being misused: %w", err)
-	}
-
-	// 👋 This is the main goal of this method: setting the `Ext` field in the sorobanOp.
-	transactionExt, err := xdr.NewTransactionExt(1, simulationResponse.TransactionData)
-	if err != nil {
-		return txnbuild.TransactionParams{}, fmt.Errorf("unable to create transaction ext: %w", err)
-	}
+	// Extract SorobanTransactionData and auth entries from the operation itself.
+	// The client is expected to have already incorporated the simulation response into the transaction.
+	var sorobanData xdr.SorobanTransactionData
+	var authEntries []xdr.SorobanAuthorizationEntry
 
 	switch sorobanOp := operations[0].(type) {
 	case *txnbuild.InvokeHostFunction:
-		sorobanOp.Ext = transactionExt
+		sd, ok := sorobanOp.Ext.GetSorobanData()
+		if !ok {
+			return txnbuild.TransactionParams{}, ErrMissingSorobanTransactionData
+		}
+		sorobanData = sd
+		authEntries = sorobanOp.Auth
 	case *txnbuild.ExtendFootprintTtl:
-		sorobanOp.Ext = transactionExt
+		sd, ok := sorobanOp.Ext.GetSorobanData()
+		if !ok {
+			return txnbuild.TransactionParams{}, ErrMissingSorobanTransactionData
+		}
+		sorobanData = sd
 	case *txnbuild.RestoreFootprint:
-		sorobanOp.Ext = transactionExt
+		sd, ok := sorobanOp.Ext.GetSorobanData()
+		if !ok {
+			return txnbuild.TransactionParams{}, ErrMissingSorobanTransactionData
+		}
+		sorobanData = sd
 	default:
 		return txnbuild.TransactionParams{}, fmt.Errorf("%w: %T", ErrInvalidSorobanOperationType, operations[0])
 	}
 
+	// Check if the channel account public key is used as a signer in any auth entry.
+	if err := sorobanauth.CheckForForbiddenSigners(authEntries, operations[0].GetSourceAccount(), channelAccountPublicKey); err != nil {
+		return txnbuild.TransactionParams{}, fmt.Errorf("ensuring the channel account is not being misused: %w", err)
+	}
+
 	// Bound the client-declared ResourceFee against a server-side re-simulation. Without this the caller can inflate
-	// `simulationResponse.TransactionData.ResourceFee` arbitrarily — the floor below would silently absorb it, but
-	// the fee-bump wrapper would still commit distribution-account funds up to the fee-bump ceiling.
-	clientResourceFee := int64(transactionExt.SorobanData.ResourceFee)
+	// `sorobanData.ResourceFee` arbitrarily — the floor below would silently absorb it, but the fee-bump wrapper
+	// would still commit distribution-account funds up to the fee-bump ceiling.
+	clientResourceFee := int64(sorobanData.ResourceFee)
 	if err := t.validateSorobanResourceFee(buildTxParams, clientResourceFee); err != nil {
 		return txnbuild.TransactionParams{}, err
 	}

--- a/internal/services/transaction_service.go
+++ b/internal/services/transaction_service.go
@@ -128,8 +128,27 @@ func (t *transactionService) BuildAndSignTransactionWithChannelAccount(ctx conte
 		return nil, fmt.Errorf("invalid transaction type in XDR")
 	}
 
-	// Validate operations
+	// Extract operations and propagate the transaction-level Ext (SorobanTransactionData) to
+	// Soroban operations. The SDK's TransactionFromXDR only copies Ext to InvokeHostFunction;
+	// ExtendFootprintTtl and RestoreFootprint need it too but their FromXDR doesn't set it.
 	operations := clientTx.Operations()
+	if txEnv := clientTx.ToXDR(); txEnv.V1 != nil && txEnv.V1.Tx.Ext.V != 0 {
+		txExt := txEnv.V1.Tx.Ext
+		for _, op := range operations {
+			switch sorobanOp := op.(type) {
+			case *txnbuild.ExtendFootprintTtl:
+				if sorobanOp.Ext.V == 0 {
+					sorobanOp.Ext = txExt
+				}
+			case *txnbuild.RestoreFootprint:
+				if sorobanOp.Ext.V == 0 {
+					sorobanOp.Ext = txExt
+				}
+			}
+		}
+	}
+
+	// Validate operations
 	for _, op := range operations {
 		// Prevent bad actors from using the channel account as a source account directly.
 		// Resolve the operation source to a G-address to handle muxed accounts (M-addresses)

--- a/internal/services/transaction_service_test.go
+++ b/internal/services/transaction_service_test.go
@@ -556,6 +556,116 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		assert.ErrorContains(t, err, sorobanauth.ErrForbiddenSigner.Error())
 	})
 
+	t.Run("🟢build_and_sign_ExtendFootprintTtl_from_xdr", func(t *testing.T) {
+		// This test verifies that ExtendFootprintTtl works through the real XDR deserialization
+		// path, which the SDK does NOT propagate Ext to (unlike InvokeHostFunction).
+		sorobanTxDataXDR := "AAAAAAAAAAEAAAAGAAAAAdeSi3LCcDzP6vfrn/TvTVBKVai5efybRQ6iyEK00c5hAAAAFAAAAAEAAAACAAAAAAAAAAAQbmtGFDrXzwTfG4CRdVV7za2AhbbJnIPIfjeT39gcpQAAAAYAAAAAAAAAABBua0YUOtfPBN8bgJF1VXvNrYCFtsmcg8h+N5Pf2BylAAAAFWhSXFSqNynLAAAAAAAKehUAAAGIAAAA3AAAAAAAAgi1"
+		var sorobanTxData xdr.SorobanTransactionData
+		err := xdr.SafeUnmarshalBase64(sorobanTxDataXDR, &sorobanTxData)
+		require.NoError(t, err)
+
+		sorobanExt, err := xdr.NewTransactionExt(1, sorobanTxData)
+		require.NoError(t, err)
+
+		// Build a transaction with ExtendFootprintTtl, serialize to XDR, then parse it back.
+		// This exercises the real deserialization path where the SDK drops Ext.
+		op := &txnbuild.ExtendFootprintTtl{ExtendTo: 1000, Ext: sorobanExt}
+		originalTx := buildTransactionForTest(t, []txnbuild.Operation{op}, txnbuild.Preconditions{
+			TimeBounds: txnbuild.NewTimeout(30),
+		})
+		txXDR, err := originalTx.Base64()
+		require.NoError(t, err)
+
+		// Parse from XDR (this is what the resolver does)
+		genericTx, err := txnbuild.TransactionFromXDR(txXDR)
+		require.NoError(t, err)
+
+		channelAccount := keypair.MustRandom()
+		mChannelAccountSignatureClient.
+			On("GetAccountPublicKey", context.Background(), 30).
+			Return(channelAccount.Address(), nil).
+			Once().
+			On("NetworkPassphrase").
+			Return("networkpassphrase").
+			On("SignStellarTransaction", context.Background(), mock.AnythingOfType("*txnbuild.Transaction"), []string{channelAccount.Address()}).
+			Return(originalTx, nil).
+			Once()
+
+		mChannelAccountStore.
+			On("AssignTxToChannelAccount", context.Background(), channelAccount.Address(), mock.AnythingOfType("string")).
+			Return(nil).
+			Once()
+
+		mRPCService.
+			On("GetAccountLedgerSequence", channelAccount.Address()).
+			Return(int64(1), nil).
+			Once().
+			On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
+			Return(entities.RPCSimulateTransactionResult{MinResourceFee: "133301"}, nil).
+			Once()
+
+		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), genericTx)
+
+		mChannelAccountSignatureClient.AssertExpectations(t)
+		mChannelAccountStore.AssertExpectations(t)
+		mRPCService.AssertExpectations(t)
+		assert.NotNil(t, tx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("🟢build_and_sign_RestoreFootprint_from_xdr", func(t *testing.T) {
+		// Same as above but for RestoreFootprint.
+		sorobanTxDataXDR := "AAAAAAAAAAEAAAAGAAAAAdeSi3LCcDzP6vfrn/TvTVBKVai5efybRQ6iyEK00c5hAAAAFAAAAAEAAAACAAAAAAAAAAAQbmtGFDrXzwTfG4CRdVV7za2AhbbJnIPIfjeT39gcpQAAAAYAAAAAAAAAABBua0YUOtfPBN8bgJF1VXvNrYCFtsmcg8h+N5Pf2BylAAAAFWhSXFSqNynLAAAAAAAKehUAAAGIAAAA3AAAAAAAAgi1"
+		var sorobanTxData xdr.SorobanTransactionData
+		err := xdr.SafeUnmarshalBase64(sorobanTxDataXDR, &sorobanTxData)
+		require.NoError(t, err)
+
+		sorobanExt, err := xdr.NewTransactionExt(1, sorobanTxData)
+		require.NoError(t, err)
+
+		op := &txnbuild.RestoreFootprint{Ext: sorobanExt}
+		originalTx := buildTransactionForTest(t, []txnbuild.Operation{op}, txnbuild.Preconditions{
+			TimeBounds: txnbuild.NewTimeout(30),
+		})
+		txXDR, err := originalTx.Base64()
+		require.NoError(t, err)
+
+		genericTx, err := txnbuild.TransactionFromXDR(txXDR)
+		require.NoError(t, err)
+
+		channelAccount := keypair.MustRandom()
+		mChannelAccountSignatureClient.
+			On("GetAccountPublicKey", context.Background(), 30).
+			Return(channelAccount.Address(), nil).
+			Once().
+			On("NetworkPassphrase").
+			Return("networkpassphrase").
+			On("SignStellarTransaction", context.Background(), mock.AnythingOfType("*txnbuild.Transaction"), []string{channelAccount.Address()}).
+			Return(originalTx, nil).
+			Once()
+
+		mChannelAccountStore.
+			On("AssignTxToChannelAccount", context.Background(), channelAccount.Address(), mock.AnythingOfType("string")).
+			Return(nil).
+			Once()
+
+		mRPCService.
+			On("GetAccountLedgerSequence", channelAccount.Address()).
+			Return(int64(1), nil).
+			Once().
+			On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
+			Return(entities.RPCSimulateTransactionResult{MinResourceFee: "133301"}, nil).
+			Once()
+
+		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), genericTx)
+
+		mChannelAccountSignatureClient.AssertExpectations(t)
+		mChannelAccountStore.AssertExpectations(t)
+		mRPCService.AssertExpectations(t)
+		assert.NotNil(t, tx)
+		assert.NoError(t, err)
+	})
+
 	t.Run("🟢handle_max_timebound_greater_than_wallet_backend_max_timebound", func(t *testing.T) {
 		channelAccount := keypair.MustRandom()
 		signedTx := buildTransactionForTest(t, []txnbuild.Operation{buildPaymentOp(t)}, txnbuild.Preconditions{

--- a/internal/services/transaction_service_test.go
+++ b/internal/services/transaction_service_test.go
@@ -82,9 +82,7 @@ func buildPaymentOp(t *testing.T) *txnbuild.Payment {
 	}
 }
 
-// buildSimulationResponse is a helper function that returns a simulation response with one auth entry with the specified credential type.
 // buildTransactionForTest creates a transaction with the given operations and parameters
-// This helper function converts from the old test signature to the new implementation signature
 func buildTransactionForTest(t *testing.T, operations []txnbuild.Operation, preconditions txnbuild.Preconditions) *txnbuild.Transaction {
 	t.Helper()
 
@@ -103,13 +101,13 @@ func buildTransactionForTest(t *testing.T, operations []txnbuild.Operation, prec
 	return tx
 }
 
-func buildSimulationResponse(
+// buildAuthEntry builds a SorobanAuthorizationEntry with the given credential type and signer.
+func buildAuthEntry(
 	t *testing.T,
-	sorobanTxData xdr.SorobanTransactionData,
 	credentialsType xdr.SorobanCredentialsType,
 	signerType xdr.ScAddressType,
 	signerID string,
-) entities.RPCSimulateTransactionResult {
+) xdr.SorobanAuthorizationEntry {
 	t.Helper()
 
 	var sorobanCredentials xdr.SorobanCredentials
@@ -125,6 +123,7 @@ func buildSimulationResponse(
 					Type:      signerType,
 					AccountId: &authEntryAccountID,
 				},
+				Signature: xdr.ScVal{Type: xdr.ScValTypeScvVoid},
 			},
 		}
 
@@ -139,6 +138,7 @@ func buildSimulationResponse(
 					Type:       signerType,
 					ContractId: &authEntryContractID,
 				},
+				Signature: xdr.ScVal{Type: xdr.ScValTypeScvVoid},
 			},
 		}
 
@@ -149,12 +149,44 @@ func buildSimulationResponse(
 		require.Failf(t, "unsupported credentials or signer type", "credentialsType: %s, signerType: %s", credentialsType, signerType)
 	}
 
-	return entities.RPCSimulateTransactionResult{
-		TransactionData: sorobanTxData,
-		Results: []entities.RPCSimulateHostFunctionResult{
-			{Auth: []xdr.SorobanAuthorizationEntry{{Credentials: sorobanCredentials}}},
+	// Build a valid contract address for the auth entry's RootInvocation.
+	nativeAssetContractID, err := xdr.Asset{Type: xdr.AssetTypeAssetTypeNative}.ContractID(network.TestNetworkPassphrase)
+	require.NoError(t, err)
+	contractID := xdr.ContractId(nativeAssetContractID)
+
+	return xdr.SorobanAuthorizationEntry{
+		Credentials: sorobanCredentials,
+		RootInvocation: xdr.SorobanAuthorizedInvocation{
+			Function: xdr.SorobanAuthorizedFunction{
+				Type: xdr.SorobanAuthorizedFunctionTypeSorobanAuthorizedFunctionTypeContractFn,
+				ContractFn: &xdr.InvokeContractArgs{
+					ContractAddress: xdr.ScAddress{
+						Type:       xdr.ScAddressTypeScAddressTypeContract,
+						ContractId: &contractID,
+					},
+					FunctionName: "transfer",
+				},
+			},
 		},
 	}
+}
+
+// buildInvokeContractOpWithSimulation creates an InvokeHostFunction op with Auth and Ext already set,
+// simulating the state of an operation after the client has incorporated the simulation response.
+func buildInvokeContractOpWithSimulation(
+	t *testing.T,
+	sorobanTxData xdr.SorobanTransactionData,
+	credentialsType xdr.SorobanCredentialsType,
+	signerID string,
+) *txnbuild.InvokeHostFunction {
+	t.Helper()
+
+	op := buildInvokeContractOp(t)
+	ext, err := xdr.NewTransactionExt(1, sorobanTxData)
+	require.NoError(t, err)
+	op.Ext = ext
+	op.Auth = []xdr.SorobanAuthorizationEntry{buildAuthEntry(t, credentialsType, xdr.ScAddressTypeScAddressTypeAccount, signerID)}
+	return op
 }
 
 func TestValidateOptions(t *testing.T) {
@@ -275,7 +307,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		signedTx := buildTransactionForTest(t, []txnbuild.Operation{buildPaymentOp(t)}, txnbuild.Preconditions{
 			TimeBounds: txnbuild.NewTimeout(30),
 		})
-		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction(), nil)
+		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction())
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
 		assert.Empty(t, tx)
@@ -296,7 +328,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		signedTx := buildTransactionForTest(t, operations, txnbuild.Preconditions{
 			TimeBounds: txnbuild.NewTimeout(30),
 		})
-		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction(), nil)
+		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction())
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
 		assert.Empty(t, tx)
@@ -321,7 +353,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		signedTx := buildTransactionForTest(t, operations, txnbuild.Preconditions{
 			TimeBounds: txnbuild.NewTimeout(30),
 		})
-		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction(), nil)
+		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction())
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
 		assert.Empty(t, tx)
@@ -341,7 +373,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		signedTx := buildTransactionForTest(t, operations, txnbuild.Preconditions{
 			TimeBounds: txnbuild.NewTimeout(30),
 		})
-		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction(), nil)
+		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction())
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
 		assert.Empty(t, tx)
@@ -363,7 +395,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		signedTx := buildTransactionForTest(t, []txnbuild.Operation{buildPaymentOp(t)}, txnbuild.Preconditions{
 			TimeBounds: txnbuild.NewTimeout(30),
 		})
-		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction(), nil)
+		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction())
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
 		mRPCService.AssertExpectations(t)
@@ -395,7 +427,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		signedTx := buildTransactionForTest(t, []txnbuild.Operation{buildPaymentOp(t)}, txnbuild.Preconditions{
 			TimeBounds: txnbuild.NewTimeout(30),
 		})
-		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction(), nil)
+		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction())
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
 		mChannelAccountStore.AssertExpectations(t)
@@ -438,7 +470,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		signedTx := buildTransactionForTest(t, operations, txnbuild.Preconditions{
 			TimeBounds: txnbuild.NewTimeout(30),
 		})
-		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction(), nil)
+		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction())
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
 		mChannelAccountStore.AssertExpectations(t)
@@ -448,8 +480,14 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 	})
 
 	t.Run("🟢build_and_sign_soroban_tx_with_channel_account", func(t *testing.T) {
-		operations := []txnbuild.Operation{buildInvokeContractOp(t)}
-		signedTx := buildTransactionForTest(t, operations, txnbuild.Preconditions{
+		sorobanTxDataXDR := "AAAAAAAAAAEAAAAGAAAAAdeSi3LCcDzP6vfrn/TvTVBKVai5efybRQ6iyEK00c5hAAAAFAAAAAEAAAACAAAAAAAAAAAQbmtGFDrXzwTfG4CRdVV7za2AhbbJnIPIfjeT39gcpQAAAAYAAAAAAAAAABBua0YUOtfPBN8bgJF1VXvNrYCFtsmcg8h+N5Pf2BylAAAAFWhSXFSqNynLAAAAAAAKehUAAAGIAAAA3AAAAAAAAgi1"
+		var sorobanTxData xdr.SorobanTransactionData
+		err := xdr.SafeUnmarshalBase64(sorobanTxDataXDR, &sorobanTxData)
+		require.NoError(t, err)
+		require.Equal(t, xdr.Int64(133301), sorobanTxData.ResourceFee)
+
+		op := buildInvokeContractOpWithSimulation(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, keypair.MustRandom().Address())
+		signedTx := buildTransactionForTest(t, []txnbuild.Operation{op}, txnbuild.Preconditions{
 			TimeBounds: txnbuild.NewTimeout(30),
 		})
 		channelAccount := keypair.MustRandom()
@@ -477,20 +515,45 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 			Return(entities.RPCSimulateTransactionResult{MinResourceFee: "133301"}, nil).
 			Once()
 
-		sorobanTxDataXDR := "AAAAAAAAAAEAAAAGAAAAAdeSi3LCcDzP6vfrn/TvTVBKVai5efybRQ6iyEK00c5hAAAAFAAAAAEAAAACAAAAAAAAAAAQbmtGFDrXzwTfG4CRdVV7za2AhbbJnIPIfjeT39gcpQAAAAYAAAAAAAAAABBua0YUOtfPBN8bgJF1VXvNrYCFtsmcg8h+N5Pf2BylAAAAFWhSXFSqNynLAAAAAAAKehUAAAGIAAAA3AAAAAAAAgi1"
-		var sorobanTxData xdr.SorobanTransactionData
-		err := xdr.SafeUnmarshalBase64(sorobanTxDataXDR, &sorobanTxData)
-		require.NoError(t, err)
-		require.Equal(t, xdr.Int64(133301), sorobanTxData.ResourceFee)
-
-		simulationResponse := buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeAccount, keypair.MustRandom().Address())
-		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction(), &simulationResponse)
+		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction())
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
 		mChannelAccountStore.AssertExpectations(t)
 		mRPCService.AssertExpectations(t)
 		assert.Equal(t, signedTx, tx)
 		assert.NoError(t, err)
+	})
+
+	t.Run("🚨reject_soroban_tx_with_channel_account_as_auth_signer", func(t *testing.T) {
+		sorobanTxDataXDR := "AAAAAAAAAAEAAAAGAAAAAdeSi3LCcDzP6vfrn/TvTVBKVai5efybRQ6iyEK00c5hAAAAFAAAAAEAAAACAAAAAAAAAAAQbmtGFDrXzwTfG4CRdVV7za2AhbbJnIPIfjeT39gcpQAAAAYAAAAAAAAAABBua0YUOtfPBN8bgJF1VXvNrYCFtsmcg8h+N5Pf2BylAAAAFWhSXFSqNynLAAAAAAAKehUAAAGIAAAA3AAAAAAAAgi1"
+		var sorobanTxData xdr.SorobanTransactionData
+		err := xdr.SafeUnmarshalBase64(sorobanTxDataXDR, &sorobanTxData)
+		require.NoError(t, err)
+
+		channelAccount := keypair.MustRandom()
+
+		// Build a Soroban tx where the channel account is a signer in the auth entries — this should be rejected.
+		op := buildInvokeContractOpWithSimulation(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, channelAccount.Address())
+		signedTx := buildTransactionForTest(t, []txnbuild.Operation{op}, txnbuild.Preconditions{
+			TimeBounds: txnbuild.NewTimeout(30),
+		})
+
+		mChannelAccountSignatureClient.
+			On("GetAccountPublicKey", context.Background(), 30).
+			Return(channelAccount.Address(), nil).
+			Once()
+
+		mRPCService.
+			On("GetAccountLedgerSequence", channelAccount.Address()).
+			Return(int64(1), nil).
+			Once()
+
+		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction())
+
+		mChannelAccountSignatureClient.AssertExpectations(t)
+		mRPCService.AssertExpectations(t)
+		assert.Empty(t, tx)
+		assert.ErrorContains(t, err, sorobanauth.ErrForbiddenSigner.Error())
 	})
 
 	t.Run("🟢handle_max_timebound_greater_than_wallet_backend_max_timebound", func(t *testing.T) {
@@ -533,7 +596,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 			Return(int64(1), nil).
 			Once()
 
-		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction(), nil)
+		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction())
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
 		mChannelAccountStore.AssertExpectations(t)
@@ -553,11 +616,13 @@ func Test_transactionService_adjustParamsForSoroban(t *testing.T) {
 	require.NoError(t, outerErr)
 	require.Equal(t, xdr.Int64(133301), sorobanTxData.ResourceFee)
 
+	sorobanExt, outerErr := xdr.NewTransactionExt(1, sorobanTxData)
+	require.NoError(t, outerErr)
+
 	testCases := []struct {
 		name                string
 		baseFee             int64
 		incomingOps         []txnbuild.Operation
-		simulationResponse  entities.RPCSimulateTransactionResult
 		setupRPCMock        func(t *testing.T, m *RPCServiceMock)
 		wantBuildTxParamsFn func(t *testing.T, initialBuildTxParams txnbuild.TransactionParams) txnbuild.TransactionParams
 		wantErrContains     string
@@ -591,64 +656,43 @@ func Test_transactionService_adjustParamsForSoroban(t *testing.T) {
 			wantErrContains: "invalid Soroban transaction: must have exactly one operation (2 provided)",
 		},
 		{
-			name:    "🔴handle_simulateTransaction_err",
+			name:    "🔴missing_soroban_transaction_data",
 			baseFee: txnbuild.MinBaseFee,
 			incomingOps: []txnbuild.Operation{
-				buildInvokeContractOp(t),
+				buildInvokeContractOp(t), // no Ext set
 			},
-			simulationResponse: entities.RPCSimulateTransactionResult{},
-			wantErrContains:    "invalid Soroban transaction: simulation response cannot be empty",
-		},
-		{
-			name:    "🔴handle_simulateTransaction_error_in_payload",
-			baseFee: txnbuild.MinBaseFee,
-			incomingOps: []txnbuild.Operation{
-				buildInvokeContractOp(t),
-			},
-			simulationResponse: entities.RPCSimulateTransactionResult{
-				Error: "simulate transaction failed because fooBar",
-			},
-			wantErrContains: "invalid Soroban transaction: simulation failed: simulate transaction failed because fooBar",
+			wantErrContains: "missing SorobanTransactionData in operation Ext field",
 		},
 		{
 			name:    "🚨catch_txSource=channelAccount(AuthEntry)",
 			baseFee: txnbuild.MinBaseFee,
 			incomingOps: []txnbuild.Operation{
-				buildInvokeContractOp(t),
+				buildInvokeContractOpWithSimulation(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, chAccPublicKey),
 			},
-			simulationResponse: buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeAccount, chAccPublicKey),
-			wantErrContains:    sorobanauth.ErrForbiddenSigner.Error(),
+			wantErrContains: sorobanauth.ErrForbiddenSigner.Error(),
 		},
 		{
 			name:    "🚨catch_txSource=channelAccount(SourceAccount)",
 			baseFee: txnbuild.MinBaseFee,
 			incomingOps: []txnbuild.Operation{
-				buildInvokeContractOp(t),
+				buildInvokeContractOpWithSimulation(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsSourceAccount, ""),
 			},
-			simulationResponse: buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsSourceAccount, 0, ""),
-			wantErrContains:    sorobanauth.ErrForbiddenSigner.Error(),
+			wantErrContains: sorobanauth.ErrForbiddenSigner.Error(),
 		},
 		{
 			name:    "🟢successful_InvokeHostFunction_largeBaseFee",
 			baseFee: 1000000,
 			incomingOps: []txnbuild.Operation{
-				buildInvokeContractOp(t),
+				buildInvokeContractOpWithSimulation(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, keypair.MustRandom().Address()),
 			},
-			simulationResponse: buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeAccount, keypair.MustRandom().Address()),
 			setupRPCMock: func(t *testing.T, m *RPCServiceMock) {
 				m.On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
 					Return(entities.RPCSimulateTransactionResult{MinResourceFee: "133301"}, nil).Once()
 			},
 			wantBuildTxParamsFn: func(t *testing.T, initialBuildTxParams txnbuild.TransactionParams) txnbuild.TransactionParams {
-				newInvokeContractOp := buildInvokeContractOp(t)
-				require.Empty(t, newInvokeContractOp.Ext)
-				var err error
-				newInvokeContractOp.Ext, err = xdr.NewTransactionExt(1, sorobanTxData)
-				require.NoError(t, err)
-
 				return txnbuild.TransactionParams{
-					Operations: []txnbuild.Operation{newInvokeContractOp},
-					BaseFee:    1000000 - 133301, // original base fee - soroban fee
+					Operations: initialBuildTxParams.Operations, // op already has Ext set
+					BaseFee:    1000000 - 133301,                // original base fee - soroban fee
 					SourceAccount: &txnbuild.SimpleAccount{
 						AccountID: txSourceAccount,
 						Sequence:  1,
@@ -663,21 +707,15 @@ func Test_transactionService_adjustParamsForSoroban(t *testing.T) {
 			name:    "🟢successful_ExtendFootprintTtl_largeBaseFee",
 			baseFee: 1000000,
 			incomingOps: []txnbuild.Operation{
-				&txnbuild.ExtendFootprintTtl{ExtendTo: 1840580937},
+				&txnbuild.ExtendFootprintTtl{ExtendTo: 1840580937, Ext: sorobanExt},
 			},
-			simulationResponse: buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeAccount, keypair.MustRandom().Address()),
 			setupRPCMock: func(t *testing.T, m *RPCServiceMock) {
 				m.On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
 					Return(entities.RPCSimulateTransactionResult{MinResourceFee: "133301"}, nil).Once()
 			},
 			wantBuildTxParamsFn: func(t *testing.T, initialBuildTxParams txnbuild.TransactionParams) txnbuild.TransactionParams {
-				newExtendFootprintTTLOp := &txnbuild.ExtendFootprintTtl{ExtendTo: 1840580937}
-				var err error
-				newExtendFootprintTTLOp.Ext, err = xdr.NewTransactionExt(1, sorobanTxData)
-				require.NoError(t, err)
-
 				return txnbuild.TransactionParams{
-					Operations: []txnbuild.Operation{newExtendFootprintTTLOp},
+					Operations: initialBuildTxParams.Operations, // op already has Ext set
 					BaseFee:    1000000 - 133301,
 					SourceAccount: &txnbuild.SimpleAccount{
 						AccountID: txSourceAccount,
@@ -693,21 +731,15 @@ func Test_transactionService_adjustParamsForSoroban(t *testing.T) {
 			name:    "🟢successful_RestoreFootprint_largeBaseFee",
 			baseFee: 1000000,
 			incomingOps: []txnbuild.Operation{
-				&txnbuild.RestoreFootprint{},
+				&txnbuild.RestoreFootprint{Ext: sorobanExt},
 			},
-			simulationResponse: buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeAccount, keypair.MustRandom().Address()),
 			setupRPCMock: func(t *testing.T, m *RPCServiceMock) {
 				m.On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
 					Return(entities.RPCSimulateTransactionResult{MinResourceFee: "133301"}, nil).Once()
 			},
 			wantBuildTxParamsFn: func(t *testing.T, initialBuildTxParams txnbuild.TransactionParams) txnbuild.TransactionParams {
-				newRestoreFootprintOp := &txnbuild.RestoreFootprint{}
-				var err error
-				newRestoreFootprintOp.Ext, err = xdr.NewTransactionExt(1, sorobanTxData)
-				require.NoError(t, err)
-
 				return txnbuild.TransactionParams{
-					Operations: []txnbuild.Operation{newRestoreFootprintOp},
+					Operations: initialBuildTxParams.Operations, // op already has Ext set
 					BaseFee:    1000000 - 133301,
 					SourceAccount: &txnbuild.SimpleAccount{
 						AccountID: txSourceAccount,
@@ -723,21 +755,15 @@ func Test_transactionService_adjustParamsForSoroban(t *testing.T) {
 			name:    "🟢successful_RestoreFootprint_largeBaseFee_signedByContractAuthEntry",
 			baseFee: 1000000,
 			incomingOps: []txnbuild.Operation{
-				&txnbuild.RestoreFootprint{},
+				&txnbuild.RestoreFootprint{Ext: sorobanExt},
 			},
-			simulationResponse: buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeContract, "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"),
 			setupRPCMock: func(t *testing.T, m *RPCServiceMock) {
 				m.On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
 					Return(entities.RPCSimulateTransactionResult{MinResourceFee: "133301"}, nil).Once()
 			},
 			wantBuildTxParamsFn: func(t *testing.T, initialBuildTxParams txnbuild.TransactionParams) txnbuild.TransactionParams {
-				newRestoreFootprintOp := &txnbuild.RestoreFootprint{}
-				var err error
-				newRestoreFootprintOp.Ext, err = xdr.NewTransactionExt(1, sorobanTxData)
-				require.NoError(t, err)
-
 				return txnbuild.TransactionParams{
-					Operations: []txnbuild.Operation{newRestoreFootprintOp},
+					Operations: initialBuildTxParams.Operations, // op already has Ext set
 					BaseFee:    1000000 - 133301,
 					SourceAccount: &txnbuild.SimpleAccount{
 						AccountID: txSourceAccount,
@@ -753,11 +779,10 @@ func Test_transactionService_adjustParamsForSoroban(t *testing.T) {
 			name:    "🚨rejects_inflated_ResourceFee_above_server_resim_bound",
 			baseFee: 10_000_000,
 			incomingOps: []txnbuild.Operation{
-				buildInvokeContractOp(t),
+				buildInvokeContractOpWithSimulation(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, keypair.MustRandom().Address()),
 			},
 			// Client-declared ResourceFee is 133301 (inside sorobanTxData), but server re-sim reports a MinResourceFee
 			// of "50000". With safety_factor=2, maxAllowed = min(100000, 10_000_000) = 100000. 133301 > 100000 → reject.
-			simulationResponse: buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeAccount, keypair.MustRandom().Address()),
 			setupRPCMock: func(t *testing.T, m *RPCServiceMock) {
 				m.On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
 					Return(entities.RPCSimulateTransactionResult{MinResourceFee: "50000"}, nil).Once()
@@ -768,11 +793,10 @@ func Test_transactionService_adjustParamsForSoroban(t *testing.T) {
 			name:    "🚨rejects_ResourceFee_above_base_fee_cap",
 			baseFee: 100_000,
 			incomingOps: []txnbuild.Operation{
-				buildInvokeContractOp(t),
+				buildInvokeContractOpWithSimulation(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, keypair.MustRandom().Address()),
 			},
 			// Client-declared ResourceFee = 133301. baseFee cap = 100000. Server returns high MinResourceFee that
 			// would *allow* it via safety factor, but hard cap at t.BaseFee should still reject.
-			simulationResponse: buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeAccount, keypair.MustRandom().Address()),
 			setupRPCMock: func(t *testing.T, m *RPCServiceMock) {
 				m.On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
 					Return(entities.RPCSimulateTransactionResult{MinResourceFee: "133301"}, nil).Once()
@@ -783,9 +807,8 @@ func Test_transactionService_adjustParamsForSoroban(t *testing.T) {
 			name:    "🚨rejects_when_server_resim_returns_payload_error",
 			baseFee: 1_000_000,
 			incomingOps: []txnbuild.Operation{
-				buildInvokeContractOp(t),
+				buildInvokeContractOpWithSimulation(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, keypair.MustRandom().Address()),
 			},
-			simulationResponse: buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeAccount, keypair.MustRandom().Address()),
 			setupRPCMock: func(t *testing.T, m *RPCServiceMock) {
 				m.On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
 					Return(entities.RPCSimulateTransactionResult{Error: "server said no"}, nil).Once()
@@ -796,9 +819,8 @@ func Test_transactionService_adjustParamsForSoroban(t *testing.T) {
 			name:    "🚨rejects_when_server_resim_rpc_error",
 			baseFee: 1_000_000,
 			incomingOps: []txnbuild.Operation{
-				buildInvokeContractOp(t),
+				buildInvokeContractOpWithSimulation(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, keypair.MustRandom().Address()),
 			},
-			simulationResponse: buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeAccount, keypair.MustRandom().Address()),
 			setupRPCMock: func(t *testing.T, m *RPCServiceMock) {
 				m.On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
 					Return(entities.RPCSimulateTransactionResult{}, errors.New("rpc down")).Once()
@@ -832,7 +854,7 @@ func Test_transactionService_adjustParamsForSoroban(t *testing.T) {
 				},
 			}
 
-			buildTxParams, err := txService.adjustParamsForSoroban(context.Background(), chAccPublicKey, incomingBuildTxParams, tc.simulationResponse)
+			buildTxParams, err := txService.adjustParamsForSoroban(context.Background(), chAccPublicKey, incomingBuildTxParams)
 			if tc.wantErrContains != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErrContains)

--- a/pkg/sorobanauth/sorobanauth.go
+++ b/pkg/sorobanauth/sorobanauth.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
-	"github.com/stellar/wallet-backend/internal/entities"
 	pkgUtils "github.com/stellar/wallet-backend/pkg/utils"
 )
 
@@ -132,9 +131,9 @@ func ptr[T any](v T) *T {
 	return &v
 }
 
-// CheckForForbiddenSigners checks if the auth entries in the simulation response expect a forbidden signer.
+// CheckForForbiddenSigners checks if the auth entries expect a forbidden signer.
 func CheckForForbiddenSigners(
-	simulationResponseResults []entities.RPCSimulateHostFunctionResult,
+	authEntries []xdr.SorobanAuthorizationEntry,
 	opSourceAccount string,
 	forbiddenSigners ...string,
 ) error {
@@ -145,26 +144,24 @@ func CheckForForbiddenSigners(
 		return fmt.Errorf("resolving operation source account: %w", err)
 	}
 
-	for _, res := range simulationResponseResults {
-		for _, auth := range res.Auth {
-			switch auth.Credentials.Type {
-			case xdr.SorobanCredentialsTypeSorobanCredentialsSourceAccount:
-				if slices.Contains(append(forbiddenSigners, ""), opSourceGAddress) {
-					return fmt.Errorf("handling %s: %w", auth.Credentials.Type.String(), ErrForbiddenSigner)
-				}
-
-			case xdr.SorobanCredentialsTypeSorobanCredentialsAddress:
-				if auth.Credentials.Address == nil {
-					return fmt.Errorf("unable to get auth entry signer because credential address is nil")
-				} else if authEntrySigner, err := auth.Credentials.Address.Address.String(); err != nil {
-					return fmt.Errorf("unable to get auth entry signer string: %w", err)
-				} else if slices.Contains(forbiddenSigners, authEntrySigner) {
-					return fmt.Errorf("handling %s: %w", auth.Credentials.Type.String(), ErrForbiddenSigner)
-				}
-
-			default:
-				return fmt.Errorf("unsupported auth entry type %d", auth.Credentials.Type)
+	for _, auth := range authEntries {
+		switch auth.Credentials.Type {
+		case xdr.SorobanCredentialsTypeSorobanCredentialsSourceAccount:
+			if slices.Contains(append(forbiddenSigners, ""), opSourceGAddress) {
+				return fmt.Errorf("handling %s: %w", auth.Credentials.Type.String(), ErrForbiddenSigner)
 			}
+
+		case xdr.SorobanCredentialsTypeSorobanCredentialsAddress:
+			if auth.Credentials.Address == nil {
+				return fmt.Errorf("unable to get auth entry signer because credential address is nil")
+			} else if authEntrySigner, err := auth.Credentials.Address.Address.String(); err != nil {
+				return fmt.Errorf("unable to get auth entry signer string: %w", err)
+			} else if slices.Contains(forbiddenSigners, authEntrySigner) {
+				return fmt.Errorf("handling %s: %w", auth.Credentials.Type.String(), ErrForbiddenSigner)
+			}
+
+		default:
+			return fmt.Errorf("unsupported auth entry type %d", auth.Credentials.Type)
 		}
 	}
 	return nil

--- a/pkg/sorobanauth/sorobanauth_test.go
+++ b/pkg/sorobanauth/sorobanauth_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/stellar/wallet-backend/internal/entities"
 )
 
 func Test_AuthSigner_AuthorizeEntry(t *testing.T) {
@@ -130,22 +128,18 @@ func Test_CheckForForbiddenSigners(t *testing.T) {
 	require.NoError(t, err)
 
 	testCases := []struct {
-		name                      string
-		simulationResponseResults []entities.RPCSimulateHostFunctionResult
-		opSourceAccount           string
-		forbiddenSigners          []string
-		wantErrContains           string
+		name             string
+		authEntries      []xdr.SorobanAuthorizationEntry
+		opSourceAccount  string
+		forbiddenSigners []string
+		wantErrContains  string
 	}{
 		{
 			name: "🔴CredentialsSourceAccount/opSourceAccount_cannot_be_empty",
-			simulationResponseResults: []entities.RPCSimulateHostFunctionResult{
+			authEntries: []xdr.SorobanAuthorizationEntry{
 				{
-					Auth: []xdr.SorobanAuthorizationEntry{
-						{
-							Credentials: xdr.SorobanCredentials{
-								Type: xdr.SorobanCredentialsTypeSorobanCredentialsSourceAccount,
-							},
-						},
+					Credentials: xdr.SorobanCredentials{
+						Type: xdr.SorobanCredentialsTypeSorobanCredentialsSourceAccount,
 					},
 				},
 			},
@@ -155,14 +149,10 @@ func Test_CheckForForbiddenSigners(t *testing.T) {
 		},
 		{
 			name: "🟢CredentialsSourceAccount/opSourceAccount_allowedSigner1",
-			simulationResponseResults: []entities.RPCSimulateHostFunctionResult{
+			authEntries: []xdr.SorobanAuthorizationEntry{
 				{
-					Auth: []xdr.SorobanAuthorizationEntry{
-						{
-							Credentials: xdr.SorobanCredentials{
-								Type: xdr.SorobanCredentialsTypeSorobanCredentialsSourceAccount,
-							},
-						},
+					Credentials: xdr.SorobanCredentials{
+						Type: xdr.SorobanCredentialsTypeSorobanCredentialsSourceAccount,
 					},
 				},
 			},
@@ -171,14 +161,10 @@ func Test_CheckForForbiddenSigners(t *testing.T) {
 		},
 		{
 			name: "🔴CredentialsAddress/empty_address",
-			simulationResponseResults: []entities.RPCSimulateHostFunctionResult{
+			authEntries: []xdr.SorobanAuthorizationEntry{
 				{
-					Auth: []xdr.SorobanAuthorizationEntry{
-						{
-							Credentials: xdr.SorobanCredentials{
-								Type: xdr.SorobanCredentialsTypeSorobanCredentialsAddress,
-							},
-						},
+					Credentials: xdr.SorobanCredentials{
+						Type: xdr.SorobanCredentialsTypeSorobanCredentialsAddress,
 					},
 				},
 			},
@@ -188,18 +174,14 @@ func Test_CheckForForbiddenSigners(t *testing.T) {
 		},
 		{
 			name: "🔴CredentialsAddress/opSourceAccount_forbiddenSigner1",
-			simulationResponseResults: []entities.RPCSimulateHostFunctionResult{
+			authEntries: []xdr.SorobanAuthorizationEntry{
 				{
-					Auth: []xdr.SorobanAuthorizationEntry{
-						{
-							Credentials: xdr.SorobanCredentials{
-								Type: xdr.SorobanCredentialsTypeSorobanCredentialsAddress,
-								Address: &xdr.SorobanAddressCredentials{
-									Address: xdr.ScAddress{
-										Type:      xdr.ScAddressTypeScAddressTypeAccount,
-										AccountId: &forbiddenSigner1AccountID,
-									},
-								},
+					Credentials: xdr.SorobanCredentials{
+						Type: xdr.SorobanCredentialsTypeSorobanCredentialsAddress,
+						Address: &xdr.SorobanAddressCredentials{
+							Address: xdr.ScAddress{
+								Type:      xdr.ScAddressTypeScAddressTypeAccount,
+								AccountId: &forbiddenSigner1AccountID,
 							},
 						},
 					},
@@ -211,18 +193,14 @@ func Test_CheckForForbiddenSigners(t *testing.T) {
 		},
 		{
 			name: "🟢CredentialsAddress/opSourceAccount_allowedSigner2",
-			simulationResponseResults: []entities.RPCSimulateHostFunctionResult{
+			authEntries: []xdr.SorobanAuthorizationEntry{
 				{
-					Auth: []xdr.SorobanAuthorizationEntry{
-						{
-							Credentials: xdr.SorobanCredentials{
-								Type: xdr.SorobanCredentialsTypeSorobanCredentialsAddress,
-								Address: &xdr.SorobanAddressCredentials{
-									Address: xdr.ScAddress{
-										Type:      xdr.ScAddressTypeScAddressTypeAccount,
-										AccountId: &allowedSigner2AccountID,
-									},
-								},
+					Credentials: xdr.SorobanCredentials{
+						Type: xdr.SorobanCredentialsTypeSorobanCredentialsAddress,
+						Address: &xdr.SorobanAddressCredentials{
+							Address: xdr.ScAddress{
+								Type:      xdr.ScAddressTypeScAddressTypeAccount,
+								AccountId: &allowedSigner2AccountID,
 							},
 						},
 					},
@@ -233,14 +211,10 @@ func Test_CheckForForbiddenSigners(t *testing.T) {
 		},
 		{
 			name: "🔴CredentialsSourceAccount/opSourceAccount_muxed_forbidden_signer",
-			simulationResponseResults: []entities.RPCSimulateHostFunctionResult{
+			authEntries: []xdr.SorobanAuthorizationEntry{
 				{
-					Auth: []xdr.SorobanAuthorizationEntry{
-						{
-							Credentials: xdr.SorobanCredentials{
-								Type: xdr.SorobanCredentialsTypeSorobanCredentialsSourceAccount,
-							},
-						},
+					Credentials: xdr.SorobanCredentials{
+						Type: xdr.SorobanCredentialsTypeSorobanCredentialsSourceAccount,
 					},
 				},
 			},
@@ -254,14 +228,10 @@ func Test_CheckForForbiddenSigners(t *testing.T) {
 		},
 		{
 			name: "🟢CredentialsSourceAccount/opSourceAccount_muxed_allowed_signer",
-			simulationResponseResults: []entities.RPCSimulateHostFunctionResult{
+			authEntries: []xdr.SorobanAuthorizationEntry{
 				{
-					Auth: []xdr.SorobanAuthorizationEntry{
-						{
-							Credentials: xdr.SorobanCredentials{
-								Type: xdr.SorobanCredentialsTypeSorobanCredentialsSourceAccount,
-							},
-						},
+					Credentials: xdr.SorobanCredentials{
+						Type: xdr.SorobanCredentialsTypeSorobanCredentialsSourceAccount,
 					},
 				},
 			},
@@ -274,14 +244,10 @@ func Test_CheckForForbiddenSigners(t *testing.T) {
 		},
 		{
 			name: "🔴CredentialsUnsupported",
-			simulationResponseResults: []entities.RPCSimulateHostFunctionResult{
+			authEntries: []xdr.SorobanAuthorizationEntry{
 				{
-					Auth: []xdr.SorobanAuthorizationEntry{
-						{
-							Credentials: xdr.SorobanCredentials{
-								Type: 3,
-							},
-						},
+					Credentials: xdr.SorobanCredentials{
+						Type: 3,
 					},
 				},
 			},
@@ -291,7 +257,7 @@ func Test_CheckForForbiddenSigners(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := CheckForForbiddenSigners(tc.simulationResponseResults, tc.opSourceAccount, tc.forbiddenSigners...)
+			err := CheckForForbiddenSigners(tc.authEntries, tc.opSourceAccount, tc.forbiddenSigners...)
 			if tc.wantErrContains != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErrContains)

--- a/pkg/wbclient/client.go
+++ b/pkg/wbclient/client.go
@@ -10,9 +10,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/stellar/go-stellar-sdk/xdr"
-
-	"github.com/stellar/wallet-backend/internal/entities"
 	"github.com/stellar/wallet-backend/internal/utils"
 	"github.com/stellar/wallet-backend/pkg/wbclient/auth"
 	"github.com/stellar/wallet-backend/pkg/wbclient/types"
@@ -152,59 +149,10 @@ func NewClient(baseURL string, requestSigner auth.HTTPRequestSigner) *Client {
 	}
 }
 
-func buildSimulationResultMap(simResult entities.RPCSimulateTransactionResult) (map[string]interface{}, error) {
-	result := make(map[string]interface{})
-
-	if !utils.IsEmpty(simResult.TransactionData) {
-		if txDataStr, err := xdr.MarshalBase64(simResult.TransactionData); err != nil {
-			return nil, fmt.Errorf("marshaling transaction data: %w", err)
-		} else {
-			result["transactionData"] = txDataStr
-		}
-	}
-
-	if len(simResult.Events) > 0 {
-		result["events"] = simResult.Events
-	}
-
-	if simResult.MinResourceFee != "" {
-		result["minResourceFee"] = simResult.MinResourceFee
-	}
-
-	if len(simResult.Results) > 0 {
-		// Convert RPCSimulateHostFunctionResult as GraphQL expects JSON
-		results := make([]string, len(simResult.Results))
-		for i, result := range simResult.Results {
-			if resultJSON, err := json.Marshal(result); err != nil {
-				return nil, fmt.Errorf("marshaling simulation result %d: %w", i, err)
-			} else {
-				results[i] = string(resultJSON)
-			}
-		}
-		result["results"] = results
-	}
-
-	if simResult.LatestLedger != 0 {
-		result["latestLedger"] = simResult.LatestLedger
-	}
-
-	if simResult.Error != "" {
-		result["error"] = simResult.Error
-	}
-
-	return result, nil
-}
-
 func (c *Client) BuildTransaction(ctx context.Context, transaction types.Transaction) (*types.BuildTransactionResponse, error) {
-	simulationResult, err := buildSimulationResultMap(transaction.SimulationResult)
-	if err != nil {
-		return nil, err
-	}
-
 	variables := map[string]interface{}{
 		"input": map[string]interface{}{
-			"transactionXdr":   transaction.TransactionXdr,
-			"simulationResult": simulationResult,
+			"transactionXdr": transaction.TransactionXdr,
 		},
 	}
 

--- a/pkg/wbclient/types/types.go
+++ b/pkg/wbclient/types/types.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
-
-	"github.com/stellar/wallet-backend/internal/entities"
 )
 
 // OperationType represents the type of Stellar operation
@@ -218,8 +216,7 @@ type Account struct {
 
 // Transaction represents a Stellar transaction
 type Transaction struct {
-	TransactionXdr   string                                `json:"transactionXdr" validate:"required"`
-	SimulationResult entities.RPCSimulateTransactionResult `json:"simulationResult,omitempty"`
+	TransactionXdr string `json:"transactionXdr" validate:"required"`
 }
 
 // GraphQLTransaction represents a transaction from the GraphQL API


### PR DESCRIPTION
Closes #565 

### What
- Remove `simulationResult` from `BuildTransactionInput` and delete the `SimulationResultInput` GraphQL type — clients now incorporate simulation data into the transaction XDR before submitting, matching how Stellar SDKs already work                                   
- Extract `SorobanTransactionData` and auth entries directly from the operation's `Ext` and `Auth` fields instead of receiving them a separate input, eliminating the `convertSimulationResult` conversion layer                                                           
- Simplify `CheckForForbiddenSigners` to accept `[]xdr.SorobanAuthorizationEntry` directly instead of `[]entities.RPCSimulateHostFunctionResult`                                                                                            
- Add end-to-end integration test proving forbidden signer rejection works through `BuildAndSignTransactionWithChannelAccount`

### Why
The previous interface required clients to pass simulation metadata as a separate structured input alongside the transaction XDR. This was redundant since client-side SDKs already incorporate simulation response data into the transaction, and it created a conversion layer (`convertSimulationResult`) where fields could be dropped. 

### Known limitations
N/A

### Issue that this PR addresses
https://github.com/stellar/wallet-backend/issues/565

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
