### PR TITLE
fix(auth): bind JWT request signature to query string

### DIFF
--- a/pkg/wbclient/auth/jwt_http_signer_verifier.go
+++ b/pkg/wbclient/auth/jwt_http_signer_verifier.go
@@ -49,8 +49,10 @@ func (s *JWTHTTPSignerVerifier) SignHTTPRequest(req *http.Request, timeout time.
 		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	}()
 
-	// Generate the method and path
-	methodAndPath := fmt.Sprintf("%s %s", req.Method, req.URL.Path)
+	// Generate the method and full request target (path + query).
+	// RequestURI() binds the signature to the query string so GET operations
+	// — whose payload lives in the URL — can't be tampered with under a valid token.
+	methodAndPath := fmt.Sprintf("%s %s", req.Method, req.URL.RequestURI())
 
 	// Generate the token and sign the request
 	jwtToken, err := s.generator.GenerateJWT(methodAndPath, bodyBytes, time.Now().Add(timeout))
@@ -87,8 +89,8 @@ func (s *JWTHTTPSignerVerifier) VerifyHTTPRequest(req *http.Request) error {
 		}
 	}
 
-	// Generate the method and path
-	methodAndPath := fmt.Sprintf("%s %s", req.Method, req.URL.Path)
+	// Generate the method and full request target (path + query) — must match the signer.
+	methodAndPath := fmt.Sprintf("%s %s", req.Method, req.URL.RequestURI())
 
 	// Parse the JWT
 	tokenString := authHeader[len("Bearer "):] // Remove "Bearer " prefix

--- a/pkg/wbclient/auth/jwt_http_signer_verifier_test.go
+++ b/pkg/wbclient/auth/jwt_http_signer_verifier_test.go
@@ -115,6 +115,67 @@ func Test_JWTHTTPSignerVerifier_Integration(t *testing.T) {
 			expectedStatus:  http.StatusOK,
 			wantErrContains: `{"message": "ok"}`,
 		},
+		{
+			name: "🟢valid_GET_with_query_string",
+			setupRequest: func(t *testing.T) *http.Request {
+				req := httptest.NewRequest("GET", "http://example.com/graphql/query?query=A&variables=%7B%7D", nil)
+				err := validSigner.SignHTTPRequest(req, time.Second*5)
+				require.NoError(t, err)
+				return req
+			},
+			expectedStatus:  http.StatusOK,
+			wantErrContains: `{"message": "ok"}`,
+		},
+		{
+			name: "🟢valid_POST_with_query_string_and_body",
+			setupRequest: func(t *testing.T) *http.Request {
+				req := httptest.NewRequest("POST", "http://example.com/graphql/query?op=build", bytes.NewBuffer([]byte(`{"foo": "bar"}`)))
+				err := validSigner.SignHTTPRequest(req, time.Second*5)
+				require.NoError(t, err)
+				return req
+			},
+			expectedStatus:  http.StatusOK,
+			wantErrContains: `{"message": "ok"}`,
+		},
+		{
+			name: "🔴tampered_query_string_value",
+			setupRequest: func(t *testing.T) *http.Request {
+				req := httptest.NewRequest("GET", "http://example.com/graphql/query?query=A", nil)
+				err := validSigner.SignHTTPRequest(req, time.Second*5)
+				require.NoError(t, err)
+				// Mutate the query string after signing — token is bound to "?query=A".
+				req.URL.RawQuery = "query=B"
+				return req
+			},
+			expectedStatus:  http.StatusUnauthorized,
+			wantErrContains: "method-and-path",
+		},
+		{
+			name: "🔴tampered_query_string_added",
+			setupRequest: func(t *testing.T) *http.Request {
+				req := httptest.NewRequest("GET", "http://example.com/graphql/query", nil)
+				err := validSigner.SignHTTPRequest(req, time.Second*5)
+				require.NoError(t, err)
+				// Add a query parameter that was not present when the token was signed.
+				req.URL.RawQuery = "injected=1"
+				return req
+			},
+			expectedStatus:  http.StatusUnauthorized,
+			wantErrContains: "method-and-path",
+		},
+		{
+			name: "🔴tampered_query_string_removed",
+			setupRequest: func(t *testing.T) *http.Request {
+				req := httptest.NewRequest("GET", "http://example.com/graphql/query?a=1", nil)
+				err := validSigner.SignHTTPRequest(req, time.Second*5)
+				require.NoError(t, err)
+				// Strip the query the token was signed for.
+				req.URL.RawQuery = ""
+				return req
+			},
+			expectedStatus:  http.StatusUnauthorized,
+			wantErrContains: "method-and-path",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### What
Switch jwt claims to include full query string.
First-party client is unaffected: it posts with an empty query, so RequestURI() returns just the path and the existing token bytes are unchanged in practice.

Adds 5 integration cases covering legitimate GET-with-query and POST-with-query paths, plus three tamper variants (value swap, param injection, param removal) that must be rejected with a method-and-path mismatch.

### Why
The signer and verifier built methodAndPath from req.URL.Path, which excludes the query string. A token signed for GET /graphql/query?query=A  could be replayed under the same TTL against ?query=B, because the empty-body hash and path-only claim both still matched. Switch both sides to req.URL.RequestURI() so the signed claim covers path + query.

### Known limitations
N/A

### Issue that this PR addresses
N/A

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
