### PR TITLE
fix(internal): Bound Soroban ResourceFee and release channel on signing failure

### DIFF
--- a/internal/services/fee_bump_service.go
+++ b/internal/services/fee_bump_service.go
@@ -47,18 +47,23 @@ func (s *feeBumpService) WrapTransaction(ctx context.Context, tx *txnbuild.Trans
 	}
 
 	// For Soroban inner transactions the base fee alone does not reflect the total cost — the ResourceFee sits on the
-	// transaction's Ext and is added on top. If the declared ResourceFee pushes the inner's total max fee above what
-	// the fee-bump envelope commits (s.BaseFee × innerOps), the network will reject the envelope with txINSUFF_FEE
-	// anyway. Reject early so the sponsor never signs.
-	if sorobanResourceFee, ok := innerSorobanResourceFee(tx); ok {
+	// transaction's Ext and is added on top. `tx.MaxFee()` on a parsed tx returns the envelope's `Fee` field which
+	// for Soroban already equals `BaseFee*innerOps + ResourceFee`; we compare it directly to the per-op sponsor cap
+	// (`s.BaseFee * innerOps`) to match the bound enforced by `validateSorobanResourceFee` in the build path.
+	//
+	// This catches envelopes that bypass the build path (i.e., client hand-crafted a Soroban envelope and submitted
+	// it directly to the fee-bump endpoint); txs that went through the build path already had their ResourceFee
+	// capped, so they land at exactly `s.BaseFee * innerOps` and pass the check.
+	if _, ok := innerSorobanResourceFee(tx); ok {
 		innerOps := int64(len(tx.Operations()))
 		if innerOps == 0 {
 			innerOps = 1
 		}
-		innerTotalMaxFee := tx.BaseFee()*innerOps + sorobanResourceFee
-		if innerTotalMaxFee > s.BaseFee*innerOps {
-			return "", "", fmt.Errorf("%w: soroban inner total max fee %d exceeds sponsor cap %d",
-				ErrFeeExceedsMaximumBaseFee, innerTotalMaxFee, s.BaseFee*innerOps)
+		innerMaxFee := tx.MaxFee()
+		sponsorCap := s.BaseFee * innerOps
+		if innerMaxFee > sponsorCap {
+			return "", "", fmt.Errorf("%w: soroban inner max fee %d exceeds sponsor cap %d",
+				ErrFeeExceedsMaximumBaseFee, innerMaxFee, sponsorCap)
 		}
 	}
 

--- a/internal/services/fee_bump_service.go
+++ b/internal/services/fee_bump_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/stellar/go-stellar-sdk/txnbuild"
+	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/wallet-backend/internal/data"
 	"github.com/stellar/wallet-backend/internal/signing"
@@ -43,6 +44,22 @@ func (s *feeBumpService) WrapTransaction(ctx context.Context, tx *txnbuild.Trans
 
 	if tx.BaseFee() > s.BaseFee {
 		return "", "", ErrFeeExceedsMaximumBaseFee
+	}
+
+	// For Soroban inner transactions the base fee alone does not reflect the total cost — the ResourceFee sits on the
+	// transaction's Ext and is added on top. If the declared ResourceFee pushes the inner's total max fee above what
+	// the fee-bump envelope commits (s.BaseFee × innerOps), the network will reject the envelope with txINSUFF_FEE
+	// anyway. Reject early so the sponsor never signs.
+	if sorobanResourceFee, ok := innerSorobanResourceFee(tx); ok {
+		innerOps := int64(len(tx.Operations()))
+		if innerOps == 0 {
+			innerOps = 1
+		}
+		innerTotalMaxFee := tx.BaseFee()*innerOps + sorobanResourceFee
+		if innerTotalMaxFee > s.BaseFee*innerOps {
+			return "", "", fmt.Errorf("%w: soroban inner total max fee %d exceeds sponsor cap %d",
+				ErrFeeExceedsMaximumBaseFee, innerTotalMaxFee, s.BaseFee*innerOps)
+		}
 	}
 
 	sigs := tx.Signatures()
@@ -116,4 +133,21 @@ func NewFeeBumpService(opts FeeBumpServiceOptions) (*feeBumpService, error) {
 		BaseFee:                            opts.BaseFee,
 		Models:                             opts.Models,
 	}, nil
+}
+
+// innerSorobanResourceFee returns the transaction-level Soroban ResourceFee declared in the inner transaction's Ext,
+// if present. Classic (non-Soroban) transactions return (0, false).
+func innerSorobanResourceFee(tx *txnbuild.Transaction) (int64, bool) {
+	envelope := tx.ToXDR()
+	v1, ok := envelope.GetV1()
+	if !ok {
+		return 0, false
+	}
+	if v1.Tx.Ext.V != 1 || v1.Tx.Ext.SorobanData == nil {
+		return 0, false
+	}
+	if envelope.Type != xdr.EnvelopeTypeEnvelopeTypeTx {
+		return 0, false
+	}
+	return int64(v1.Tx.Ext.SorobanData.ResourceFee), true
 }

--- a/internal/services/fee_bump_service_test.go
+++ b/internal/services/fee_bump_service_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/network"
 	"github.com/stellar/go-stellar-sdk/txnbuild"
+	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -201,5 +202,65 @@ func TestFeeBumpServiceWrapTransaction(t *testing.T) {
 		assert.Equal(t, distributionAccount.Address(), feeBumpTx.FeeAccount())
 		assert.Len(t, feeBumpTx.InnerTransaction().Operations(), 1)
 		assert.Len(t, feeBumpTx.Signatures(), 1)
+	})
+
+	t.Run("🚨soroban_inner_with_inflated_resource_fee_is_rejected", func(t *testing.T) {
+		accountToSponsor := keypair.MustRandom()
+
+		// Insert into channel_accounts to make account fee-bump eligible
+		_, err := dbConnectionPool.Exec(ctx, "INSERT INTO channel_accounts (public_key, encrypted_private_key) VALUES ($1, 'encrypted')", accountToSponsor.Address())
+		require.NoError(t, err)
+
+		// Build a Soroban InvokeHostFunction op whose transaction-level Ext declares a ResourceFee of 500 — well above
+		// s.BaseFee (MinBaseFee = 100) times the inner op count. The network would reject the fee-bump envelope for
+		// insufficient fee at submit time; the wallet-backend must reject it earlier so the sponsor never signs.
+		nativeAssetContractIDBytes, err := xdr.Asset{Type: xdr.AssetTypeAssetTypeNative}.ContractID(network.TestNetworkPassphrase)
+		require.NoError(t, err)
+		nativeAssetContractID := xdr.ContractId(nativeAssetContractIDBytes)
+		invokeOp := &txnbuild.InvokeHostFunction{
+			HostFunction: xdr.HostFunction{
+				Type: xdr.HostFunctionTypeHostFunctionTypeInvokeContract,
+				InvokeContract: &xdr.InvokeContractArgs{
+					ContractAddress: xdr.ScAddress{
+						Type:       xdr.ScAddressTypeScAddressTypeContract,
+						ContractId: &nativeAssetContractID,
+					},
+					FunctionName: "noop",
+					Args:         xdr.ScVec{},
+				},
+			},
+			SourceAccount: accountToSponsor.Address(),
+		}
+		sorobanData := xdr.SorobanTransactionData{
+			Resources: xdr.SorobanResources{
+				Footprint: xdr.LedgerFootprint{},
+			},
+			ResourceFee: 500,
+		}
+		invokeOp.Ext, err = xdr.NewTransactionExt(1, sorobanData)
+		require.NoError(t, err)
+
+		// Inner base fee set to MinBaseFee (100). After adjustParamsForSoroban would normally subtract ResourceFee,
+		// but here we construct the tx directly — simulating a raw client submission that bypasses the backend's
+		// build path.
+		tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+			SourceAccount: &txnbuild.SimpleAccount{
+				AccountID: accountToSponsor.Address(),
+				Sequence:  123,
+			},
+			IncrementSequenceNum: true,
+			Operations:           []txnbuild.Operation{invokeOp},
+			BaseFee:              txnbuild.MinBaseFee,
+			Preconditions:        txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(30)},
+		})
+		require.NoError(t, err)
+
+		tx, err = tx.Sign(network.TestNetworkPassphrase, accountToSponsor)
+		require.NoError(t, err)
+
+		feeBumpTxe, networkPassphrase, err := s.WrapTransaction(ctx, tx)
+		assert.ErrorIs(t, err, ErrFeeExceedsMaximumBaseFee)
+		assert.Empty(t, feeBumpTxe)
+		assert.Empty(t, networkPassphrase)
 	})
 }

