### PR TITLE
Remove `balanceByAccountAddress` endpoint and make it callable from the `accountByAddress` query

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ The wallet-backend includes several internal services that power its high-perfor
 The wallet-backend implements a high-performance **Account Token Cache** system that enables fast retrieval of account balances across all token types. This Redis-backed cache tracks every account's token holdings, including native XLM, classic trustlines, and Stellar Asset Contract (SAC) tokens.
 
 **Why it exists:**
-- **Fast Balance Queries**: Enables sub-second response times for the GraphQL query `balancesByAccountAddress`
+- **Fast Balance Queries**: Enables sub-second response times for the GraphQL query shape `accountByAddress { balances }`
 - **Complete Token Coverage**: Tracks all token types an account holds without expensive RPC lookups
 - **Efficient Updates**: Incrementally updates during live ingestion without rescanning the entire ledger
 - **Horizontal Scalability**: Redis-based architecture supports distributed deployments
@@ -284,7 +284,7 @@ flowchart TD
 
 #### GraphQL Integration
 
-The Account Token Cache powers the [`balancesByAccountAddress`](#7-get-account-balances) GraphQL query. See the [Get Account Balances](#7-get-account-balances) section for query examples and response formats.
+The Account Token Cache powers the `accountByAddress { balances }` GraphQL query shape. See the [Get Account Balances](#7-get-account-balances) section for query examples and response formats.
 
 #### Storage Optimization Strategies
 
@@ -552,7 +552,7 @@ The wallet-backend implements a **Contract Validator Service** that validates wh
 - **Automatic Token Classification**: Identifies which contracts follow the SEP-41 fungible token standard without manual configuration
 - **Standards Compliance**: Ensures contracts expose the required token interface (balance, transfer, decimals, etc.)
 - **Balance Tracking**: Only SEP-41-compliant contracts are tracked in the account token cache for balance queries
-- **Integration with GraphQL**: Powers the [`balancesByAccountAddress`](#7-get-account-balances) query by distinguishing SEP-41 tokens from unknown contracts
+- **Integration with GraphQL**: Powers the `accountByAddress { balances }` query shape by distinguishing SEP-41 tokens from unknown contracts
 
 #### How Validation Works
 
@@ -778,7 +778,7 @@ This is handled automatically in `PopulateAccountTokens()`.
 
 ### Contract Metadata Service
 
-The wallet-backend implements a **Contract Metadata Service** that fetches and stores rich metadata for Stellar Asset Contract (SAC) and SEP-41 token contracts. This service enriches the [Account Token Cache](#account-token-cache) by providing human-readable token information (name, symbol, decimals) that powers the [`balancesByAccountAddress`](#7-get-account-balances) GraphQL query.
+The wallet-backend implements a **Contract Metadata Service** that fetches and stores rich metadata for Stellar Asset Contract (SAC) and SEP-41 token contracts. This service enriches the [Account Token Cache](#account-token-cache) by providing human-readable token information (name, symbol, decimals) that powers the `accountByAddress { balances }` GraphQL query shape.
 
 **Why it exists:**
 - **Rich Token Information**: Provides name, symbol, and decimals for contract tokens without requiring clients to fetch this data
@@ -934,17 +934,19 @@ This allows the GraphQL API to return both the contract address and the underlyi
 
 #### Integration with GraphQL Balances
 
-Contract metadata stored in `contract_tokens` enriches the [`balancesByAccountAddress`](#7-get-account-balances) query:
+Contract metadata stored in `contract_tokens` enriches the `accountByAddress { balances }` query shape:
 
 **For SAC Balances:**
 ```graphql
 {
-  balancesByAccountAddress(address: "GABC...") {
-    ... on SACBalance {
-      code       # From contract_tokens.code
-      issuer     # From contract_tokens.issuer
-      decimals   # From contract_tokens.decimals
-      balance    # From RPC ledger entry
+  accountByAddress(address: "GABC...") {
+    balances {
+      ... on SACBalance {
+        code       # From contract_tokens.code
+        issuer     # From contract_tokens.issuer
+        decimals   # From contract_tokens.decimals
+        balance    # From RPC ledger entry
+      }
     }
   }
 }
@@ -953,12 +955,14 @@ Contract metadata stored in `contract_tokens` enriches the [`balancesByAccountAd
 **For SEP-41 Balances:**
 ```graphql
 {
-  balancesByAccountAddress(address: "GABC...") {
-    ... on SEP41Balance {
-      name       # From contract_tokens.name
-      symbol     # From contract_tokens.symbol
-      decimals   # From contract_tokens.decimals
-      balance    # From RPC ledger entry
+  accountByAddress(address: "GABC...") {
+    balances {
+      ... on SEP41Balance {
+        name       # From contract_tokens.name
+        symbol     # From contract_tokens.symbol
+        decimals   # From contract_tokens.decimals
+        balance    # From RPC ledger entry
+      }
     }
   }
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -34,7 +34,6 @@ func (c *serveCmd) Command() *cobra.Command {
 		utils.StellarEnvironmentOption(&stellarEnvironment),
 		utils.ServerBaseURLOption(&cfg.ServerBaseURL),
 		utils.GraphQLComplexityLimitOption(&cfg.GraphQLComplexityLimit),
-		utils.MaxGraphQLWorkerPoolSizeOption(&cfg.MaxGraphQLWorkerPoolSize),
 		{
 			Name:        "port",
 			Usage:       "Port to listen and serve on",

--- a/cmd/utils/global_options.go
+++ b/cmd/utils/global_options.go
@@ -235,7 +235,7 @@ func GraphQLComplexityLimitOption(configKey *int) *config.ConfigOption {
 		Usage:       "The maximum complexity limit for GraphQL queries. Complexity is calculated based on fields and pagination parameters.",
 		OptType:     types.Int,
 		ConfigKey:   configKey,
-		FlagDefault: 1000,
+		FlagDefault: 5000,
 		Required:    false,
 	}
 }

--- a/cmd/utils/global_options.go
+++ b/cmd/utils/global_options.go
@@ -240,17 +240,6 @@ func GraphQLComplexityLimitOption(configKey *int) *config.ConfigOption {
 	}
 }
 
-func MaxGraphQLWorkerPoolSizeOption(configKey *int) *config.ConfigOption {
-	return &config.ConfigOption{
-		Name:        "max-graphql-worker-pool-size",
-		Usage:       "Maximum number of concurrent workers for GraphQL parallel operations.",
-		OptType:     types.Int,
-		ConfigKey:   configKey,
-		FlagDefault: 100,
-		Required:    false,
-	}
-}
-
 func DistributionAccountSignatureProviderOption(scOpts *SignatureClientOptions) config.ConfigOptions {
 	opts := config.ConfigOptions{}
 	opts = append(opts, DistributionAccountPublicKeyOption(&scOpts.DistributionAccountPublicKey))

--- a/internal/data/account_contract_tokens.go
+++ b/internal/data/account_contract_tokens.go
@@ -20,6 +20,10 @@ import (
 type AccountContractTokensModelInterface interface {
 	// Read operations (for API/balances queries)
 	GetByAccount(ctx context.Context, accountAddress string) ([]*Contract, error)
+	// GetSEP41ByAccount returns only SEP-41 contracts ordered by the
+	// junction-table contract UUID so the GraphQL balances connection can page
+	// without loading every contract membership first.
+	GetSEP41ByAccount(ctx context.Context, accountAddress string, limit *int32, cursor *uuid.UUID, sortOrder SortOrder) ([]*Contract, error)
 
 	// Write operations (for initial population and live ingestion)
 	BatchInsert(ctx context.Context, dbTx pgx.Tx, contractsByAccount map[string][]uuid.UUID) error
@@ -54,6 +58,57 @@ func (m *AccountContractTokensModel) GetByAccount(ctx context.Context, accountAd
 	if err != nil {
 		m.Metrics.QueryErrors.WithLabelValues("GetByAccount", "account_contract_tokens", utils.GetDBErrorType(err)).Inc()
 		return nil, fmt.Errorf("querying contracts for %s: %w", accountAddress, err)
+	}
+	return contracts, nil
+}
+
+// GetSEP41ByAccount retrieves SEP-41 contracts for an account ordered
+// by contract UUID. The cursor is the last seen contract UUID from the previous page.
+func (m *AccountContractTokensModel) GetSEP41ByAccount(ctx context.Context, accountAddress string, limit *int32, cursor *uuid.UUID, sortOrder SortOrder) ([]*Contract, error) {
+	if accountAddress == "" {
+		return nil, fmt.Errorf("empty account address")
+	}
+
+	query := `
+		SELECT ct.id, ct.contract_id, ct.type, ct.code, ct.issuer,
+		       ct.name, ct.symbol, ct.decimals, ct.created_at, ct.updated_at
+		FROM account_contract_tokens ac
+		INNER JOIN contract_tokens ct ON ct.id = ac.contract_id
+		WHERE ac.account_address = $1
+		  AND ct.type = 'SEP41'`
+	args := []interface{}{accountAddress}
+	argIndex := 2
+
+	if cursor != nil {
+		// Cursor comparisons implement keyset pagination over the junction PK.
+		op := ">"
+		if sortOrder == DESC {
+			op = "<"
+		}
+		query += fmt.Sprintf(" AND ac.contract_id %s $%d", op, argIndex)
+		args = append(args, *cursor)
+		argIndex++
+	}
+
+	if sortOrder == DESC {
+		query += " ORDER BY ac.contract_id DESC"
+	} else {
+		query += " ORDER BY ac.contract_id ASC"
+	}
+
+	if limit != nil {
+		query += fmt.Sprintf(" LIMIT $%d", argIndex)
+		args = append(args, *limit)
+	}
+
+	start := time.Now()
+	contracts, err := db.QueryManyPtrs[Contract](ctx, m.DB, query, args...)
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("GetSEP41ByAccount", "account_contract_tokens").Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("GetSEP41ByAccount", "account_contract_tokens").Inc()
+	if err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("GetSEP41ByAccount", "account_contract_tokens", utils.GetDBErrorType(err)).Inc()
+		return nil, fmt.Errorf("querying paginated SEP-41 contracts for %s: %w", accountAddress, err)
 	}
 	return contracts, nil
 }

--- a/internal/data/account_contract_tokens_test.go
+++ b/internal/data/account_contract_tokens_test.go
@@ -1,0 +1,81 @@
+package data
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/metrics"
+)
+
+func TestAccountContractTokensModel_GetSEP41ByAccount(t *testing.T) {
+	ctx := context.Background()
+
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	sep41Addr1 := "CSEP41A1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	sep41Addr2 := "CSEP41A2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	sep41Addr3 := "CSEP41A3AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	sacAddr := "CSACAAAAAAQ2JQQF3NCRU7GYMDJNZ2NMQN6IGN4FCT5DWPODMPVEXSND"
+
+	sep41ID1 := DeterministicContractID(sep41Addr1)
+	sep41ID2 := DeterministicContractID(sep41Addr2)
+	sep41ID3 := DeterministicContractID(sep41Addr3)
+	sacID := DeterministicContractID(sacAddr)
+
+	_, err = dbConnectionPool.Exec(ctx, `
+		INSERT INTO contract_tokens (id, contract_id, type, name, symbol, decimals) VALUES
+		($1, $2, 'SEP41', 'Token One', 'ONE', 7),
+		($3, $4, 'SEP41', 'Token Two', 'TWO', 7),
+		($5, $6, 'SEP41', 'Token Three', 'THREE', 7),
+		($7, $8, 'SAC', 'SAC Token', 'SAC', 7)
+	`, sep41ID1, sep41Addr1, sep41ID2, sep41Addr2, sep41ID3, sep41Addr3, sacID, sacAddr)
+	require.NoError(t, err)
+
+	_, err = dbConnectionPool.Exec(ctx, `
+		INSERT INTO account_contract_tokens (account_address, contract_id) VALUES
+		('GACCOUNT1', $1),
+		('GACCOUNT1', $2),
+		('GACCOUNT1', $3),
+		('GACCOUNT1', $4)
+	`, sep41ID1, sep41ID2, sep41ID3, sacID)
+	require.NoError(t, err)
+
+	reg := prometheus.NewRegistry()
+	dbMetrics := metrics.NewMetrics(reg).DB
+	m := &AccountContractTokensModel{
+		DB:      dbConnectionPool,
+		Metrics: dbMetrics,
+	}
+
+	expectedOrder := []string{sep41ID1.String(), sep41ID2.String(), sep41ID3.String()}
+	slices.Sort(expectedOrder)
+
+	limit := int32(2)
+	page, err := m.GetSEP41ByAccount(ctx, "GACCOUNT1", &limit, nil, ASC)
+	require.NoError(t, err)
+	require.Len(t, page, 2)
+	require.Equal(t, expectedOrder[0], page[0].ID.String())
+	require.Equal(t, expectedOrder[1], page[1].ID.String())
+
+	cursor := page[1].ID
+	nextPage, err := m.GetSEP41ByAccount(ctx, "GACCOUNT1", &limit, &cursor, ASC)
+	require.NoError(t, err)
+	require.Len(t, nextPage, 1)
+	require.Equal(t, expectedOrder[2], nextPage[0].ID.String())
+
+	descPage, err := m.GetSEP41ByAccount(ctx, "GACCOUNT1", &limit, nil, DESC)
+	require.NoError(t, err)
+	require.Len(t, descPage, 2)
+	require.Equal(t, expectedOrder[2], descPage[0].ID.String())
+	require.Equal(t, expectedOrder[1], descPage[1].ID.String())
+}

--- a/internal/data/mocks.go
+++ b/internal/data/mocks.go
@@ -65,8 +65,8 @@ func NewTrustlineBalanceModelMock(t interface {
 	return mockModel
 }
 
-func (m *TrustlineBalanceModelMock) GetByAccount(ctx context.Context, accountAddress string) ([]TrustlineBalance, error) {
-	args := m.Called(ctx, accountAddress)
+func (m *TrustlineBalanceModelMock) GetByAccount(ctx context.Context, accountAddress string, limit *int32, cursor *uuid.UUID, sortOrder SortOrder) ([]TrustlineBalance, error) {
+	args := m.Called(ctx, accountAddress, limit, cursor, sortOrder)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -143,8 +143,8 @@ func NewSACBalanceModelMock(t interface {
 	return mockModel
 }
 
-func (m *SACBalanceModelMock) GetByAccount(ctx context.Context, accountAddress string) ([]SACBalance, error) {
-	args := m.Called(ctx, accountAddress)
+func (m *SACBalanceModelMock) GetByAccount(ctx context.Context, accountAddress string, limit *int32, cursor *uuid.UUID, sortOrder SortOrder) ([]SACBalance, error) {
+	args := m.Called(ctx, accountAddress, limit, cursor, sortOrder)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -184,6 +184,14 @@ func NewAccountContractTokensModelMock(t interface {
 
 func (m *AccountContractTokensModelMock) GetByAccount(ctx context.Context, accountAddress string) ([]*Contract, error) {
 	args := m.Called(ctx, accountAddress)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*Contract), args.Error(1)
+}
+
+func (m *AccountContractTokensModelMock) GetSEP41ByAccount(ctx context.Context, accountAddress string, limit *int32, cursor *uuid.UUID, sortOrder SortOrder) ([]*Contract, error) {
+	args := m.Called(ctx, accountAddress, limit, cursor, sortOrder)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/internal/data/sac_balances.go
+++ b/internal/data/sac_balances.go
@@ -35,8 +35,10 @@ type SACBalance struct {
 
 // SACBalanceModelInterface defines the interface for SAC balance operations.
 type SACBalanceModelInterface interface {
-	// Read operations (for API/balances queries)
-	GetByAccount(ctx context.Context, accountAddress string) ([]SACBalance, error)
+	// GetByAccount returns SAC balances for a contract holder ordered by
+	// contract_id. Pass nil limit/cursor to fetch all rows, or provide them for
+	// keyset pagination so GraphQL can page with stable cursors.
+	GetByAccount(ctx context.Context, accountAddress string, limit *int32, cursor *uuid.UUID, sortOrder SortOrder) ([]SACBalance, error)
 
 	// Write operations (for live ingestion)
 	BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts []SACBalance, deletes []SACBalance) error
@@ -53,29 +55,55 @@ type SACBalanceModel struct {
 
 var _ SACBalanceModelInterface = (*SACBalanceModel)(nil)
 
-// GetByAccount retrieves all SAC balances for a contract address with contract metadata.
-// JOINs with contract_tokens to get code, issuer, and decimals for API responses.
-func (m *SACBalanceModel) GetByAccount(ctx context.Context, accountAddress string) ([]SACBalance, error) {
+// GetByAccount retrieves SAC balances for a contract holder ordered by
+// contract_id, JOINed with contract_tokens for code/issuer/decimals. Pass nil
+// limit/cursor to fetch all rows; provide them for keyset pagination (the
+// cursor is the last seen contract UUID from the previous page).
+func (m *SACBalanceModel) GetByAccount(ctx context.Context, accountAddress string, limit *int32, cursor *uuid.UUID, sortOrder SortOrder) ([]SACBalance, error) {
 	if accountAddress == "" {
 		return nil, fmt.Errorf("empty account address")
 	}
 
-	const query = `
+	query := `
 		SELECT asb.account_address, asb.contract_id, asb.balance, asb.is_authorized,
 		       asb.is_clawback_enabled, asb.last_modified_ledger,
 		       ct.contract_id AS token_id, ct.code, ct.issuer, ct.decimals
 		FROM sac_balances asb
 		INNER JOIN contract_tokens ct ON ct.id = asb.contract_id
 		WHERE asb.account_address = $1`
+	args := []interface{}{accountAddress}
+	argIndex := 2
+
+	if cursor != nil {
+		// Cursor comparisons implement keyset pagination over the primary key.
+		op := ">"
+		if sortOrder == DESC {
+			op = "<"
+		}
+		query += fmt.Sprintf(" AND asb.contract_id %s $%d", op, argIndex)
+		args = append(args, *cursor)
+		argIndex++
+	}
+
+	if sortOrder == DESC {
+		query += " ORDER BY asb.contract_id DESC"
+	} else {
+		query += " ORDER BY asb.contract_id ASC"
+	}
+
+	if limit != nil {
+		query += fmt.Sprintf(" LIMIT $%d", argIndex)
+		args = append(args, *limit)
+	}
 
 	start := time.Now()
-	balances, err := db.QueryMany[SACBalance](ctx, m.DB, query, accountAddress)
+	balances, err := db.QueryMany[SACBalance](ctx, m.DB, query, args...)
 	duration := time.Since(start).Seconds()
 	m.Metrics.QueryDuration.WithLabelValues("GetByAccount", "sac_balances").Observe(duration)
 	m.Metrics.QueriesTotal.WithLabelValues("GetByAccount", "sac_balances").Inc()
 	if err != nil {
 		m.Metrics.QueryErrors.WithLabelValues("GetByAccount", "sac_balances", utils.GetDBErrorType(err)).Inc()
-		return nil, fmt.Errorf("querying SAC balances for %s: %w", accountAddress, err)
+		return nil, fmt.Errorf("querying paginated SAC balances for %s: %w", accountAddress, err)
 	}
 	return balances, nil
 }

--- a/internal/data/sac_balances_test.go
+++ b/internal/data/sac_balances_test.go
@@ -3,6 +3,7 @@ package data
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,13 +26,16 @@ func TestSACBalanceModel_GetByAccount(t *testing.T) {
 	// Insert test contract tokens for foreign key references
 	contractAddr1 := "CCONTRACT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 	contractAddr2 := "CCONTRACT2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	contractAddr3 := "CCONTRACT3AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 	contractID1 := DeterministicContractID(contractAddr1)
 	contractID2 := DeterministicContractID(contractAddr2)
+	contractID3 := DeterministicContractID(contractAddr3)
 	_, err = dbConnectionPool.Exec(ctx, `
 		INSERT INTO contract_tokens (id, contract_id, type, code, issuer, decimals) VALUES
 		($1, $2, 'SAC', 'USDC', 'GISSUER1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 7),
-		($3, $4, 'SAC', 'EURC', 'GISSUER2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 7)
-	`, contractID1, contractAddr1, contractID2, contractAddr2)
+		($3, $4, 'SAC', 'EURC', 'GISSUER2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 7),
+		($5, $6, 'SAC', 'BTC', 'GISSUER3AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 7)
+	`, contractID1, contractAddr1, contractID2, contractAddr2, contractID3, contractAddr3)
 	require.NoError(t, err)
 
 	cleanUpDB := func() {
@@ -48,7 +52,7 @@ func TestSACBalanceModel_GetByAccount(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		balances, err := m.GetByAccount(ctx, "")
+		balances, err := m.GetByAccount(ctx, "", nil, nil, ASC)
 		require.Error(t, err)
 		require.Nil(t, balances)
 		require.Contains(t, err.Error(), "empty account address")
@@ -62,7 +66,7 @@ func TestSACBalanceModel_GetByAccount(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		balances, err := m.GetByAccount(ctx, "CNOTEXISTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+		balances, err := m.GetByAccount(ctx, "CNOTEXISTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", nil, nil, ASC)
 		require.NoError(t, err)
 		require.Empty(t, balances)
 	})
@@ -83,7 +87,7 @@ func TestSACBalanceModel_GetByAccount(t *testing.T) {
 		`, accountAddr, contractID1)
 		require.NoError(t, err)
 
-		balances, err := m.GetByAccount(ctx, accountAddr)
+		balances, err := m.GetByAccount(ctx, accountAddr, nil, nil, ASC)
 		require.NoError(t, err)
 		require.Len(t, balances, 1)
 
@@ -119,7 +123,7 @@ func TestSACBalanceModel_GetByAccount(t *testing.T) {
 		`, accountAddr, contractID1, contractID2)
 		require.NoError(t, err)
 
-		balances, err := m.GetByAccount(ctx, accountAddr)
+		balances, err := m.GetByAccount(ctx, accountAddr, nil, nil, ASC)
 		require.NoError(t, err)
 		require.Len(t, balances, 2)
 
@@ -127,6 +131,48 @@ func TestSACBalanceModel_GetByAccount(t *testing.T) {
 		for _, b := range balances {
 			require.Equal(t, accountAddr, b.AccountAddress)
 		}
+	})
+
+	t.Run("paginates with limit and cursor in ASC and DESC order", func(t *testing.T) {
+		cleanUpDB()
+
+		m := &SACBalanceModel{
+			DB:      dbConnectionPool,
+			Metrics: dbMetrics,
+		}
+
+		accountAddr := "CACCOUNT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+		_, err := dbConnectionPool.Exec(ctx, `
+			INSERT INTO sac_balances
+			(account_address, contract_id, balance, is_authorized, is_clawback_enabled, last_modified_ledger)
+			VALUES
+			($1, $2, '1000', true, false, 100),
+			($1, $3, '2000', true, false, 101),
+			($1, $4, '3000', true, false, 102)
+		`, accountAddr, contractID1, contractID2, contractID3)
+		require.NoError(t, err)
+
+		expectedOrder := []string{contractID1.String(), contractID2.String(), contractID3.String()}
+		slices.Sort(expectedOrder)
+
+		limit := int32(2)
+		page, err := m.GetByAccount(ctx, accountAddr, &limit, nil, ASC)
+		require.NoError(t, err)
+		require.Len(t, page, 2)
+		require.Equal(t, expectedOrder[0], page[0].ContractID.String())
+		require.Equal(t, expectedOrder[1], page[1].ContractID.String())
+
+		cursor := page[1].ContractID
+		nextPage, err := m.GetByAccount(ctx, accountAddr, &limit, &cursor, ASC)
+		require.NoError(t, err)
+		require.Len(t, nextPage, 1)
+		require.Equal(t, expectedOrder[2], nextPage[0].ContractID.String())
+
+		descPage, err := m.GetByAccount(ctx, accountAddr, &limit, nil, DESC)
+		require.NoError(t, err)
+		require.Len(t, descPage, 2)
+		require.Equal(t, expectedOrder[2], descPage[0].ContractID.String())
+		require.Equal(t, expectedOrder[1], descPage[1].ContractID.String())
 	})
 }
 

--- a/internal/data/trustline_balances.go
+++ b/internal/data/trustline_balances.go
@@ -32,8 +32,10 @@ type TrustlineBalance struct {
 
 // TrustlineBalanceModelInterface defines the interface for trustline balance operations.
 type TrustlineBalanceModelInterface interface {
-	// Read operations (for API/balances queries)
-	GetByAccount(ctx context.Context, accountAddress string) ([]TrustlineBalance, error)
+	// GetByAccount returns trustlines for an account ordered by asset_id. Pass nil
+	// limit/cursor to fetch all rows, or provide them for keyset pagination so the
+	// GraphQL balances connection can page without scanning the full account set.
+	GetByAccount(ctx context.Context, accountAddress string, limit *int32, cursor *uuid.UUID, sortOrder SortOrder) ([]TrustlineBalance, error)
 
 	// Write operations (for live ingestion)
 	BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts []TrustlineBalance, deletes []TrustlineBalance) error
@@ -50,28 +52,56 @@ type TrustlineBalanceModel struct {
 
 var _ TrustlineBalanceModelInterface = (*TrustlineBalanceModel)(nil)
 
-// GetByAccount retrieves all trustline balances for an account with full data via JOIN.
-func (m *TrustlineBalanceModel) GetByAccount(ctx context.Context, accountAddress string) ([]TrustlineBalance, error) {
+// GetByAccount retrieves trustline balances for an account ordered by asset_id.
+// Pass nil limit/cursor to fetch all rows; provide them for keyset pagination
+// (the cursor is the last seen asset UUID from the previous page).
+func (m *TrustlineBalanceModel) GetByAccount(ctx context.Context, accountAddress string, limit *int32, cursor *uuid.UUID, sortOrder SortOrder) ([]TrustlineBalance, error) {
 	if accountAddress == "" {
 		return nil, fmt.Errorf("empty account address")
 	}
 
-	const query = `
+	query := `
 		SELECT atb.account_address, atb.asset_id, ta.code, ta.issuer,
 		       atb.balance, atb.trust_limit, atb.buying_liabilities,
 		       atb.selling_liabilities, atb.flags, atb.last_modified_ledger
 		FROM trustline_balances atb
 		INNER JOIN trustline_assets ta ON ta.id = atb.asset_id
 		WHERE atb.account_address = $1`
+	args := []interface{}{accountAddress}
+	argIndex := 2
+
+	if cursor != nil {
+		// Cursor comparisons mirror keyset pagination semantics:
+		// - ASC pages fetch rows greater than the previous row
+		// - DESC pages fetch rows less than the previous row
+		op := ">"
+		if sortOrder == DESC {
+			op = "<"
+		}
+		query += fmt.Sprintf(" AND atb.asset_id %s $%d", op, argIndex)
+		args = append(args, *cursor)
+		argIndex++
+	}
+
+	if sortOrder == DESC {
+		query += " ORDER BY atb.asset_id DESC"
+	} else {
+		query += " ORDER BY atb.asset_id ASC"
+	}
+
+	if limit != nil {
+		query += fmt.Sprintf(" LIMIT $%d", argIndex)
+		args = append(args, *limit)
+	}
 
 	start := time.Now()
-	balances, err := db.QueryMany[TrustlineBalance](ctx, m.DB, query, accountAddress)
+	balances, err := db.QueryMany[TrustlineBalance](ctx, m.DB, query, args...)
 	duration := time.Since(start).Seconds()
 	m.Metrics.QueryDuration.WithLabelValues("GetByAccount", "trustline_balances").Observe(duration)
 	m.Metrics.QueriesTotal.WithLabelValues("GetByAccount", "trustline_balances").Inc()
 	if err != nil {
 		m.Metrics.QueryErrors.WithLabelValues("GetByAccount", "trustline_balances", utils.GetDBErrorType(err)).Inc()
-		return nil, fmt.Errorf("querying trustline balances for %s: %w", accountAddress, err)
+		return nil, fmt.Errorf("querying paginated trustline balances for %s: %w", accountAddress, err)
 	}
 	return balances, nil
 }

--- a/internal/data/trustline_balances_test.go
+++ b/internal/data/trustline_balances_test.go
@@ -3,6 +3,7 @@ package data
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,11 +26,13 @@ func TestTrustlineBalanceModel_GetByAccount(t *testing.T) {
 	// Insert test assets for foreign key references
 	assetID1 := DeterministicAssetID("USDC", "ISSUER1")
 	assetID2 := DeterministicAssetID("EURC", "ISSUER2")
+	assetID3 := DeterministicAssetID("BTC", "ISSUER3")
 	_, err = dbConnectionPool.Exec(ctx, `
 		INSERT INTO trustline_assets (id, code, issuer) VALUES
 		($1, 'USDC', 'ISSUER1'),
-		($2, 'EURC', 'ISSUER2')
-	`, assetID1, assetID2)
+		($2, 'EURC', 'ISSUER2'),
+		($3, 'BTC', 'ISSUER3')
+	`, assetID1, assetID2, assetID3)
 	require.NoError(t, err)
 
 	cleanUpDB := func() {
@@ -46,7 +49,7 @@ func TestTrustlineBalanceModel_GetByAccount(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		balances, err := m.GetByAccount(ctx, "")
+		balances, err := m.GetByAccount(ctx, "", nil, nil, ASC)
 		require.Error(t, err)
 		require.Nil(t, balances)
 		require.Contains(t, err.Error(), "empty account address")
@@ -60,7 +63,7 @@ func TestTrustlineBalanceModel_GetByAccount(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		balances, err := m.GetByAccount(ctx, "GNOTEXIST")
+		balances, err := m.GetByAccount(ctx, "GNOTEXIST", nil, nil, ASC)
 		require.NoError(t, err)
 		require.Empty(t, balances)
 	})
@@ -81,7 +84,7 @@ func TestTrustlineBalanceModel_GetByAccount(t *testing.T) {
 		`, accountAddr, assetID1)
 		require.NoError(t, err)
 
-		balances, err := m.GetByAccount(ctx, accountAddr)
+		balances, err := m.GetByAccount(ctx, accountAddr, nil, nil, ASC)
 		require.NoError(t, err)
 		require.Len(t, balances, 1)
 
@@ -116,7 +119,7 @@ func TestTrustlineBalanceModel_GetByAccount(t *testing.T) {
 		`, accountAddr, assetID1, assetID2)
 		require.NoError(t, err)
 
-		balances, err := m.GetByAccount(ctx, accountAddr)
+		balances, err := m.GetByAccount(ctx, accountAddr, nil, nil, ASC)
 		require.NoError(t, err)
 		require.Len(t, balances, 2)
 
@@ -124,6 +127,47 @@ func TestTrustlineBalanceModel_GetByAccount(t *testing.T) {
 		for _, b := range balances {
 			require.Equal(t, accountAddr, b.AccountAddress)
 		}
+	})
+
+	t.Run("paginates with limit and cursor in ASC and DESC order", func(t *testing.T) {
+		cleanUpDB()
+
+		m := &TrustlineBalanceModel{
+			DB:      dbConnectionPool,
+			Metrics: dbMetrics,
+		}
+
+		_, err := dbConnectionPool.Exec(ctx, `
+			INSERT INTO trustline_balances
+			(account_address, asset_id, balance, trust_limit, buying_liabilities, selling_liabilities, flags, last_modified_ledger)
+			VALUES
+			('GACCOUNT1', $1, 1000, 10000, 0, 0, 0, 100),
+			('GACCOUNT1', $2, 2000, 20000, 0, 0, 0, 101),
+			('GACCOUNT1', $3, 3000, 30000, 0, 0, 0, 102)
+		`, assetID1, assetID2, assetID3)
+		require.NoError(t, err)
+
+		expectedOrder := []string{assetID1.String(), assetID2.String(), assetID3.String()}
+		slices.Sort(expectedOrder)
+
+		limit := int32(2)
+		page, err := m.GetByAccount(ctx, "GACCOUNT1", &limit, nil, ASC)
+		require.NoError(t, err)
+		require.Len(t, page, 2)
+		require.Equal(t, expectedOrder[0], page[0].AssetID.String())
+		require.Equal(t, expectedOrder[1], page[1].AssetID.String())
+
+		cursor := page[1].AssetID
+		nextPage, err := m.GetByAccount(ctx, "GACCOUNT1", &limit, &cursor, ASC)
+		require.NoError(t, err)
+		require.Len(t, nextPage, 1)
+		require.Equal(t, expectedOrder[2], nextPage[0].AssetID.String())
+
+		descPage, err := m.GetByAccount(ctx, "GACCOUNT1", &limit, nil, DESC)
+		require.NoError(t, err)
+		require.Len(t, descPage, 2)
+		require.Equal(t, expectedOrder[2], descPage[0].AssetID.String())
+		require.Equal(t, expectedOrder[1], descPage[1].AssetID.String())
 	})
 }
 

--- a/internal/integrationtests/account_balances_test.go
+++ b/internal/integrationtests/account_balances_test.go
@@ -64,7 +64,7 @@ type AccountBalancesAfterCheckpointTestSuite struct {
 // - EURC trustline (100)
 // - SEP-41 contract tokens (500)
 func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account1_HasInitialBalances() {
-	balances, err := suite.testEnv.WBClient.GetBalancesByAccountAddress(
+	balances, err := suite.testEnv.WBClient.GetAccountBalances(
 		context.Background(),
 		suite.testEnv.BalanceTestAccount1KP.Address(),
 	)
@@ -121,7 +121,7 @@ func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account1_Ha
 // - Native XLM (~10000)
 // - USDC trustline (100)
 func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account2_HasInitialBalances() {
-	balances, err := suite.testEnv.WBClient.GetBalancesByAccountAddress(
+	balances, err := suite.testEnv.WBClient.GetAccountBalances(
 		context.Background(),
 		suite.testEnv.BalanceTestAccount2KP.Address(),
 	)
@@ -163,7 +163,7 @@ func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account2_Ha
 // - USDC SAC tokens (200)
 // - SEP-41 contract tokens (500)
 func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_HolderContract_HasInitialBalances() {
-	balances, err := suite.testEnv.WBClient.GetBalancesByAccountAddress(
+	balances, err := suite.testEnv.WBClient.GetAccountBalances(
 		context.Background(),
 		suite.testEnv.HolderContractAddress,
 	)
@@ -215,7 +215,7 @@ type AccountBalancesAfterLiveIngestionTestSuite struct {
 // - EURC trustline (50) - reduced from 100 after transfer to contract
 // - SEP-41 contract tokens (0) - reduced from 500 after transfer to account 2
 func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_Account1_HasUpdatedBalances() {
-	balances, err := suite.testEnv.WBClient.GetBalancesByAccountAddress(
+	balances, err := suite.testEnv.WBClient.GetAccountBalances(
 		context.Background(),
 		suite.testEnv.BalanceTestAccount1KP.Address(),
 	)
@@ -276,7 +276,7 @@ func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_Accou
 // - EURC trustline (75) - NEW from trustline creation and payment
 // - SEP-41 contract tokens (500) - NEW from transfer from account 1
 func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_Account2_HasNewBalances() {
-	balances, err := suite.testEnv.WBClient.GetBalancesByAccountAddress(
+	balances, err := suite.testEnv.WBClient.GetAccountBalances(
 		context.Background(),
 		suite.testEnv.BalanceTestAccount2KP.Address(),
 	)
@@ -336,7 +336,7 @@ func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_Accou
 // - SEP-41 contract tokens (500) - unchanged
 // - EURC SAC tokens (50) - NEW from transfer from account 1
 func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_HolderContract_HasNewEURC() {
-	balances, err := suite.testEnv.WBClient.GetBalancesByAccountAddress(
+	balances, err := suite.testEnv.WBClient.GetAccountBalances(
 		context.Background(),
 		suite.testEnv.HolderContractAddress,
 	)

--- a/internal/integrationtests/infrastructure/containers.go
+++ b/internal/integrationtests/infrastructure/containers.go
@@ -441,7 +441,7 @@ func createWalletBackendAPIContainer(ctx context.Context, name string, imageName
 			"RPC_URL":                          "http://stellar-rpc:8000",
 			"DATABASE_URL":                     "postgres://postgres@wallet-backend-db:5432/wallet-backend?sslmode=disable",
 			"PORT":                             walletBackendContainerAPIPort,
-			"GRAPHQL_COMPLEXITY_LIMIT":         "2000",
+			"GRAPHQL_COMPLEXITY_LIMIT":         "5000",
 			"LOG_LEVEL":                        "DEBUG",
 			"NETWORK":                          "standalone",
 			"NETWORK_PASSPHRASE":               networkPassphrase,

--- a/internal/serve/complexity_test.go
+++ b/internal/serve/complexity_test.go
@@ -124,6 +124,22 @@ func TestGraphQLComplexityLimitRejectsLargeQueries(t *testing.T) {
 			expectedMessage: "operation has complexity 151, which exceeds the limit of 100",
 		},
 		{
+			name:  "account balances use default page size",
+			limit: 100,
+			query: `query {
+				accountByAddress(address: "` + complexityTestAccountAddress + `") {
+					balances {
+						edges {
+							node {
+								tokenId
+							}
+						}
+					}
+				}
+			}`,
+			expectedMessage: "operation has complexity 151, which exceeds the limit of 100",
+		},
+		{
 			name:  "transaction accounts can no longer bypass account pagination complexity",
 			limit: 100,
 			query: `query {
@@ -199,6 +215,22 @@ func TestGraphQLComplexityAccountingUsesSharedDefaultsAndExplicitArgs(t *testing
 						edges {
 							node {
 								id
+							}
+						}
+					}
+				}
+			}`,
+			expectedMessage: "operation has complexity 7, which exceeds the limit of 6",
+		},
+		{
+			name:  "account balances first argument is used in complexity calculation",
+			limit: 6,
+			query: `query {
+				accountByAddress(address: "` + complexityTestAccountAddress + `") {
+					balances(first: 2) {
+						edges {
+							node {
+								tokenId
 							}
 						}
 					}

--- a/internal/serve/complexity_test.go
+++ b/internal/serve/complexity_test.go
@@ -1,0 +1,349 @@
+package serve
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go-stellar-sdk/keypair"
+	godbtest "github.com/stellar/go-stellar-sdk/support/db/dbtest"
+	"github.com/stellar/go-stellar-sdk/toid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/data"
+	"github.com/stellar/wallet-backend/internal/db"
+	walletdbtest "github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+)
+
+var (
+	complexityTestCtx  context.Context
+	complexityTestDB   *godbtest.DB
+	complexityTestPool *pgxpool.Pool
+
+	complexityTestAccountAddress = keypair.MustRandom().Address()
+	complexityTestTxHash         = "3476b7b0133690fbfb2de8fa9ca2273cb4f2e29447e0cf0e14a5f82d0daa4870"
+	complexityTestTxToID         = toid.New(1000, 1, 0).ToInt64()
+	complexityTestOperationID    = toid.New(1000, 1, 1).ToInt64()
+)
+
+type graphQLHTTPResponse struct {
+	Data   json.RawMessage `json:"data"`
+	Errors []graphQLError  `json:"errors"`
+}
+
+type graphQLError struct {
+	Message    string         `json:"message"`
+	Extensions map[string]any `json:"extensions"`
+}
+
+func TestMain(m *testing.M) {
+	complexityTestCtx = context.Background()
+
+	complexityTestDB = walletdbtest.Open(&testing.T{})
+	var err error
+	complexityTestPool, err = db.OpenDBConnectionPool(complexityTestCtx, complexityTestDB.DSN)
+	if err != nil {
+		panic(err)
+	}
+
+	setupComplexityTestDB(complexityTestCtx, &testing.T{}, complexityTestPool)
+
+	code := m.Run()
+
+	cleanUpComplexityTestDB(complexityTestCtx, &testing.T{}, complexityTestPool)
+	complexityTestPool.Close()
+	complexityTestDB.Close()
+
+	os.Exit(code)
+}
+
+func TestGraphQLComplexityLimitRejectsLargeQueries(t *testing.T) {
+	testCases := []struct {
+		name            string
+		limit           int
+		query           string
+		expectedMessage string
+	}{
+		{
+			name:  "account transactions use default page size",
+			limit: 100,
+			query: `query {
+				accountByAddress(address: "` + complexityTestAccountAddress + `") {
+					transactions {
+						edges {
+							node {
+								hash
+							}
+						}
+					}
+				}
+			}`,
+			expectedMessage: "operation has complexity 151, which exceeds the limit of 100",
+		},
+		{
+			name:  "account operations use default page size",
+			limit: 100,
+			query: `query {
+				accountByAddress(address: "` + complexityTestAccountAddress + `") {
+					operations {
+						edges {
+							node {
+								id
+							}
+						}
+					}
+				}
+			}`,
+			expectedMessage: "operation has complexity 151, which exceeds the limit of 100",
+		},
+		{
+			name:  "account state changes use default page size",
+			limit: 100,
+			query: `query {
+				accountByAddress(address: "` + complexityTestAccountAddress + `") {
+					stateChanges {
+						edges {
+							node {
+								ledgerNumber
+							}
+						}
+					}
+				}
+			}`,
+			expectedMessage: "operation has complexity 151, which exceeds the limit of 100",
+		},
+		{
+			name:  "transaction accounts can no longer bypass account pagination complexity",
+			limit: 100,
+			query: `query {
+				transactionByHash(hash: "` + complexityTestTxHash + `") {
+					accounts {
+						transactions {
+							edges {
+								node {
+									hash
+								}
+							}
+						}
+					}
+				}
+			}`,
+			expectedMessage: "operation has complexity 152, which exceeds the limit of 100",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := performGraphQLRequest(t, newGraphQLTestHandler(t, tc.limit), tc.query)
+
+			require.Len(t, resp.Errors, 1)
+			assert.Equal(t, tc.expectedMessage, resp.Errors[0].Message)
+			assert.Equal(t, "COMPLEXITY_LIMIT_EXCEEDED", resp.Errors[0].Extensions["code"])
+			assert.Equal(t, "null", string(resp.Data))
+		})
+	}
+}
+
+func TestGraphQLComplexityAccountingUsesSharedDefaultsAndExplicitArgs(t *testing.T) {
+	testCases := []struct {
+		name            string
+		limit           int
+		query           string
+		expectedMessage string
+	}{
+		{
+			name:  "root pagination without explicit args uses shared default page limit",
+			limit: 149,
+			query: `query {
+				transactions {
+					edges {
+						node {
+							hash
+						}
+					}
+				}
+			}`,
+			expectedMessage: "operation has complexity 150, which exceeds the limit of 149",
+		},
+		{
+			name:  "root first argument is used in complexity calculation",
+			limit: 5,
+			query: `query {
+				transactions(first: 2) {
+					edges {
+						node {
+							hash
+						}
+					}
+				}
+			}`,
+			expectedMessage: "operation has complexity 6, which exceeds the limit of 5",
+		},
+		{
+			name:  "nested last argument is used in complexity calculation",
+			limit: 6,
+			query: `query {
+				transactionByHash(hash: "` + complexityTestTxHash + `") {
+					operations(last: 2) {
+						edges {
+							node {
+								id
+							}
+						}
+					}
+				}
+			}`,
+			expectedMessage: "operation has complexity 7, which exceeds the limit of 6",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := performGraphQLRequest(t, newGraphQLTestHandler(t, tc.limit), tc.query)
+
+			require.Len(t, resp.Errors, 1)
+			assert.Equal(t, tc.expectedMessage, resp.Errors[0].Message)
+			assert.Equal(t, "COMPLEXITY_LIMIT_EXCEEDED", resp.Errors[0].Extensions["code"])
+			assert.Equal(t, "null", string(resp.Data))
+		})
+	}
+}
+
+func TestGraphQLComplexityLimitAllowsSmallQueries(t *testing.T) {
+	resp := performGraphQLRequest(t, newGraphQLTestHandler(t, 10), `query {
+		transactionByHash(hash: "`+complexityTestTxHash+`") {
+			hash
+		}
+	}`)
+
+	require.Empty(t, resp.Errors)
+	assert.JSONEq(t, `{
+		"transactionByHash": {
+			"hash": "`+complexityTestTxHash+`"
+		}
+	}`, string(resp.Data))
+}
+
+func newGraphQLTestHandler(t *testing.T, complexityLimit int) http.Handler {
+	t.Helper()
+
+	registry := prometheus.NewRegistry()
+	m := metrics.NewMetrics(registry)
+	models, err := data.NewModels(complexityTestPool, m.DB)
+	require.NoError(t, err)
+
+	return handler(handlerDeps{
+		Models:                     models,
+		Metrics:                    m,
+		TrustlineBalanceModel:      models.TrustlineBalance,
+		NativeBalanceModel:         models.NativeBalance,
+		SACBalanceModel:            models.SACBalance,
+		AccountContractTokensModel: models.AccountContractTokens,
+		GraphQLComplexityLimit:     complexityLimit,
+		MaxGraphQLWorkerPoolSize:   10,
+	})
+}
+
+func performGraphQLRequest(t *testing.T, h http.Handler, query string) graphQLHTTPResponse {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]string{
+		"query": query,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/graphql/query", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+
+	var resp graphQLHTTPResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
+	return resp
+}
+
+func setupComplexityTestDB(ctx context.Context, t *testing.T, dbConnectionPool *pgxpool.Pool) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+
+	transaction := &types.Transaction{
+		Hash:            types.HashBytea(complexityTestTxHash),
+		ToID:            complexityTestTxToID,
+		FeeCharged:      100,
+		ResultCode:      "TransactionResultCodeTxSuccess",
+		LedgerNumber:    1000,
+		LedgerCreatedAt: now,
+		IsFeeBump:       false,
+	}
+	operation := &types.Operation{
+		ID:              complexityTestOperationID,
+		OperationType:   "PAYMENT",
+		OperationXDR:    types.XDRBytea([]byte("opxdr1")),
+		ResultCode:      "op_success",
+		Successful:      true,
+		LedgerNumber:    1000,
+		LedgerCreatedAt: now,
+	}
+	stateChange := &types.StateChange{
+		ToID:                complexityTestTxToID,
+		StateChangeID:       1,
+		StateChangeCategory: types.StateChangeCategoryBalance,
+		StateChangeReason:   types.StateChangeReasonCredit,
+		OperationID:         complexityTestOperationID,
+		AccountID:           types.AddressBytea(complexityTestAccountAddress),
+		LedgerCreatedAt:     now,
+		LedgerNumber:        1000,
+	}
+
+	dbErr := db.RunInTransaction(ctx, dbConnectionPool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx,
+			`INSERT INTO transactions (hash, to_id, fee_charged, result_code, ledger_number, ledger_created_at, is_fee_bump) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+			transaction.Hash, transaction.ToID, transaction.FeeCharged, transaction.ResultCode, transaction.LedgerNumber, transaction.LedgerCreatedAt, transaction.IsFeeBump)
+		require.NoError(t, err)
+
+		_, err = tx.Exec(ctx,
+			`INSERT INTO transactions_accounts (ledger_created_at, tx_to_id, account_id) VALUES ($1, $2, $3)`,
+			transaction.LedgerCreatedAt, transaction.ToID, stateChange.AccountID)
+		require.NoError(t, err)
+
+		_, err = tx.Exec(ctx,
+			`INSERT INTO operations (id, operation_type, operation_xdr, result_code, successful, ledger_number, ledger_created_at) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+			operation.ID, operation.OperationType, operation.OperationXDR, operation.ResultCode, operation.Successful, operation.LedgerNumber, operation.LedgerCreatedAt)
+		require.NoError(t, err)
+
+		_, err = tx.Exec(ctx,
+			`INSERT INTO operations_accounts (ledger_created_at, operation_id, account_id) VALUES ($1, $2, $3)`,
+			operation.LedgerCreatedAt, operation.ID, stateChange.AccountID)
+		require.NoError(t, err)
+
+		_, err = tx.Exec(ctx,
+			`INSERT INTO state_changes (to_id, state_change_id, state_change_category, state_change_reason, operation_id, account_id, ledger_created_at, ledger_number) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+			stateChange.ToID, stateChange.StateChangeID, stateChange.StateChangeCategory, stateChange.StateChangeReason, stateChange.OperationID, stateChange.AccountID, stateChange.LedgerCreatedAt, stateChange.LedgerNumber)
+		require.NoError(t, err)
+
+		return nil
+	})
+	require.NoError(t, dbErr)
+}
+
+func cleanUpComplexityTestDB(ctx context.Context, t *testing.T, dbConnectionPool *pgxpool.Pool) {
+	_, err := dbConnectionPool.Exec(ctx, `DELETE FROM state_changes`)
+	require.NoError(t, err)
+	_, err = dbConnectionPool.Exec(ctx, `DELETE FROM operations`)
+	require.NoError(t, err)
+	_, err = dbConnectionPool.Exec(ctx, `DELETE FROM transactions`)
+	require.NoError(t, err)
+}

--- a/internal/serve/complexity_test.go
+++ b/internal/serve/complexity_test.go
@@ -251,7 +251,6 @@ func newGraphQLTestHandler(t *testing.T, complexityLimit int) http.Handler {
 		SACBalanceModel:            models.SACBalance,
 		AccountContractTokensModel: models.AccountContractTokens,
 		GraphQLComplexityLimit:     complexityLimit,
-		MaxGraphQLWorkerPoolSize:   10,
 	})
 }
 

--- a/internal/serve/graphql/README.md
+++ b/internal/serve/graphql/README.md
@@ -448,48 +448,56 @@ query ListStateChanges {
 
 ### 7. Get Account Balances
 
-Retrieve all token balances for an account, including native XLM, classic trustlines, and contract tokens.
+Retrieve account balances through a Relay-style connection, including native XLM, classic trustlines, and contract tokens.
 
 ```graphql
 query GetAccountBalances {
   accountByAddress(address: "GABC...") {
-    balances {
-      __typename
-      tokenId
-      tokenType
-      balance
+    balances(first: 50) {
+      edges {
+        node {
+          __typename
+          tokenId
+          tokenType
+          balance
 
-      ... on NativeBalance {
-        minimumBalance
-        buyingLiabilities
-        sellingLiabilities
-        lastModifiedLedger
+          ... on NativeBalance {
+            minimumBalance
+            buyingLiabilities
+            sellingLiabilities
+            lastModifiedLedger
+          }
+
+          ... on TrustlineBalance {
+            code
+            issuer
+            type
+            limit
+            buyingLiabilities
+            sellingLiabilities
+            lastModifiedLedger
+            isAuthorized
+            isAuthorizedToMaintainLiabilities
+          }
+
+          ... on SACBalance {
+            code
+            issuer
+            decimals
+            isAuthorized
+            isClawbackEnabled
+          }
+
+          ... on SEP41Balance {
+            name
+            symbol
+            decimals
+          }
+        }
       }
-
-      ... on TrustlineBalance {
-        code
-        issuer
-        type
-        limit
-        buyingLiabilities
-        sellingLiabilities
-        lastModifiedLedger
-        isAuthorized
-        isAuthorizedToMaintainLiabilities
-      }
-
-      ... on SACBalance {
-        code
-        issuer
-        decimals
-        isAuthorized
-        isClawbackEnabled
-      }
-
-      ... on SEP41Balance {
-        name
-        symbol
-        decimals
+      pageInfo {
+        endCursor
+        hasNextPage
       }
     }
   }
@@ -529,35 +537,39 @@ The query returns different balance types based on the token:
 ```graphql
 query GetDetailedBalances {
   accountByAddress(address: "GABC...") {
-    balances {
-      tokenId
-      balance
-      tokenType
+    balances(first: 25) {
+      edges {
+        node {
+          tokenId
+          balance
+          tokenType
 
-      ... on NativeBalance {
-        minimumBalance
-        buyingLiabilities
-        sellingLiabilities
-        lastModifiedLedger
-      }
+          ... on NativeBalance {
+            minimumBalance
+            buyingLiabilities
+            sellingLiabilities
+            lastModifiedLedger
+          }
 
-      ... on TrustlineBalance {
-        code
-        issuer
-        limit
-        isAuthorized
-      }
+          ... on TrustlineBalance {
+            code
+            issuer
+            limit
+            isAuthorized
+          }
 
-      ... on SACBalance {
-        code
-        issuer
-        decimals
-      }
+          ... on SACBalance {
+            code
+            issuer
+            decimals
+          }
 
-      ... on SEP41Balance {
-        name
-        symbol
-        decimals
+          ... on SEP41Balance {
+            name
+            symbol
+            decimals
+          }
+        }
       }
     }
   }
@@ -570,34 +582,36 @@ query GetDetailedBalances {
 {
   "data": {
     "accountByAddress": {
-      "balances": [
-        {
-          "tokenId": "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
-          "balance": "100.0000000",
-          "tokenType": "NATIVE",
-          "minimumBalance": "1.0000000",
-          "buyingLiabilities": "0.0000000",
-          "sellingLiabilities": "0.0000000",
-          "lastModifiedLedger": 12345678
-        },
-        {
-          "tokenId": "CAQCMV4JFG4EZXQEAV7TUV2E52DMSO2LQKBOSA7UM3B4NIP4DQJ3JHQJ",
-          "balance": "500.0000000",
-          "tokenType": "CLASSIC",
-          "code": "USDC",
-          "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
-          "limit": "922337203685.4775807",
-          "isAuthorized": true
-        },
-        {
-          "tokenId": "CCVLZ3SQWV4R5OYTXM7FYNVJLUBXZ3FXOVQXMKIFXFPJT3YNG3HLKXPS",
-          "balance": "1000.0000000",
-          "tokenType": "SEP41",
-          "name": "Example Token",
-          "symbol": "EXT",
-          "decimals": 7
+      "balances": {
+        "edges": [
+          {
+            "node": {
+              "tokenId": "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+              "balance": "100.0000000",
+              "tokenType": "NATIVE",
+              "minimumBalance": "1.0000000",
+              "buyingLiabilities": "0.0000000",
+              "sellingLiabilities": "0.0000000",
+              "lastModifiedLedger": 12345678
+            }
+          },
+          {
+            "node": {
+              "tokenId": "CAQCMV4JFG4EZXQEAV7TUV2E52DMSO2LQKBOSA7UM3B4NIP4DQJ3JHQJ",
+              "balance": "500.0000000",
+              "tokenType": "CLASSIC",
+              "code": "USDC",
+              "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+              "limit": "922337203685.4775807",
+              "isAuthorized": true
+            }
+          }
+        ],
+        "pageInfo": {
+          "endCursor": "djE6Y2xhc3NpYzoxMjNlNDU2Ny1lODliLTEyZDMtYTQ1Ni00MjY2MTQxNzQwMDA=",
+          "hasNextPage": true
         }
-      ]
+      }
     }
   }
 }
@@ -605,12 +619,12 @@ query GetDetailedBalances {
 
 **How It Works:**
 
-This query leverages the Account Token Cache (see [Account Token Cache](../../../README.md#account-token-cache) in the main README) to efficiently retrieve balances:
+This query uses keyset pagination over the balance backing tables:
 
-1. Fetches token identifiers from Redis cache (trustlines and contracts)
-2. Retrieves contract metadata from PostgreSQL (for SAC/SEP-41 tokens)
-3. Builds ledger keys and queries Stellar RPC for current balances
-4. Parses XDR entries and returns typed balance responses
+1. Reads native, trustline, and SAC balances from PostgreSQL in a stable source order
+2. Reads SEP-41 contract memberships from PostgreSQL using the same cursor order
+3. Fetches SEP-41 `balance(address)` values only for contracts in the returned page
+4. Builds Relay `edges` and `pageInfo` so clients can continue paging with opaque cursors
 
 **Supported Address Types:**
 - **G-addresses**: Returns native XLM, trustlines, SAC, and SEP-41 balances

--- a/internal/serve/graphql/README.md
+++ b/internal/serve/graphql/README.md
@@ -119,7 +119,7 @@ query {
 
 ## Queries
 
-The GraphQL API provides seven root queries for accessing blockchain data:
+The GraphQL API provides six root queries for accessing blockchain data. Account balances are fetched through `accountByAddress`:
 
 | # | Query | Description |
 |---|-------|-------------|
@@ -129,7 +129,6 @@ The GraphQL API provides seven root queries for accessing blockchain data:
 | 4 | [`operations`](#4-list-all-operations) | List all operations with pagination |
 | 5 | [`operationById`](#5-get-operation-by-id) | Get a specific operation by ID |
 | 6 | [`stateChanges`](#6-list-state-changes) | List all state changes with pagination |
-| 7 | [`balancesByAccountAddress`](#7-get-account-balances) | Get all token balances for an account |
 
 ### 1. Get Transaction by Hash
 
@@ -453,43 +452,45 @@ Retrieve all token balances for an account, including native XLM, classic trustl
 
 ```graphql
 query GetAccountBalances {
-  balancesByAccountAddress(address: "GABC...") {
-    __typename
-    tokenId
-    tokenType
-    balance
+  accountByAddress(address: "GABC...") {
+    balances {
+      __typename
+      tokenId
+      tokenType
+      balance
 
-    ... on NativeBalance {
-      minimumBalance
-      buyingLiabilities
-      sellingLiabilities
-      lastModifiedLedger
-    }
+      ... on NativeBalance {
+        minimumBalance
+        buyingLiabilities
+        sellingLiabilities
+        lastModifiedLedger
+      }
 
-    ... on TrustlineBalance {
-      code
-      issuer
-      type
-      limit
-      buyingLiabilities
-      sellingLiabilities
-      lastModifiedLedger
-      isAuthorized
-      isAuthorizedToMaintainLiabilities
-    }
+      ... on TrustlineBalance {
+        code
+        issuer
+        type
+        limit
+        buyingLiabilities
+        sellingLiabilities
+        lastModifiedLedger
+        isAuthorized
+        isAuthorizedToMaintainLiabilities
+      }
 
-    ... on SACBalance {
-      code
-      issuer
-      decimals
-      isAuthorized
-      isClawbackEnabled
-    }
+      ... on SACBalance {
+        code
+        issuer
+        decimals
+        isAuthorized
+        isClawbackEnabled
+      }
 
-    ... on SEP41Balance {
-      name
-      symbol
-      decimals
+      ... on SEP41Balance {
+        name
+        symbol
+        decimals
+      }
     }
   }
 }
@@ -527,35 +528,37 @@ The query returns different balance types based on the token:
 
 ```graphql
 query GetDetailedBalances {
-  balancesByAccountAddress(address: "GABC...") {
-    tokenId
-    balance
-    tokenType
+  accountByAddress(address: "GABC...") {
+    balances {
+      tokenId
+      balance
+      tokenType
 
-    ... on NativeBalance {
-      minimumBalance
-      buyingLiabilities
-      sellingLiabilities
-      lastModifiedLedger
-    }
+      ... on NativeBalance {
+        minimumBalance
+        buyingLiabilities
+        sellingLiabilities
+        lastModifiedLedger
+      }
 
-    ... on TrustlineBalance {
-      code
-      issuer
-      limit
-      isAuthorized
-    }
+      ... on TrustlineBalance {
+        code
+        issuer
+        limit
+        isAuthorized
+      }
 
-    ... on SACBalance {
-      code
-      issuer
-      decimals
-    }
+      ... on SACBalance {
+        code
+        issuer
+        decimals
+      }
 
-    ... on SEP41Balance {
-      name
-      symbol
-      decimals
+      ... on SEP41Balance {
+        name
+        symbol
+        decimals
+      }
     }
   }
 }
@@ -566,34 +569,36 @@ query GetDetailedBalances {
 ```json
 {
   "data": {
-    "balancesByAccountAddress": [
-      {
-        "tokenId": "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
-        "balance": "100.0000000",
-        "tokenType": "NATIVE",
-        "minimumBalance": "1.0000000",
-        "buyingLiabilities": "0.0000000",
-        "sellingLiabilities": "0.0000000",
-        "lastModifiedLedger": 12345678
-      },
-      {
-        "tokenId": "CAQCMV4JFG4EZXQEAV7TUV2E52DMSO2LQKBOSA7UM3B4NIP4DQJ3JHQJ",
-        "balance": "500.0000000",
-        "tokenType": "CLASSIC",
-        "code": "USDC",
-        "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
-        "limit": "922337203685.4775807",
-        "isAuthorized": true
-      },
-      {
-        "tokenId": "CCVLZ3SQWV4R5OYTXM7FYNVJLUBXZ3FXOVQXMKIFXFPJT3YNG3HLKXPS",
-        "balance": "1000.0000000",
-        "tokenType": "SEP41",
-        "name": "Example Token",
-        "symbol": "EXT",
-        "decimals": 7
-      }
-    ]
+    "accountByAddress": {
+      "balances": [
+        {
+          "tokenId": "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+          "balance": "100.0000000",
+          "tokenType": "NATIVE",
+          "minimumBalance": "1.0000000",
+          "buyingLiabilities": "0.0000000",
+          "sellingLiabilities": "0.0000000",
+          "lastModifiedLedger": 12345678
+        },
+        {
+          "tokenId": "CAQCMV4JFG4EZXQEAV7TUV2E52DMSO2LQKBOSA7UM3B4NIP4DQJ3JHQJ",
+          "balance": "500.0000000",
+          "tokenType": "CLASSIC",
+          "code": "USDC",
+          "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+          "limit": "922337203685.4775807",
+          "isAuthorized": true
+        },
+        {
+          "tokenId": "CCVLZ3SQWV4R5OYTXM7FYNVJLUBXZ3FXOVQXMKIFXFPJT3YNG3HLKXPS",
+          "balance": "1000.0000000",
+          "tokenType": "SEP41",
+          "name": "Example Token",
+          "symbol": "EXT",
+          "decimals": 7
+        }
+      ]
+    }
   }
 }
 ```
@@ -632,10 +637,12 @@ This query returns structured GraphQL errors with error codes in the `extensions
         "code": "INVALID_ADDRESS",
         "address": "invalid-address"
       },
-      "path": ["balancesByAccountAddress"]
+      "path": ["accountByAddress"]
     }
   ],
-  "data": null
+  "data": {
+    "accountByAddress": null
+  }
 }
 ```
 

--- a/internal/serve/graphql/generated/generated.go
+++ b/internal/serve/graphql/generated/generated.go
@@ -63,7 +63,7 @@ type DirectiveRoot struct {
 type ComplexityRoot struct {
 	Account struct {
 		Address      func(childComplexity int) int
-		Balances     func(childComplexity int) int
+		Balances     func(childComplexity int, first *int32, after *string, last *int32, before *string) int
 		Operations   func(childComplexity int, since *time.Time, until *time.Time, first *int32, after *string, last *int32, before *string) int
 		StateChanges func(childComplexity int, filter *AccountStateChangeFilterInput, since *time.Time, until *time.Time, first *int32, after *string, last *int32, before *string) int
 		Transactions func(childComplexity int, since *time.Time, until *time.Time, first *int32, after *string, last *int32, before *string) int
@@ -93,6 +93,16 @@ type ComplexityRoot struct {
 		TokenID         func(childComplexity int) int
 		Transaction     func(childComplexity int) int
 		Type            func(childComplexity int) int
+	}
+
+	BalanceConnection struct {
+		Edges    func(childComplexity int) int
+		PageInfo func(childComplexity int) int
+	}
+
+	BalanceEdge struct {
+		Cursor func(childComplexity int) int
+		Node   func(childComplexity int) int
 	}
 
 	BuildTransactionPayload struct {
@@ -325,7 +335,7 @@ type ComplexityRoot struct {
 
 type AccountResolver interface {
 	Address(ctx context.Context, obj *types.Account) (string, error)
-	Balances(ctx context.Context, obj *types.Account) ([]Balance, error)
+	Balances(ctx context.Context, obj *types.Account, first *int32, after *string, last *int32, before *string) (*BalanceConnection, error)
 	Transactions(ctx context.Context, obj *types.Account, since *time.Time, until *time.Time, first *int32, after *string, last *int32, before *string) (*TransactionConnection, error)
 	Operations(ctx context.Context, obj *types.Account, since *time.Time, until *time.Time, first *int32, after *string, last *int32, before *string) (*OperationConnection, error)
 	StateChanges(ctx context.Context, obj *types.Account, filter *AccountStateChangeFilterInput, since *time.Time, until *time.Time, first *int32, after *string, last *int32, before *string) (*StateChangeConnection, error)
@@ -480,7 +490,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			break
 		}
 
-		return e.complexity.Account.Balances(childComplexity), true
+		args, err := ec.field_Account_balances_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Account.Balances(childComplexity, args["first"].(*int32), args["after"].(*string), args["last"].(*int32), args["before"].(*string)), true
 
 	case "Account.operations":
 		if e.complexity.Account.Operations == nil {
@@ -657,6 +672,34 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.BalanceAuthorizationChange.Type(childComplexity), true
+
+	case "BalanceConnection.edges":
+		if e.complexity.BalanceConnection.Edges == nil {
+			break
+		}
+
+		return e.complexity.BalanceConnection.Edges(childComplexity), true
+
+	case "BalanceConnection.pageInfo":
+		if e.complexity.BalanceConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.BalanceConnection.PageInfo(childComplexity), true
+
+	case "BalanceEdge.cursor":
+		if e.complexity.BalanceEdge.Cursor == nil {
+			break
+		}
+
+		return e.complexity.BalanceEdge.Cursor(childComplexity), true
+
+	case "BalanceEdge.node":
+		if e.complexity.BalanceEdge.Node == nil {
+			break
+		}
+
+		return e.complexity.BalanceEdge.Node(childComplexity), true
 
 	case "BuildTransactionPayload.success":
 		if e.complexity.BuildTransactionPayload.Success == nil {
@@ -1917,7 +1960,7 @@ type Account{
 
   # All balances associated with this account
   # Returns native XLM, trustlines, SAC, and SEP-41 balances for the account address
-  balances: [Balance!]
+  balances(first: Int, after: String, last: Int, before: String): BalanceConnection!
 
   # All transactions associated with this account
   # Optional since/until params enable TimescaleDB chunk pruning on ledger_created_at
@@ -2210,6 +2253,16 @@ type StateChangeEdge {
     cursor: String!
 }
 
+type BalanceConnection {
+    edges: [BalanceEdge!]!
+    pageInfo: PageInfo!
+}
+
+type BalanceEdge {
+    node: Balance!
+    cursor: String!
+}
+
 type PageInfo {
     startCursor: String
     endCursor: String
@@ -2423,6 +2476,83 @@ var parsedSchema = gqlparser.MustLoadSchema(sources...)
 // endregion ************************** generated!.gotpl **************************
 
 // region    ***************************** args.gotpl *****************************
+
+func (ec *executionContext) field_Account_balances_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Account_balances_argsFirst(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["first"] = arg0
+	arg1, err := ec.field_Account_balances_argsAfter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["after"] = arg1
+	arg2, err := ec.field_Account_balances_argsLast(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["last"] = arg2
+	arg3, err := ec.field_Account_balances_argsBefore(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["before"] = arg3
+	return args, nil
+}
+func (ec *executionContext) field_Account_balances_argsFirst(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int32, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("first"))
+	if tmp, ok := rawArgs["first"]; ok {
+		return ec.unmarshalOInt2ᚖint32(ctx, tmp)
+	}
+
+	var zeroVal *int32
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Account_balances_argsAfter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*string, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("after"))
+	if tmp, ok := rawArgs["after"]; ok {
+		return ec.unmarshalOString2ᚖstring(ctx, tmp)
+	}
+
+	var zeroVal *string
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Account_balances_argsLast(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int32, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("last"))
+	if tmp, ok := rawArgs["last"]; ok {
+		return ec.unmarshalOInt2ᚖint32(ctx, tmp)
+	}
+
+	var zeroVal *int32
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Account_balances_argsBefore(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*string, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("before"))
+	if tmp, ok := rawArgs["before"]; ok {
+		return ec.unmarshalOString2ᚖstring(ctx, tmp)
+	}
+
+	var zeroVal *string
+	return zeroVal, nil
+}
 
 func (ec *executionContext) field_Account_operations_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
@@ -3539,29 +3669,49 @@ func (ec *executionContext) _Account_balances(ctx context.Context, field graphql
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Account().Balances(rctx, obj)
+		return ec.resolvers.Account().Balances(rctx, obj, fc.Args["first"].(*int32), fc.Args["after"].(*string), fc.Args["last"].(*int32), fc.Args["before"].(*string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.([]Balance)
+	res := resTmp.(*BalanceConnection)
 	fc.Result = res
-	return ec.marshalOBalance2ᚕgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐBalanceᚄ(ctx, field.Selections, res)
+	return ec.marshalNBalanceConnection2ᚖgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐBalanceConnection(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Account_balances(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Account_balances(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Account",
 		Field:      field,
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("FieldContext.Child cannot be called on type INTERFACE")
+			switch field.Name {
+			case "edges":
+				return ec.fieldContext_BalanceConnection_edges(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_BalanceConnection_pageInfo(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type BalanceConnection", field.Name)
 		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Account_balances_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -4714,6 +4864,198 @@ func (ec *executionContext) fieldContext_BalanceAuthorizationChange_flags(_ cont
 		Field:      field,
 		IsMethod:   true,
 		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _BalanceConnection_edges(ctx context.Context, field graphql.CollectedField, obj *BalanceConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_BalanceConnection_edges(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Edges, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*BalanceEdge)
+	fc.Result = res
+	return ec.marshalNBalanceEdge2ᚕᚖgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐBalanceEdgeᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_BalanceConnection_edges(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "BalanceConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "node":
+				return ec.fieldContext_BalanceEdge_node(ctx, field)
+			case "cursor":
+				return ec.fieldContext_BalanceEdge_cursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type BalanceEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _BalanceConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *BalanceConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_BalanceConnection_pageInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PageInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*PageInfo)
+	fc.Result = res
+	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐPageInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_BalanceConnection_pageInfo(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "BalanceConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "startCursor":
+				return ec.fieldContext_PageInfo_startCursor(ctx, field)
+			case "endCursor":
+				return ec.fieldContext_PageInfo_endCursor(ctx, field)
+			case "hasNextPage":
+				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
+			case "hasPreviousPage":
+				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _BalanceEdge_node(ctx context.Context, field graphql.CollectedField, obj *BalanceEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_BalanceEdge_node(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Node, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(Balance)
+	fc.Result = res
+	return ec.marshalNBalance2githubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐBalance(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_BalanceEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "BalanceEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("FieldContext.Child cannot be called on type INTERFACE")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _BalanceEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *BalanceEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_BalanceEdge_cursor(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Cursor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_BalanceEdge_cursor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "BalanceEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
 		},
@@ -14631,13 +14973,16 @@ func (ec *executionContext) _Account(ctx context.Context, sel ast.SelectionSet, 
 		case "balances":
 			field := field
 
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
 				res = ec._Account_balances(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -15347,6 +15692,94 @@ func (ec *executionContext) _BalanceAuthorizationChange(ctx context.Context, sel
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var balanceConnectionImplementors = []string{"BalanceConnection"}
+
+func (ec *executionContext) _BalanceConnection(ctx context.Context, sel ast.SelectionSet, obj *BalanceConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, balanceConnectionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("BalanceConnection")
+		case "edges":
+			out.Values[i] = ec._BalanceConnection_edges(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "pageInfo":
+			out.Values[i] = ec._BalanceConnection_pageInfo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var balanceEdgeImplementors = []string{"BalanceEdge"}
+
+func (ec *executionContext) _BalanceEdge(ctx context.Context, sel ast.SelectionSet, obj *BalanceEdge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, balanceEdgeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("BalanceEdge")
+		case "node":
+			out.Values[i] = ec._BalanceEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "cursor":
+			out.Values[i] = ec._BalanceEdge_cursor(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -19218,6 +19651,74 @@ func (ec *executionContext) marshalNBalance2githubᚗcomᚋstellarᚋwalletᚑba
 	return ec._Balance(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNBalanceConnection2githubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐBalanceConnection(ctx context.Context, sel ast.SelectionSet, v BalanceConnection) graphql.Marshaler {
+	return ec._BalanceConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNBalanceConnection2ᚖgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐBalanceConnection(ctx context.Context, sel ast.SelectionSet, v *BalanceConnection) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._BalanceConnection(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNBalanceEdge2ᚕᚖgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐBalanceEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*BalanceEdge) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNBalanceEdge2ᚖgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐBalanceEdge(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNBalanceEdge2ᚖgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐBalanceEdge(ctx context.Context, sel ast.SelectionSet, v *BalanceEdge) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._BalanceEdge(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v any) (bool, error) {
 	res, err := graphql.UnmarshalBoolean(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -19763,53 +20264,6 @@ func (ec *executionContext) unmarshalOAccountStateChangeFilterInput2ᚖgithubᚗ
 	}
 	res, err := ec.unmarshalInputAccountStateChangeFilterInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOBalance2ᚕgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐBalanceᚄ(ctx context.Context, sel ast.SelectionSet, v []Balance) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNBalance2githubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐBalance(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
 }
 
 func (ec *executionContext) marshalOBaseStateChange2githubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐBaseStateChange(ctx context.Context, sel ast.SelectionSet, v BaseStateChange) graphql.Marshaler {

--- a/internal/serve/graphql/generated/generated.go
+++ b/internal/serve/graphql/generated/generated.go
@@ -63,6 +63,7 @@ type DirectiveRoot struct {
 type ComplexityRoot struct {
 	Account struct {
 		Address      func(childComplexity int) int
+		Balances     func(childComplexity int) int
 		Operations   func(childComplexity int, since *time.Time, until *time.Time, first *int32, after *string, last *int32, before *string) int
 		StateChanges func(childComplexity int, filter *AccountStateChangeFilterInput, since *time.Time, until *time.Time, first *int32, after *string, last *int32, before *string) int
 		Transactions func(childComplexity int, since *time.Time, until *time.Time, first *int32, after *string, last *int32, before *string) int
@@ -176,13 +177,12 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		AccountByAddress         func(childComplexity int, address string) int
-		BalancesByAccountAddress func(childComplexity int, address string) int
-		OperationByID            func(childComplexity int, id int64) int
-		Operations               func(childComplexity int, first *int32, after *string, last *int32, before *string) int
-		StateChanges             func(childComplexity int, first *int32, after *string, last *int32, before *string) int
-		TransactionByHash        func(childComplexity int, hash string) int
-		Transactions             func(childComplexity int, first *int32, after *string, last *int32, before *string) int
+		AccountByAddress  func(childComplexity int, address string) int
+		OperationByID     func(childComplexity int, id int64) int
+		Operations        func(childComplexity int, first *int32, after *string, last *int32, before *string) int
+		StateChanges      func(childComplexity int, first *int32, after *string, last *int32, before *string) int
+		TransactionByHash func(childComplexity int, hash string) int
+		Transactions      func(childComplexity int, first *int32, after *string, last *int32, before *string) int
 	}
 
 	ReservesChange struct {
@@ -325,6 +325,7 @@ type ComplexityRoot struct {
 
 type AccountResolver interface {
 	Address(ctx context.Context, obj *types.Account) (string, error)
+	Balances(ctx context.Context, obj *types.Account) ([]Balance, error)
 	Transactions(ctx context.Context, obj *types.Account, since *time.Time, until *time.Time, first *int32, after *string, last *int32, before *string) (*TransactionConnection, error)
 	Operations(ctx context.Context, obj *types.Account, since *time.Time, until *time.Time, first *int32, after *string, last *int32, before *string) (*OperationConnection, error)
 	StateChanges(ctx context.Context, obj *types.Account, filter *AccountStateChangeFilterInput, since *time.Time, until *time.Time, first *int32, after *string, last *int32, before *string) (*StateChangeConnection, error)
@@ -385,7 +386,6 @@ type QueryResolver interface {
 	Operations(ctx context.Context, first *int32, after *string, last *int32, before *string) (*OperationConnection, error)
 	OperationByID(ctx context.Context, id int64) (*types.Operation, error)
 	StateChanges(ctx context.Context, first *int32, after *string, last *int32, before *string) (*StateChangeConnection, error)
-	BalancesByAccountAddress(ctx context.Context, address string) ([]Balance, error)
 }
 type ReservesChangeResolver interface {
 	Type(ctx context.Context, obj *types.ReservesStateChangeModel) (types.StateChangeCategory, error)
@@ -474,6 +474,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Account.Address(childComplexity), true
+
+	case "Account.balances":
+		if e.complexity.Account.Balances == nil {
+			break
+		}
+
+		return e.complexity.Account.Balances(childComplexity), true
 
 	case "Account.operations":
 		if e.complexity.Account.Operations == nil {
@@ -1034,18 +1041,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.AccountByAddress(childComplexity, args["address"].(string)), true
-
-	case "Query.balancesByAccountAddress":
-		if e.complexity.Query.BalancesByAccountAddress == nil {
-			break
-		}
-
-		args, err := ec.field_Query_balancesByAccountAddress_args(ctx, rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.BalancesByAccountAddress(childComplexity, args["address"].(string)), true
 
 	case "Query.operationById":
 		if e.complexity.Query.OperationByID == nil {
@@ -1920,6 +1915,10 @@ type Account{
   # GraphQL Relationships - these fields use resolvers for data fetching
   # Each relationship resolver will be called when the field is requested
 
+  # All balances associated with this account
+  # Returns native XLM, trustlines, SAC, and SEP-41 balances for the account address
+  balances: [Balance!]
+
   # All transactions associated with this account
   # Optional since/until params enable TimescaleDB chunk pruning on ledger_created_at
   transactions(since: Time, until: Time, first: Int, after: String, last: Int, before: String):   TransactionConnection
@@ -2227,7 +2226,6 @@ type Query {
     operations(first: Int, after: String, last: Int, before: String):     OperationConnection
     operationById(id: Int64!):                                            Operation
     stateChanges(first: Int, after: String, last: Int, before: String):   StateChangeConnection
-    balancesByAccountAddress(address: String!):                           [Balance!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/scalars.graphqls", Input: `# GraphQL Custom Scalars - extend GraphQL's built-in scalar types
@@ -2952,29 +2950,6 @@ func (ec *executionContext) field_Query_accountByAddress_argsAddress(
 	return zeroVal, nil
 }
 
-func (ec *executionContext) field_Query_balancesByAccountAddress_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := ec.field_Query_balancesByAccountAddress_argsAddress(ctx, rawArgs)
-	if err != nil {
-		return nil, err
-	}
-	args["address"] = arg0
-	return args, nil
-}
-func (ec *executionContext) field_Query_balancesByAccountAddress_argsAddress(
-	ctx context.Context,
-	rawArgs map[string]any,
-) (string, error) {
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("address"))
-	if tmp, ok := rawArgs["address"]; ok {
-		return ec.unmarshalNString2string(ctx, tmp)
-	}
-
-	var zeroVal string
-	return zeroVal, nil
-}
-
 func (ec *executionContext) field_Query_operationById_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -3550,6 +3525,47 @@ func (ec *executionContext) fieldContext_Account_address(_ context.Context, fiel
 	return fc, nil
 }
 
+func (ec *executionContext) _Account_balances(ctx context.Context, field graphql.CollectedField, obj *types.Account) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Account_balances(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Account().Balances(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]Balance)
+	fc.Result = res
+	return ec.marshalOBalance2ᚕgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐBalanceᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Account_balances(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Account",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("FieldContext.Child cannot be called on type INTERFACE")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Account_transactions(ctx context.Context, field graphql.CollectedField, obj *types.Account) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Account_transactions(ctx, field)
 	if err != nil {
@@ -3985,6 +4001,8 @@ func (ec *executionContext) fieldContext_AccountChange_account(_ context.Context
 			switch field.Name {
 			case "address":
 				return ec.fieldContext_Account_address(ctx, field)
+			case "balances":
+				return ec.fieldContext_Account_balances(ctx, field)
 			case "transactions":
 				return ec.fieldContext_Account_transactions(ctx, field)
 			case "operations":
@@ -4431,6 +4449,8 @@ func (ec *executionContext) fieldContext_BalanceAuthorizationChange_account(_ co
 			switch field.Name {
 			case "address":
 				return ec.fieldContext_Account_address(ctx, field)
+			case "balances":
+				return ec.fieldContext_Account_balances(ctx, field)
 			case "transactions":
 				return ec.fieldContext_Account_transactions(ctx, field)
 			case "operations":
@@ -5182,6 +5202,8 @@ func (ec *executionContext) fieldContext_FlagsChange_account(_ context.Context, 
 			switch field.Name {
 			case "address":
 				return ec.fieldContext_Account_address(ctx, field)
+			case "balances":
+				return ec.fieldContext_Account_balances(ctx, field)
 			case "transactions":
 				return ec.fieldContext_Account_transactions(ctx, field)
 			case "operations":
@@ -5631,6 +5653,8 @@ func (ec *executionContext) fieldContext_MetadataChange_account(_ context.Contex
 			switch field.Name {
 			case "address":
 				return ec.fieldContext_Account_address(ctx, field)
+			case "balances":
+				return ec.fieldContext_Account_balances(ctx, field)
 			case "transactions":
 				return ec.fieldContext_Account_transactions(ctx, field)
 			case "operations":
@@ -6710,6 +6734,8 @@ func (ec *executionContext) fieldContext_Operation_accounts(_ context.Context, f
 			switch field.Name {
 			case "address":
 				return ec.fieldContext_Account_address(ctx, field)
+			case "balances":
+				return ec.fieldContext_Account_balances(ctx, field)
 			case "transactions":
 				return ec.fieldContext_Account_transactions(ctx, field)
 			case "operations":
@@ -7331,6 +7357,8 @@ func (ec *executionContext) fieldContext_Query_accountByAddress(ctx context.Cont
 			switch field.Name {
 			case "address":
 				return ec.fieldContext_Account_address(ctx, field)
+			case "balances":
+				return ec.fieldContext_Account_balances(ctx, field)
 			case "transactions":
 				return ec.fieldContext_Account_transactions(ctx, field)
 			case "operations":
@@ -7541,61 +7569,6 @@ func (ec *executionContext) fieldContext_Query_stateChanges(ctx context.Context,
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_stateChanges_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Query_balancesByAccountAddress(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_balancesByAccountAddress(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().BalancesByAccountAddress(rctx, fc.Args["address"].(string))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]Balance)
-	fc.Result = res
-	return ec.marshalNBalance2ᚕgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐBalanceᚄ(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Query_balancesByAccountAddress(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Query",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("FieldContext.Child cannot be called on type INTERFACE")
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_balancesByAccountAddress_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -7994,6 +7967,8 @@ func (ec *executionContext) fieldContext_ReservesChange_account(_ context.Contex
 			switch field.Name {
 			case "address":
 				return ec.fieldContext_Account_address(ctx, field)
+			case "balances":
+				return ec.fieldContext_Account_balances(ctx, field)
 			case "transactions":
 				return ec.fieldContext_Account_transactions(ctx, field)
 			case "operations":
@@ -9261,6 +9236,8 @@ func (ec *executionContext) fieldContext_SignerChange_account(_ context.Context,
 			switch field.Name {
 			case "address":
 				return ec.fieldContext_Account_address(ctx, field)
+			case "balances":
+				return ec.fieldContext_Account_balances(ctx, field)
 			case "transactions":
 				return ec.fieldContext_Account_transactions(ctx, field)
 			case "operations":
@@ -9748,6 +9725,8 @@ func (ec *executionContext) fieldContext_SignerThresholdsChange_account(_ contex
 			switch field.Name {
 			case "address":
 				return ec.fieldContext_Account_address(ctx, field)
+			case "balances":
+				return ec.fieldContext_Account_balances(ctx, field)
 			case "transactions":
 				return ec.fieldContext_Account_transactions(ctx, field)
 			case "operations":
@@ -10197,6 +10176,8 @@ func (ec *executionContext) fieldContext_StandardBalanceChange_account(_ context
 			switch field.Name {
 			case "address":
 				return ec.fieldContext_Account_address(ctx, field)
+			case "balances":
+				return ec.fieldContext_Account_balances(ctx, field)
 			case "transactions":
 				return ec.fieldContext_Account_transactions(ctx, field)
 			case "operations":
@@ -11022,6 +11003,8 @@ func (ec *executionContext) fieldContext_Transaction_accounts(_ context.Context,
 			switch field.Name {
 			case "address":
 				return ec.fieldContext_Account_address(ctx, field)
+			case "balances":
+				return ec.fieldContext_Account_balances(ctx, field)
 			case "transactions":
 				return ec.fieldContext_Account_transactions(ctx, field)
 			case "operations":
@@ -12090,6 +12073,8 @@ func (ec *executionContext) fieldContext_TrustlineChange_account(_ context.Conte
 			switch field.Name {
 			case "address":
 				return ec.fieldContext_Account_address(ctx, field)
+			case "balances":
+				return ec.fieldContext_Account_balances(ctx, field)
 			case "transactions":
 				return ec.fieldContext_Account_transactions(ctx, field)
 			case "operations":
@@ -14643,6 +14628,39 @@ func (ec *executionContext) _Account(ctx context.Context, sel ast.SelectionSet, 
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "balances":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Account_balances(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "transactions":
 			field := field
 
@@ -16558,28 +16576,6 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_stateChanges(ctx, field)
-				return res
-			}
-
-			rrm := func(ctx context.Context) graphql.Marshaler {
-				return ec.OperationContext.RootResolverMiddleware(ctx,
-					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "balancesByAccountAddress":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_balancesByAccountAddress(ctx, field)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
 				return res
 			}
 
@@ -19222,50 +19218,6 @@ func (ec *executionContext) marshalNBalance2githubᚗcomᚋstellarᚋwalletᚑba
 	return ec._Balance(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalNBalance2ᚕgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐBalanceᚄ(ctx context.Context, sel ast.SelectionSet, v []Balance) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNBalance2githubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐBalance(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
-}
-
 func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v any) (bool, error) {
 	res, err := graphql.UnmarshalBoolean(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -19811,6 +19763,53 @@ func (ec *executionContext) unmarshalOAccountStateChangeFilterInput2ᚖgithubᚗ
 	}
 	res, err := ec.unmarshalInputAccountStateChangeFilterInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOBalance2ᚕgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐBalanceᚄ(ctx context.Context, sel ast.SelectionSet, v []Balance) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNBalance2githubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐBalance(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalOBaseStateChange2githubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐBaseStateChange(ctx context.Context, sel ast.SelectionSet, v BaseStateChange) graphql.Marshaler {

--- a/internal/serve/graphql/generated/models_gen.go
+++ b/internal/serve/graphql/generated/models_gen.go
@@ -43,6 +43,16 @@ type AccountStateChangeFilterInput struct {
 	Reason *string `json:"reason,omitempty"`
 }
 
+type BalanceConnection struct {
+	Edges    []*BalanceEdge `json:"edges"`
+	PageInfo *PageInfo      `json:"pageInfo"`
+}
+
+type BalanceEdge struct {
+	Node   Balance `json:"node"`
+	Cursor string  `json:"cursor"`
+}
+
 type BuildTransactionInput struct {
 	TransactionXdr   string                 `json:"transactionXdr"`
 	SimulationResult *SimulationResultInput `json:"simulationResult,omitempty"`

--- a/internal/serve/graphql/resolvers/account.resolvers.go
+++ b/internal/serve/graphql/resolvers/account.resolvers.go
@@ -22,6 +22,11 @@ func (r *accountResolver) Address(ctx context.Context, obj *types.Account) (stri
 	return string(obj.StellarAddress), nil
 }
 
+// Balances is the resolver for the balances field.
+func (r *accountResolver) Balances(ctx context.Context, obj *types.Account) ([]graphql1.Balance, error) {
+	return r.getAccountBalances(ctx, string(obj.StellarAddress))
+}
+
 // Transactions is the resolver for the transactions field.
 // This is a field resolver - it resolves the "transactions" field on an Account object
 // gqlgen calls this when a GraphQL query requests the transactions field on an Account

--- a/internal/serve/graphql/resolvers/account.resolvers.go
+++ b/internal/serve/graphql/resolvers/account.resolvers.go
@@ -23,8 +23,8 @@ func (r *accountResolver) Address(ctx context.Context, obj *types.Account) (stri
 }
 
 // Balances is the resolver for the balances field.
-func (r *accountResolver) Balances(ctx context.Context, obj *types.Account) ([]graphql1.Balance, error) {
-	return r.getAccountBalances(ctx, string(obj.StellarAddress))
+func (r *accountResolver) Balances(ctx context.Context, obj *types.Account, first *int32, after *string, last *int32, before *string) (*graphql1.BalanceConnection, error) {
+	return r.getAccountBalances(ctx, string(obj.StellarAddress), first, after, last, before)
 }
 
 // Transactions is the resolver for the transactions field.

--- a/internal/serve/graphql/resolvers/account_balances.go
+++ b/internal/serve/graphql/resolvers/account_balances.go
@@ -2,7 +2,11 @@ package resolvers
 
 import (
 	"context"
+	"fmt"
+	"slices"
+	"strings"
 
+	"github.com/google/uuid"
 	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
@@ -11,80 +15,557 @@ import (
 	"github.com/stellar/wallet-backend/internal/utils"
 )
 
-func (r *Resolver) getAccountBalances(ctx context.Context, address string) ([]graphql1.Balance, error) {
-	internalErr := func() error {
-		return &gqlerror.Error{
-			Message: ErrMsgBalancesFetchFailed,
-			Extensions: map[string]interface{}{
-				"code": "INTERNAL_ERROR",
-			},
-		}
+const (
+	// maxBalancePageLimit is intentionally smaller than "load everything" behavior
+	// because balances can fan out across trustlines and contract tokens for a single account.
+	maxBalancePageLimit int32 = 100
+	// balanceCursorPrefix versions the opaque cursor payload so future cursor
+	// formats can be introduced without silently misreading old cursors.
+	balanceCursorPrefix = "v1"
+)
+
+type balanceSource string
+
+const (
+	// The source order is the canonical connection order exposed by Account.balances.
+	// Cursors are opaque to clients, but the resolver must keep this ordering stable
+	// so forward/backward pagination works consistently across mixed balance types.
+	balanceSourceNative  balanceSource = "native"
+	balanceSourceClassic balanceSource = "classic"
+	balanceSourceSAC     balanceSource = "sac"
+	balanceSourceSEP41   balanceSource = "sep41"
+)
+
+// balanceCursor is the decoded form of our opaque cursor payload:
+//
+//	base64("v1:<source>:<id>")
+//
+// The cursor represents a position in the single logical Account.balances
+// connection, not just a position inside one backing table. The <source> part
+// tells the resolver which source owned the last returned edge, and the <id>
+// part is that source's local keyset cursor.
+//
+// The ID is source-specific:
+// - native -> literal "native"
+// - classic -> trustline asset UUID
+// - sac/sep41 -> contract UUID
+//
+// Example:
+//   - canonical order: native, classic(A), classic(B), sep41(X)
+//   - endCursor after returning classic(B): base64("v1:classic:<B-uuid>")
+//   - next forward page skips native entirely, resumes classic after B, then
+//     continues into later sources if it still needs more rows.
+type balanceCursor struct {
+	Source balanceSource
+	ID     string
+}
+
+// balanceNode keeps the GraphQL node together with the internal key used to
+// rebuild a stable cursor after the page has been assembled.
+type balanceNode struct {
+	Balance graphql1.Balance
+	Source  balanceSource
+	ID      string
+}
+
+func (n *balanceNode) CursorID() string {
+	return fmt.Sprintf("%s:%s:%s", balanceCursorPrefix, n.Source, n.ID)
+}
+
+// balanceBadUserInputError normalizes pagination validation failures to the
+// GraphQL error code used elsewhere in the API for client-correctable input issues.
+func balanceBadUserInputError(message string) error {
+	return &gqlerror.Error{
+		Message: message,
+		Extensions: map[string]interface{}{
+			"code": "BAD_USER_INPUT",
+		},
 	}
+}
 
-	networkPassphrase := r.rpcService.NetworkPassphrase()
-	var balances []graphql1.Balance
+// balanceInternalError hides storage/RPC details from clients while preserving
+// a stable machine-readable error code for operational failures.
+func balanceInternalError() error {
+	return &gqlerror.Error{
+		Message: ErrMsgBalancesFetchFailed,
+		Extensions: map[string]interface{}{
+			"code": "INTERNAL_ERROR",
+		},
+	}
+}
 
+// balanceSourcesForAddress returns the ordered set of balance sources that can
+// apply to the requested address type.
+//
+// G-addresses can have native XLM, classic trustlines, and SEP-41 balances.
+// C-addresses can hold SAC balances and SEP-41 balances, but never native/classic rows.
+func balanceSourcesForAddress(address string) []balanceSource {
 	if utils.IsContractAddress(address) {
-		sacBalances, err := r.balanceReader.GetSACBalances(ctx, address)
-		if err != nil {
-			log.Ctx(ctx).Errorf("failed to get SAC balances for %s: %v", address, err)
-			return nil, internalErr()
-		}
-		for _, sacBalance := range sacBalances {
-			balances = append(balances, buildSACBalanceFromDB(sacBalance))
-		}
-	} else {
-		nativeBalance, err := r.balanceReader.GetNativeBalance(ctx, address)
-		if err != nil {
-			log.Ctx(ctx).Errorf("failed to get native balance for %s: %v", address, err)
-			return nil, internalErr()
-		}
-		if nativeBalance != nil {
-			nativeBalanceResult, err := buildNativeBalanceFromDB(nativeBalance, networkPassphrase)
-			if err != nil {
-				return nil, internalErr()
-			}
-			balances = append(balances, nativeBalanceResult)
-		}
+		return []balanceSource{balanceSourceSAC, balanceSourceSEP41}
+	}
+	return []balanceSource{balanceSourceNative, balanceSourceClassic, balanceSourceSEP41}
+}
 
-		trustlines, err := r.balanceReader.GetTrustlineBalances(ctx, address)
-		if err != nil {
-			log.Ctx(ctx).Errorf("failed to get trustline balances for %s: %v", address, err)
-			return nil, internalErr()
-		}
-		for _, trustline := range trustlines {
-			trustlineBalance, err := buildTrustlineBalanceFromDB(trustline, networkPassphrase)
-			if err != nil {
-				return nil, internalErr()
-			}
-			balances = append(balances, trustlineBalance)
-		}
+// balanceSourceIndex maps a source to its canonical order position. The walkers
+// use this to decide which sources fall before or after the decoded cursor.
+func balanceSourceIndex(sources []balanceSource, source balanceSource) int {
+	return slices.Index(sources, source)
+}
+
+// parseBalancePaginationParams layers balances-specific policy on top of the
+// shared Relay pagination parser:
+// - same first/after/last/before semantics as the other connections
+// - string cursors instead of int/composite cursors
+// - a field-specific max page size to protect this multi-source resolver
+func parseBalancePaginationParams(first *int32, after *string, last *int32, before *string) (PaginationParams, error) {
+	if first != nil && *first > maxBalancePageLimit {
+		return PaginationParams{}, balanceBadUserInputError(fmt.Sprintf("first must be less than or equal to %d", maxBalancePageLimit))
+	}
+	if last != nil && *last > maxBalancePageLimit {
+		return PaginationParams{}, balanceBadUserInputError(fmt.Sprintf("last must be less than or equal to %d", maxBalancePageLimit))
 	}
 
-	contractTokens, err := r.accountContractTokensModel.GetByAccount(ctx, address)
+	params, err := parsePaginationParams(first, after, last, before, CursorTypeString)
 	if err != nil {
-		log.Ctx(ctx).Errorf("failed to get contract tokens for %s: %v", address, err)
-		return nil, internalErr()
+		return PaginationParams{}, balanceBadUserInputError(err.Error())
+	}
+	return params, nil
+}
+
+// parseBalanceCursor validates and decodes the inner cursor payload into a typed
+// form the resolver can dispatch to the correct backing source. The outer
+// base64 layer was already removed by parsePaginationParams.
+//
+// Validation is intentionally source-aware:
+// - the source must exist in the canonical source list for this address type
+// - the id must match the source's local key type
+//
+// That prevents a cursor from one balance collection shape from being replayed
+// against another, such as passing a native/classic cursor to a contract address.
+func parseBalanceCursor(cursor *string, sources []balanceSource) (*balanceCursor, error) {
+	if cursor == nil {
+		return nil, nil
 	}
 
-	contractsByContractID := make(map[string]*data.Contract)
-	sep41TokenIDs := make([]string, 0)
-	for _, contract := range contractTokens {
-		if contract.Type == "SEP41" {
-			sep41TokenIDs = append(sep41TokenIDs, contract.ContractID)
-			contractsByContractID[contract.ContractID] = contract
+	parts := strings.SplitN(*cursor, ":", 3)
+	if len(parts) != 3 {
+		return nil, balanceBadUserInputError("invalid balance cursor")
+	}
+	if parts[0] != balanceCursorPrefix {
+		return nil, balanceBadUserInputError("invalid balance cursor version")
+	}
+
+	source := balanceSource(parts[1])
+	if balanceSourceIndex(sources, source) == -1 {
+		return nil, balanceBadUserInputError("invalid balance cursor source")
+	}
+
+	switch source {
+	case balanceSourceNative:
+		if parts[2] != string(balanceSourceNative) {
+			return nil, balanceBadUserInputError("invalid balance cursor id")
+		}
+	default:
+		if _, err := uuid.Parse(parts[2]); err != nil {
+			return nil, balanceBadUserInputError("invalid balance cursor id")
 		}
 	}
 
-	if len(sep41TokenIDs) == 0 {
-		return balances, nil
+	return &balanceCursor{
+		Source: source,
+		ID:     parts[2],
+	}, nil
+}
+
+// uuid converts cursor IDs for the UUID-backed sources. Native uses a sentinel
+// string rather than a UUID because there is at most one native balance row.
+func (c *balanceCursor) uuid() (*uuid.UUID, error) {
+	if c == nil || c.Source == balanceSourceNative {
+		return nil, nil
 	}
 
-	sep41Balances, err := getSep41Balances(ctx, address, r.contractMetadataService, sep41TokenIDs, contractsByContractID)
+	id, err := uuid.Parse(c.ID)
 	if err != nil {
-		return nil, internalErr()
+		return nil, fmt.Errorf("parsing balance cursor uuid: %w", err)
 	}
-	balances = append(balances, sep41Balances...)
+	return &id, nil
+}
 
-	return balances, nil
+// getAccountBalances is the main field implementation for Account.balances.
+// It treats native/classic/SAC/SEP-41 balances as one logical Relay
+// connection:
+//  1. parse Relay args
+//  2. decode the source-aware cursor into a global boundary
+//  3. fetch requested+1 rows across the ordered sources
+//  4. hand the assembled nodes to the shared Relay helper for edges/PageInfo
+func (r *Resolver) getAccountBalances(ctx context.Context, address string, first *int32, after *string, last *int32, before *string) (*graphql1.BalanceConnection, error) {
+	params, err := parseBalancePaginationParams(first, after, last, before)
+	if err != nil {
+		return nil, err
+	}
+
+	sources := balanceSourcesForAddress(address)
+	cursor, err := parseBalanceCursor(params.StringCursor, sources)
+	if err != nil {
+		return nil, err
+	}
+
+	queryLimit := *params.Limit + 1
+	networkPassphrase := r.rpcService.NetworkPassphrase()
+
+	nodes, err := r.getAccountBalanceNodes(ctx, address, sources, cursor, params, queryLimit, networkPassphrase)
+	if err != nil {
+		return nil, err
+	}
+
+	conn := NewConnectionWithRelayPagination(nodes, params, func(node *balanceNode) string {
+		return node.CursorID()
+	})
+
+	edges := make([]*graphql1.BalanceEdge, len(conn.Edges))
+	for i, edge := range conn.Edges {
+		edges[i] = &graphql1.BalanceEdge{
+			Node:   edge.Node.Balance,
+			Cursor: edge.Cursor,
+		}
+	}
+
+	return &graphql1.BalanceConnection{
+		Edges:    edges,
+		PageInfo: conn.PageInfo,
+	}, nil
+}
+
+// getAccountBalanceNodes delegates to separate forward/backward walkers because
+// the backing data comes from multiple sources rather than one DB query.
+//
+// The important rule is that the decoded cursor marks one boundary in the
+// global source-ordered list. Only the source that owns that boundary receives
+// a source-local cursor; earlier/later sources are either skipped or scanned
+// from their natural start depending on pagination direction.
+//
+// Both walkers gather requested+1 nodes so PageInfo can be computed by the
+// shared Relay helper without loading the full balance set.
+func (r *Resolver) getAccountBalanceNodes(
+	ctx context.Context,
+	address string,
+	sources []balanceSource,
+	cursor *balanceCursor,
+	params PaginationParams,
+	queryLimit int32,
+	networkPassphrase string,
+) ([]*balanceNode, error) {
+	if params.ForwardPagination {
+		return r.getAccountBalanceNodesForward(ctx, address, sources, cursor, queryLimit, networkPassphrase)
+	}
+
+	nodes, err := r.getAccountBalanceNodesBackward(ctx, address, sources, cursor, queryLimit, networkPassphrase)
+	if err != nil {
+		return nil, err
+	}
+
+	slices.Reverse(nodes)
+	return nodes, nil
+}
+
+// getAccountBalanceNodesForward walks sources in canonical order and only uses
+// the decoded cursor on the source where the previous page ended.
+//
+// Example:
+// - canonical order: native -> classic -> sep41
+// - after = classic:<uuid-B>
+// Then the forward walk:
+// - skips native (already fully consumed by earlier pages)
+// - resumes classic after uuid-B
+// - continues into sep41 only if classic does not fill the page
+func (r *Resolver) getAccountBalanceNodesForward(
+	ctx context.Context,
+	address string,
+	sources []balanceSource,
+	cursor *balanceCursor,
+	queryLimit int32,
+	networkPassphrase string,
+) ([]*balanceNode, error) {
+	nodes := make([]*balanceNode, 0, queryLimit)
+	remaining := queryLimit
+	cursorSourceIndex := -1
+	if cursor != nil {
+		cursorSourceIndex = balanceSourceIndex(sources, cursor.Source)
+	}
+
+	for i, source := range sources {
+		// All sources before the cursor source were already fully consumed by the
+		// previous page, so they can be skipped entirely.
+		if cursor != nil && i < cursorSourceIndex {
+			continue
+		}
+
+		var sourceCursor *balanceCursor
+		if cursor != nil && i == cursorSourceIndex {
+			// Only the source that produced the end cursor should apply the
+			// source-local keyset comparison for the next page.
+			sourceCursor = cursor
+		}
+
+		sourceNodes, err := r.getBalanceNodesForSource(ctx, address, source, sourceCursor, data.ASC, remaining, networkPassphrase)
+		if err != nil {
+			return nil, err
+		}
+
+		nodes = append(nodes, sourceNodes...)
+		if int32(len(sourceNodes)) >= remaining {
+			break
+		}
+		remaining -= int32(len(sourceNodes))
+	}
+
+	return nodes, nil
+}
+
+// getAccountBalanceNodesBackward mirrors the forward walk but traverses sources
+// in reverse. Each source fetch runs DESC in the DB, and the combined slice is
+// reversed once at the end so the final connection still returns canonical ASC
+// order.
+//
+// Example:
+// - canonical order: native -> classic -> sep41
+// - before = sep41:<uuid-X>
+// Then the backward walk:
+// - skips sources after sep41 in canonical order (none in this example)
+// - resumes sep41 before uuid-X
+// - falls back into classic, then native, until the page is full
+func (r *Resolver) getAccountBalanceNodesBackward(
+	ctx context.Context,
+	address string,
+	sources []balanceSource,
+	cursor *balanceCursor,
+	queryLimit int32,
+	networkPassphrase string,
+) ([]*balanceNode, error) {
+	nodes := make([]*balanceNode, 0, queryLimit)
+	remaining := queryLimit
+	cursorSourceIndex := len(sources)
+	if cursor != nil {
+		cursorSourceIndex = balanceSourceIndex(sources, cursor.Source)
+	}
+
+	for i := len(sources) - 1; i >= 0; i-- {
+		source := sources[i]
+		// When paging backwards, sources that come after the cursor source in
+		// canonical order were already consumed by the current page window.
+		if cursor != nil && i > cursorSourceIndex {
+			continue
+		}
+
+		var sourceCursor *balanceCursor
+		if cursor != nil && i == cursorSourceIndex {
+			// As with forward pagination, only one source uses the decoded cursor.
+			sourceCursor = cursor
+		}
+
+		sourceNodes, err := r.getBalanceNodesForSource(ctx, address, source, sourceCursor, data.DESC, remaining, networkPassphrase)
+		if err != nil {
+			return nil, err
+		}
+
+		nodes = append(nodes, sourceNodes...)
+		if int32(len(sourceNodes)) >= remaining {
+			break
+		}
+		remaining -= int32(len(sourceNodes))
+	}
+
+	return nodes, nil
+}
+
+// getBalanceNodesForSource converts one backing source into connection nodes.
+// Each source owns its own local keyset semantics, but all of them flow into
+// the same balanceNode shape for final connection assembly.
+//
+// The caller only passes a non-nil cursor when this source owns the global page
+// boundary. Every other source either starts from its natural beginning/end or
+// is skipped entirely by the source walkers above.
+func (r *Resolver) getBalanceNodesForSource(
+	ctx context.Context,
+	address string,
+	source balanceSource,
+	cursor *balanceCursor,
+	sortOrder data.SortOrder,
+	limit int32,
+	networkPassphrase string,
+) ([]*balanceNode, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+
+	switch source {
+	case balanceSourceNative:
+		// Native has at most one row — a cursor means it was already emitted.
+		if cursor != nil {
+			return nil, nil
+		}
+		return r.getNativeBalanceNodes(ctx, address, networkPassphrase)
+	case balanceSourceClassic:
+		return r.getTrustlineBalanceNodes(ctx, address, cursor, sortOrder, limit, networkPassphrase)
+	case balanceSourceSAC:
+		return r.getSACBalanceNodes(ctx, address, cursor, sortOrder, limit)
+	case balanceSourceSEP41:
+		return r.getSEP41BalanceNodes(ctx, address, cursor, sortOrder, limit)
+	default:
+		return nil, balanceBadUserInputError("invalid balance source")
+	}
+}
+
+// getNativeBalanceNodes fetches the single native XLM balance for the account.
+func (r *Resolver) getNativeBalanceNodes(ctx context.Context, address string, networkPassphrase string) ([]*balanceNode, error) {
+	nativeBalance, err := r.balanceReader.GetNativeBalance(ctx, address)
+	if err != nil {
+		log.Ctx(ctx).Errorf("failed to get native balance for %s: %v", address, err)
+		return nil, balanceInternalError()
+	}
+	if nativeBalance == nil {
+		return nil, nil
+	}
+
+	nativeBalanceResult, err := buildNativeBalanceFromDB(nativeBalance, networkPassphrase)
+	if err != nil {
+		log.Ctx(ctx).Errorf("failed to build native balance for %s: %v", address, err)
+		return nil, balanceInternalError()
+	}
+
+	return []*balanceNode{{
+		Balance: nativeBalanceResult,
+		Source:  balanceSourceNative,
+		ID:      string(balanceSourceNative),
+	}}, nil
+}
+
+// getTrustlineBalanceNodes pages classic trustlines by their stable internal
+// asset UUID, then converts each DB row into the GraphQL trustline shape.
+func (r *Resolver) getTrustlineBalanceNodes(
+	ctx context.Context,
+	address string,
+	cursor *balanceCursor,
+	sortOrder data.SortOrder,
+	limit int32,
+	networkPassphrase string,
+) ([]*balanceNode, error) {
+	cursorID, err := cursor.uuid()
+	if err != nil {
+		return nil, balanceBadUserInputError("invalid balance cursor id")
+	}
+
+	trustlines, err := r.balanceReader.GetTrustlineBalances(ctx, address, &limit, cursorID, sortOrder)
+	if err != nil {
+		log.Ctx(ctx).Errorf("failed to get paginated trustline balances for %s: %v", address, err)
+		return nil, balanceInternalError()
+	}
+
+	nodes := make([]*balanceNode, 0, len(trustlines))
+	for _, trustline := range trustlines {
+		trustlineBalance, balanceErr := buildTrustlineBalanceFromDB(trustline, networkPassphrase)
+		if balanceErr != nil {
+			log.Ctx(ctx).Errorf("failed to build trustline balance for %s and asset %s: %v", address, trustline.AssetID, balanceErr)
+			return nil, balanceInternalError()
+		}
+
+		nodes = append(nodes, &balanceNode{
+			Balance: trustlineBalance,
+			Source:  balanceSourceClassic,
+			ID:      trustline.AssetID.String(),
+		})
+	}
+
+	return nodes, nil
+}
+
+// getSACBalanceNodes pages contract-holder SAC balances by contract UUID. Unlike
+// SEP-41, all fields needed for the GraphQL node are already present in PostgreSQL.
+func (r *Resolver) getSACBalanceNodes(
+	ctx context.Context,
+	address string,
+	cursor *balanceCursor,
+	sortOrder data.SortOrder,
+	limit int32,
+) ([]*balanceNode, error) {
+	cursorID, err := cursor.uuid()
+	if err != nil {
+		return nil, balanceBadUserInputError("invalid balance cursor id")
+	}
+
+	sacBalances, err := r.balanceReader.GetSACBalances(ctx, address, &limit, cursorID, sortOrder)
+	if err != nil {
+		log.Ctx(ctx).Errorf("failed to get paginated SAC balances for %s: %v", address, err)
+		return nil, balanceInternalError()
+	}
+
+	nodes := make([]*balanceNode, 0, len(sacBalances))
+	for _, sacBalance := range sacBalances {
+		nodes = append(nodes, &balanceNode{
+			Balance: buildSACBalanceFromDB(sacBalance),
+			Source:  balanceSourceSAC,
+			ID:      sacBalance.ContractID.String(),
+		})
+	}
+
+	return nodes, nil
+}
+
+// SEP-41 balances are the only source that still needs RPC work. To avoid
+// spending RPC calls on the extra row fetched for hasNextPage detection, this
+// method converts only the visible contracts and carries the final fetched row
+// through as a cursor-only sentinel node.
+func (r *Resolver) getSEP41BalanceNodes(
+	ctx context.Context,
+	address string,
+	cursor *balanceCursor,
+	sortOrder data.SortOrder,
+	limit int32,
+) ([]*balanceNode, error) {
+	cursorID, err := cursor.uuid()
+	if err != nil {
+		return nil, balanceBadUserInputError("invalid balance cursor id")
+	}
+
+	contracts, err := r.accountContractTokensModel.GetSEP41ByAccount(ctx, address, &limit, cursorID, sortOrder)
+	if err != nil {
+		log.Ctx(ctx).Errorf("failed to get paginated SEP-41 contracts for %s: %v", address, err)
+		return nil, balanceInternalError()
+	}
+
+	nodes := make([]*balanceNode, 0, len(contracts))
+	visibleContracts := contracts
+	var sentinel *balanceNode
+	if len(contracts) == int(limit) {
+		// The last fetched row is reserved as a cursor-only sentinel so Relay can
+		// detect a next page without paying one extra RPC balance lookup.
+		extraContract := contracts[len(contracts)-1]
+		visibleContracts = contracts[:len(contracts)-1]
+		sentinel = &balanceNode{
+			Source: balanceSourceSEP41,
+			ID:     extraContract.ID.String(),
+		}
+	}
+
+	for _, contract := range visibleContracts {
+		sep41Balance, balanceErr := getSep41Balance(ctx, address, r.contractMetadataService, contract)
+		if balanceErr != nil {
+			log.Ctx(ctx).Errorf("failed to get SEP-41 balance for %s and contract %s: %v", address, contract.ContractID, balanceErr)
+			return nil, balanceInternalError()
+		}
+
+		nodes = append(nodes, &balanceNode{
+			Balance: sep41Balance,
+			Source:  balanceSourceSEP41,
+			ID:      contract.ID.String(),
+		})
+	}
+
+	if sentinel != nil {
+		// The sentinel intentionally has no GraphQL node payload. It exists only
+		// so NewConnectionWithRelayPagination can compute hasNextPage/endCursor.
+		nodes = append(nodes, sentinel)
+	}
+
+	return nodes, nil
 }

--- a/internal/serve/graphql/resolvers/account_balances.go
+++ b/internal/serve/graphql/resolvers/account_balances.go
@@ -1,0 +1,90 @@
+package resolvers
+
+import (
+	"context"
+
+	"github.com/stellar/go-stellar-sdk/support/log"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+
+	"github.com/stellar/wallet-backend/internal/data"
+	graphql1 "github.com/stellar/wallet-backend/internal/serve/graphql/generated"
+	"github.com/stellar/wallet-backend/internal/utils"
+)
+
+func (r *Resolver) getAccountBalances(ctx context.Context, address string) ([]graphql1.Balance, error) {
+	internalErr := func() error {
+		return &gqlerror.Error{
+			Message: ErrMsgBalancesFetchFailed,
+			Extensions: map[string]interface{}{
+				"code": "INTERNAL_ERROR",
+			},
+		}
+	}
+
+	networkPassphrase := r.rpcService.NetworkPassphrase()
+	var balances []graphql1.Balance
+
+	if utils.IsContractAddress(address) {
+		sacBalances, err := r.balanceReader.GetSACBalances(ctx, address)
+		if err != nil {
+			log.Ctx(ctx).Errorf("failed to get SAC balances for %s: %v", address, err)
+			return nil, internalErr()
+		}
+		for _, sacBalance := range sacBalances {
+			balances = append(balances, buildSACBalanceFromDB(sacBalance))
+		}
+	} else {
+		nativeBalance, err := r.balanceReader.GetNativeBalance(ctx, address)
+		if err != nil {
+			log.Ctx(ctx).Errorf("failed to get native balance for %s: %v", address, err)
+			return nil, internalErr()
+		}
+		if nativeBalance != nil {
+			nativeBalanceResult, err := buildNativeBalanceFromDB(nativeBalance, networkPassphrase)
+			if err != nil {
+				return nil, internalErr()
+			}
+			balances = append(balances, nativeBalanceResult)
+		}
+
+		trustlines, err := r.balanceReader.GetTrustlineBalances(ctx, address)
+		if err != nil {
+			log.Ctx(ctx).Errorf("failed to get trustline balances for %s: %v", address, err)
+			return nil, internalErr()
+		}
+		for _, trustline := range trustlines {
+			trustlineBalance, err := buildTrustlineBalanceFromDB(trustline, networkPassphrase)
+			if err != nil {
+				return nil, internalErr()
+			}
+			balances = append(balances, trustlineBalance)
+		}
+	}
+
+	contractTokens, err := r.accountContractTokensModel.GetByAccount(ctx, address)
+	if err != nil {
+		log.Ctx(ctx).Errorf("failed to get contract tokens for %s: %v", address, err)
+		return nil, internalErr()
+	}
+
+	contractsByContractID := make(map[string]*data.Contract)
+	sep41TokenIDs := make([]string, 0)
+	for _, contract := range contractTokens {
+		if contract.Type == "SEP41" {
+			sep41TokenIDs = append(sep41TokenIDs, contract.ContractID)
+			contractsByContractID[contract.ContractID] = contract
+		}
+	}
+
+	if len(sep41TokenIDs) == 0 {
+		return balances, nil
+	}
+
+	sep41Balances, err := getSep41Balances(ctx, address, r.contractMetadataService, sep41TokenIDs, contractsByContractID, r.pool)
+	if err != nil {
+		return nil, internalErr()
+	}
+	balances = append(balances, sep41Balances...)
+
+	return balances, nil
+}

--- a/internal/serve/graphql/resolvers/account_balances.go
+++ b/internal/serve/graphql/resolvers/account_balances.go
@@ -80,7 +80,7 @@ func (r *Resolver) getAccountBalances(ctx context.Context, address string) ([]gr
 		return balances, nil
 	}
 
-	sep41Balances, err := getSep41Balances(ctx, address, r.contractMetadataService, sep41TokenIDs, contractsByContractID, r.pool)
+	sep41Balances, err := getSep41Balances(ctx, address, r.contractMetadataService, sep41TokenIDs, contractsByContractID)
 	if err != nil {
 		return nil, internalErr()
 	}

--- a/internal/serve/graphql/resolvers/account_balances_test.go
+++ b/internal/serve/graphql/resolvers/account_balances_test.go
@@ -1,4 +1,4 @@
-// Tests for the balancesByAccountAddress GraphQL query resolver
+// Tests for the Account.balances GraphQL field resolver
 package resolvers
 
 import (
@@ -69,7 +69,11 @@ func createI128ScVal(amount int64) xdr.ScVal {
 	}
 }
 
-func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
+func testParentAccount(address string) *types.Account {
+	return &types.Account{StellarAddress: types.AddressBytea(address)}
+}
+
+func TestAccountResolver_Balances(t *testing.T) {
 	// Success Cases
 	t.Run("success - native balance only", func(t *testing.T) {
 		ctx := context.Background()
@@ -85,7 +89,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
 		// No GetLedgerEntries call needed - native balance comes from DB
 
-		resolver := &queryResolver{
+		resolver := &accountResolver{
 			&Resolver{
 				balanceReader:              NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
 				accountContractTokensModel: mockAccountContractTokens,
@@ -93,7 +97,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 			},
 		}
 
-		balances, err := resolver.BalancesByAccountAddress(ctx, testAccountAddress)
+		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
 		require.NoError(t, err)
 		require.Len(t, balances, 1)
 
@@ -149,7 +153,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
 		// No GetLedgerEntries call needed - native and trustlines come from DB
 
-		resolver := &queryResolver{
+		resolver := &accountResolver{
 			&Resolver{
 				balanceReader:              NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
 				accountContractTokensModel: mockAccountContractTokens,
@@ -157,7 +161,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 			},
 		}
 
-		balances, err := resolver.BalancesByAccountAddress(ctx, testAccountAddress)
+		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
 		require.NoError(t, err)
 		require.Len(t, balances, 3) // 1 native + 2 trustlines
 
@@ -218,7 +222,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 		mockAccountContractTokens.On("GetByAccount", ctx, testContractAddress).Return([]*data.Contract{}, nil)
 		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
 
-		resolver := &queryResolver{
+		resolver := &accountResolver{
 			&Resolver{
 				balanceReader:              NewBalanceReader(data.NewTrustlineBalanceModelMock(t), data.NewNativeBalanceModelMock(t), mockSACBalanceModel),
 				accountContractTokensModel: mockAccountContractTokens,
@@ -226,7 +230,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 			},
 		}
 
-		balances, err := resolver.BalancesByAccountAddress(ctx, testContractAddress)
+		balances, err := resolver.Balances(ctx, testParentAccount(testContractAddress))
 		require.NoError(t, err)
 		require.Len(t, balances, 1) // 1 SAC
 
@@ -267,7 +271,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 			Return(createI128ScVal(50000000000), nil)
 		// No GetLedgerEntries call needed - SEP-41 uses FetchSingleField, native comes from DB
 
-		resolver := &queryResolver{
+		resolver := &accountResolver{
 			&Resolver{
 				balanceReader:              NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
 				accountContractTokensModel: mockAccountContractTokens,
@@ -277,7 +281,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 			},
 		}
 
-		balances, err := resolver.BalancesByAccountAddress(ctx, testAccountAddress)
+		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
 		require.NoError(t, err)
 		require.Len(t, balances, 2) // 1 native + 1 SEP-41
 
@@ -333,7 +337,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 		mockContractMetadataService.On("FetchSingleField", ctx, testSEP41ContractAddress, "balance", mock.Anything).
 			Return(createI128ScVal(30000000000), nil)
 
-		resolver := &queryResolver{
+		resolver := &accountResolver{
 			&Resolver{
 				balanceReader:              NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
 				accountContractTokensModel: mockAccountContractTokens,
@@ -343,7 +347,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 			},
 		}
 
-		balances, err := resolver.BalancesByAccountAddress(ctx, testAccountAddress)
+		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
 		require.NoError(t, err)
 		require.Len(t, balances, 3) // native + trustline + SEP-41
 
@@ -382,7 +386,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 		mockContractMetadataService.On("FetchSingleField", ctx, testSEP41ContractAddress, "balance", mock.Anything).
 			Return(createI128ScVal(10000000000), nil)
 
-		resolver := &queryResolver{
+		resolver := &accountResolver{
 			&Resolver{
 				balanceReader:              NewBalanceReader(data.NewTrustlineBalanceModelMock(t), data.NewNativeBalanceModelMock(t), mockSACBalanceModel),
 				accountContractTokensModel: mockAccountContractTokens,
@@ -392,7 +396,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 			},
 		}
 
-		balances, err := resolver.BalancesByAccountAddress(ctx, testContractAddress)
+		balances, err := resolver.Balances(ctx, testParentAccount(testContractAddress))
 		require.NoError(t, err)
 		require.Len(t, balances, 1)
 
@@ -437,7 +441,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
 		// No GetLedgerEntries call needed - native and trustlines come from DB
 
-		resolver := &queryResolver{
+		resolver := &accountResolver{
 			&Resolver{
 				balanceReader:              NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
 				accountContractTokensModel: mockAccountContractTokens,
@@ -445,7 +449,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 			},
 		}
 
-		balances, err := resolver.BalancesByAccountAddress(ctx, testAccountAddress)
+		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
 		require.NoError(t, err)
 
 		for _, balance := range balances {
@@ -464,15 +468,6 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 
 	// Error Cases
 
-	t.Run("error - empty address", func(t *testing.T) {
-		ctx := context.Background()
-		resolver := &queryResolver{&Resolver{}}
-
-		balances, err := resolver.BalancesByAccountAddress(ctx, "")
-		assert.Error(t, err)
-		assert.Nil(t, balances)
-	})
-
 	t.Run("error - GetTrustlineBalances fails", func(t *testing.T) {
 		ctx := context.Background()
 		mockTrustlineBalanceModel := data.NewTrustlineBalanceModelMock(t)
@@ -484,14 +479,14 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress).
 			Return([]data.TrustlineBalance{}, errors.New("database query failed"))
 
-		resolver := &queryResolver{
+		resolver := &accountResolver{
 			&Resolver{
 				balanceReader: NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
 				rpcService:    mockRPCService,
 			},
 		}
 
-		balances, err := resolver.BalancesByAccountAddress(ctx, testAccountAddress)
+		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), ErrMsgBalancesFetchFailed)
 		assert.Nil(t, balances)
@@ -511,7 +506,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 		mockAccountContractTokens.On("GetByAccount", ctx, testAccountAddress).
 			Return([]*data.Contract{}, errors.New("database query failed"))
 
-		resolver := &queryResolver{
+		resolver := &accountResolver{
 			&Resolver{
 				balanceReader:              NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
 				accountContractTokensModel: mockAccountContractTokens,
@@ -519,7 +514,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 			},
 		}
 
-		balances, err := resolver.BalancesByAccountAddress(ctx, testAccountAddress)
+		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), ErrMsgBalancesFetchFailed)
 		assert.Nil(t, balances)
@@ -535,14 +530,14 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 			Return(nil, errors.New("database connection failed"))
 		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
 
-		resolver := &queryResolver{
+		resolver := &accountResolver{
 			&Resolver{
 				balanceReader: NewBalanceReader(data.NewTrustlineBalanceModelMock(t), data.NewNativeBalanceModelMock(t), mockSACBalanceModel),
 				rpcService:    mockRPCService,
 			},
 		}
 
-		balances, err := resolver.BalancesByAccountAddress(ctx, testContractAddress)
+		balances, err := resolver.Balances(ctx, testParentAccount(testContractAddress))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), ErrMsgBalancesFetchFailed)
 		assert.Nil(t, balances)
@@ -566,14 +561,14 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 			}, nil)
 		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
 
-		resolver := &queryResolver{
+		resolver := &accountResolver{
 			&Resolver{
 				balanceReader: NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
 				rpcService:    mockRPCService,
 			},
 		}
 
-		balances, err := resolver.BalancesByAccountAddress(ctx, testAccountAddress)
+		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), ErrMsgBalancesFetchFailed)
 		assert.Nil(t, balances)
@@ -620,7 +615,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 			Return(wrongTypeScVal, nil)
 		// No GetLedgerEntries call needed - SEP-41 uses FetchSingleField, native comes from DB
 
-		resolver := &queryResolver{
+		resolver := &accountResolver{
 			&Resolver{
 				balanceReader:              NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
 				accountContractTokensModel: mockAccountContractTokens,
@@ -630,7 +625,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 			},
 		}
 
-		balances, err := resolver.BalancesByAccountAddress(ctx, testAccountAddress)
+		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), ErrMsgBalancesFetchFailed)
 		assert.Nil(t, balances)
@@ -658,7 +653,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
 		// No GetLedgerEntries call needed - native comes from DB, unknown contracts are skipped
 
-		resolver := &queryResolver{
+		resolver := &accountResolver{
 			&Resolver{
 				balanceReader:              NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
 				accountContractTokensModel: mockAccountContractTokens,
@@ -666,7 +661,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 			},
 		}
 
-		balances, err := resolver.BalancesByAccountAddress(ctx, testAccountAddress)
+		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
 		require.NoError(t, err)
 		// Should only have native balance, contract balance skipped
 		require.Len(t, balances, 1)
@@ -714,7 +709,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
 		// No GetLedgerEntries call needed - native and trustlines come from DB
 
-		resolver := &queryResolver{
+		resolver := &accountResolver{
 			&Resolver{
 				balanceReader:              NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
 				accountContractTokensModel: mockAccountContractTokens,
@@ -722,7 +717,7 @@ func TestQueryResolver_BalancesByAccountAddress(t *testing.T) {
 			},
 		}
 
-		balances, err := resolver.BalancesByAccountAddress(ctx, testAccountAddress)
+		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
 		require.NoError(t, err)
 		require.Len(t, balances, 3)
 

--- a/internal/serve/graphql/resolvers/account_balances_test.go
+++ b/internal/serve/graphql/resolvers/account_balances_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/alitto/pond/v2"
 	"github.com/google/uuid"
 	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/assert"
@@ -277,7 +276,6 @@ func TestAccountResolver_Balances(t *testing.T) {
 				accountContractTokensModel: mockAccountContractTokens,
 				rpcService:                 mockRPCService,
 				contractMetadataService:    mockContractMetadataService,
-				pool:                       pond.NewPool(0),
 			},
 		}
 
@@ -343,7 +341,6 @@ func TestAccountResolver_Balances(t *testing.T) {
 				accountContractTokensModel: mockAccountContractTokens,
 				rpcService:                 mockRPCService,
 				contractMetadataService:    mockContractMetadataService,
-				pool:                       pond.NewPool(0),
 			},
 		}
 
@@ -392,7 +389,6 @@ func TestAccountResolver_Balances(t *testing.T) {
 				accountContractTokensModel: mockAccountContractTokens,
 				rpcService:                 mockRPCService,
 				contractMetadataService:    mockContractMetadataService,
-				pool:                       pond.NewPool(0),
 			},
 		}
 
@@ -621,7 +617,6 @@ func TestAccountResolver_Balances(t *testing.T) {
 				accountContractTokensModel: mockAccountContractTokens,
 				rpcService:                 mockRPCService,
 				contractMetadataService:    mockContractMetadataService,
-				pool:                       pond.NewPool(0),
 			},
 		}
 

--- a/internal/serve/graphql/resolvers/account_balances_test.go
+++ b/internal/serve/graphql/resolvers/account_balances_test.go
@@ -1,4 +1,4 @@
-// Tests for the Account.balances GraphQL field resolver
+// Tests for the Account.balances GraphQL field resolver.
 package resolvers
 
 import (
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 
 	"github.com/stellar/wallet-backend/internal/data"
 	"github.com/stellar/wallet-backend/internal/indexer/types"
@@ -19,31 +20,18 @@ import (
 )
 
 const (
-	testAccountAddress       = "GAFOZZL77R57WMGES6BO6WJDEIFJ6662GMCVEX6ZESULRX3FRBGSSV5N"
-	testContractAddress      = "CAZXRTOKNUQ2JQQF3NCRU7GYMDJNZ2NMQN6IGN4FCT5DWPODMPVEXSND"
-	testSACContractAddress   = "CBHBD77PWZ3AXPQVYVDBHDKEMVNOR26UZUZHWCB6QC7J5SETQPRUQAS4"
-	testSEP41ContractAddress = "CAZXRTOKNUQ2JQQF3NCRU7GYMDJNZ2NMQN6IGN4FCT5DWPODMPVEXSND"
-	testUSDCIssuer           = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
-	testEURIssuer            = "GCEODJVUUVYVFD5KT4TOEDTMXQ76OPFOQC2EMYYMLPXQCUVPOB6XRWPQ"
-	testNetworkPassphrase    = "Test SDF Network ; September 2015"
+	testAccountAddress        = "GAFOZZL77R57WMGES6BO6WJDEIFJ6662GMCVEX6ZESULRX3FRBGSSV5N"
+	testContractAddress       = "CAZXRTOKNUQ2JQQF3NCRU7GYMDJNZ2NMQN6IGN4FCT5DWPODMPVEXSND"
+	testSACContractAddress    = "CBHBD77PWZ3AXPQVYVDBHDKEMVNOR26UZUZHWCB6QC7J5SETQPRUQAS4"
+	testSEP41ContractAddress  = "CAZXRTOKNUQ2JQQF3NCRU7GYMDJNZ2NMQN6IGN4FCT5DWPODMPVEXSND"
+	testSEP41ContractAddress2 = "CBZXRTOKNUQ2JQQF3NCRU7GYMDJNZ2NMQN6IGN4FCT5DWPODMPVEXSNA"
+	testUSDCIssuer            = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+	testNetworkPassphrase     = "Test SDF Network ; September 2015"
 )
 
-// Helper to create ScSymbol pointer
-func ptrToScSymbol(s string) *xdr.ScSymbol {
-	sym := xdr.ScSymbol(s)
-	return &sym
-}
-
-// Helper to create ScMap pointer
-func ptrToScMap(entries []xdr.ScMapEntry) **xdr.ScMap {
-	m := xdr.ScMap(entries)
-	ptr := &m
-	return &ptr
-}
-
-// Helper to create SEP-41 contract data
-func createSEP41Contract(contractID, name, symbol string, decimals uint32) *data.Contract { //nolint:unparam
+func createSEP41Contract(contractID, name, symbol string, decimals uint32) *data.Contract {
 	return &data.Contract{
+		ID:         data.DeterministicContractID(contractID),
 		ContractID: contractID,
 		Type:       string(types.ContractTypeSEP41),
 		Name:       &name,
@@ -52,7 +40,6 @@ func createSEP41Contract(contractID, name, symbol string, decimals uint32) *data
 	}
 }
 
-// Helper to create i128 ScVal for SEP-41 balance simulation response
 func createI128ScVal(amount int64) xdr.ScVal {
 	hi := int64(0)
 	if amount < 0 {
@@ -72,21 +59,48 @@ func testParentAccount(address string) *types.Account {
 	return &types.Account{StellarAddress: types.AddressBytea(address)}
 }
 
+func int32Ptr(v int32) *int32 {
+	return &v
+}
+
+func limitMatcher(expected int32) interface{} {
+	return mock.MatchedBy(func(limit *int32) bool {
+		return limit != nil && *limit == expected
+	})
+}
+
+func cursorUUIDMatcher(expected uuid.UUID) interface{} {
+	return mock.MatchedBy(func(cursor *uuid.UUID) bool {
+		return cursor != nil && *cursor == expected
+	})
+}
+
+func flattenBalanceNodes(conn *graphql1.BalanceConnection) []graphql1.Balance {
+	if conn == nil {
+		return nil
+	}
+
+	nodes := make([]graphql1.Balance, 0, len(conn.Edges))
+	for _, edge := range conn.Edges {
+		nodes = append(nodes, edge.Node)
+	}
+	return nodes
+}
+
 func TestAccountResolver_Balances(t *testing.T) {
-	// Success Cases
-	t.Run("success - native balance only", func(t *testing.T) {
+	t.Run("empty account returns empty connection", func(t *testing.T) {
 		ctx := context.Background()
 		mockTrustlineBalanceModel := data.NewTrustlineBalanceModelMock(t)
 		mockNativeBalanceModel := data.NewNativeBalanceModelMock(t)
 		mockAccountContractTokens := data.NewAccountContractTokensModelMock(t)
 		mockRPCService := services.NewRPCServiceMock(t)
 
-		// Setup mocks - native balance comes from DB, not RPC
-		mockNativeBalanceModel.On("GetByAccount", ctx, testAccountAddress).Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 10000000000}, nil)
-		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress).Return([]data.TrustlineBalance{}, nil)
-		mockAccountContractTokens.On("GetByAccount", ctx, testAccountAddress).Return([]*data.Contract{}, nil)
+		mockNativeBalanceModel.On("GetByAccount", ctx, testAccountAddress).Return(nil, nil)
+		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress, limitMatcher(51), (*uuid.UUID)(nil), data.ASC).
+			Return([]data.TrustlineBalance{}, nil)
+		mockAccountContractTokens.On("GetSEP41ByAccount", ctx, testAccountAddress, limitMatcher(51), (*uuid.UUID)(nil), data.ASC).
+			Return([]*data.Contract{}, nil)
 		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
-		// No GetLedgerEntries call needed - native balance comes from DB
 
 		resolver := &accountResolver{
 			&Resolver{
@@ -96,161 +110,17 @@ func TestAccountResolver_Balances(t *testing.T) {
 			},
 		}
 
-		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
+		conn, err := resolver.Balances(ctx, testParentAccount(testAccountAddress), nil, nil, nil, nil)
 		require.NoError(t, err)
-		require.Len(t, balances, 1)
-
-		// Verify it's a native balance
-		for _, balance := range balances {
-			switch balance.GetTokenType() {
-			case graphql1.TokenTypeNative:
-				nativeBalance := balance.(*graphql1.NativeBalance)
-				assert.Equal(t, "1000.0000000", nativeBalance.Balance)
-				assert.Equal(t, graphql1.TokenTypeNative, nativeBalance.TokenType)
-				assert.NotEmpty(t, nativeBalance.TokenID) // Native asset contract ID
-			default:
-				t.Errorf("unexpected balance type: %v", balance.GetTokenType())
-			}
-		}
+		require.NotNil(t, conn)
+		assert.Empty(t, conn.Edges)
+		assert.False(t, conn.PageInfo.HasNextPage)
+		assert.False(t, conn.PageInfo.HasPreviousPage)
+		assert.Nil(t, conn.PageInfo.StartCursor)
+		assert.Nil(t, conn.PageInfo.EndCursor)
 	})
 
-	t.Run("success - account with classic trustlines", func(t *testing.T) {
-		ctx := context.Background()
-		mockTrustlineBalanceModel := data.NewTrustlineBalanceModelMock(t)
-		mockNativeBalanceModel := data.NewNativeBalanceModelMock(t)
-		mockAccountContractTokens := data.NewAccountContractTokensModelMock(t)
-		mockRPCService := services.NewRPCServiceMock(t)
-
-		// Setup mocks - native and trustlines come from DB, not RPC
-		mockNativeBalanceModel.On("GetByAccount", ctx, testAccountAddress).Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 5000000000}, nil) // 500 XLM
-		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress).
-			Return([]data.TrustlineBalance{
-				{
-					AssetID:            data.DeterministicAssetID("USDC", testUSDCIssuer),
-					Code:               "USDC",
-					Issuer:             testUSDCIssuer,
-					Balance:            1000000000,  // 100 USDC
-					Limit:              10000000000, // 1000 USDC
-					BuyingLiabilities:  1000000,
-					SellingLiabilities: 2000000,
-					Flags:              uint32(xdr.TrustLineFlagsAuthorizedFlag),
-					LedgerNumber:       12345,
-				},
-				{
-					AssetID:            data.DeterministicAssetID("EUR", testEURIssuer),
-					Code:               "EUR",
-					Issuer:             testEURIssuer,
-					Balance:            5000000000,  // 500 EUR
-					Limit:              20000000000, // 2000 EUR
-					BuyingLiabilities:  0,
-					SellingLiabilities: 0,
-					Flags:              uint32(xdr.TrustLineFlagsAuthorizedToMaintainLiabilitiesFlag),
-					LedgerNumber:       12345,
-				},
-			}, nil)
-		mockAccountContractTokens.On("GetByAccount", ctx, testAccountAddress).Return([]*data.Contract{}, nil)
-		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
-		// No GetLedgerEntries call needed - native and trustlines come from DB
-
-		resolver := &accountResolver{
-			&Resolver{
-				balanceReader:              NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
-				accountContractTokensModel: mockAccountContractTokens,
-				rpcService:                 mockRPCService,
-			},
-		}
-
-		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
-		require.NoError(t, err)
-		require.Len(t, balances, 3) // 1 native + 2 trustlines
-
-		for _, balance := range balances {
-			switch balance.GetTokenType() {
-			case graphql1.TokenTypeNative:
-				nativeBalance := balance.(*graphql1.NativeBalance)
-				assert.Equal(t, "500.0000000", nativeBalance.Balance)
-			case graphql1.TokenTypeClassic:
-				trustlineBalance := balance.(*graphql1.TrustlineBalance)
-				switch trustlineBalance.Code {
-				case "USDC":
-					assert.Equal(t, "100.0000000", trustlineBalance.Balance)
-					assert.Equal(t, graphql1.TokenTypeClassic, trustlineBalance.TokenType)
-					assert.Equal(t, testUSDCIssuer, trustlineBalance.Issuer)
-					assert.Equal(t, "1000.0000000", trustlineBalance.Limit)
-					assert.Equal(t, "0.1000000", trustlineBalance.BuyingLiabilities)
-					assert.Equal(t, "0.2000000", trustlineBalance.SellingLiabilities)
-					assert.True(t, trustlineBalance.IsAuthorized)
-					assert.False(t, trustlineBalance.IsAuthorizedToMaintainLiabilities)
-				case "EUR":
-					assert.Equal(t, "500.0000000", trustlineBalance.Balance)
-					assert.Equal(t, testEURIssuer, trustlineBalance.Issuer)
-					assert.False(t, trustlineBalance.IsAuthorized)
-					assert.True(t, trustlineBalance.IsAuthorizedToMaintainLiabilities)
-				default:
-					t.Errorf("unexpected trustline code: %s", trustlineBalance.Code)
-				}
-			default:
-				t.Errorf("unexpected balance type: %v", balance.GetTokenType())
-			}
-		}
-	})
-
-	t.Run("success - contract address with SAC balances from DB", func(t *testing.T) {
-		ctx := context.Background()
-		mockSACBalanceModel := data.NewSACBalanceModelMock(t)
-		mockAccountContractTokens := data.NewAccountContractTokensModelMock(t)
-		mockRPCService := services.NewRPCServiceMock(t)
-
-		// For contract addresses (C...), SAC balances come from DB
-		sacContractID := data.DeterministicContractID(testSACContractAddress)
-		mockSACBalanceModel.On("GetByAccount", ctx, testContractAddress).
-			Return([]data.SACBalance{
-				{
-					AccountAddress:    testContractAddress,
-					ContractID:        sacContractID,
-					TokenID:           testSACContractAddress,
-					Balance:           "2500.0000000",
-					IsAuthorized:      true,
-					IsClawbackEnabled: false,
-					LedgerNumber:      1000,
-					Code:              "USDC",
-					Issuer:            testUSDCIssuer,
-					Decimals:          7,
-				},
-			}, nil)
-		mockAccountContractTokens.On("GetByAccount", ctx, testContractAddress).Return([]*data.Contract{}, nil)
-		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
-
-		resolver := &accountResolver{
-			&Resolver{
-				balanceReader:              NewBalanceReader(data.NewTrustlineBalanceModelMock(t), data.NewNativeBalanceModelMock(t), mockSACBalanceModel),
-				accountContractTokensModel: mockAccountContractTokens,
-				rpcService:                 mockRPCService,
-			},
-		}
-
-		balances, err := resolver.Balances(ctx, testParentAccount(testContractAddress))
-		require.NoError(t, err)
-		require.Len(t, balances, 1) // 1 SAC
-
-		for _, balance := range balances {
-			switch balance.GetTokenType() {
-			case graphql1.TokenTypeSac:
-				sacBalance := balance.(*graphql1.SACBalance)
-				assert.Equal(t, "2500.0000000", sacBalance.Balance)
-				assert.Equal(t, graphql1.TokenTypeSac, sacBalance.TokenType)
-				assert.Equal(t, testSACContractAddress, sacBalance.TokenID)
-				assert.Equal(t, "USDC", sacBalance.Code)
-				assert.Equal(t, testUSDCIssuer, sacBalance.Issuer)
-				assert.True(t, sacBalance.IsAuthorized)
-				assert.False(t, sacBalance.IsClawbackEnabled)
-			default:
-				t.Errorf("unexpected balance type: %v", balance.GetTokenType())
-			}
-		}
-	})
-
-	t.Run("success - account with SEP-41 contract balances", func(t *testing.T) {
+	t.Run("mixed balances return connection in canonical source order", func(t *testing.T) {
 		ctx := context.Background()
 		mockTrustlineBalanceModel := data.NewTrustlineBalanceModelMock(t)
 		mockNativeBalanceModel := data.NewNativeBalanceModelMock(t)
@@ -258,80 +128,24 @@ func TestAccountResolver_Balances(t *testing.T) {
 		mockRPCService := services.NewRPCServiceMock(t)
 		mockContractMetadataService := services.NewContractMetadataServiceMock(t)
 
-		// Setup mocks - native balance comes from DB
-		mockNativeBalanceModel.On("GetByAccount", ctx, testAccountAddress).Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 1000000000}, nil) // 100 XLM
-		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress).Return([]data.TrustlineBalance{}, nil)
-		mockAccountContractTokens.On("GetByAccount", ctx, testAccountAddress).
-			Return([]*data.Contract{createSEP41Contract(testSEP41ContractAddress, "MyToken", "MTK", 7)}, nil)
+		trustlineID := data.DeterministicAssetID("USDC", testUSDCIssuer)
+		sep41Contract := createSEP41Contract(testSEP41ContractAddress, "CustomToken", "CTK", 6)
+
+		mockNativeBalanceModel.On("GetByAccount", ctx, testAccountAddress).
+			Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 2000000000}, nil)
+		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress, limitMatcher(50), (*uuid.UUID)(nil), data.ASC).
+			Return([]data.TrustlineBalance{{
+				AssetID:      trustlineID,
+				Code:         "USDC",
+				Issuer:       testUSDCIssuer,
+				Balance:      1000000000,
+				Limit:        10000000000,
+				Flags:        uint32(xdr.TrustLineFlagsAuthorizedFlag),
+				LedgerNumber: 12345,
+			}}, nil)
+		mockAccountContractTokens.On("GetSEP41ByAccount", ctx, testAccountAddress, limitMatcher(49), (*uuid.UUID)(nil), data.ASC).
+			Return([]*data.Contract{sep41Contract}, nil)
 		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
-
-		// Mock FetchSingleField for SEP-41 balance call
-		mockContractMetadataService.On("FetchSingleField", ctx, testSEP41ContractAddress, "balance", mock.Anything).
-			Return(createI128ScVal(50000000000), nil)
-		// No GetLedgerEntries call needed - SEP-41 uses FetchSingleField, native comes from DB
-
-		resolver := &accountResolver{
-			&Resolver{
-				balanceReader:              NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
-				accountContractTokensModel: mockAccountContractTokens,
-				rpcService:                 mockRPCService,
-				contractMetadataService:    mockContractMetadataService,
-			},
-		}
-
-		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
-		require.NoError(t, err)
-		require.Len(t, balances, 2) // 1 native + 1 SEP-41
-
-		for _, balance := range balances {
-			switch balance.GetTokenType() {
-			case graphql1.TokenTypeNative:
-				// Native balance verified by count
-			case graphql1.TokenTypeSep41:
-				sep41Balance := balance.(*graphql1.SEP41Balance)
-				assert.Equal(t, "5000.0000000", sep41Balance.Balance)
-				assert.Equal(t, graphql1.TokenTypeSep41, sep41Balance.TokenType)
-				assert.Equal(t, testSEP41ContractAddress, sep41Balance.TokenID)
-				assert.Equal(t, "MyToken", sep41Balance.Name)
-				assert.Equal(t, "MTK", sep41Balance.Symbol)
-				assert.Equal(t, int32(7), sep41Balance.Decimals)
-			default:
-				t.Errorf("unexpected balance type: %v", balance.GetTokenType())
-			}
-		}
-	})
-
-	t.Run("success - mixed balances (native + trustlines + SEP-41)", func(t *testing.T) {
-		ctx := context.Background()
-		mockTrustlineBalanceModel := data.NewTrustlineBalanceModelMock(t)
-		mockNativeBalanceModel := data.NewNativeBalanceModelMock(t)
-		mockAccountContractTokens := data.NewAccountContractTokensModelMock(t)
-		mockRPCService := services.NewRPCServiceMock(t)
-		mockContractMetadataService := services.NewContractMetadataServiceMock(t)
-
-		// Setup mocks - native and trustlines come from DB
-		// For G-addresses, SAC balances ARE trustlines (same underlying data)
-		mockNativeBalanceModel.On("GetByAccount", ctx, testAccountAddress).Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 2000000000}, nil) // 200 XLM
-		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress).
-			Return([]data.TrustlineBalance{
-				{
-					AssetID:      data.DeterministicAssetID("USDC", testUSDCIssuer),
-					Code:         "USDC",
-					Issuer:       testUSDCIssuer,
-					Balance:      1000000000,
-					Limit:        10000000000,
-					Flags:        uint32(xdr.TrustLineFlagsAuthorizedFlag),
-					LedgerNumber: 12345,
-				},
-			}, nil)
-		// For G-addresses, only SEP-41 contracts are returned (SAC balances are trustlines)
-		mockAccountContractTokens.On("GetByAccount", ctx, testAccountAddress).
-			Return([]*data.Contract{
-				createSEP41Contract(testSEP41ContractAddress, "CustomToken", "CTK", 6),
-			}, nil)
-		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
-
-		// Mock FetchSingleField for SEP-41 balance call
 		mockContractMetadataService.On("FetchSingleField", ctx, testSEP41ContractAddress, "balance", mock.Anything).
 			Return(createI128ScVal(30000000000), nil)
 
@@ -344,42 +158,55 @@ func TestAccountResolver_Balances(t *testing.T) {
 			},
 		}
 
-		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
+		conn, err := resolver.Balances(ctx, testParentAccount(testAccountAddress), nil, nil, nil, nil)
 		require.NoError(t, err)
-		require.Len(t, balances, 3) // native + trustline + SEP-41
+		require.Len(t, conn.Edges, 3)
+		assert.False(t, conn.PageInfo.HasNextPage)
+		assert.False(t, conn.PageInfo.HasPreviousPage)
 
-		for _, balance := range balances {
-			switch balance.GetTokenType() {
-			case graphql1.TokenTypeNative:
-				// Native balance verified by count
-			case graphql1.TokenTypeClassic:
-				// Classic trustline verified by count
-			case graphql1.TokenTypeSep41:
-				sep41Balance := balance.(*graphql1.SEP41Balance)
-				assert.Equal(t, "CustomToken", sep41Balance.Name)
-				assert.Equal(t, "CTK", sep41Balance.Symbol)
-				assert.Equal(t, int32(6), sep41Balance.Decimals)
-			default:
-				t.Errorf("unexpected balance type: %v", balance.GetTokenType())
-			}
-		}
+		nodes := flattenBalanceNodes(conn)
+		require.IsType(t, &graphql1.NativeBalance{}, nodes[0])
+		require.IsType(t, &graphql1.TrustlineBalance{}, nodes[1])
+		require.IsType(t, &graphql1.SEP41Balance{}, nodes[2])
+
+		native := nodes[0].(*graphql1.NativeBalance)
+		assert.Equal(t, "200.0000000", native.Balance)
+
+		trustline := nodes[1].(*graphql1.TrustlineBalance)
+		assert.Equal(t, "USDC", trustline.Code)
+		assert.Equal(t, "100.0000000", trustline.Balance)
+
+		sep41 := nodes[2].(*graphql1.SEP41Balance)
+		assert.Equal(t, "CustomToken", sep41.Name)
+		assert.Equal(t, "CTK", sep41.Symbol)
 	})
 
-	t.Run("success - contract address with SEP-41 only (no SAC balances)", func(t *testing.T) {
+	t.Run("contract address returns SAC and SEP41 balances", func(t *testing.T) {
 		ctx := context.Background()
 		mockSACBalanceModel := data.NewSACBalanceModelMock(t)
 		mockAccountContractTokens := data.NewAccountContractTokensModelMock(t)
 		mockRPCService := services.NewRPCServiceMock(t)
 		mockContractMetadataService := services.NewContractMetadataServiceMock(t)
 
-		// For contract addresses (C...), SAC balances come from DB (empty in this test)
-		mockSACBalanceModel.On("GetByAccount", ctx, testContractAddress).Return([]data.SACBalance{}, nil)
-		// SEP-41 contracts come from account_contract_tokens
-		mockAccountContractTokens.On("GetByAccount", ctx, testContractAddress).
-			Return([]*data.Contract{createSEP41Contract(testSEP41ContractAddress, "Token", "TKN", 7)}, nil)
-		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
+		sacContractID := data.DeterministicContractID(testSACContractAddress)
+		sep41Contract := createSEP41Contract(testSEP41ContractAddress, "Token", "TKN", 7)
 
-		// Mock FetchSingleField for SEP-41 balance call
+		mockSACBalanceModel.On("GetByAccount", ctx, testContractAddress, limitMatcher(51), (*uuid.UUID)(nil), data.ASC).
+			Return([]data.SACBalance{{
+				AccountAddress:    testContractAddress,
+				ContractID:        sacContractID,
+				TokenID:           testSACContractAddress,
+				Balance:           "2500.0000000",
+				IsAuthorized:      true,
+				IsClawbackEnabled: false,
+				LedgerNumber:      1000,
+				Code:              "USDC",
+				Issuer:            testUSDCIssuer,
+				Decimals:          7,
+			}}, nil)
+		mockAccountContractTokens.On("GetSEP41ByAccount", ctx, testContractAddress, limitMatcher(50), (*uuid.UUID)(nil), data.ASC).
+			Return([]*data.Contract{sep41Contract}, nil)
+		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
 		mockContractMetadataService.On("FetchSingleField", ctx, testSEP41ContractAddress, "balance", mock.Anything).
 			Return(createI128ScVal(10000000000), nil)
 
@@ -392,189 +219,16 @@ func TestAccountResolver_Balances(t *testing.T) {
 			},
 		}
 
-		balances, err := resolver.Balances(ctx, testParentAccount(testContractAddress))
+		conn, err := resolver.Balances(ctx, testParentAccount(testContractAddress), nil, nil, nil, nil)
 		require.NoError(t, err)
-		require.Len(t, balances, 1)
+		require.Len(t, conn.Edges, 2)
 
-		for _, balance := range balances {
-			switch balance.GetTokenType() {
-			case graphql1.TokenTypeSep41:
-				sep41Balance := balance.(*graphql1.SEP41Balance)
-				assert.Equal(t, "1000.0000000", sep41Balance.Balance)
-				assert.Equal(t, "Token", sep41Balance.Name)
-				assert.Equal(t, "TKN", sep41Balance.Symbol)
-				assert.Equal(t, int32(7), sep41Balance.Decimals)
-			default:
-				t.Errorf("unexpected balance type: %v", balance.GetTokenType())
-			}
-		}
+		nodes := flattenBalanceNodes(conn)
+		require.IsType(t, &graphql1.SACBalance{}, nodes[0])
+		require.IsType(t, &graphql1.SEP41Balance{}, nodes[1])
 	})
 
-	t.Run("success - trustline with V0 extension (no liabilities)", func(t *testing.T) {
-		ctx := context.Background()
-		mockTrustlineBalanceModel := data.NewTrustlineBalanceModelMock(t)
-		mockNativeBalanceModel := data.NewNativeBalanceModelMock(t)
-		mockAccountContractTokens := data.NewAccountContractTokensModelMock(t)
-		mockRPCService := services.NewRPCServiceMock(t)
-
-		// Native and trustlines come from DB (V0 extension - no liabilities)
-		mockNativeBalanceModel.On("GetByAccount", ctx, testAccountAddress).Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 1000000000}, nil) // 100 XLM
-		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress).
-			Return([]data.TrustlineBalance{
-				{
-					AssetID:            data.DeterministicAssetID("USDC", testUSDCIssuer),
-					Code:               "USDC",
-					Issuer:             testUSDCIssuer,
-					Balance:            1000000000,
-					Limit:              10000000000,
-					Flags:              uint32(xdr.TrustLineFlagsAuthorizedFlag),
-					BuyingLiabilities:  0,
-					SellingLiabilities: 0,
-					LedgerNumber:       12345,
-				},
-			}, nil)
-		mockAccountContractTokens.On("GetByAccount", ctx, testAccountAddress).Return([]*data.Contract{}, nil)
-		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
-		// No GetLedgerEntries call needed - native and trustlines come from DB
-
-		resolver := &accountResolver{
-			&Resolver{
-				balanceReader:              NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
-				accountContractTokensModel: mockAccountContractTokens,
-				rpcService:                 mockRPCService,
-			},
-		}
-
-		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
-		require.NoError(t, err)
-
-		for _, balance := range balances {
-			switch balance.GetTokenType() {
-			case graphql1.TokenTypeNative:
-				// Native balance verified by count
-			case graphql1.TokenTypeClassic:
-				trustlineBalance := balance.(*graphql1.TrustlineBalance)
-				assert.Equal(t, "0.0000000", trustlineBalance.BuyingLiabilities)
-				assert.Equal(t, "0.0000000", trustlineBalance.SellingLiabilities)
-			default:
-				t.Errorf("unexpected balance type: %v", balance.GetTokenType())
-			}
-		}
-	})
-
-	// Error Cases
-
-	t.Run("error - GetTrustlineBalances fails", func(t *testing.T) {
-		ctx := context.Background()
-		mockTrustlineBalanceModel := data.NewTrustlineBalanceModelMock(t)
-		mockNativeBalanceModel := data.NewNativeBalanceModelMock(t)
-		mockNativeBalanceModel.On("GetByAccount", mock.Anything, mock.Anything).Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 10000000000}, nil).Maybe()
-		mockRPCService := services.NewRPCServiceMock(t)
-
-		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
-		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress).
-			Return([]data.TrustlineBalance{}, errors.New("database query failed"))
-
-		resolver := &accountResolver{
-			&Resolver{
-				balanceReader: NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
-				rpcService:    mockRPCService,
-			},
-		}
-
-		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), ErrMsgBalancesFetchFailed)
-		assert.Nil(t, balances)
-	})
-
-	t.Run("error - GetAccountContracts fails", func(t *testing.T) {
-		ctx := context.Background()
-		mockTrustlineBalanceModel := data.NewTrustlineBalanceModelMock(t)
-		mockNativeBalanceModel := data.NewNativeBalanceModelMock(t)
-		mockNativeBalanceModel.On("GetByAccount", mock.Anything, mock.Anything).Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 10000000000}, nil).Maybe()
-		mockAccountContractTokens := data.NewAccountContractTokensModelMock(t)
-		mockRPCService := services.NewRPCServiceMock(t)
-
-		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
-		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress).
-			Return([]data.TrustlineBalance{}, nil)
-		mockAccountContractTokens.On("GetByAccount", ctx, testAccountAddress).
-			Return([]*data.Contract{}, errors.New("database query failed"))
-
-		resolver := &accountResolver{
-			&Resolver{
-				balanceReader:              NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
-				accountContractTokensModel: mockAccountContractTokens,
-				rpcService:                 mockRPCService,
-			},
-		}
-
-		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), ErrMsgBalancesFetchFailed)
-		assert.Nil(t, balances)
-	})
-
-	t.Run("error - GetSACBalances DB fails for contract address", func(t *testing.T) {
-		ctx := context.Background()
-		mockSACBalanceModel := data.NewSACBalanceModelMock(t)
-		mockRPCService := services.NewRPCServiceMock(t)
-
-		// For contract addresses (C...), SAC balances come from DB - mock DB error
-		mockSACBalanceModel.On("GetByAccount", ctx, testContractAddress).
-			Return(nil, errors.New("database connection failed"))
-		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
-
-		resolver := &accountResolver{
-			&Resolver{
-				balanceReader: NewBalanceReader(data.NewTrustlineBalanceModelMock(t), data.NewNativeBalanceModelMock(t), mockSACBalanceModel),
-				rpcService:    mockRPCService,
-			},
-		}
-
-		balances, err := resolver.Balances(ctx, testParentAccount(testContractAddress))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), ErrMsgBalancesFetchFailed)
-		assert.Nil(t, balances)
-	})
-
-	t.Run("error - invalid trustline issuer causes error", func(t *testing.T) {
-		ctx := context.Background()
-		mockTrustlineBalanceModel := data.NewTrustlineBalanceModelMock(t)
-		mockNativeBalanceModel := data.NewNativeBalanceModelMock(t)
-		mockNativeBalanceModel.On("GetByAccount", mock.Anything, mock.Anything).Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 10000000000}, nil).Maybe()
-		mockRPCService := services.NewRPCServiceMock(t)
-
-		// Return trustline with invalid issuer that will fail ContractID computation
-		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress).
-			Return([]data.TrustlineBalance{
-				{
-					AssetID: uuid.New(),
-					Code:    ":",
-					Issuer:  "@:::", // Invalid issuer address
-				},
-			}, nil)
-		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
-
-		resolver := &accountResolver{
-			&Resolver{
-				balanceReader: NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
-				rpcService:    mockRPCService,
-			},
-		}
-
-		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), ErrMsgBalancesFetchFailed)
-		assert.Nil(t, balances)
-	})
-
-	// Note: Tests for "XDR decoding fails" and "SAC missing amount field" were removed
-	// because SAC balances for G-addresses now come from trustlines, and SAC balances
-	// for C-addresses come from the database with pre-validated data.
-
-	t.Run("error - SEP-41 wrong type (map instead of i128)", func(t *testing.T) {
+	t.Run("forward pagination crosses sources and only fetches returned SEP41 pages", func(t *testing.T) {
 		ctx := context.Background()
 		mockTrustlineBalanceModel := data.NewTrustlineBalanceModelMock(t)
 		mockNativeBalanceModel := data.NewNativeBalanceModelMock(t)
@@ -582,34 +236,41 @@ func TestAccountResolver_Balances(t *testing.T) {
 		mockRPCService := services.NewRPCServiceMock(t)
 		mockContractMetadataService := services.NewContractMetadataServiceMock(t)
 
-		// Setup mocks - native balance comes from DB
-		mockNativeBalanceModel.On("GetByAccount", ctx, testAccountAddress).Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 1000000000}, nil)
-		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress).Return([]data.TrustlineBalance{}, nil)
-		mockAccountContractTokens.On("GetByAccount", ctx, testAccountAddress).
-			Return([]*data.Contract{createSEP41Contract(testContractAddress, "Test", "TST", 7)}, nil)
-		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
+		trustlineID := data.DeterministicAssetID("USDC", testUSDCIssuer)
+		sep41Contract1 := createSEP41Contract(testSEP41ContractAddress, "TokenOne", "ONE", 7)
+		sep41Contract2 := createSEP41Contract(testSEP41ContractAddress2, "TokenTwo", "TWO", 7)
 
-		// Mock FetchSingleField returning wrong type (map instead of i128) - use SAC map structure
-		authorizedSym := ptrToScSymbol("authorized")
-		clawbackSym := ptrToScSymbol("clawback")
-		authorizedBool := true
-		clawbackBool := false
-		wrongTypeScVal := xdr.ScVal{
-			Type: xdr.ScValTypeScvMap,
-			Map: ptrToScMap([]xdr.ScMapEntry{
-				{
-					Key: xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: authorizedSym},
-					Val: xdr.ScVal{Type: xdr.ScValTypeScvBool, B: &authorizedBool},
-				},
-				{
-					Key: xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: clawbackSym},
-					Val: xdr.ScVal{Type: xdr.ScValTypeScvBool, B: &clawbackBool},
-				},
-			}),
-		}
-		mockContractMetadataService.On("FetchSingleField", ctx, testContractAddress, "balance", mock.Anything).
-			Return(wrongTypeScVal, nil)
-		// No GetLedgerEntries call needed - SEP-41 uses FetchSingleField, native comes from DB
+		mockNativeBalanceModel.On("GetByAccount", ctx, testAccountAddress).
+			Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 1000000000}, nil).
+			Once()
+		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress, limitMatcher(2), (*uuid.UUID)(nil), data.ASC).
+			Return([]data.TrustlineBalance{{
+				AssetID:      trustlineID,
+				Code:         "USDC",
+				Issuer:       testUSDCIssuer,
+				Balance:      500000000,
+				Limit:        10000000000,
+				Flags:        uint32(xdr.TrustLineFlagsAuthorizedFlag),
+				LedgerNumber: 12345,
+			}}, nil).
+			Once()
+		mockAccountContractTokens.On("GetSEP41ByAccount", ctx, testAccountAddress, limitMatcher(1), (*uuid.UUID)(nil), data.ASC).
+			Return([]*data.Contract{sep41Contract1}, nil).
+			Once()
+
+		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress, limitMatcher(3), cursorUUIDMatcher(trustlineID), data.ASC).
+			Return([]data.TrustlineBalance{}, nil).
+			Once()
+		mockAccountContractTokens.On("GetSEP41ByAccount", ctx, testAccountAddress, limitMatcher(3), (*uuid.UUID)(nil), data.ASC).
+			Return([]*data.Contract{sep41Contract1, sep41Contract2}, nil).
+			Once()
+		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
+		mockContractMetadataService.On("FetchSingleField", ctx, testSEP41ContractAddress, "balance", mock.Anything).
+			Return(createI128ScVal(10000000000), nil).
+			Once()
+		mockContractMetadataService.On("FetchSingleField", ctx, testSEP41ContractAddress2, "balance", mock.Anything).
+			Return(createI128ScVal(20000000000), nil).
+			Once()
 
 		resolver := &accountResolver{
 			&Resolver{
@@ -620,123 +281,116 @@ func TestAccountResolver_Balances(t *testing.T) {
 			},
 		}
 
-		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
+		firstPage, err := resolver.Balances(ctx, testParentAccount(testAccountAddress), int32Ptr(2), nil, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, firstPage.Edges, 2)
+		assert.True(t, firstPage.PageInfo.HasNextPage)
+		assert.False(t, firstPage.PageInfo.HasPreviousPage)
+
+		firstNodes := flattenBalanceNodes(firstPage)
+		require.IsType(t, &graphql1.NativeBalance{}, firstNodes[0])
+		require.IsType(t, &graphql1.TrustlineBalance{}, firstNodes[1])
+
+		secondPage, err := resolver.Balances(ctx, testParentAccount(testAccountAddress), int32Ptr(2), firstPage.PageInfo.EndCursor, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, secondPage.Edges, 2)
+		assert.False(t, secondPage.PageInfo.HasNextPage)
+		assert.True(t, secondPage.PageInfo.HasPreviousPage)
+
+		secondNodes := flattenBalanceNodes(secondPage)
+		require.IsType(t, &graphql1.SEP41Balance{}, secondNodes[0])
+		require.IsType(t, &graphql1.SEP41Balance{}, secondNodes[1])
+	})
+
+	t.Run("backward pagination returns the last balances in canonical order", func(t *testing.T) {
+		ctx := context.Background()
+		mockTrustlineBalanceModel := data.NewTrustlineBalanceModelMock(t)
+		mockNativeBalanceModel := data.NewNativeBalanceModelMock(t)
+		mockAccountContractTokens := data.NewAccountContractTokensModelMock(t)
+		mockRPCService := services.NewRPCServiceMock(t)
+		mockContractMetadataService := services.NewContractMetadataServiceMock(t)
+
+		trustlineID := data.DeterministicAssetID("USDC", testUSDCIssuer)
+		sep41Contract := createSEP41Contract(testSEP41ContractAddress, "Token", "TKN", 7)
+
+		mockAccountContractTokens.On("GetSEP41ByAccount", ctx, testAccountAddress, limitMatcher(3), (*uuid.UUID)(nil), data.DESC).
+			Return([]*data.Contract{sep41Contract}, nil)
+		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress, limitMatcher(2), (*uuid.UUID)(nil), data.DESC).
+			Return([]data.TrustlineBalance{{
+				AssetID:      trustlineID,
+				Code:         "USDC",
+				Issuer:       testUSDCIssuer,
+				Balance:      500000000,
+				Limit:        10000000000,
+				Flags:        uint32(xdr.TrustLineFlagsAuthorizedFlag),
+				LedgerNumber: 12345,
+			}}, nil)
+		mockNativeBalanceModel.On("GetByAccount", ctx, testAccountAddress).
+			Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 1000000000}, nil)
+		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
+		mockContractMetadataService.On("FetchSingleField", ctx, testSEP41ContractAddress, "balance", mock.Anything).
+			Return(createI128ScVal(10000000000), nil)
+
+		resolver := &accountResolver{
+			&Resolver{
+				balanceReader:              NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
+				accountContractTokensModel: mockAccountContractTokens,
+				rpcService:                 mockRPCService,
+				contractMetadataService:    mockContractMetadataService,
+			},
+		}
+
+		conn, err := resolver.Balances(ctx, testParentAccount(testAccountAddress), nil, nil, int32Ptr(2), nil)
+		require.NoError(t, err)
+		require.Len(t, conn.Edges, 2)
+		assert.False(t, conn.PageInfo.HasNextPage)
+		assert.True(t, conn.PageInfo.HasPreviousPage)
+
+		nodes := flattenBalanceNodes(conn)
+		require.IsType(t, &graphql1.TrustlineBalance{}, nodes[0])
+		require.IsType(t, &graphql1.SEP41Balance{}, nodes[1])
+	})
+
+	t.Run("rejects page sizes above the balance max", func(t *testing.T) {
+		ctx := context.Background()
+		resolver := &accountResolver{&Resolver{}}
+
+		conn, err := resolver.Balances(ctx, testParentAccount(testAccountAddress), int32Ptr(101), nil, nil, nil)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), ErrMsgBalancesFetchFailed)
-		assert.Nil(t, balances)
+		assert.Nil(t, conn)
+
+		var gqlErr *gqlerror.Error
+		require.True(t, errors.As(err, &gqlErr))
+		assert.Equal(t, "BAD_USER_INPUT", gqlErr.Extensions["code"])
+		assert.Contains(t, gqlErr.Message, "first must be less than or equal to 100")
 	})
 
-	// Edge Cases
-
-	t.Run("edge - unknown contract type skipped", func(t *testing.T) {
+	t.Run("returns internal error when trustline pagination fails", func(t *testing.T) {
 		ctx := context.Background()
 		mockTrustlineBalanceModel := data.NewTrustlineBalanceModelMock(t)
 		mockNativeBalanceModel := data.NewNativeBalanceModelMock(t)
-		mockAccountContractTokens := data.NewAccountContractTokensModelMock(t)
 		mockRPCService := services.NewRPCServiceMock(t)
 
-		// Setup mocks - native balance comes from DB
-		mockNativeBalanceModel.On("GetByAccount", ctx, testAccountAddress).Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 1000000000}, nil) // 100 XLM
-		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress).Return([]data.TrustlineBalance{}, nil)
-		// GetByAccount now returns full Contract objects directly
-		unknownContract := &data.Contract{
-			ContractID: testContractAddress,
-			Type:       string(types.ContractTypeUnknown),
-		}
-		mockAccountContractTokens.On("GetByAccount", ctx, testAccountAddress).
-			Return([]*data.Contract{unknownContract}, nil)
+		mockNativeBalanceModel.On("GetByAccount", ctx, testAccountAddress).
+			Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 1000000000}, nil)
+		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress, limitMatcher(50), (*uuid.UUID)(nil), data.ASC).
+			Return(nil, errors.New("database query failed"))
 		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
-		// No GetLedgerEntries call needed - native comes from DB, unknown contracts are skipped
 
 		resolver := &accountResolver{
 			&Resolver{
-				balanceReader:              NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
-				accountContractTokensModel: mockAccountContractTokens,
-				rpcService:                 mockRPCService,
+				balanceReader: NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
+				rpcService:    mockRPCService,
 			},
 		}
 
-		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
-		require.NoError(t, err)
-		// Should only have native balance, contract balance skipped
-		require.Len(t, balances, 1)
-		for _, balance := range balances {
-			switch balance.GetTokenType() {
-			case graphql1.TokenTypeNative:
-				assert.IsType(t, &graphql1.NativeBalance{}, balance)
-			default:
-				t.Errorf("unexpected balance type: %v", balance.GetTokenType())
-			}
-		}
-	})
+		conn, err := resolver.Balances(ctx, testParentAccount(testAccountAddress), nil, nil, nil, nil)
+		require.Error(t, err)
+		assert.Nil(t, conn)
 
-	t.Run("edge - trustline authorization flags combinations", func(t *testing.T) {
-		ctx := context.Background()
-		mockTrustlineBalanceModel := data.NewTrustlineBalanceModelMock(t)
-		mockNativeBalanceModel := data.NewNativeBalanceModelMock(t)
-		mockAccountContractTokens := data.NewAccountContractTokensModelMock(t)
-		mockRPCService := services.NewRPCServiceMock(t)
-
-		// Setup mocks - native and trustlines come from DB
-		mockNativeBalanceModel.On("GetByAccount", ctx, testAccountAddress).Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 1000000000}, nil) // 100 XLM
-		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress).
-			Return([]data.TrustlineBalance{
-				{
-					AssetID:      data.DeterministicAssetID("USDC", testUSDCIssuer),
-					Code:         "USDC",
-					Issuer:       testUSDCIssuer,
-					Balance:      1000000000,
-					Limit:        10000000000,
-					Flags:        uint32(xdr.TrustLineFlagsAuthorizedFlag | xdr.TrustLineFlagsAuthorizedToMaintainLiabilitiesFlag),
-					LedgerNumber: 12345,
-				},
-				{
-					AssetID:      data.DeterministicAssetID("EUR", testEURIssuer),
-					Code:         "EUR",
-					Issuer:       testEURIssuer,
-					Balance:      1000000000,
-					Limit:        10000000000,
-					Flags:        0, // No flags set
-					LedgerNumber: 12345,
-				},
-			}, nil)
-		mockAccountContractTokens.On("GetByAccount", ctx, testAccountAddress).Return([]*data.Contract{}, nil)
-		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
-		// No GetLedgerEntries call needed - native and trustlines come from DB
-
-		resolver := &accountResolver{
-			&Resolver{
-				balanceReader:              NewBalanceReader(mockTrustlineBalanceModel, mockNativeBalanceModel, data.NewSACBalanceModelMock(t)),
-				accountContractTokensModel: mockAccountContractTokens,
-				rpcService:                 mockRPCService,
-			},
-		}
-
-		balances, err := resolver.Balances(ctx, testParentAccount(testAccountAddress))
-		require.NoError(t, err)
-		require.Len(t, balances, 3)
-
-		for _, balance := range balances {
-			switch balance.GetTokenType() {
-			case graphql1.TokenTypeNative:
-				// Native balance verified by count
-			case graphql1.TokenTypeClassic:
-				trustlineBalance := balance.(*graphql1.TrustlineBalance)
-				switch trustlineBalance.Code {
-				case "USDC":
-					// USDC - both flags set
-					assert.True(t, trustlineBalance.IsAuthorized)
-					assert.True(t, trustlineBalance.IsAuthorizedToMaintainLiabilities)
-				case "EUR":
-					// EUR - no flags set
-					assert.False(t, trustlineBalance.IsAuthorized)
-					assert.False(t, trustlineBalance.IsAuthorizedToMaintainLiabilities)
-				default:
-					t.Errorf("unexpected trustline code: %s", trustlineBalance.Code)
-				}
-			default:
-				t.Errorf("unexpected balance type: %v", balance.GetTokenType())
-			}
-		}
+		var gqlErr *gqlerror.Error
+		require.True(t, errors.As(err, &gqlErr))
+		assert.Equal(t, "INTERNAL_ERROR", gqlErr.Extensions["code"])
+		assert.Equal(t, ErrMsgBalancesFetchFailed, gqlErr.Message)
 	})
 }

--- a/internal/serve/graphql/resolvers/account_balances_utils.go
+++ b/internal/serve/graphql/resolvers/account_balances_utils.go
@@ -6,9 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"sync"
 
-	"github.com/alitto/pond/v2"
 	"github.com/stellar/go-stellar-sdk/amount"
 	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stellar/go-stellar-sdk/xdr"
@@ -192,43 +190,33 @@ func parseSEP41Balance(val xdr.ScVal, contractIDStr string, contract *data.Contr
 
 // getSep41Balances simulates an RPC call to the `balance(id)` function of each SEP-41 contract.
 // The accountAddress parameter is the address of the account whose balance we're querying.
-func getSep41Balances(ctx context.Context, accountAddress string, contractMetadataService services.ContractMetadataService, contractIDs []string, contractsByContractID map[string]*data.Contract, pool pond.Pool) ([]graphql1.Balance, error) {
-	results := make([]graphql1.Balance, len(contractIDs))
-	group := pool.NewGroupContext(ctx)
+func getSep41Balances(ctx context.Context, accountAddress string, contractMetadataService services.ContractMetadataService, contractIDs []string, contractsByContractID map[string]*data.Contract) ([]graphql1.Balance, error) {
+	results := make([]graphql1.Balance, 0, len(contractIDs))
 	var errs []error
-	mu := sync.Mutex{}
 
-	appendError := func(err error) {
-		mu.Lock()
-		errs = append(errs, err)
-		mu.Unlock()
-	}
+	for _, contractID := range contractIDs {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("context cancelled while fetching SEP41 balances: %w", err)
+		}
 
-	for i, contractID := range contractIDs {
-		group.Submit(func() {
-			// Convert the account address to an xdr.ScVal for passing to the balance function
-			addressArg, err := addressToScVal(accountAddress)
-			if err != nil {
-				appendError(fmt.Errorf("converting account address to ScVal: %w", err))
-				return
-			}
+		// Convert the account address to an xdr.ScVal for passing to the balance function
+		addressArg, err := addressToScVal(accountAddress)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("converting account address to ScVal: %w", err))
+			continue
+		}
 
-			balanceResult, err := contractMetadataService.FetchSingleField(ctx, contractID, "balance", addressArg)
-			if err != nil {
-				appendError(fmt.Errorf("getting SEP41 balance for contract %s: %w", contractID, err))
-				return
-			}
-			balance, err := parseSEP41Balance(balanceResult, contractID, contractsByContractID[contractID])
-			if err != nil {
-				appendError(fmt.Errorf("parsing SEP41 balance for contract %s: %w", contractID, err))
-				return
-			}
-			results[i] = balance
-		})
-	}
-
-	if err := group.Wait(); err != nil {
-		return nil, fmt.Errorf("waiting for SEP41 balance fetch group: %w", err)
+		balanceResult, err := contractMetadataService.FetchSingleField(ctx, contractID, "balance", addressArg)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("getting SEP41 balance for contract %s: %w", contractID, err))
+			continue
+		}
+		balance, err := parseSEP41Balance(balanceResult, contractID, contractsByContractID[contractID])
+		if err != nil {
+			errs = append(errs, fmt.Errorf("parsing SEP41 balance for contract %s: %w", contractID, err))
+			continue
+		}
+		results = append(results, balance)
 	}
 
 	if len(errs) > 0 {

--- a/internal/serve/graphql/resolvers/account_balances_utils.go
+++ b/internal/serve/graphql/resolvers/account_balances_utils.go
@@ -4,7 +4,6 @@ package resolvers
 import (
 	"context"
 	"encoding/hex"
-	"errors"
 	"fmt"
 
 	"github.com/stellar/go-stellar-sdk/amount"
@@ -188,40 +187,28 @@ func parseSEP41Balance(val xdr.ScVal, contractIDStr string, contract *data.Contr
 	}, nil
 }
 
-// getSep41Balances simulates an RPC call to the `balance(id)` function of each SEP-41 contract.
-// The accountAddress parameter is the address of the account whose balance we're querying.
-func getSep41Balances(ctx context.Context, accountAddress string, contractMetadataService services.ContractMetadataService, contractIDs []string, contractsByContractID map[string]*data.Contract) ([]graphql1.Balance, error) {
-	results := make([]graphql1.Balance, 0, len(contractIDs))
-	var errs []error
-
-	for _, contractID := range contractIDs {
-		if err := ctx.Err(); err != nil {
-			return nil, fmt.Errorf("context cancelled while fetching SEP41 balances: %w", err)
-		}
-
-		// Convert the account address to an xdr.ScVal for passing to the balance function
-		addressArg, err := addressToScVal(accountAddress)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("converting account address to ScVal: %w", err))
-			continue
-		}
-
-		balanceResult, err := contractMetadataService.FetchSingleField(ctx, contractID, "balance", addressArg)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("getting SEP41 balance for contract %s: %w", contractID, err))
-			continue
-		}
-		balance, err := parseSEP41Balance(balanceResult, contractID, contractsByContractID[contractID])
-		if err != nil {
-			errs = append(errs, fmt.Errorf("parsing SEP41 balance for contract %s: %w", contractID, err))
-			continue
-		}
-		results = append(results, balance)
+// getSep41Balance fetches and parses a single SEP-41 balance. The paginated
+// balances resolver uses this one-at-a-time form so it can avoid RPC calls for
+// rows that are fetched only to determine PageInfo.
+func getSep41Balance(ctx context.Context, accountAddress string, contractMetadataService services.ContractMetadataService, contract *data.Contract) (*graphql1.SEP41Balance, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("context cancelled while fetching SEP41 balances: %w", err)
 	}
 
-	if len(errs) > 0 {
-		return nil, fmt.Errorf("getting SEP41 balances: %w", errors.Join(errs...))
+	addressArg, err := addressToScVal(accountAddress)
+	if err != nil {
+		return nil, fmt.Errorf("converting account address to ScVal: %w", err)
 	}
 
-	return results, nil
+	balanceResult, err := contractMetadataService.FetchSingleField(ctx, contract.ContractID, "balance", addressArg)
+	if err != nil {
+		return nil, fmt.Errorf("getting SEP41 balance: %w", err)
+	}
+
+	balance, err := parseSEP41Balance(balanceResult, contract.ContractID, contract)
+	if err != nil {
+		return nil, fmt.Errorf("parsing SEP41 balance: %w", err)
+	}
+
+	return balance, nil
 }

--- a/internal/serve/graphql/resolvers/balance_reader.go
+++ b/internal/serve/graphql/resolvers/balance_reader.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
+
 	"github.com/stellar/wallet-backend/internal/data"
 )
 
@@ -26,9 +28,10 @@ func NewBalanceReader(trustlineBalanceModel data.TrustlineBalanceModelInterface,
 	}
 }
 
-// GetTrustlineBalances retrieves all trustline balances for an account.
-func (r *balanceReaderAdapter) GetTrustlineBalances(ctx context.Context, accountAddress string) ([]data.TrustlineBalance, error) {
-	balances, err := r.trustlineBalanceModel.GetByAccount(ctx, accountAddress)
+// GetTrustlineBalances retrieves trustline balances for an account. Pass nil
+// limit/cursor to fetch all rows, or provide them for keyset pagination.
+func (r *balanceReaderAdapter) GetTrustlineBalances(ctx context.Context, accountAddress string, limit *int32, cursor *uuid.UUID, sortOrder data.SortOrder) ([]data.TrustlineBalance, error) {
+	balances, err := r.trustlineBalanceModel.GetByAccount(ctx, accountAddress, limit, cursor, sortOrder)
 	if err != nil {
 		return nil, fmt.Errorf("getting trustline balances: %w", err)
 	}
@@ -44,9 +47,10 @@ func (r *balanceReaderAdapter) GetNativeBalance(ctx context.Context, accountAddr
 	return balance, nil
 }
 
-// GetSACBalances retrieves all SAC balances for a contract address.
-func (r *balanceReaderAdapter) GetSACBalances(ctx context.Context, accountAddress string) ([]data.SACBalance, error) {
-	balances, err := r.sacBalanceModel.GetByAccount(ctx, accountAddress)
+// GetSACBalances retrieves SAC balances for a contract address. Pass nil
+// limit/cursor to fetch all rows, or provide them for keyset pagination.
+func (r *balanceReaderAdapter) GetSACBalances(ctx context.Context, accountAddress string, limit *int32, cursor *uuid.UUID, sortOrder data.SortOrder) ([]data.SACBalance, error) {
+	balances, err := r.sacBalanceModel.GetByAccount(ctx, accountAddress, limit, cursor, sortOrder)
 	if err != nil {
 		return nil, fmt.Errorf("getting SAC balances: %w", err)
 	}

--- a/internal/serve/graphql/resolvers/errors.go
+++ b/internal/serve/graphql/resolvers/errors.go
@@ -9,7 +9,7 @@ const (
 	ErrMsgInvalidTransaction               = "Transaction is not a valid transaction"
 	ErrMsgFeeBumpCreationFailed            = "Failed to create fee bump transaction: %s"
 
-	// BalancesByAccountAddress errors (single account)
+	// Account balance errors
 	ErrMsgSingleInvalidAddress = "invalid address format: must be a valid Stellar account (G...) or contract (C...) address"
 
 	// TransactionByHash / StateChanges hash filter errors

--- a/internal/serve/graphql/resolvers/queries.resolvers.go
+++ b/internal/serve/graphql/resolvers/queries.resolvers.go
@@ -9,10 +9,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
-	"github.com/stellar/wallet-backend/internal/data"
 	"github.com/stellar/wallet-backend/internal/indexer/types"
 	graphql1 "github.com/stellar/wallet-backend/internal/serve/graphql/generated"
 	"github.com/stellar/wallet-backend/internal/utils"
@@ -73,7 +71,7 @@ func (r *queryResolver) Transactions(ctx context.Context, first *int32, after *s
 func (r *queryResolver) AccountByAddress(ctx context.Context, address string) (*types.Account, error) {
 	if !utils.IsValidStellarAddress(address) {
 		return nil, &gqlerror.Error{
-			Message: "invalid Stellar address",
+			Message: ErrMsgSingleInvalidAddress,
 			Extensions: map[string]interface{}{
 				"code":    "INVALID_ADDRESS",
 				"address": address,
@@ -153,130 +151,6 @@ func (r *queryResolver) StateChanges(ctx context.Context, first *int32, after *s
 		Edges:    edges,
 		PageInfo: conn.PageInfo,
 	}, nil
-}
-
-// BalancesByAccountAddress is the resolver for the balancesByAccountAddress field.
-func (r *queryResolver) BalancesByAccountAddress(ctx context.Context, address string) ([]graphql1.Balance, error) {
-	// Validate input: address format
-	if !utils.IsValidStellarAddress(address) {
-		return nil, &gqlerror.Error{
-			Message: ErrMsgSingleInvalidAddress,
-			Extensions: map[string]interface{}{
-				"code":    "INVALID_ADDRESS",
-				"address": address,
-			},
-		}
-	}
-
-	networkPassphrase := r.rpcService.NetworkPassphrase()
-	var balances []graphql1.Balance
-
-	if utils.IsContractAddress(address) {
-		// Contract addresses (C...): Fetch SAC balances from DB
-		// SAC balances have embedded contract metadata from JOIN with contract_tokens
-		sacBalances, sacErr := r.balanceReader.GetSACBalances(ctx, address)
-		if sacErr != nil {
-			log.Ctx(ctx).Errorf("failed to get SAC balances for %s: %v", address, sacErr)
-			return nil, &gqlerror.Error{
-				Message: ErrMsgBalancesFetchFailed,
-				Extensions: map[string]interface{}{
-					"code": "INTERNAL_ERROR",
-				},
-			}
-		}
-		for _, sacBalance := range sacBalances {
-			balances = append(balances, buildSACBalanceFromDB(sacBalance))
-		}
-	} else {
-		// G-addresses: Fetch native XLM balance and trustlines from DB
-		nativeBalance, nativeErr := r.balanceReader.GetNativeBalance(ctx, address)
-		if nativeErr != nil {
-			log.Ctx(ctx).Errorf("failed to get native balance for %s: %v", address, nativeErr)
-			return nil, &gqlerror.Error{
-				Message: ErrMsgBalancesFetchFailed,
-				Extensions: map[string]interface{}{
-					"code": "INTERNAL_ERROR",
-				},
-			}
-		}
-		if nativeBalance != nil {
-			nativeBalanceResult, buildErr := buildNativeBalanceFromDB(nativeBalance, networkPassphrase)
-			if buildErr != nil {
-				return nil, &gqlerror.Error{
-					Message: ErrMsgBalancesFetchFailed,
-					Extensions: map[string]interface{}{
-						"code": "INTERNAL_ERROR",
-					},
-				}
-			}
-			balances = append(balances, nativeBalanceResult)
-		}
-
-		// Fetch trustline balances from DB
-		trustlines, trustlineErr := r.balanceReader.GetTrustlineBalances(ctx, address)
-		if trustlineErr != nil {
-			log.Ctx(ctx).Errorf("failed to get trustline balances for %s: %v", address, trustlineErr)
-			return nil, &gqlerror.Error{
-				Message: ErrMsgBalancesFetchFailed,
-				Extensions: map[string]interface{}{
-					"code": "INTERNAL_ERROR",
-				},
-			}
-		}
-
-		for _, trustline := range trustlines {
-			trustlineBalance, buildErr := buildTrustlineBalanceFromDB(trustline, networkPassphrase)
-			if buildErr != nil {
-				return nil, &gqlerror.Error{
-					Message: ErrMsgBalancesFetchFailed,
-					Extensions: map[string]interface{}{
-						"code": "INTERNAL_ERROR",
-					},
-				}
-			}
-			balances = append(balances, trustlineBalance)
-		}
-	}
-
-	// Fetch SEP-41 contract tokens for the account (both G-addresses and C-addresses)
-	contractTokens, err := r.accountContractTokensModel.GetByAccount(ctx, address)
-	if err != nil {
-		log.Ctx(ctx).Errorf("failed to get contract tokens for %s: %v", address, err)
-		return nil, &gqlerror.Error{
-			Message: ErrMsgBalancesFetchFailed,
-			Extensions: map[string]interface{}{
-				"code": "INTERNAL_ERROR",
-			},
-		}
-	}
-
-	// Collect SEP-41 contract IDs for balance simulation
-	contractsByContractID := make(map[string]*data.Contract)
-	sep41TokenIDs := make([]string, 0)
-	for _, contract := range contractTokens {
-		if contract.Type == "SEP41" {
-			sep41TokenIDs = append(sep41TokenIDs, contract.ContractID)
-			contractsByContractID[contract.ContractID] = contract
-		}
-	}
-
-	// Simulate call to `balance(id)` function of SEP-41 contracts
-	if len(sep41TokenIDs) > 0 {
-		sep41Balances, err := getSep41Balances(ctx, address, r.contractMetadataService, sep41TokenIDs, contractsByContractID, r.pool)
-		if err != nil {
-			return nil, &gqlerror.Error{
-				Message: ErrMsgBalancesFetchFailed,
-				Extensions: map[string]interface{}{
-					"code": "INTERNAL_ERROR",
-				},
-			}
-		}
-		for _, result := range sep41Balances {
-			balances = append(balances, result)
-		}
-	}
-
-	return balances, nil
 }
 
 // Query returns graphql1.QueryResolver implementation.

--- a/internal/serve/graphql/resolvers/resolver.go
+++ b/internal/serve/graphql/resolvers/resolver.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/wallet-backend/internal/data"
@@ -30,9 +31,9 @@ import (
 // BalanceReader provides read-only access to account balance data.
 // This interface abstracts balance retrieval for trustlines, native XLM, and SAC balances.
 type BalanceReader interface {
-	GetTrustlineBalances(ctx context.Context, accountAddress string) ([]data.TrustlineBalance, error)
+	GetTrustlineBalances(ctx context.Context, accountAddress string, limit *int32, cursor *uuid.UUID, sortOrder data.SortOrder) ([]data.TrustlineBalance, error)
 	GetNativeBalance(ctx context.Context, accountAddress string) (*data.NativeBalance, error)
-	GetSACBalances(ctx context.Context, accountAddress string) ([]data.SACBalance, error)
+	GetSACBalances(ctx context.Context, accountAddress string, limit *int32, cursor *uuid.UUID, sortOrder data.SortOrder) ([]data.SACBalance, error)
 }
 
 const (

--- a/internal/serve/graphql/resolvers/resolver.go
+++ b/internal/serve/graphql/resolvers/resolver.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/alitto/pond/v2"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/wallet-backend/internal/data"
@@ -41,9 +40,7 @@ const (
 )
 
 // ResolverConfig holds configuration values for the GraphQL resolver.
-type ResolverConfig struct {
-	MaxWorkerPoolSize int
-}
+type ResolverConfig struct{}
 
 var ErrNotStateChange = errors.New("object is not a StateChange")
 
@@ -64,8 +61,6 @@ type Resolver struct {
 	contractMetadataService    services.ContractMetadataService
 	// metrics provides metrics collection capabilities
 	metrics *metrics.Metrics
-	// pool provides parallel processing capabilities for batch operations
-	pool pond.Pool
 	// config holds resolver-specific configuration values
 	config ResolverConfig
 }
@@ -74,10 +69,6 @@ type Resolver struct {
 // This constructor is called during server startup to initialize the resolver
 // Dependencies are injected here and available to all resolver functions.
 func NewResolver(models *data.Models, transactionService services.TransactionService, feeBumpService services.FeeBumpService, rpcService services.RPCService, balanceReader BalanceReader, accountContractTokensModel data.AccountContractTokensModelInterface, contractMetadataService services.ContractMetadataService, m *metrics.Metrics, config ResolverConfig) *Resolver {
-	poolSize := config.MaxWorkerPoolSize
-	if poolSize <= 0 {
-		poolSize = 100 // default fallback
-	}
 	return &Resolver{
 		models:                     models,
 		transactionService:         transactionService,
@@ -87,7 +78,6 @@ func NewResolver(models *data.Models, transactionService services.TransactionSer
 		accountContractTokensModel: accountContractTokensModel,
 		contractMetadataService:    contractMetadataService,
 		metrics:                    m,
-		pool:                       pond.NewPool(poolSize),
 		config:                     config,
 	}
 }

--- a/internal/serve/graphql/resolvers/utils.go
+++ b/internal/serve/graphql/resolvers/utils.go
@@ -13,11 +13,8 @@ import (
 
 	"github.com/stellar/wallet-backend/internal/data"
 	"github.com/stellar/wallet-backend/internal/indexer/types"
+	graphqlutils "github.com/stellar/wallet-backend/internal/serve/graphql"
 	generated "github.com/stellar/wallet-backend/internal/serve/graphql/generated"
-)
-
-const (
-	DefaultLimit = int32(50)
 )
 
 // GenericEdge is a generic wrapper for a GraphQL edge.
@@ -292,7 +289,7 @@ func parsePaginationParams(first *int32, after *string, last *int32, before *str
 	}
 
 	var cursor *string
-	limit := DefaultLimit
+	limit := graphqlutils.DefaultPageLimit
 	forwardPagination := true
 	sortOrder := data.ASC
 	if first != nil {

--- a/internal/serve/graphql/resolvers/utils.go
+++ b/internal/serve/graphql/resolvers/utils.go
@@ -39,11 +39,14 @@ const (
 	CursorTypeComposite
 	// CursorTypeStateChange is used for state change queries (ledger_created_at:to_id:op_id:sc_order format)
 	CursorTypeStateChange
+	// CursorTypeString is used for opaque string-based cursors.
+	CursorTypeString
 )
 
 type PaginationParams struct {
 	Limit             *int32
 	Cursor            *int64
+	StringCursor      *string
 	CompositeCursor   *types.CompositeCursor
 	StateChangeCursor *types.StateChangeCursor
 	ForwardPagination bool
@@ -60,7 +63,7 @@ func NewConnectionWithRelayPagination[T any, C int64 | string](nodes []T, params
 	hasNextPage := false
 	hasPreviousPage := false
 
-	hasCursor := params.Cursor != nil || params.CompositeCursor != nil || params.StateChangeCursor != nil
+	hasCursor := params.Cursor != nil || params.StringCursor != nil || params.CompositeCursor != nil || params.StateChangeCursor != nil
 
 	if params.ForwardPagination {
 		if int32(len(nodes)) > *params.Limit {
@@ -321,6 +324,12 @@ func parsePaginationParams(first *int32, after *string, last *int32, before *str
 			return PaginationParams{}, fmt.Errorf("parsing composite cursor: %w", err)
 		}
 		paginationParams.CompositeCursor = compositeCursor
+	case CursorTypeString:
+		decodedCursor, err := decodeStringCursor(cursor)
+		if err != nil {
+			return PaginationParams{}, fmt.Errorf("decoding cursor: %w", err)
+		}
+		paginationParams.StringCursor = decodedCursor
 	default:
 		decodedCursor, err := decodeInt64Cursor(cursor)
 		if err != nil {

--- a/internal/serve/graphql/schema/account.graphqls
+++ b/internal/serve/graphql/schema/account.graphqls
@@ -8,7 +8,7 @@ type Account{
 
   # All balances associated with this account
   # Returns native XLM, trustlines, SAC, and SEP-41 balances for the account address
-  balances: [Balance!]
+  balances(first: Int, after: String, last: Int, before: String): BalanceConnection!
 
   # All transactions associated with this account
   # Optional since/until params enable TimescaleDB chunk pruning on ledger_created_at

--- a/internal/serve/graphql/schema/account.graphqls
+++ b/internal/serve/graphql/schema/account.graphqls
@@ -6,6 +6,10 @@ type Account{
   # GraphQL Relationships - these fields use resolvers for data fetching
   # Each relationship resolver will be called when the field is requested
 
+  # All balances associated with this account
+  # Returns native XLM, trustlines, SAC, and SEP-41 balances for the account address
+  balances: [Balance!]
+
   # All transactions associated with this account
   # Optional since/until params enable TimescaleDB chunk pruning on ledger_created_at
   transactions(since: Time, until: Time, first: Int, after: String, last: Int, before: String):   TransactionConnection

--- a/internal/serve/graphql/schema/pagination.graphqls
+++ b/internal/serve/graphql/schema/pagination.graphqls
@@ -28,6 +28,16 @@ type StateChangeEdge {
     cursor: String!
 }
 
+type BalanceConnection {
+    edges: [BalanceEdge!]!
+    pageInfo: PageInfo!
+}
+
+type BalanceEdge {
+    node: Balance!
+    cursor: String!
+}
+
 type PageInfo {
     startCursor: String
     endCursor: String

--- a/internal/serve/graphql/schema/queries.graphqls
+++ b/internal/serve/graphql/schema/queries.graphqls
@@ -7,5 +7,4 @@ type Query {
     operations(first: Int, after: String, last: Int, before: String):     OperationConnection
     operationById(id: Int64!):                                            Operation
     stateChanges(first: Int, after: String, last: Int, before: String):   StateChangeConnection
-    balancesByAccountAddress(address: String!):                           [Balance!]!
 }

--- a/internal/serve/graphql/utils.go
+++ b/internal/serve/graphql/utils.go
@@ -11,6 +11,10 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
+// DefaultPageLimit is the implicit page size used when GraphQL pagination args
+// are omitted. Execution and complexity accounting must share this value.
+const DefaultPageLimit int32 = 50
+
 // CustomErrorPresenter provides more detailed error messages for GraphQL validation errors
 func CustomErrorPresenter(ctx context.Context, err error) *gqlerror.Error {
 	var gqlErr *gqlerror.Error

--- a/internal/serve/middleware/graphql_utils_test.go
+++ b/internal/serve/middleware/graphql_utils_test.go
@@ -93,11 +93,11 @@ func TestGetOperationIdentifier(t *testing.T) {
 				Operation: &ast.OperationDefinition{
 					SelectionSet: ast.SelectionSet{
 						&ast.InlineFragment{},
-						&ast.Field{Name: "balancesByAccountAddress"},
+						&ast.Field{Name: "accountByAddress"},
 					},
 				},
 			},
-			expected: "balancesByAccountAddress",
+			expected: "accountByAddress",
 		},
 	}
 

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -363,8 +363,9 @@ func addComplexityCalculation(config *generated.Config) {
 		Complexity = 10*(1+1+1+2*(1+1+1+5*(1+1+1+1))) = 490
 		--------------------------------
 	*/
-	paginatedQueryComplexityFunc := func(childComplexity int, first *int32, after *string, last *int32, before *string) int {
-		limit := 10 // default limit when no pagination parameters provided
+	calculatePaginatedComplexity := func(childComplexity int, first *int32, last *int32) int {
+		// Use the same default page size as resolver execution when pagination args are omitted.
+		limit := int(graphqlutils.DefaultPageLimit)
 		if first != nil {
 			limit = int(*first)
 		} else if last != nil {
@@ -372,9 +373,21 @@ func addComplexityCalculation(config *generated.Config) {
 		}
 		return childComplexity * limit
 	}
+	paginatedQueryComplexityFunc := func(childComplexity int, first *int32, _ *string, last *int32, _ *string) int {
+		return calculatePaginatedComplexity(childComplexity, first, last)
+	}
 	config.Complexity.Query.Transactions = paginatedQueryComplexityFunc
 	config.Complexity.Query.Operations = paginatedQueryComplexityFunc
 	config.Complexity.Query.StateChanges = paginatedQueryComplexityFunc
+	config.Complexity.Account.Transactions = func(childComplexity int, since *time.Time, until *time.Time, first *int32, after *string, last *int32, before *string) int {
+		return calculatePaginatedComplexity(childComplexity, first, last)
+	}
+	config.Complexity.Account.Operations = func(childComplexity int, since *time.Time, until *time.Time, first *int32, after *string, last *int32, before *string) int {
+		return calculatePaginatedComplexity(childComplexity, first, last)
+	}
+	config.Complexity.Account.StateChanges = func(childComplexity int, filter *generated.AccountStateChangeFilterInput, since *time.Time, until *time.Time, first *int32, after *string, last *int32, before *string) int {
+		return calculatePaginatedComplexity(childComplexity, first, last)
+	}
 	config.Complexity.Transaction.Operations = paginatedQueryComplexityFunc
 	config.Complexity.Transaction.StateChanges = paginatedQueryComplexityFunc
 	config.Complexity.Operation.StateChanges = paginatedQueryComplexityFunc

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -381,6 +381,7 @@ func addComplexityCalculation(config *generated.Config) {
 	config.Complexity.Query.Transactions = paginatedQueryComplexityFunc
 	config.Complexity.Query.Operations = paginatedQueryComplexityFunc
 	config.Complexity.Query.StateChanges = paginatedQueryComplexityFunc
+	config.Complexity.Account.Balances = paginatedQueryComplexityFunc
 	config.Complexity.Account.Transactions = func(childComplexity int, since *time.Time, until *time.Time, first *int32, after *string, last *int32, before *string) int {
 		return calculatePaginatedComplexity(childComplexity, first, last)
 	}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -62,8 +62,7 @@ type Configs struct {
 	RPCURL string
 
 	// GraphQL
-	GraphQLComplexityLimit   int
-	MaxGraphQLWorkerPoolSize int
+	GraphQLComplexityLimit int
 
 	// Error Tracker
 	AppTracker apptracker.AppTracker
@@ -115,8 +114,7 @@ type handlerDeps struct {
 	ContractMetadataService    services.ContractMetadataService
 
 	// GraphQL
-	GraphQLComplexityLimit   int
-	MaxGraphQLWorkerPoolSize int
+	GraphQLComplexityLimit int
 
 	// Error Tracker
 	AppTracker apptracker.AppTracker
@@ -230,7 +228,6 @@ func initHandlerDeps(ctx context.Context, cfg Configs) (handlerDeps, error) {
 		NetworkPassphrase:          cfg.NetworkPassphrase,
 		TransactionService:         txService,
 		GraphQLComplexityLimit:     cfg.GraphQLComplexityLimit,
-		MaxGraphQLWorkerPoolSize:   cfg.MaxGraphQLWorkerPoolSize,
 	}, nil
 }
 
@@ -279,9 +276,7 @@ func handler(deps handlerDeps) http.Handler {
 				deps.AccountContractTokensModel,
 				deps.ContractMetadataService,
 				deps.Metrics,
-				resolvers.ResolverConfig{
-					MaxWorkerPoolSize: deps.MaxGraphQLWorkerPoolSize,
-				},
+				resolvers.ResolverConfig{},
 			)
 
 			config := generated.Config{

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -326,11 +326,12 @@ func addComplexityCalculation(config *generated.Config) {
 		It is used to determine the performance of a query and to prevent
 		queries that are too complex from being executed.
 
-		By default, graphql assigns a complexity of 1 to each field. This means that a query with 10 fields will have a complexity of 10.
-		However, we also want to take into account the number of items requested for paginated queries. So we use the first/last parameters
-		to calculate the final complexity.
+		By default, graphql assigns a complexity of 1 to each field.
+		For paginated connections, the child complexity is multiplied by the
+		page size: the explicit first/last argument, or DefaultPageLimit (50)
+		when omitted.
 
-		For example, for the following query, the complexity is calculated as follows:
+		Example — explicit pagination arguments:
 		--------------------------------
 		transactions(first: 10) {
 				edges {
@@ -356,6 +357,12 @@ func addComplexityCalculation(config *generated.Config) {
 			}
 		--------------------------------
 		Complexity = 10*(1+1+1+2*(1+1+1+5*(1+1+1+1))) = 490
+
+		Without explicit args the same shape uses DefaultPageLimit (50):
+		Complexity = 50*(1+1+1+50*(1+1+1+50*(1+1+1+1))) = 507,650
+
+		Clients should provide explicit first/last arguments to keep
+		query complexity within the configured limit (default 5000).
 		--------------------------------
 	*/
 	calculatePaginatedComplexity := func(childComplexity int, first *int32, last *int32) int {

--- a/internal/services/token_ingestion_test.go
+++ b/internal/services/token_ingestion_test.go
@@ -263,7 +263,7 @@ func TestGetAccountTrustlineBalances(t *testing.T) {
 
 		trustlineBalanceModel := &wbdata.TrustlineBalanceModel{DB: dbConnectionPool, Metrics: dbMetrics}
 
-		got, err := trustlineBalanceModel.GetByAccount(ctx, "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB")
+		got, err := trustlineBalanceModel.GetByAccount(ctx, "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB", nil, nil, wbdata.ASC)
 		assert.NoError(t, err)
 		assert.Empty(t, got)
 	})
@@ -294,7 +294,7 @@ func TestGetAccountTrustlineBalances(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		got, err := trustlineBalanceModel.GetByAccount(ctx, accountAddress)
+		got, err := trustlineBalanceModel.GetByAccount(ctx, accountAddress, nil, nil, wbdata.ASC)
 		assert.NoError(t, err)
 		assert.Len(t, got, 1)
 		assert.Equal(t, "USDC", got[0].Code)

--- a/pkg/wbclient/client.go
+++ b/pkg/wbclient/client.go
@@ -112,8 +112,10 @@ type OperationStateChangesData struct {
 	} `json:"operationById"`
 }
 
-type BalancesByAccountAddressData struct {
-	BalancesByAccountAddress []json.RawMessage `json:"balancesByAccountAddress"`
+type AccountBalancesData struct {
+	AccountByAddress struct {
+		Balances []json.RawMessage `json:"balances"`
+	} `json:"accountByAddress"`
 }
 
 // QueryOptions allows clients to specify which fields to fetch for each entity type
@@ -612,19 +614,19 @@ func (c *Client) GetOperationStateChanges(ctx context.Context, id int64, first, 
 	return data.OperationByID.StateChanges, nil
 }
 
-func (c *Client) GetBalancesByAccountAddress(ctx context.Context, address string) ([]types.Balance, error) {
+func (c *Client) GetAccountBalances(ctx context.Context, address string) ([]types.Balance, error) {
 	variables := map[string]any{
 		"address": address,
 	}
 
-	data, err := executeGraphQL[BalancesByAccountAddressData](c, ctx, buildBalancesByAccountAddressQuery(), variables)
+	data, err := executeGraphQL[AccountBalancesData](c, ctx, buildAccountBalancesQuery(), variables)
 	if err != nil {
 		return nil, err
 	}
 
 	// Unmarshal each raw balance into the appropriate concrete type
-	balances := make([]types.Balance, 0, len(data.BalancesByAccountAddress))
-	for i, rawBalance := range data.BalancesByAccountAddress {
+	balances := make([]types.Balance, 0, len(data.AccountByAddress.Balances))
+	for i, rawBalance := range data.AccountByAddress.Balances {
 		balance, err := types.UnmarshalBalance(rawBalance)
 		if err != nil {
 			return nil, fmt.Errorf("unmarshaling balance %d: %w", i, err)

--- a/pkg/wbclient/client.go
+++ b/pkg/wbclient/client.go
@@ -114,7 +114,12 @@ type OperationStateChangesData struct {
 
 type AccountBalancesData struct {
 	AccountByAddress struct {
-		Balances []json.RawMessage `json:"balances"`
+		Balances struct {
+			Edges []struct {
+				Node json.RawMessage `json:"node"`
+			} `json:"edges"`
+			PageInfo *types.PageInfo `json:"pageInfo"`
+		} `json:"balances"`
 	} `json:"accountByAddress"`
 }
 
@@ -615,23 +620,38 @@ func (c *Client) GetOperationStateChanges(ctx context.Context, id int64, first, 
 }
 
 func (c *Client) GetAccountBalances(ctx context.Context, address string) ([]types.Balance, error) {
-	variables := map[string]any{
-		"address": address,
-	}
+	const pageSize int32 = 100
 
-	data, err := executeGraphQL[AccountBalancesData](c, ctx, buildAccountBalancesQuery(), variables)
-	if err != nil {
-		return nil, err
-	}
+	var (
+		after    *string
+		balances []types.Balance
+	)
 
-	// Unmarshal each raw balance into the appropriate concrete type
-	balances := make([]types.Balance, 0, len(data.AccountByAddress.Balances))
-	for i, rawBalance := range data.AccountByAddress.Balances {
-		balance, err := types.UnmarshalBalance(rawBalance)
-		if err != nil {
-			return nil, fmt.Errorf("unmarshaling balance %d: %w", i, err)
+	for {
+		variables := map[string]any{
+			"address": address,
+			"first":   pageSize,
+			"after":   after,
 		}
-		balances = append(balances, balance)
+
+		data, err := executeGraphQL[AccountBalancesData](c, ctx, buildAccountBalancesQuery(), variables)
+		if err != nil {
+			return nil, err
+		}
+
+		for i, edge := range data.AccountByAddress.Balances.Edges {
+			balance, unmarshalErr := types.UnmarshalBalance(edge.Node)
+			if unmarshalErr != nil {
+				return nil, fmt.Errorf("unmarshaling balance %d: %w", len(balances)+i, unmarshalErr)
+			}
+			balances = append(balances, balance)
+		}
+
+		pageInfo := data.AccountByAddress.Balances.PageInfo
+		if pageInfo == nil || !pageInfo.HasNextPage || pageInfo.EndCursor == nil {
+			break
+		}
+		after = pageInfo.EndCursor
 	}
 
 	return balances, nil

--- a/pkg/wbclient/queries.go
+++ b/pkg/wbclient/queries.go
@@ -401,12 +401,14 @@ const balanceFragments = `
 		}
 	`
 
-// buildBalancesByAccountAddressQuery builds the GraphQL query for fetching account balances
-func buildBalancesByAccountAddressQuery() string {
+// buildAccountBalancesQuery builds the GraphQL query for fetching account balances.
+func buildAccountBalancesQuery() string {
 	return fmt.Sprintf(`
-		query BalancesByAccountAddress($address: String!) {
-			balancesByAccountAddress(address: $address) {
-				%s
+		query GetAccountBalances($address: String!) {
+			accountByAddress(address: $address) {
+				balances {
+					%s
+				}
 			}
 		}
 	`, balanceFragments)

--- a/pkg/wbclient/queries.go
+++ b/pkg/wbclient/queries.go
@@ -404,10 +404,18 @@ const balanceFragments = `
 // buildAccountBalancesQuery builds the GraphQL query for fetching account balances.
 func buildAccountBalancesQuery() string {
 	return fmt.Sprintf(`
-		query GetAccountBalances($address: String!) {
+		query GetAccountBalances($address: String!, $first: Int, $after: String) {
 			accountByAddress(address: $address) {
-				balances {
-					%s
+				balances(first: $first, after: $after) {
+					edges {
+						node {
+							%s
+						}
+					}
+					pageInfo {
+						endCursor
+						hasNextPage
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### What

- Removed the `balancesByAccountAddress` root query from the GraphQL schema.
- Added `balances: [Balance!]` to `Account`, so balances are now fetched via `accountByAddress(address) { balances }`.
- Moved the balance-loading flow into the `Account` field resolver and shared helper logic, while keeping existing balance behavior intact for native, trustline, SAC, and SEP-41 balances.
- Updated the repo-owned GraphQL client to use the nested query shape and renamed `GetBalancesByAccountAddress` to `GetAccountBalances`.
- Regenerated gqlgen code with `make gql-generate`.
- Updated resolver tests, middleware tests, integration tests, and docs/examples to match the new schema shape.


### Why

- This makes the schema more idiomatic GraphQL by treating `accountByAddress` as the entry point and exposing account-scoped data as fields on `Account`.
- `balances` was the outlier in the current API; `transactions`, `operations`, and `stateChanges` already hang off `Account`, so this change makes the account graph consistent.
- Removing the extra root query simplifies the schema and avoids maintaining two ways to access the same account resource.
- Since the backend is not yet in production and has no external clients, this breaking cleanup can be done now without a compatibility layer.
- The change is schema-shape only; it does not change balance semantics or supported balance types.

### Known limitations

N/A

### Issue that this PR addresses

Closes #570 