### PR TITLE
fix(internal): release channel account lock on all build failure paths

### DIFF
--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -57,7 +57,7 @@ type Configs struct {
 	MaxSponsoredBaseReserves           int
 	BaseFee                            int
 	DistributionAccountSignatureClient signing.SignatureClient
-	ChannelAccountSignatureClient      signing.SignatureClient
+	ChannelAccountSignatureClient      signing.ChannelAccountSignatureClient
 
 	// RPC
 	RPCURL string

--- a/internal/services/transaction_service.go
+++ b/internal/services/transaction_service.go
@@ -118,6 +118,21 @@ func (t *transactionService) BuildAndSignTransactionWithChannelAccount(ctx conte
 		return nil, fmt.Errorf("getting channel account public key: %w", err)
 	}
 
+	// GetAccountPublicKey already set locked_until in the DB. If anything below fails before the tx is submitted,
+	// the row would otherwise be held hostage for the full locked_until TTL — an authenticated caller who flooded
+	// buildTransaction with requests that fail during Soroban validation (or any later build step) could drain the
+	// pool. Register release-on-error here so every failure path unlocks the account. The unlock matches by
+	// public_key (not locked_tx_hash) because that column may still be NULL — AssignTxToChannelAccount runs later.
+	//
+	// Use a cancel-detached context so cleanup still runs when the caller's request context is cancelled
+	// (client disconnect, request timeout).
+	unlockCtx := context.WithoutCancel(ctx)
+	defer func() {
+		if retErr != nil {
+			t.releaseChannelAccountLockByPublicKey(unlockCtx, channelAccountPublicKey)
+		}
+	}()
+
 	// Extract the inner transaction (handle both regular and fee-bump transactions)
 	var clientTx *txnbuild.Transaction
 	if feeBumpTx, ok := transaction.FeeBump(); ok {
@@ -219,20 +234,6 @@ func (t *transactionService) BuildAndSignTransactionWithChannelAccount(ctx conte
 		return nil, fmt.Errorf("assigning channel account to tx: %w", err)
 	}
 
-	// After AssignTxToChannelAccount succeeds, the channel row is locked to this tx hash until the ingest path
-	// confirms the tx on ledger (see internal/services/ingest_live.go:unlockChannelAccounts) or the locked_until
-	// TTL expires. If anything below fails, the channel would otherwise be held hostage for the full TTL. Release on error.
-	//
-	// Use a cancel-detached context so the cleanup still runs when the caller's request context is cancelled
-	// (client disconnect, request timeout); otherwise the DB op inside releaseChannelAccountLock would inherit
-	// the cancellation and leave the channel locked until the locked_until TTL expires.
-	unlockCtx := context.WithoutCancel(ctx)
-	defer func() {
-		if retErr != nil {
-			t.releaseChannelAccountLock(unlockCtx, txHash)
-		}
-	}()
-
 	tx, err = t.ChannelAccountSignatureClient.SignStellarTransaction(ctx, tx, channelAccountPublicKey)
 	if err != nil {
 		return nil, fmt.Errorf("signing transaction with channel account: %w", err)
@@ -241,18 +242,22 @@ func (t *transactionService) BuildAndSignTransactionWithChannelAccount(ctx conte
 	return tx, nil
 }
 
-// releaseChannelAccountLock is a best-effort unlock of the channel account previously assigned to txHash. Failures
+// releaseChannelAccountLockByPublicKey is a best-effort unlock of the channel account by public key. Failures
 // are logged but not surfaced: the caller is already unwinding with a more meaningful error, and the lock will
 // eventually expire via the channel's locked_until TTL even if this release fails.
-func (t *transactionService) releaseChannelAccountLock(ctx context.Context, txHash string) {
+//
+// Matches by public_key rather than locked_tx_hash because the defer that calls this fires for every failure
+// path after GetAndLockIdleChannelAccount — including those before AssignTxToChannelAccount runs, when
+// locked_tx_hash is still NULL.
+func (t *transactionService) releaseChannelAccountLockByPublicKey(ctx context.Context, publicKey string) {
 	releaseErr := db.RunInTransaction(ctx, t.DB, func(pgxTx pgx.Tx) error {
-		if _, err := t.ChannelAccountStore.UnassignTxAndUnlockChannelAccounts(ctx, pgxTx, txHash); err != nil {
-			return fmt.Errorf("unassigning channel account for tx %s: %w", txHash, err)
+		if _, err := t.ChannelAccountStore.UnlockChannelAccountByPublicKey(ctx, pgxTx, publicKey); err != nil {
+			return fmt.Errorf("unlocking channel account %s: %w", publicKey, err)
 		}
 		return nil
 	})
 	if releaseErr != nil {
-		log.Ctx(ctx).Errorf("failed to release channel account lock for tx %s: %v", txHash, releaseErr)
+		log.Ctx(ctx).Errorf("failed to release channel account lock for %s: %v", publicKey, releaseErr)
 	}
 }
 

--- a/internal/services/transaction_service.go
+++ b/internal/services/transaction_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -49,7 +50,7 @@ type TransactionService interface {
 type transactionService struct {
 	DB                                 *pgxpool.Pool
 	DistributionAccountSignatureClient signing.SignatureClient
-	ChannelAccountSignatureClient      signing.SignatureClient
+	ChannelAccountSignatureClient      signing.ChannelAccountSignatureClient
 	ChannelAccountStore                store.ChannelAccountStore
 	RPCService                         RPCService
 	BaseFee                            int64
@@ -60,7 +61,7 @@ var _ TransactionService = (*transactionService)(nil)
 type TransactionServiceOptions struct {
 	DB                                 *pgxpool.Pool
 	DistributionAccountSignatureClient signing.SignatureClient
-	ChannelAccountSignatureClient      signing.SignatureClient
+	ChannelAccountSignatureClient      signing.ChannelAccountSignatureClient
 	ChannelAccountStore                store.ChannelAccountStore
 	RPCService                         RPCService
 	BaseFee                            int64
@@ -113,23 +114,27 @@ func (t *transactionService) NetworkPassphrase() string {
 
 func (t *transactionService) BuildAndSignTransactionWithChannelAccount(ctx context.Context, transaction *txnbuild.GenericTransaction) (signedTx *txnbuild.Transaction, retErr error) {
 	timeoutInSecs := DefaultTimeoutInSeconds
-	channelAccountPublicKey, err := t.ChannelAccountSignatureClient.GetAccountPublicKey(ctx, timeoutInSecs)
+	channelAccountPublicKey, lockedAt, err := t.ChannelAccountSignatureClient.AcquireChannelAccount(ctx, timeoutInSecs)
 	if err != nil {
-		return nil, fmt.Errorf("getting channel account public key: %w", err)
+		return nil, fmt.Errorf("acquiring channel account: %w", err)
 	}
 
-	// GetAccountPublicKey already set locked_until in the DB. If anything below fails before the tx is submitted,
-	// the row would otherwise be held hostage for the full locked_until TTL — an authenticated caller who flooded
-	// buildTransaction with requests that fail during Soroban validation (or any later build step) could drain the
-	// pool. Register release-on-error here so every failure path unlocks the account. The unlock matches by
-	// public_key (not locked_tx_hash) because that column may still be NULL — AssignTxToChannelAccount runs later.
+	// AcquireChannelAccount set locked_until in the DB. If anything below fails before the tx is submitted, the row
+	// would otherwise be held hostage for the full locked_until TTL — an authenticated caller who flooded buildTransaction
+	// with requests that fail during Soroban validation (or any later build step) could drain the pool. Register
+	// release-on-error here so every failure path unlocks the account.
+	//
+	// The release matches on (public_key, locked_at) because locked_tx_hash is still NULL in the pre-AssignTx window,
+	// and matching on public_key alone would let a late defer (fired after our locked_until TTL expired and another
+	// request re-acquired the same row) wipe the newer lock. Using locked_at as a lock token makes a stale release
+	// a no-op rather than a silent lock-steal.
 	//
 	// Use a cancel-detached context so cleanup still runs when the caller's request context is cancelled
 	// (client disconnect, request timeout).
 	unlockCtx := context.WithoutCancel(ctx)
 	defer func() {
 		if retErr != nil {
-			t.releaseChannelAccountLockByPublicKey(unlockCtx, channelAccountPublicKey)
+			t.releaseChannelAccountLock(unlockCtx, channelAccountPublicKey, lockedAt)
 		}
 	}()
 
@@ -242,16 +247,17 @@ func (t *transactionService) BuildAndSignTransactionWithChannelAccount(ctx conte
 	return tx, nil
 }
 
-// releaseChannelAccountLockByPublicKey is a best-effort unlock of the channel account by public key. Failures
-// are logged but not surfaced: the caller is already unwinding with a more meaningful error, and the lock will
-// eventually expire via the channel's locked_until TTL even if this release fails.
+// releaseChannelAccountLock is a best-effort unlock of the channel account identified by (publicKey, lockedAt).
+// Failures are logged but not surfaced: the caller is already unwinding with a more meaningful error, and the
+// lock will eventually expire via the channel's locked_until TTL even if this release fails.
 //
-// Matches by public_key rather than locked_tx_hash because the defer that calls this fires for every failure
-// path after GetAndLockIdleChannelAccount — including those before AssignTxToChannelAccount runs, when
-// locked_tx_hash is still NULL.
-func (t *transactionService) releaseChannelAccountLockByPublicKey(ctx context.Context, publicKey string) {
+// Matches on both public_key and locked_at so a stale release (fired after the lock's TTL expired and another
+// request re-acquired the same row) is a no-op rather than a destructive unlock. locked_tx_hash is deliberately
+// not part of the match — the defer calling this runs for every failure path after lock acquisition, including
+// the pre-AssignTx window where locked_tx_hash is still NULL.
+func (t *transactionService) releaseChannelAccountLock(ctx context.Context, publicKey string, lockedAt time.Time) {
 	releaseErr := db.RunInTransaction(ctx, t.DB, func(pgxTx pgx.Tx) error {
-		if _, err := t.ChannelAccountStore.UnlockChannelAccountByPublicKey(ctx, pgxTx, publicKey); err != nil {
+		if _, err := t.ChannelAccountStore.UnlockChannelAccountByLockToken(ctx, pgxTx, publicKey, lockedAt); err != nil {
 			return fmt.Errorf("unlocking channel account %s: %w", publicKey, err)
 		}
 		return nil

--- a/internal/services/transaction_service_test.go
+++ b/internal/services/transaction_service_test.go
@@ -321,6 +321,11 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 			Return(channelAccount.Address(), nil).
 			Once()
 
+		mChannelAccountStore.
+			On("UnlockChannelAccountByPublicKey", mock.Anything, mock.Anything, channelAccount.Address()).
+			Return(int64(1), nil).
+			Once()
+
 		operations := []txnbuild.Operation{&txnbuild.AccountMerge{
 			Destination:   keypair.MustRandom().Address(),
 			SourceAccount: channelAccount.Address(),
@@ -331,6 +336,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction())
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
+		mChannelAccountStore.AssertExpectations(t)
 		assert.Empty(t, tx)
 		assert.ErrorContains(t, err, "invalid operation: operation source account cannot be the channel account")
 	})
@@ -340,6 +346,11 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		mChannelAccountSignatureClient.
 			On("GetAccountPublicKey", context.Background(), 30).
 			Return(channelAccount.Address(), nil).
+			Once()
+
+		mChannelAccountStore.
+			On("UnlockChannelAccountByPublicKey", mock.Anything, mock.Anything, channelAccount.Address()).
+			Return(int64(1), nil).
 			Once()
 
 		// Create a muxed M-address from the channel account's G-address.
@@ -356,6 +367,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction())
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
+		mChannelAccountStore.AssertExpectations(t)
 		assert.Empty(t, tx)
 		assert.ErrorContains(t, err, "invalid operation: operation source account cannot be the channel account")
 	})
@@ -367,6 +379,11 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 			Return(channelAccount.Address(), nil).
 			Once()
 
+		mChannelAccountStore.
+			On("UnlockChannelAccountByPublicKey", mock.Anything, mock.Anything, channelAccount.Address()).
+			Return(int64(1), nil).
+			Once()
+
 		operations := []txnbuild.Operation{&txnbuild.AccountMerge{
 			Destination: keypair.MustRandom().Address(),
 		}}
@@ -376,6 +393,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction())
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
+		mChannelAccountStore.AssertExpectations(t)
 		assert.Empty(t, tx)
 		assert.ErrorContains(t, err, "invalid operation: operation source account cannot be empty for non-Soroban operations")
 	})
@@ -385,6 +403,11 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		mChannelAccountSignatureClient.
 			On("GetAccountPublicKey", context.Background(), 30).
 			Return(channelAccount.Address(), nil).
+			Once()
+
+		mChannelAccountStore.
+			On("UnlockChannelAccountByPublicKey", mock.Anything, mock.Anything, channelAccount.Address()).
+			Return(int64(1), nil).
 			Once()
 
 		mRPCService.
@@ -398,6 +421,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction())
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
+		mChannelAccountStore.AssertExpectations(t)
 		mRPCService.AssertExpectations(t)
 		assert.Empty(t, tx)
 		expectedErr := fmt.Errorf("getting ledger sequence for channel account public key %q: rpc service down", channelAccount.Address())
@@ -417,6 +441,9 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		mChannelAccountStore.
 			On("AssignTxToChannelAccount", context.Background(), channelAccount.Address(), mock.AnythingOfType("string")).
 			Return(errors.New("unable to assign channel account to tx")).
+			Once().
+			On("UnlockChannelAccountByPublicKey", mock.Anything, mock.Anything, channelAccount.Address()).
+			Return(int64(1), nil).
 			Once()
 
 		mRPCService.
@@ -457,7 +484,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 			// bad/incomplete build call. Otherwise an attacker flooding buildTransaction can wedge the pool for
 			// up to the lock TTL (minutes) with a handful of requests. The ctx here is context.WithoutCancel-wrapped
 			// so the unlock still runs when the request ctx is cancelled — mock.Anything matches the wrapped type.
-			On("UnassignTxAndUnlockChannelAccounts", mock.Anything, mock.Anything, mock.AnythingOfType("string")).
+			On("UnlockChannelAccountByPublicKey", mock.Anything, mock.Anything, channelAccount.Address()).
 			Return(int64(1), nil).
 			Once()
 
@@ -543,6 +570,11 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 			Return(channelAccount.Address(), nil).
 			Once()
 
+		mChannelAccountStore.
+			On("UnlockChannelAccountByPublicKey", mock.Anything, mock.Anything, channelAccount.Address()).
+			Return(int64(1), nil).
+			Once()
+
 		mRPCService.
 			On("GetAccountLedgerSequence", channelAccount.Address()).
 			Return(int64(1), nil).
@@ -551,9 +583,54 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction())
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
+		mChannelAccountStore.AssertExpectations(t)
 		mRPCService.AssertExpectations(t)
 		assert.Empty(t, tx)
 		assert.ErrorContains(t, err, sorobanauth.ErrForbiddenSigner.Error())
+	})
+
+	t.Run("🚨adjustParamsForSoroban_fee_exceeds_bound_releases_channel_account", func(t *testing.T) {
+		// Regression test for the pre-Soroban-validation lock leak: when adjustParamsForSoroban fails
+		// (here via ErrSorobanResourceFeeExceedsBound), the channel account must be released so an
+		// authenticated attacker can't drain the pool by flooding inflated-ResourceFee builds.
+		sorobanTxDataXDR := "AAAAAAAAAAEAAAAGAAAAAdeSi3LCcDzP6vfrn/TvTVBKVai5efybRQ6iyEK00c5hAAAAFAAAAAEAAAACAAAAAAAAAAAQbmtGFDrXzwTfG4CRdVV7za2AhbbJnIPIfjeT39gcpQAAAAYAAAAAAAAAABBua0YUOtfPBN8bgJF1VXvNrYCFtsmcg8h+N5Pf2BylAAAAFWhSXFSqNynLAAAAAAAKehUAAAGIAAAA3AAAAAAAAgi1"
+		var sorobanTxData xdr.SorobanTransactionData
+		err := xdr.SafeUnmarshalBase64(sorobanTxDataXDR, &sorobanTxData)
+		require.NoError(t, err)
+		require.Equal(t, xdr.Int64(133301), sorobanTxData.ResourceFee)
+
+		channelAccount := keypair.MustRandom()
+		op := buildInvokeContractOpWithSimulation(t, sorobanTxData, xdr.SorobanCredentialsTypeSorobanCredentialsAddress, keypair.MustRandom().Address())
+		signedTx := buildTransactionForTest(t, []txnbuild.Operation{op}, txnbuild.Preconditions{
+			TimeBounds: txnbuild.NewTimeout(30),
+		})
+
+		mChannelAccountSignatureClient.
+			On("GetAccountPublicKey", context.Background(), 30).
+			Return(channelAccount.Address(), nil).
+			Once()
+
+		mChannelAccountStore.
+			On("UnlockChannelAccountByPublicKey", mock.Anything, mock.Anything, channelAccount.Address()).
+			Return(int64(1), nil).
+			Once()
+
+		// Server's MinResourceFee is 50000 → maxAllowed = min(100000, BaseFee) = 100000 < clientResourceFee 133301.
+		mRPCService.
+			On("GetAccountLedgerSequence", channelAccount.Address()).
+			Return(int64(1), nil).
+			Once().
+			On("SimulateTransaction", mock.AnythingOfType("string"), entities.RPCResourceConfig{}).
+			Return(entities.RPCSimulateTransactionResult{MinResourceFee: "50000"}, nil).
+			Once()
+
+		tx, err := txService.BuildAndSignTransactionWithChannelAccount(context.Background(), signedTx.ToGenericTransaction())
+
+		mChannelAccountSignatureClient.AssertExpectations(t)
+		mChannelAccountStore.AssertExpectations(t)
+		mRPCService.AssertExpectations(t)
+		assert.Empty(t, tx)
+		assert.ErrorContains(t, err, "client resource fee 133301 exceeds allowed maximum")
 	})
 
 	t.Run("🟢build_and_sign_ExtendFootprintTtl_from_xdr", func(t *testing.T) {

--- a/internal/services/transaction_service_test.go
+++ b/internal/services/transaction_service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stellar/go-stellar-sdk/amount"
 	"github.com/stellar/go-stellar-sdk/keypair"
@@ -298,10 +299,15 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 	})
 	require.NoError(t, outerErr)
 
-	t.Run("🔴handle_GetAccountPublicKey_err", func(t *testing.T) {
+	// lockedAt is the lock token returned by AcquireChannelAccount and threaded back into the defer's
+	// UnlockChannelAccountByLockToken call. Subtests reuse the same value to assert the service plumbs
+	// the token through unchanged.
+	lockedAt := time.Now().UTC()
+
+	t.Run("🔴handle_AcquireChannelAccount_err", func(t *testing.T) {
 		mChannelAccountSignatureClient.
-			On("GetAccountPublicKey", context.Background(), 30).
-			Return("", errors.New("channel accounts unavailable")).
+			On("AcquireChannelAccount", context.Background(), 30).
+			Return("", time.Time{}, errors.New("channel accounts unavailable")).
 			Once()
 
 		signedTx := buildTransactionForTest(t, []txnbuild.Operation{buildPaymentOp(t)}, txnbuild.Preconditions{
@@ -311,18 +317,18 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 
 		mChannelAccountSignatureClient.AssertExpectations(t)
 		assert.Empty(t, tx)
-		assert.EqualError(t, err, "getting channel account public key: channel accounts unavailable")
+		assert.EqualError(t, err, "acquiring channel account: channel accounts unavailable")
 	})
 
 	t.Run("🚨operation_source_account_cannot_be_channel_account", func(t *testing.T) {
 		channelAccount := keypair.MustRandom()
 		mChannelAccountSignatureClient.
-			On("GetAccountPublicKey", context.Background(), 30).
-			Return(channelAccount.Address(), nil).
+			On("AcquireChannelAccount", context.Background(), 30).
+			Return(channelAccount.Address(), lockedAt, nil).
 			Once()
 
 		mChannelAccountStore.
-			On("UnlockChannelAccountByPublicKey", mock.Anything, mock.Anything, channelAccount.Address()).
+			On("UnlockChannelAccountByLockToken", mock.Anything, mock.Anything, channelAccount.Address(), lockedAt).
 			Return(int64(1), nil).
 			Once()
 
@@ -344,12 +350,12 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 	t.Run("🚨operation_source_account_cannot_be_channel_account_via_muxed_address", func(t *testing.T) {
 		channelAccount := keypair.MustRandom()
 		mChannelAccountSignatureClient.
-			On("GetAccountPublicKey", context.Background(), 30).
-			Return(channelAccount.Address(), nil).
+			On("AcquireChannelAccount", context.Background(), 30).
+			Return(channelAccount.Address(), lockedAt, nil).
 			Once()
 
 		mChannelAccountStore.
-			On("UnlockChannelAccountByPublicKey", mock.Anything, mock.Anything, channelAccount.Address()).
+			On("UnlockChannelAccountByLockToken", mock.Anything, mock.Anything, channelAccount.Address(), lockedAt).
 			Return(int64(1), nil).
 			Once()
 
@@ -375,12 +381,12 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 	t.Run("🚨operation_source_account_cannot_be_empty", func(t *testing.T) {
 		channelAccount := keypair.MustRandom()
 		mChannelAccountSignatureClient.
-			On("GetAccountPublicKey", context.Background(), 30).
-			Return(channelAccount.Address(), nil).
+			On("AcquireChannelAccount", context.Background(), 30).
+			Return(channelAccount.Address(), lockedAt, nil).
 			Once()
 
 		mChannelAccountStore.
-			On("UnlockChannelAccountByPublicKey", mock.Anything, mock.Anything, channelAccount.Address()).
+			On("UnlockChannelAccountByLockToken", mock.Anything, mock.Anything, channelAccount.Address(), lockedAt).
 			Return(int64(1), nil).
 			Once()
 
@@ -401,12 +407,12 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 	t.Run("🔴handle_GetAccountLedgerSequence_err", func(t *testing.T) {
 		channelAccount := keypair.MustRandom()
 		mChannelAccountSignatureClient.
-			On("GetAccountPublicKey", context.Background(), 30).
-			Return(channelAccount.Address(), nil).
+			On("AcquireChannelAccount", context.Background(), 30).
+			Return(channelAccount.Address(), lockedAt, nil).
 			Once()
 
 		mChannelAccountStore.
-			On("UnlockChannelAccountByPublicKey", mock.Anything, mock.Anything, channelAccount.Address()).
+			On("UnlockChannelAccountByLockToken", mock.Anything, mock.Anything, channelAccount.Address(), lockedAt).
 			Return(int64(1), nil).
 			Once()
 
@@ -431,8 +437,8 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 	t.Run("🔴handle_AssignTxToChannelAccount_err", func(t *testing.T) {
 		channelAccount := keypair.MustRandom()
 		mChannelAccountSignatureClient.
-			On("GetAccountPublicKey", context.Background(), 30).
-			Return(channelAccount.Address(), nil).
+			On("AcquireChannelAccount", context.Background(), 30).
+			Return(channelAccount.Address(), lockedAt, nil).
 			Once().
 			On("NetworkPassphrase").
 			Return("networkpassphrase").
@@ -442,7 +448,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 			On("AssignTxToChannelAccount", context.Background(), channelAccount.Address(), mock.AnythingOfType("string")).
 			Return(errors.New("unable to assign channel account to tx")).
 			Once().
-			On("UnlockChannelAccountByPublicKey", mock.Anything, mock.Anything, channelAccount.Address()).
+			On("UnlockChannelAccountByLockToken", mock.Anything, mock.Anything, channelAccount.Address(), lockedAt).
 			Return(int64(1), nil).
 			Once()
 
@@ -466,8 +472,8 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 	t.Run("🔴handle_SignStellarTransaction_err_releases_channel_account", func(t *testing.T) {
 		channelAccount := keypair.MustRandom()
 		mChannelAccountSignatureClient.
-			On("GetAccountPublicKey", context.Background(), 30).
-			Return(channelAccount.Address(), nil).
+			On("AcquireChannelAccount", context.Background(), 30).
+			Return(channelAccount.Address(), lockedAt, nil).
 			Once().
 			On("NetworkPassphrase").
 			Return("networkpassphrase").
@@ -484,7 +490,7 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 			// bad/incomplete build call. Otherwise an attacker flooding buildTransaction can wedge the pool for
 			// up to the lock TTL (minutes) with a handful of requests. The ctx here is context.WithoutCancel-wrapped
 			// so the unlock still runs when the request ctx is cancelled — mock.Anything matches the wrapped type.
-			On("UnlockChannelAccountByPublicKey", mock.Anything, mock.Anything, channelAccount.Address()).
+			On("UnlockChannelAccountByLockToken", mock.Anything, mock.Anything, channelAccount.Address(), lockedAt).
 			Return(int64(1), nil).
 			Once()
 
@@ -520,8 +526,8 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		channelAccount := keypair.MustRandom()
 
 		mChannelAccountSignatureClient.
-			On("GetAccountPublicKey", context.Background(), 30).
-			Return(channelAccount.Address(), nil).
+			On("AcquireChannelAccount", context.Background(), 30).
+			Return(channelAccount.Address(), lockedAt, nil).
 			Once().
 			On("NetworkPassphrase").
 			Return("networkpassphrase").
@@ -566,12 +572,12 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		})
 
 		mChannelAccountSignatureClient.
-			On("GetAccountPublicKey", context.Background(), 30).
-			Return(channelAccount.Address(), nil).
+			On("AcquireChannelAccount", context.Background(), 30).
+			Return(channelAccount.Address(), lockedAt, nil).
 			Once()
 
 		mChannelAccountStore.
-			On("UnlockChannelAccountByPublicKey", mock.Anything, mock.Anything, channelAccount.Address()).
+			On("UnlockChannelAccountByLockToken", mock.Anything, mock.Anything, channelAccount.Address(), lockedAt).
 			Return(int64(1), nil).
 			Once()
 
@@ -606,12 +612,12 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		})
 
 		mChannelAccountSignatureClient.
-			On("GetAccountPublicKey", context.Background(), 30).
-			Return(channelAccount.Address(), nil).
+			On("AcquireChannelAccount", context.Background(), 30).
+			Return(channelAccount.Address(), lockedAt, nil).
 			Once()
 
 		mChannelAccountStore.
-			On("UnlockChannelAccountByPublicKey", mock.Anything, mock.Anything, channelAccount.Address()).
+			On("UnlockChannelAccountByLockToken", mock.Anything, mock.Anything, channelAccount.Address(), lockedAt).
 			Return(int64(1), nil).
 			Once()
 
@@ -659,8 +665,8 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 
 		channelAccount := keypair.MustRandom()
 		mChannelAccountSignatureClient.
-			On("GetAccountPublicKey", context.Background(), 30).
-			Return(channelAccount.Address(), nil).
+			On("AcquireChannelAccount", context.Background(), 30).
+			Return(channelAccount.Address(), lockedAt, nil).
 			Once().
 			On("NetworkPassphrase").
 			Return("networkpassphrase").
@@ -712,8 +718,8 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 
 		channelAccount := keypair.MustRandom()
 		mChannelAccountSignatureClient.
-			On("GetAccountPublicKey", context.Background(), 30).
-			Return(channelAccount.Address(), nil).
+			On("AcquireChannelAccount", context.Background(), 30).
+			Return(channelAccount.Address(), lockedAt, nil).
 			Once().
 			On("NetworkPassphrase").
 			Return("networkpassphrase").
@@ -753,8 +759,8 @@ func TestBuildAndSignTransactionWithChannelAccount(t *testing.T) {
 		})
 
 		mChannelAccountSignatureClient.
-			On("GetAccountPublicKey", context.Background(), 30).
-			Return(channelAccount.Address(), nil).
+			On("AcquireChannelAccount", context.Background(), 30).
+			Return(channelAccount.Address(), lockedAt, nil).
 			Once().
 			On("NetworkPassphrase").
 			Return("networkpassphrase").

--- a/internal/signing/channel_account_db_signature_client.go
+++ b/internal/signing/channel_account_db_signature_client.go
@@ -66,6 +66,16 @@ func (sc *channelAccountDBSignatureClient) NetworkPassphrase() string {
 }
 
 func (sc *channelAccountDBSignatureClient) GetAccountPublicKey(ctx context.Context, opts ...int) (string, error) {
+	publicKey, _, err := sc.AcquireChannelAccount(ctx, opts...)
+	return publicKey, err
+}
+
+// AcquireChannelAccount locks an idle channel account and returns its public key along with the locked_at
+// timestamp that uniquely identifies this particular lock acquisition. The lockedAt value is the caller's
+// lock token: passing it back to the store's UnlockChannelAccountByLockToken ensures a stale release can't
+// wipe a newer lock on the same public_key if the original locked_until TTL expired and another request
+// re-acquired the row first.
+func (sc *channelAccountDBSignatureClient) AcquireChannelAccount(ctx context.Context, opts ...int) (string, time.Time, error) {
 	var lockedUntil time.Duration
 	if len(opts) > 0 {
 		lockedUntil = time.Duration(opts[0]) * time.Second
@@ -73,7 +83,6 @@ func (sc *channelAccountDBSignatureClient) GetAccountPublicKey(ctx context.Conte
 		lockedUntil = time.Minute
 	}
 	for range sc.RetryCount() {
-		// check to see if the variadic parameter for time exists and if so, use it here
 		channelAccount, err := sc.channelAccountStore.GetAndLockIdleChannelAccount(ctx, lockedUntil)
 		if err != nil {
 			if errors.Is(err, store.ErrNoIdleChannelAccountAvailable) {
@@ -82,22 +91,25 @@ func (sc *channelAccountDBSignatureClient) GetAccountPublicKey(ctx context.Conte
 				continue
 			}
 
-			return "", fmt.Errorf("%w: total time spent waiting for an idle channel account: %v", ErrUnavailableChannelAccounts, time.Duration(sc.RetryCount())*sc.RetryInterval())
+			return "", time.Time{}, fmt.Errorf("%w: total time spent waiting for an idle channel account: %v", ErrUnavailableChannelAccounts, time.Duration(sc.RetryCount())*sc.RetryInterval())
 		}
 
-		return channelAccount.PublicKey, nil
+		if !channelAccount.LockedAt.Valid {
+			return "", time.Time{}, fmt.Errorf("channel account %s has no locked_at after acquisition; cannot form a lock token", channelAccount.PublicKey)
+		}
+		return channelAccount.PublicKey, channelAccount.LockedAt.Time, nil
 	}
 
 	numOfChannelAccounts, err := sc.channelAccountStore.Count(ctx)
 	if err != nil {
-		return "", fmt.Errorf("getting the number of channel accounts: %w", err)
+		return "", time.Time{}, fmt.Errorf("getting the number of channel accounts: %w", err)
 	}
 
 	if numOfChannelAccounts > 0 {
-		return "", store.ErrNoIdleChannelAccountAvailable
+		return "", time.Time{}, store.ErrNoIdleChannelAccountAvailable
 	}
 
-	return "", store.ErrNoChannelAccountConfigured
+	return "", time.Time{}, store.ErrNoChannelAccountConfigured
 }
 
 func (sc *channelAccountDBSignatureClient) getKPsForPublicKeys(ctx context.Context, stellarAccounts ...string) ([]*keypair.Full, error) {

--- a/internal/signing/channel_account_db_signature_client_test.go
+++ b/internal/signing/channel_account_db_signature_client_test.go
@@ -2,6 +2,7 @@ package signing
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"testing"
 	"time"
@@ -84,15 +85,36 @@ func TestChannelAccountDBSignatureClientGetAccountPublicKey(t *testing.T) {
 
 	t.Run("gets_an_idle_channel_account", func(t *testing.T) {
 		channelAccountPublicKey := keypair.MustRandom().Address()
+		lockedAt := time.Now().UTC()
 		channelAccountStore.
 			On("GetAndLockIdleChannelAccount", ctx, time.Minute).
-			Return(&store.ChannelAccount{PublicKey: channelAccountPublicKey}, nil).
+			Return(&store.ChannelAccount{
+				PublicKey: channelAccountPublicKey,
+				LockedAt:  sql.NullTime{Time: lockedAt, Valid: true},
+			}, nil).
 			Once()
 		defer channelAccountStore.AssertExpectations(t)
 
 		publicKey, err := sc.GetAccountPublicKey(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, channelAccountPublicKey, publicKey)
+	})
+
+	t.Run("returns_error_when_locked_at_missing_after_lock_acquisition", func(t *testing.T) {
+		// Defensive guard: GetAndLockIdleChannelAccount sets locked_at = NOW(), so a valid locked_at is
+		// invariant. If the store somehow returned a row without it (schema drift, test fixture bug),
+		// we can't form a safe unlock token and must fail closed rather than attempt a racy public-key unlock.
+		channelAccountPublicKey := keypair.MustRandom().Address()
+		channelAccountStore.
+			On("GetAndLockIdleChannelAccount", ctx, time.Minute).
+			Return(&store.ChannelAccount{PublicKey: channelAccountPublicKey}, nil).
+			Once()
+		defer channelAccountStore.AssertExpectations(t)
+
+		publicKey, lockedAt, err := sc.AcquireChannelAccount(ctx)
+		require.ErrorContains(t, err, "has no locked_at after acquisition")
+		assert.Empty(t, publicKey)
+		assert.True(t, lockedAt.IsZero())
 	})
 }
 

--- a/internal/signing/mocks.go
+++ b/internal/signing/mocks.go
@@ -2,6 +2,7 @@ package signing
 
 import (
 	"context"
+	"time"
 
 	"github.com/stellar/go-stellar-sdk/txnbuild"
 	"github.com/stretchr/testify/mock"
@@ -11,7 +12,10 @@ type SignatureClientMock struct {
 	mock.Mock
 }
 
-var _ SignatureClient = (*SignatureClientMock)(nil)
+var (
+	_ SignatureClient               = (*SignatureClientMock)(nil)
+	_ ChannelAccountSignatureClient = (*SignatureClientMock)(nil)
+)
 
 func (s *SignatureClientMock) NetworkPassphrase() string {
 	args := s.Called()
@@ -25,6 +29,15 @@ func (s *SignatureClientMock) GetAccountPublicKey(ctx context.Context, opts ...i
 	}
 	args := s.Called(_ca...)
 	return args.String(0), args.Error(1)
+}
+
+func (s *SignatureClientMock) AcquireChannelAccount(ctx context.Context, opts ...int) (string, time.Time, error) {
+	_ca := []any{ctx}
+	for _, opt := range opts {
+		_ca = append(_ca, opt)
+	}
+	args := s.Called(_ca...)
+	return args.String(0), args.Get(1).(time.Time), args.Error(2)
 }
 
 func (s *SignatureClientMock) SignStellarTransaction(ctx context.Context, tx *txnbuild.Transaction, accounts ...string) (*txnbuild.Transaction, error) {

--- a/internal/signing/signature_client.go
+++ b/internal/signing/signature_client.go
@@ -3,6 +3,7 @@ package signing
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/stellar/go-stellar-sdk/txnbuild"
 )
@@ -18,6 +19,17 @@ type SignatureClient interface {
 	GetAccountPublicKey(ctx context.Context, opts ...int) (string, error)
 	SignStellarTransaction(ctx context.Context, tx *txnbuild.Transaction, stellarAccounts ...string) (*txnbuild.Transaction, error)
 	SignStellarFeeBumpTransaction(ctx context.Context, feeBumpTx *txnbuild.FeeBumpTransaction) (*txnbuild.FeeBumpTransaction, error)
+}
+
+// ChannelAccountSignatureClient is a SignatureClient backed by a DB-managed pool of channel accounts, whose
+// GetAccountPublicKey atomically locks a row for the duration of transaction building. Callers that need
+// to safely release that lock on a failure path should use AcquireChannelAccount to obtain both the public
+// key and the lockedAt token that identifies this specific acquisition — passing the token to the store's
+// UnlockChannelAccountByLockToken guarantees the release only matches the caller's own lock and is a no-op
+// if the TTL expired and another request already re-acquired the same row.
+type ChannelAccountSignatureClient interface {
+	SignatureClient
+	AcquireChannelAccount(ctx context.Context, opts ...int) (publicKey string, lockedAt time.Time, err error)
 }
 
 type SignatureClientType string

--- a/internal/signing/store/channel_accounts_model.go
+++ b/internal/signing/store/channel_accounts_model.go
@@ -89,6 +89,32 @@ func (ca *ChannelAccountModel) AssignTxToChannelAccount(ctx context.Context, pub
 	return nil
 }
 
+// UnlockChannelAccountByPublicKey clears locked_tx_hash / locked_at / locked_until for the row matching publicKey.
+// Needed for failure paths that acquire a channel-account lock via GetAndLockIdleChannelAccount but return before
+// AssignTxToChannelAccount runs — in that window locked_tx_hash is still NULL, so UnassignTxAndUnlockChannelAccounts
+// (which matches on locked_tx_hash) can't release the row.
+func (ca *ChannelAccountModel) UnlockChannelAccountByPublicKey(ctx context.Context, pgxTx pgx.Tx, publicKey string) (int64, error) {
+	if publicKey == "" {
+		return 0, errors.New("publicKey cannot be empty")
+	}
+
+	const query = `
+		UPDATE channel_accounts
+		SET
+			locked_tx_hash = NULL,
+			locked_at = NULL,
+			locked_until = NULL
+		WHERE
+			public_key = $1
+	`
+	result, err := pgxTx.Exec(ctx, query, publicKey)
+	if err != nil {
+		return 0, fmt.Errorf("unlocking channel account %s: %w", publicKey, err)
+	}
+
+	return result.RowsAffected(), nil
+}
+
 func (ca *ChannelAccountModel) UnassignTxAndUnlockChannelAccounts(ctx context.Context, pgxTx pgx.Tx, txHashes ...string) (int64, error) {
 	if len(txHashes) == 0 {
 		return 0, errors.New("txHashes cannot be empty")

--- a/internal/signing/store/channel_accounts_model.go
+++ b/internal/signing/store/channel_accounts_model.go
@@ -89,13 +89,23 @@ func (ca *ChannelAccountModel) AssignTxToChannelAccount(ctx context.Context, pub
 	return nil
 }
 
-// UnlockChannelAccountByPublicKey clears locked_tx_hash / locked_at / locked_until for the row matching publicKey.
-// Needed for failure paths that acquire a channel-account lock via GetAndLockIdleChannelAccount but return before
-// AssignTxToChannelAccount runs — in that window locked_tx_hash is still NULL, so UnassignTxAndUnlockChannelAccounts
-// (which matches on locked_tx_hash) can't release the row.
-func (ca *ChannelAccountModel) UnlockChannelAccountByPublicKey(ctx context.Context, pgxTx pgx.Tx, publicKey string) (int64, error) {
+// UnlockChannelAccountByLockToken clears locked_tx_hash / locked_at / locked_until for the row matching
+// (publicKey, lockedAt). Needed for failure paths that acquire a channel-account lock via
+// GetAndLockIdleChannelAccount but return before AssignTxToChannelAccount runs — in that window
+// locked_tx_hash is still NULL, so UnassignTxAndUnlockChannelAccounts (which matches on locked_tx_hash)
+// can't release the row.
+//
+// The lockedAt parameter is the lock token: the value of locked_at at the moment this caller acquired
+// the lock. Matching on it prevents a stale defer from wiping a newly-acquired lock on the same public_key
+// if the original lock's locked_until TTL expired and another request re-acquired the row in the meantime.
+// A zero rows-affected return means the lock had already been replaced (or never existed) and no unlock
+// was needed — this is the race-safe no-op case.
+func (ca *ChannelAccountModel) UnlockChannelAccountByLockToken(ctx context.Context, pgxTx pgx.Tx, publicKey string, lockedAt time.Time) (int64, error) {
 	if publicKey == "" {
 		return 0, errors.New("publicKey cannot be empty")
+	}
+	if lockedAt.IsZero() {
+		return 0, errors.New("lockedAt cannot be zero")
 	}
 
 	const query = `
@@ -106,8 +116,9 @@ func (ca *ChannelAccountModel) UnlockChannelAccountByPublicKey(ctx context.Conte
 			locked_until = NULL
 		WHERE
 			public_key = $1
+			AND locked_at = $2
 	`
-	result, err := pgxTx.Exec(ctx, query, publicKey)
+	result, err := pgxTx.Exec(ctx, query, publicKey, lockedAt)
 	if err != nil {
 		return 0, fmt.Errorf("unlocking channel account %s: %w", publicKey, err)
 	}

--- a/internal/signing/store/channel_accounts_model_test.go
+++ b/internal/signing/store/channel_accounts_model_test.go
@@ -284,6 +284,103 @@ func Test_ChannelAccountModel_UnassignTxAndUnlockChannelAccounts(t *testing.T) {
 	}
 }
 
+func Test_ChannelAccountModel_UnlockChannelAccountByPublicKey(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+
+	ctx := context.Background()
+	dbConnectionPool, outerErr := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, outerErr)
+	defer dbConnectionPool.Close()
+
+	m := NewChannelAccountModel(dbConnectionPool)
+
+	t.Run("🟢unlocks_locked_channel_account_when_locked_tx_hash_set", func(t *testing.T) {
+		defer func() {
+			_, err := dbConnectionPool.Exec(ctx, `DELETE from channel_accounts`)
+			require.NoError(t, err)
+		}()
+
+		channelAccount := keypair.MustRandom()
+		now := time.Now()
+		createChannelAccountFixture(t, ctx, dbConnectionPool, ChannelAccount{
+			PublicKey:           channelAccount.Address(),
+			EncryptedPrivateKey: channelAccount.Seed(),
+			LockedTxHash:        utils.SQLNullString("txhash_" + channelAccount.Address()),
+			LockedAt:            utils.SQLNullTime(now),
+			LockedUntil:         utils.SQLNullTime(now.Add(time.Minute)),
+		})
+
+		pgxTx, err := dbConnectionPool.Begin(ctx)
+		require.NoError(t, err)
+		defer pgxTx.Rollback(ctx) //nolint:errcheck
+
+		rowsAffected, err := m.UnlockChannelAccountByPublicKey(ctx, pgxTx, channelAccount.Address())
+		require.NoError(t, err)
+		require.Equal(t, int64(1), rowsAffected)
+		require.NoError(t, pgxTx.Commit(ctx))
+
+		chAccFromDB, err := m.Get(ctx, channelAccount.Address())
+		require.NoError(t, err)
+		require.False(t, chAccFromDB.LockedTxHash.Valid)
+		require.False(t, chAccFromDB.LockedAt.Valid)
+		require.False(t, chAccFromDB.LockedUntil.Valid)
+	})
+
+	t.Run("🟢unlocks_locked_channel_account_when_locked_tx_hash_null", func(t *testing.T) {
+		// Mirrors the pre-Soroban-validation failure path: GetAndLockIdleChannelAccount sets locked_until
+		// but AssignTxToChannelAccount never runs, so locked_tx_hash stays NULL. UnassignTxAndUnlock
+		// can't match this row — UnlockChannelAccountByPublicKey must.
+		defer func() {
+			_, err := dbConnectionPool.Exec(ctx, `DELETE from channel_accounts`)
+			require.NoError(t, err)
+		}()
+
+		channelAccount := keypair.MustRandom()
+		now := time.Now()
+		createChannelAccountFixture(t, ctx, dbConnectionPool, ChannelAccount{
+			PublicKey:           channelAccount.Address(),
+			EncryptedPrivateKey: channelAccount.Seed(),
+			LockedAt:            utils.SQLNullTime(now),
+			LockedUntil:         utils.SQLNullTime(now.Add(time.Minute)),
+		})
+
+		pgxTx, err := dbConnectionPool.Begin(ctx)
+		require.NoError(t, err)
+		defer pgxTx.Rollback(ctx) //nolint:errcheck
+
+		rowsAffected, err := m.UnlockChannelAccountByPublicKey(ctx, pgxTx, channelAccount.Address())
+		require.NoError(t, err)
+		require.Equal(t, int64(1), rowsAffected)
+		require.NoError(t, pgxTx.Commit(ctx))
+
+		chAccFromDB, err := m.Get(ctx, channelAccount.Address())
+		require.NoError(t, err)
+		require.False(t, chAccFromDB.LockedTxHash.Valid)
+		require.False(t, chAccFromDB.LockedAt.Valid)
+		require.False(t, chAccFromDB.LockedUntil.Valid)
+	})
+
+	t.Run("🟡public_key_not_found_returns_zero_rows", func(t *testing.T) {
+		pgxTx, err := dbConnectionPool.Begin(ctx)
+		require.NoError(t, err)
+		defer pgxTx.Rollback(ctx) //nolint:errcheck
+
+		rowsAffected, err := m.UnlockChannelAccountByPublicKey(ctx, pgxTx, "GABCDEFG_NOT_A_REAL_KEY")
+		require.NoError(t, err)
+		require.Equal(t, int64(0), rowsAffected)
+	})
+
+	t.Run("🔴empty_public_key_returns_error", func(t *testing.T) {
+		pgxTx, err := dbConnectionPool.Begin(ctx)
+		require.NoError(t, err)
+		defer pgxTx.Rollback(ctx) //nolint:errcheck
+
+		_, err = m.UnlockChannelAccountByPublicKey(ctx, pgxTx, "")
+		require.ErrorContains(t, err, "publicKey cannot be empty")
+	})
+}
+
 func TestChannelAccountModelBatchInsert(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()

--- a/internal/signing/store/channel_accounts_model_test.go
+++ b/internal/signing/store/channel_accounts_model_test.go
@@ -284,7 +284,7 @@ func Test_ChannelAccountModel_UnassignTxAndUnlockChannelAccounts(t *testing.T) {
 	}
 }
 
-func Test_ChannelAccountModel_UnlockChannelAccountByPublicKey(t *testing.T) {
+func Test_ChannelAccountModel_UnlockChannelAccountByLockToken(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()
 
@@ -302,7 +302,7 @@ func Test_ChannelAccountModel_UnlockChannelAccountByPublicKey(t *testing.T) {
 		}()
 
 		channelAccount := keypair.MustRandom()
-		now := time.Now()
+		now := time.Now().UTC().Truncate(time.Microsecond)
 		createChannelAccountFixture(t, ctx, dbConnectionPool, ChannelAccount{
 			PublicKey:           channelAccount.Address(),
 			EncryptedPrivateKey: channelAccount.Seed(),
@@ -315,7 +315,7 @@ func Test_ChannelAccountModel_UnlockChannelAccountByPublicKey(t *testing.T) {
 		require.NoError(t, err)
 		defer pgxTx.Rollback(ctx) //nolint:errcheck
 
-		rowsAffected, err := m.UnlockChannelAccountByPublicKey(ctx, pgxTx, channelAccount.Address())
+		rowsAffected, err := m.UnlockChannelAccountByLockToken(ctx, pgxTx, channelAccount.Address(), now)
 		require.NoError(t, err)
 		require.Equal(t, int64(1), rowsAffected)
 		require.NoError(t, pgxTx.Commit(ctx))
@@ -328,16 +328,15 @@ func Test_ChannelAccountModel_UnlockChannelAccountByPublicKey(t *testing.T) {
 	})
 
 	t.Run("🟢unlocks_locked_channel_account_when_locked_tx_hash_null", func(t *testing.T) {
-		// Mirrors the pre-Soroban-validation failure path: GetAndLockIdleChannelAccount sets locked_until
-		// but AssignTxToChannelAccount never runs, so locked_tx_hash stays NULL. UnassignTxAndUnlock
-		// can't match this row — UnlockChannelAccountByPublicKey must.
+		// Mirrors the pre-AssignTx failure path: GetAndLockIdleChannelAccount sets locked_until but
+		// AssignTxToChannelAccount never runs, so locked_tx_hash stays NULL.
 		defer func() {
 			_, err := dbConnectionPool.Exec(ctx, `DELETE from channel_accounts`)
 			require.NoError(t, err)
 		}()
 
 		channelAccount := keypair.MustRandom()
-		now := time.Now()
+		now := time.Now().UTC().Truncate(time.Microsecond)
 		createChannelAccountFixture(t, ctx, dbConnectionPool, ChannelAccount{
 			PublicKey:           channelAccount.Address(),
 			EncryptedPrivateKey: channelAccount.Seed(),
@@ -349,7 +348,7 @@ func Test_ChannelAccountModel_UnlockChannelAccountByPublicKey(t *testing.T) {
 		require.NoError(t, err)
 		defer pgxTx.Rollback(ctx) //nolint:errcheck
 
-		rowsAffected, err := m.UnlockChannelAccountByPublicKey(ctx, pgxTx, channelAccount.Address())
+		rowsAffected, err := m.UnlockChannelAccountByLockToken(ctx, pgxTx, channelAccount.Address(), now)
 		require.NoError(t, err)
 		require.Equal(t, int64(1), rowsAffected)
 		require.NoError(t, pgxTx.Commit(ctx))
@@ -361,12 +360,51 @@ func Test_ChannelAccountModel_UnlockChannelAccountByPublicKey(t *testing.T) {
 		require.False(t, chAccFromDB.LockedUntil.Valid)
 	})
 
+	t.Run("🚨stale_locked_at_does_not_wipe_new_lock_on_same_row", func(t *testing.T) {
+		// Race scenario: request A acquires lock at t1, then delays beyond locked_until TTL.
+		// Request B re-acquires the same account at t2 (> t1). Request A's defer fires with the stale t1
+		// token — it MUST NOT clear request B's lock or assigned tx hash.
+		defer func() {
+			_, err := dbConnectionPool.Exec(ctx, `DELETE from channel_accounts`)
+			require.NoError(t, err)
+		}()
+
+		channelAccount := keypair.MustRandom()
+		t1 := time.Now().UTC().Add(-5 * time.Minute).Truncate(time.Microsecond)
+		t2 := time.Now().UTC().Truncate(time.Microsecond)
+		createChannelAccountFixture(t, ctx, dbConnectionPool, ChannelAccount{
+			PublicKey:           channelAccount.Address(),
+			EncryptedPrivateKey: channelAccount.Seed(),
+			LockedTxHash:        utils.SQLNullString("txhash_B"),
+			LockedAt:            utils.SQLNullTime(t2),
+			LockedUntil:         utils.SQLNullTime(t2.Add(30 * time.Second)),
+		})
+
+		pgxTx, err := dbConnectionPool.Begin(ctx)
+		require.NoError(t, err)
+		defer pgxTx.Rollback(ctx) //nolint:errcheck
+
+		// Request A's stale release — should be a no-op.
+		rowsAffected, err := m.UnlockChannelAccountByLockToken(ctx, pgxTx, channelAccount.Address(), t1)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), rowsAffected)
+		require.NoError(t, pgxTx.Commit(ctx))
+
+		// Request B's lock must still be intact.
+		chAccFromDB, err := m.Get(ctx, channelAccount.Address())
+		require.NoError(t, err)
+		require.True(t, chAccFromDB.LockedTxHash.Valid)
+		require.Equal(t, "txhash_B", chAccFromDB.LockedTxHash.String)
+		require.True(t, chAccFromDB.LockedAt.Valid)
+		require.True(t, chAccFromDB.LockedUntil.Valid)
+	})
+
 	t.Run("🟡public_key_not_found_returns_zero_rows", func(t *testing.T) {
 		pgxTx, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 		defer pgxTx.Rollback(ctx) //nolint:errcheck
 
-		rowsAffected, err := m.UnlockChannelAccountByPublicKey(ctx, pgxTx, "GABCDEFG_NOT_A_REAL_KEY")
+		rowsAffected, err := m.UnlockChannelAccountByLockToken(ctx, pgxTx, "GABCDEFG_NOT_A_REAL_KEY", time.Now().UTC())
 		require.NoError(t, err)
 		require.Equal(t, int64(0), rowsAffected)
 	})
@@ -376,8 +414,17 @@ func Test_ChannelAccountModel_UnlockChannelAccountByPublicKey(t *testing.T) {
 		require.NoError(t, err)
 		defer pgxTx.Rollback(ctx) //nolint:errcheck
 
-		_, err = m.UnlockChannelAccountByPublicKey(ctx, pgxTx, "")
+		_, err = m.UnlockChannelAccountByLockToken(ctx, pgxTx, "", time.Now().UTC())
 		require.ErrorContains(t, err, "publicKey cannot be empty")
+	})
+
+	t.Run("🔴zero_locked_at_returns_error", func(t *testing.T) {
+		pgxTx, err := dbConnectionPool.Begin(ctx)
+		require.NoError(t, err)
+		defer pgxTx.Rollback(ctx) //nolint:errcheck
+
+		_, err = m.UnlockChannelAccountByLockToken(ctx, pgxTx, "GABCDEFG", time.Time{})
+		require.ErrorContains(t, err, "lockedAt cannot be zero")
 	})
 }
 

--- a/internal/signing/store/mocks.go
+++ b/internal/signing/store/mocks.go
@@ -52,6 +52,11 @@ func (s *ChannelAccountStoreMock) UnassignTxAndUnlockChannelAccounts(ctx context
 	return args.Get(0).(int64), args.Error(1)
 }
 
+func (s *ChannelAccountStoreMock) UnlockChannelAccountByPublicKey(ctx context.Context, pgxTx pgx.Tx, publicKey string) (int64, error) {
+	args := s.Called(ctx, pgxTx, publicKey)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 func (s *ChannelAccountStoreMock) BatchInsert(ctx context.Context, channelAccounts []*ChannelAccount) error {
 	args := s.Called(ctx, channelAccounts)
 	return args.Error(0)

--- a/internal/signing/store/mocks.go
+++ b/internal/signing/store/mocks.go
@@ -52,8 +52,8 @@ func (s *ChannelAccountStoreMock) UnassignTxAndUnlockChannelAccounts(ctx context
 	return args.Get(0).(int64), args.Error(1)
 }
 
-func (s *ChannelAccountStoreMock) UnlockChannelAccountByPublicKey(ctx context.Context, pgxTx pgx.Tx, publicKey string) (int64, error) {
-	args := s.Called(ctx, pgxTx, publicKey)
+func (s *ChannelAccountStoreMock) UnlockChannelAccountByLockToken(ctx context.Context, pgxTx pgx.Tx, publicKey string, lockedAt time.Time) (int64, error) {
+	args := s.Called(ctx, pgxTx, publicKey, lockedAt)
 	return args.Get(0).(int64), args.Error(1)
 }
 

--- a/internal/signing/store/types.go
+++ b/internal/signing/store/types.go
@@ -26,7 +26,7 @@ type ChannelAccountStore interface {
 	GetAllByPublicKey(ctx context.Context, publicKeys ...string) ([]*ChannelAccount, error)
 	AssignTxToChannelAccount(ctx context.Context, publicKey string, txHash string) error
 	UnassignTxAndUnlockChannelAccounts(ctx context.Context, pgxTx pgx.Tx, txHashes ...string) (int64, error)
-	UnlockChannelAccountByPublicKey(ctx context.Context, pgxTx pgx.Tx, publicKey string) (int64, error)
+	UnlockChannelAccountByLockToken(ctx context.Context, pgxTx pgx.Tx, publicKey string, lockedAt time.Time) (int64, error)
 	BatchInsert(ctx context.Context, channelAccounts []*ChannelAccount) error
 	Delete(ctx context.Context, pgxTx pgx.Tx, publicKeys ...string) (int64, error)
 	Count(ctx context.Context) (int64, error)

--- a/internal/signing/store/types.go
+++ b/internal/signing/store/types.go
@@ -26,6 +26,7 @@ type ChannelAccountStore interface {
 	GetAllByPublicKey(ctx context.Context, publicKeys ...string) ([]*ChannelAccount, error)
 	AssignTxToChannelAccount(ctx context.Context, publicKey string, txHash string) error
 	UnassignTxAndUnlockChannelAccounts(ctx context.Context, pgxTx pgx.Tx, txHashes ...string) (int64, error)
+	UnlockChannelAccountByPublicKey(ctx context.Context, pgxTx pgx.Tx, publicKey string) (int64, error)
 	BatchInsert(ctx context.Context, channelAccounts []*ChannelAccount) error
 	Delete(ctx context.Context, pgxTx pgx.Tx, publicKeys ...string) (int64, error)
 	Count(ctx context.Context) (int64, error)


### PR DESCRIPTION
### What
- Register the channel-account release-on-error defer immediately after `GetAccountPublicKey`, so every failure path between lock acquisition and signing unlocks the row. Previously the defer lived after `AssignTxToChannelAccount`, leaving a window where Soroban validation, RPC failures, or operation-validation errors leaked the lock for the full 30s TTL.
- Add `UnlockChannelAccountByPublicKey` on the channel-account store. `UnassignTxAndUnlockChannelAccounts` matches on `locked_tx_hash`, which is still NULL before `AssignTxToChannelAccount` runs, so moving the defer up alone would not have released the row — the unlock has to match by `public_key`.
- Extend `TestBuildAndSignTransactionWithChannelAccount` to assert the unlock fires on every failure branch (operation source validation, ledger-sequence RPC error, AssignTx error, signing error, forbidden Soroban signer). New regression subtest `🚨adjustParamsForSoroban_fee_exceeds_bound_releases_channel_account` covers the primary attacker-reachable trigger.

### Why
`BuildAndSignTransactionWithChannelAccount` acquires a 30-second database lock on an idle channel account via `GetAccountPublicKey` as its first step, but only installs the release-on-error defer after `AssignTxToChannelAccount` succeeds much later. Any error between those two points — `adjustParamsForSoroban` rejecting an inflated `ResourceFee`, the re-simulation RPC failing, operation-source validation tripping, `GetAccountLedgerSequence` erroring — returns without unlocking. The account stays held until the `locked_until` TTL naturally expires.

An authenticated caller can exploit this to deny service: N concurrent requests that each trigger a pre-assign failure (inflated `ResourceFee` is trivial) leak N locks, exhausting an N-account pool and blocking `buildTransaction` / `createFeeBumpTransaction` for 30 seconds per burst, sustainable indefinitely. The same window bites benign traffic too — a misconfigured client retrying inflated fees or a simulation-RPC outage silently drains the pool, because the lock cost is per failed build regardless of request velocity, so upstream rate limiting mitigates but does not eliminate the issue.

### Known limitations
N/A

### Issue that this PR addresses
N/A

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or \`all\` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.