--- a/internal/services/transaction_service.go
+++ b/internal/services/transaction_service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"slices"
 	"strconv"
 
@@ -207,9 +206,14 @@ func (t *transactionService) BuildAndSignTransactionWithChannelAccount(ctx conte
 	// After AssignTxToChannelAccount succeeds, the channel row is locked to this tx hash until the ingest path
 	// confirms the tx on ledger (see internal/services/ingest_live.go:unlockChannelAccounts) or the locked_until
 	// TTL expires. If anything below fails, the channel would otherwise be held hostage for the full TTL. Release on error.
+	//
+	// Use a cancel-detached context so the cleanup still runs when the caller's request context is cancelled
+	// (client disconnect, request timeout); otherwise the DB op inside releaseChannelAccountLock would inherit
+	// the cancellation and leave the channel locked until the locked_until TTL expires.
+	unlockCtx := context.WithoutCancel(ctx)
 	defer func() {
 		if retErr != nil {
-			t.releaseChannelAccountLock(ctx, txHash)
+			t.releaseChannelAccountLock(unlockCtx, txHash)
 		}
 	}()
 
@@ -293,20 +297,30 @@ func (t *transactionService) adjustParamsForSoroban(_ context.Context, channelAc
 		return txnbuild.TransactionParams{}, err
 	}
 
-	// Adjust the base fee to ensure the total fee computed by `txnbuild.NewTransaction` (baseFee+sorobanFee) will stay
-	// within the limits configured by the host.
+	// Adjust the base fee so the total computed by `txnbuild.NewTransaction` (BaseFee*ops + ResourceFee) stays within
+	// the sponsor's per-op cap. The floor at MinBaseFee is protocol-required; validateSorobanResourceFee has already
+	// ensured clientResourceFee leaves enough headroom that adjustedBaseFee >= MinBaseFee, so the flooring is a no-op
+	// in practice and total ≤ t.BaseFee is provable rather than asymptotic.
 	adjustedBaseFee := buildTxParams.BaseFee - clientResourceFee
-	buildTxParams.BaseFee = int64(math.Max(float64(adjustedBaseFee), float64(txnbuild.MinBaseFee)))
+	if adjustedBaseFee < int64(txnbuild.MinBaseFee) {
+		adjustedBaseFee = int64(txnbuild.MinBaseFee)
+	}
+	buildTxParams.BaseFee = adjustedBaseFee
 
 	return buildTxParams, nil
 }
 
 // validateSorobanResourceFee re-simulates the Soroban transaction against the wallet-backend's own Stellar RPC and
 // rejects the request if the client-declared resource fee exceeds the bound
-// `min(serverMinResourceFee * sorobanResourceFeeSafetyFactor, t.BaseFee)`.
+// `min(serverMinResourceFee * sorobanResourceFeeSafetyFactor, t.BaseFee - MinBaseFee*ops)`.
+//
+// The `t.BaseFee - MinBaseFee*ops` term (rather than plain t.BaseFee) reserves room for the protocol-required base-fee
+// floor after adjustParamsForSoroban subtracts the resource fee, guaranteeing the total envelope fee stays within the
+// sponsor's configured per-op cap.
 func (t *transactionService) validateSorobanResourceFee(buildTxParams txnbuild.TransactionParams, clientResourceFee int64) error {
 	// Build a throw-away transaction for simulation. Copy the source account so the real build path's sequence is
-	// untouched, and explicitly disable sequence increment since simulation does not consume a sequence number.
+	// untouched. IncrementSequenceNum matches the real build path so the simulated tx has the exact sequence the
+	// submitted tx will have.
 	var simSourceAccount txnbuild.SimpleAccount
 	if src, ok := buildTxParams.SourceAccount.(*txnbuild.SimpleAccount); ok && src != nil {
 		simSourceAccount = *src
@@ -320,7 +334,7 @@ func (t *transactionService) validateSorobanResourceFee(buildTxParams txnbuild.T
 		BaseFee:              txnbuild.MinBaseFee,
 		Preconditions:        buildTxParams.Preconditions,
 		Memo:                 buildTxParams.Memo,
-		IncrementSequenceNum: false,
+		IncrementSequenceNum: true,
 	})
 	if err != nil {
 		return fmt.Errorf("building soroban re-simulation transaction: %w", err)
@@ -344,9 +358,20 @@ func (t *transactionService) validateSorobanResourceFee(buildTxParams txnbuild.T
 		return fmt.Errorf("parsing server-side re-simulation MinResourceFee %q: %w", serverSim.MinResourceFee, err)
 	}
 
+	// Reserve MinBaseFee per op for the base fee portion so that after adjustParamsForSoroban subtracts resource
+	// fee and floors at MinBaseFee, the total `BaseFee*ops + ResourceFee` provably stays ≤ t.BaseFee.
+	opsCount := int64(len(buildTxParams.Operations))
+	if opsCount < 1 {
+		opsCount = 1
+	}
+	baseFeeCap := t.BaseFee - int64(txnbuild.MinBaseFee)*opsCount
+	if baseFeeCap < 0 {
+		baseFeeCap = 0
+	}
+
 	maxAllowedResourceFee := serverMinResourceFee * sorobanResourceFeeSafetyFactor
-	if t.BaseFee < maxAllowedResourceFee {
-		maxAllowedResourceFee = t.BaseFee
+	if baseFeeCap < maxAllowedResourceFee {
+		maxAllowedResourceFee = baseFeeCap
 	}
 
 	if clientResourceFee > maxAllowedResourceFee {

--- a/internal/services/transaction_service.go
+++ b/internal/services/transaction_service.go
@@ -6,11 +6,15 @@ import (
 	"fmt"
 	"math"
 	"slices"
+	"strconv"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/txnbuild"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
+	"github.com/stellar/wallet-backend/internal/db"
 	"github.com/stellar/wallet-backend/internal/entities"
 	"github.com/stellar/wallet-backend/internal/signing"
 	"github.com/stellar/wallet-backend/internal/signing/store"
@@ -22,6 +26,11 @@ import (
 const (
 	MaxTimeoutInSeconds     = 300
 	DefaultTimeoutInSeconds = 30
+
+	// sorobanResourceFeeSafetyFactor multiplies the server-authoritative MinResourceFee to produce the upper bound
+	// we accept from the client. This absorbs normal simulation drift while preventing inflated ResourceFee values
+	// from draining the sponsor account. The value is also capped by the operator-configured BaseFee.
+	sorobanResourceFeeSafetyFactor = 2
 )
 
 var (
@@ -32,6 +41,7 @@ var (
 	ErrInvalidSorobanSimulationEmpty  = errors.New("invalid Soroban transaction: simulation response cannot be empty")
 	ErrInvalidSorobanSimulationFailed = errors.New("invalid Soroban transaction: simulation failed")
 	ErrInvalidSorobanOperationType    = errors.New("invalid Soroban transaction: operation type not supported")
+	ErrSorobanResourceFeeExceedsBound = errors.New("invalid Soroban transaction: client-declared resource fee exceeds the allowed bound")
 )
 
 type TransactionService interface {
@@ -104,7 +114,7 @@ func (t *transactionService) NetworkPassphrase() string {
 	return t.DistributionAccountSignatureClient.NetworkPassphrase()
 }
 
-func (t *transactionService) BuildAndSignTransactionWithChannelAccount(ctx context.Context, transaction *txnbuild.GenericTransaction, simulationResponse *entities.RPCSimulateTransactionResult) (*txnbuild.Transaction, error) {
+func (t *transactionService) BuildAndSignTransactionWithChannelAccount(ctx context.Context, transaction *txnbuild.GenericTransaction, simulationResponse *entities.RPCSimulateTransactionResult) (signedTx *txnbuild.Transaction, retErr error) {
 	timeoutInSecs := DefaultTimeoutInSeconds
 	channelAccountPublicKey, err := t.ChannelAccountSignatureClient.GetAccountPublicKey(ctx, timeoutInSecs)
 	if err != nil {
@@ -194,6 +204,15 @@ func (t *transactionService) BuildAndSignTransactionWithChannelAccount(ctx conte
 		return nil, fmt.Errorf("assigning channel account to tx: %w", err)
 	}
 
+	// After AssignTxToChannelAccount succeeds, the channel row is locked to this tx hash until the ingest path
+	// confirms the tx on ledger (see internal/services/ingest_live.go:unlockChannelAccounts) or the locked_until
+	// TTL expires. If anything below fails, the channel would otherwise be held hostage for the full TTL. Release on error.
+	defer func() {
+		if retErr != nil {
+			t.releaseChannelAccountLock(ctx, txHash)
+		}
+	}()
+
 	tx, err = t.ChannelAccountSignatureClient.SignStellarTransaction(ctx, tx, channelAccountPublicKey)
 	if err != nil {
 		return nil, fmt.Errorf("signing transaction with channel account: %w", err)
@@ -202,10 +221,28 @@ func (t *transactionService) BuildAndSignTransactionWithChannelAccount(ctx conte
 	return tx, nil
 }
 
+// releaseChannelAccountLock is a best-effort unlock of the channel account previously assigned to txHash. Failures
+// are logged but not surfaced: the caller is already unwinding with a more meaningful error, and the lock will
+// eventually expire via the channel's locked_until TTL even if this release fails.
+func (t *transactionService) releaseChannelAccountLock(ctx context.Context, txHash string) {
+	releaseErr := db.RunInTransaction(ctx, t.DB, func(pgxTx pgx.Tx) error {
+		if _, err := t.ChannelAccountStore.UnassignTxAndUnlockChannelAccounts(ctx, pgxTx, txHash); err != nil {
+			return fmt.Errorf("unassigning channel account for tx %s: %w", txHash, err)
+		}
+		return nil
+	})
+	if releaseErr != nil {
+		log.Ctx(ctx).Errorf("failed to release channel account lock for tx %s: %v", txHash, releaseErr)
+	}
+}
+
 // adjustParamsForSoroban will use the `simulationResponse` to set the `Ext` field in the sorobanOp, in case the transaction
 // is a soroban transaction. The resulting `buildTxParams` will be later used by `txnbuild.NewTransaction` to:
 // - Calculate the total fee.
 // - Include the `Ext` information to the transaction envelope.
+//
+// Before the fee is accepted, this method re-simulates the transaction server-side and rejects any client-declared
+// `ResourceFee` that exceeds `min(serverMinResourceFee * sorobanResourceFeeSafetyFactor, t.BaseFee)`.
 func (t *transactionService) adjustParamsForSoroban(_ context.Context, channelAccountPublicKey string, buildTxParams txnbuild.TransactionParams, simulationResponse entities.RPCSimulateTransactionResult) (txnbuild.TransactionParams, error) {
 	// Ensure this is a soroban transaction.
 	operations := buildTxParams.Operations
@@ -250,11 +287,72 @@ func (t *transactionService) adjustParamsForSoroban(_ context.Context, channelAc
 		return txnbuild.TransactionParams{}, fmt.Errorf("%w: %T", ErrInvalidSorobanOperationType, operations[0])
 	}
 
+	// Bound the client-declared ResourceFee against a server-side re-simulation.
+	clientResourceFee := int64(transactionExt.SorobanData.ResourceFee)
+	if err := t.validateSorobanResourceFee(buildTxParams, clientResourceFee); err != nil {
+		return txnbuild.TransactionParams{}, err
+	}
+
 	// Adjust the base fee to ensure the total fee computed by `txnbuild.NewTransaction` (baseFee+sorobanFee) will stay
 	// within the limits configured by the host.
-	sorobanFee := int64(transactionExt.SorobanData.ResourceFee)
-	adjustedBaseFee := buildTxParams.BaseFee - sorobanFee
+	adjustedBaseFee := buildTxParams.BaseFee - clientResourceFee
 	buildTxParams.BaseFee = int64(math.Max(float64(adjustedBaseFee), float64(txnbuild.MinBaseFee)))
 
 	return buildTxParams, nil
+}
+
+// validateSorobanResourceFee re-simulates the Soroban transaction against the wallet-backend's own Stellar RPC and
+// rejects the request if the client-declared resource fee exceeds the bound
+// `min(serverMinResourceFee * sorobanResourceFeeSafetyFactor, t.BaseFee)`.
+func (t *transactionService) validateSorobanResourceFee(buildTxParams txnbuild.TransactionParams, clientResourceFee int64) error {
+	// Build a throw-away transaction for simulation. Copy the source account so the real build path's sequence is
+	// untouched, and explicitly disable sequence increment since simulation does not consume a sequence number.
+	var simSourceAccount txnbuild.SimpleAccount
+	if src, ok := buildTxParams.SourceAccount.(*txnbuild.SimpleAccount); ok && src != nil {
+		simSourceAccount = *src
+	} else {
+		return fmt.Errorf("unexpected source account type for soroban re-simulation: %T", buildTxParams.SourceAccount)
+	}
+
+	simTx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount:        &simSourceAccount,
+		Operations:           buildTxParams.Operations,
+		BaseFee:              txnbuild.MinBaseFee,
+		Preconditions:        buildTxParams.Preconditions,
+		Memo:                 buildTxParams.Memo,
+		IncrementSequenceNum: false,
+	})
+	if err != nil {
+		return fmt.Errorf("building soroban re-simulation transaction: %w", err)
+	}
+
+	simTxXDR, err := simTx.Base64()
+	if err != nil {
+		return fmt.Errorf("serializing soroban re-simulation transaction: %w", err)
+	}
+
+	serverSim, err := t.RPCService.SimulateTransaction(simTxXDR, entities.RPCResourceConfig{})
+	if err != nil {
+		return fmt.Errorf("server-side re-simulation of soroban transaction: %w", err)
+	}
+	if serverSim.Error != "" {
+		return fmt.Errorf("server-side re-simulation failed: %s", serverSim.Error)
+	}
+
+	serverMinResourceFee, err := strconv.ParseInt(serverSim.MinResourceFee, 10, 64)
+	if err != nil {
+		return fmt.Errorf("parsing server-side re-simulation MinResourceFee %q: %w", serverSim.MinResourceFee, err)
+	}
+
+	maxAllowedResourceFee := serverMinResourceFee * sorobanResourceFeeSafetyFactor
+	if t.BaseFee < maxAllowedResourceFee {
+		maxAllowedResourceFee = t.BaseFee
+	}
+
+	if clientResourceFee > maxAllowedResourceFee {
+		return fmt.Errorf("%w: client resource fee %d exceeds allowed maximum %d (server MinResourceFee %d, base fee cap %d)",
+			ErrSorobanResourceFeeExceedsBound, clientResourceFee, maxAllowedResourceFee, serverMinResourceFee, t.BaseFee)
+	}
+
+	return nil
 }

--- a/internal/services/transaction_service.go
+++ b/internal/services/transaction_service.go
@@ -291,7 +291,9 @@ func (t *transactionService) adjustParamsForSoroban(_ context.Context, channelAc
 		return txnbuild.TransactionParams{}, fmt.Errorf("%w: %T", ErrInvalidSorobanOperationType, operations[0])
 	}
 
-	// Bound the client-declared ResourceFee against a server-side re-simulation.
+	// Bound the client-declared ResourceFee against a server-side re-simulation. Without this the caller can inflate
+	// `simulationResponse.TransactionData.ResourceFee` arbitrarily — the floor below would silently absorb it, but
+	// the fee-bump wrapper would still commit distribution-account funds up to the fee-bump ceiling.
 	clientResourceFee := int64(transactionExt.SorobanData.ResourceFee)
 	if err := t.validateSorobanResourceFee(buildTxParams, clientResourceFee); err != nil {
 		return txnbuild.TransactionParams{}, err

--- a/internal/services/transaction_service_test.go
+++ b/internal/services/transaction_service_test.go
@@ -423,8 +423,9 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 			Once().
 			// After signing fails, the channel account must be released so the pool doesn't leak locks on every
 			// bad/incomplete build call. Otherwise an attacker flooding buildTransaction can wedge the pool for
-			// up to the lock TTL (minutes) with a handful of requests.
-			On("UnassignTxAndUnlockChannelAccounts", context.Background(), mock.Anything, mock.AnythingOfType("string")).
+			// up to the lock TTL (minutes) with a handful of requests. The ctx here is context.WithoutCancel-wrapped
+			// so the unlock still runs when the request ctx is cancelled — mock.Anything matches the wrapped type.
+			On("UnassignTxAndUnlockChannelAccounts", mock.Anything, mock.Anything, mock.AnythingOfType("string")).
 			Return(int64(1), nil).
 			Once()
 

--- a/internal/services/transaction_service_test.go
+++ b/internal/services/transaction_service_test.go
@@ -259,7 +259,10 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		ChannelAccountSignatureClient:      &mChannelAccountSignatureClient,
 		ChannelAccountStore:                &mChannelAccountStore,
 		RPCService:                         &mRPCService,
-		BaseFee:                            114,
+		// Use a BaseFee large enough to accommodate typical Soroban ResourceFees under the server-side re-simulation
+		// bound. The specific value is not meaningful to any single subtest; it just needs to be > ResourceFee for
+		// the Soroban success path to clear the cap.
+		BaseFee: 1_000_000,
 	})
 	require.NoError(t, outerErr)
 
@@ -401,7 +404,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		assert.EqualError(t, err, "assigning channel account to tx: unable to assign channel account to tx")
 	})
 
-	t.Run("🔴handle_SignStellarTransaction_err", func(t *testing.T) {
+	t.Run("🔴handle_SignStellarTransaction_err_releases_channel_account", func(t *testing.T) {
 		channelAccount := keypair.MustRandom()
 		mChannelAccountSignatureClient.
 			On("GetAccountPublicKey", context.Background(), 30).
@@ -417,6 +420,12 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		mChannelAccountStore.
 			On("AssignTxToChannelAccount", context.Background(), channelAccount.Address(), mock.AnythingOfType("string")).
 			Return(nil).
+			Once().
+			// After signing fails, the channel account must be released so the pool doesn't leak locks on every
+			// bad/incomplete build call. Otherwise an attacker flooding buildTransaction can wedge the pool for
+			// up to the lock TTL (minutes) with a handful of requests.
+			On("UnassignTxAndUnlockChannelAccounts", context.Background(), mock.Anything, mock.AnythingOfType("string")).
+			Return(int64(1), nil).
 			Once()
 
 		mRPCService.
@@ -462,6 +471,9 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		mRPCService.
 			On("GetAccountLedgerSequence", channelAccount.Address()).
 			Return(int64(1), nil).
+			Once().
+			On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
+			Return(entities.RPCSimulateTransactionResult{MinResourceFee: "133301"}, nil).
 			Once()
 
 		sorobanTxDataXDR := "AAAAAAAAAAEAAAAGAAAAAdeSi3LCcDzP6vfrn/TvTVBKVai5efybRQ6iyEK00c5hAAAAFAAAAAEAAAACAAAAAAAAAAAQbmtGFDrXzwTfG4CRdVV7za2AhbbJnIPIfjeT39gcpQAAAAYAAAAAAAAAABBua0YUOtfPBN8bgJF1VXvNrYCFtsmcg8h+N5Pf2BylAAAAFWhSXFSqNynLAAAAAAAKehUAAAGIAAAA3AAAAAAAAgi1"
@@ -545,6 +557,7 @@ func Test_transactionService_adjustParamsForSoroban(t *testing.T) {
 		baseFee             int64
 		incomingOps         []txnbuild.Operation
 		simulationResponse  entities.RPCSimulateTransactionResult
+		setupRPCMock        func(t *testing.T, m *RPCServiceMock)
 		wantBuildTxParamsFn func(t *testing.T, initialBuildTxParams txnbuild.TransactionParams) txnbuild.TransactionParams
 		wantErrContains     string
 	}{
@@ -621,6 +634,10 @@ func Test_transactionService_adjustParamsForSoroban(t *testing.T) {
 				buildInvokeContractOp(t),
 			},
 			simulationResponse: buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeAccount, keypair.MustRandom().Address()),
+			setupRPCMock: func(t *testing.T, m *RPCServiceMock) {
+				m.On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
+					Return(entities.RPCSimulateTransactionResult{MinResourceFee: "133301"}, nil).Once()
+			},
 			wantBuildTxParamsFn: func(t *testing.T, initialBuildTxParams txnbuild.TransactionParams) txnbuild.TransactionParams {
 				newInvokeContractOp := buildInvokeContractOp(t)
 				require.Empty(t, newInvokeContractOp.Ext)
@@ -642,39 +659,16 @@ func Test_transactionService_adjustParamsForSoroban(t *testing.T) {
 			},
 		},
 		{
-			name:    "🟢successful_InvokeHostFunction_minBaseFee",
-			baseFee: txnbuild.MinBaseFee,
-			incomingOps: []txnbuild.Operation{
-				buildInvokeContractOp(t),
-			},
-			simulationResponse: buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeAccount, keypair.MustRandom().Address()),
-			wantBuildTxParamsFn: func(t *testing.T, initialBuildTxParams txnbuild.TransactionParams) txnbuild.TransactionParams {
-				newInvokeContractOp := buildInvokeContractOp(t)
-				require.Empty(t, newInvokeContractOp.Ext)
-				var err error
-				newInvokeContractOp.Ext, err = xdr.NewTransactionExt(1, sorobanTxData)
-				require.NoError(t, err)
-
-				return txnbuild.TransactionParams{
-					Operations: []txnbuild.Operation{newInvokeContractOp},
-					BaseFee:    initialBuildTxParams.BaseFee,
-					SourceAccount: &txnbuild.SimpleAccount{
-						AccountID: txSourceAccount,
-						Sequence:  1,
-					},
-					Preconditions: txnbuild.Preconditions{
-						TimeBounds: txnbuild.NewTimeout(300),
-					},
-				}
-			},
-		},
-		{
-			name:    "🟢successful_ExtendFootprintTtl_minBaseFee",
-			baseFee: txnbuild.MinBaseFee,
+			name:    "🟢successful_ExtendFootprintTtl_largeBaseFee",
+			baseFee: 1000000,
 			incomingOps: []txnbuild.Operation{
 				&txnbuild.ExtendFootprintTtl{ExtendTo: 1840580937},
 			},
 			simulationResponse: buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeAccount, keypair.MustRandom().Address()),
+			setupRPCMock: func(t *testing.T, m *RPCServiceMock) {
+				m.On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
+					Return(entities.RPCSimulateTransactionResult{MinResourceFee: "133301"}, nil).Once()
+			},
 			wantBuildTxParamsFn: func(t *testing.T, initialBuildTxParams txnbuild.TransactionParams) txnbuild.TransactionParams {
 				newExtendFootprintTTLOp := &txnbuild.ExtendFootprintTtl{ExtendTo: 1840580937}
 				var err error
@@ -683,7 +677,7 @@ func Test_transactionService_adjustParamsForSoroban(t *testing.T) {
 
 				return txnbuild.TransactionParams{
 					Operations: []txnbuild.Operation{newExtendFootprintTTLOp},
-					BaseFee:    initialBuildTxParams.BaseFee,
+					BaseFee:    1000000 - 133301,
 					SourceAccount: &txnbuild.SimpleAccount{
 						AccountID: txSourceAccount,
 						Sequence:  1,
@@ -695,12 +689,16 @@ func Test_transactionService_adjustParamsForSoroban(t *testing.T) {
 			},
 		},
 		{
-			name:    "🟢successful_RestoreFootprint_minBaseFee",
-			baseFee: txnbuild.MinBaseFee,
+			name:    "🟢successful_RestoreFootprint_largeBaseFee",
+			baseFee: 1000000,
 			incomingOps: []txnbuild.Operation{
 				&txnbuild.RestoreFootprint{},
 			},
 			simulationResponse: buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeAccount, keypair.MustRandom().Address()),
+			setupRPCMock: func(t *testing.T, m *RPCServiceMock) {
+				m.On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
+					Return(entities.RPCSimulateTransactionResult{MinResourceFee: "133301"}, nil).Once()
+			},
 			wantBuildTxParamsFn: func(t *testing.T, initialBuildTxParams txnbuild.TransactionParams) txnbuild.TransactionParams {
 				newRestoreFootprintOp := &txnbuild.RestoreFootprint{}
 				var err error
@@ -709,7 +707,7 @@ func Test_transactionService_adjustParamsForSoroban(t *testing.T) {
 
 				return txnbuild.TransactionParams{
 					Operations: []txnbuild.Operation{newRestoreFootprintOp},
-					BaseFee:    initialBuildTxParams.BaseFee,
+					BaseFee:    1000000 - 133301,
 					SourceAccount: &txnbuild.SimpleAccount{
 						AccountID: txSourceAccount,
 						Sequence:  1,
@@ -721,12 +719,16 @@ func Test_transactionService_adjustParamsForSoroban(t *testing.T) {
 			},
 		},
 		{
-			name:    "🟢successful_RestoreFootprint_minBaseFee_signedByContractAuthEntry",
-			baseFee: txnbuild.MinBaseFee,
+			name:    "🟢successful_RestoreFootprint_largeBaseFee_signedByContractAuthEntry",
+			baseFee: 1000000,
 			incomingOps: []txnbuild.Operation{
 				&txnbuild.RestoreFootprint{},
 			},
 			simulationResponse: buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeContract, "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"),
+			setupRPCMock: func(t *testing.T, m *RPCServiceMock) {
+				m.On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
+					Return(entities.RPCSimulateTransactionResult{MinResourceFee: "133301"}, nil).Once()
+			},
 			wantBuildTxParamsFn: func(t *testing.T, initialBuildTxParams txnbuild.TransactionParams) txnbuild.TransactionParams {
 				newRestoreFootprintOp := &txnbuild.RestoreFootprint{}
 				var err error
@@ -735,7 +737,7 @@ func Test_transactionService_adjustParamsForSoroban(t *testing.T) {
 
 				return txnbuild.TransactionParams{
 					Operations: []txnbuild.Operation{newRestoreFootprintOp},
-					BaseFee:    initialBuildTxParams.BaseFee,
+					BaseFee:    1000000 - 133301,
 					SourceAccount: &txnbuild.SimpleAccount{
 						AccountID: txSourceAccount,
 						Sequence:  1,
@@ -745,13 +747,76 @@ func Test_transactionService_adjustParamsForSoroban(t *testing.T) {
 					},
 				}
 			},
+		},
+		{
+			name:    "🚨rejects_inflated_ResourceFee_above_server_resim_bound",
+			baseFee: 10_000_000,
+			incomingOps: []txnbuild.Operation{
+				buildInvokeContractOp(t),
+			},
+			// Client-declared ResourceFee is 133301 (inside sorobanTxData), but server re-sim reports a MinResourceFee
+			// of "50000". With safety_factor=2, maxAllowed = min(100000, 10_000_000) = 100000. 133301 > 100000 → reject.
+			simulationResponse: buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeAccount, keypair.MustRandom().Address()),
+			setupRPCMock: func(t *testing.T, m *RPCServiceMock) {
+				m.On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
+					Return(entities.RPCSimulateTransactionResult{MinResourceFee: "50000"}, nil).Once()
+			},
+			wantErrContains: "resource fee",
+		},
+		{
+			name:    "🚨rejects_ResourceFee_above_base_fee_cap",
+			baseFee: 100_000,
+			incomingOps: []txnbuild.Operation{
+				buildInvokeContractOp(t),
+			},
+			// Client-declared ResourceFee = 133301. baseFee cap = 100000. Server returns high MinResourceFee that
+			// would *allow* it via safety factor, but hard cap at t.BaseFee should still reject.
+			simulationResponse: buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeAccount, keypair.MustRandom().Address()),
+			setupRPCMock: func(t *testing.T, m *RPCServiceMock) {
+				m.On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
+					Return(entities.RPCSimulateTransactionResult{MinResourceFee: "133301"}, nil).Once()
+			},
+			wantErrContains: "resource fee",
+		},
+		{
+			name:    "🚨rejects_when_server_resim_returns_payload_error",
+			baseFee: 1_000_000,
+			incomingOps: []txnbuild.Operation{
+				buildInvokeContractOp(t),
+			},
+			simulationResponse: buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeAccount, keypair.MustRandom().Address()),
+			setupRPCMock: func(t *testing.T, m *RPCServiceMock) {
+				m.On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
+					Return(entities.RPCSimulateTransactionResult{Error: "server said no"}, nil).Once()
+			},
+			wantErrContains: "server-side re-simulation failed",
+		},
+		{
+			name:    "🚨rejects_when_server_resim_rpc_error",
+			baseFee: 1_000_000,
+			incomingOps: []txnbuild.Operation{
+				buildInvokeContractOp(t),
+			},
+			simulationResponse: buildSimulationResponse(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, xdr.ScAddressTypeScAddressTypeAccount, keypair.MustRandom().Address()),
+			setupRPCMock: func(t *testing.T, m *RPCServiceMock) {
+				m.On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
+					Return(entities.RPCSimulateTransactionResult{}, errors.New("rpc down")).Once()
+			},
+			wantErrContains: "server-side re-simulation",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			mRPCService := &RPCServiceMock{}
+			if tc.setupRPCMock != nil {
+				tc.setupRPCMock(t, mRPCService)
+			}
+			defer mRPCService.AssertExpectations(t)
+
 			txService := &transactionService{
-				BaseFee: tc.baseFee,
+				BaseFee:    tc.baseFee,
+				RPCService: mRPCService,
 			}
 
 			incomingBuildTxParams := txnbuild.TransactionParams{


### PR DESCRIPTION
### What
- adjustParamsForSoroban now re-simulates the Soroban tx via RPCService.SimulateTransaction and rejects when the client-declared ResourceFee exceeds min(serverMinResourceFee * 2, t.BaseFee).
- fee_bump_service inspects the inner tx's Soroban Ext and rejects when resourceFee + baseFee*ops exceeds s.BaseFee*ops, catching raw envelopes that bypass the build path.
- BuildAndSignTransactionWithChannelAccount releases the channel account lock when signing fails after AssignTxToChannelAccount, so a flood of failing builds no longer holds channels for the full locked_until TTL.

### Why
The client-supplied simulation response was trusted verbatim by adjustParamsForSoroban, so a caller could inflate SorobanData.ResourceFee up to the fee-bump protocol ceiling and the sponsor would cover it. The fee-bump guard at fee_bump_service.go:44 inspects the post-adjustment BaseFee (floored to MinBaseFee) and was structurally unable to see the injected resource fee.

### Known limitations
N/A

### Issue that this PR addresses
N/A

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
