### PR TITLE
Store account address in balance tables as `BYTEA` instead of `TEXT`

### DIFF
--- a/internal/data/mocks.go
+++ b/internal/data/mocks.go
@@ -8,6 +8,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/stellar/wallet-backend/internal/indexer/types"
 )
 
 // ContractModelMock is a mock implementation of ContractModelInterface.
@@ -112,7 +114,7 @@ func (m *NativeBalanceModelMock) GetByAccount(ctx context.Context, accountAddres
 	return args.Get(0).(*NativeBalance), args.Error(1)
 }
 
-func (m *NativeBalanceModelMock) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts []NativeBalance, deletes []string) error {
+func (m *NativeBalanceModelMock) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts []NativeBalance, deletes []types.AddressBytea) error {
 	args := m.Called(ctx, dbTx, upserts, deletes)
 	return args.Error(0)
 }

--- a/internal/data/native_balances.go
+++ b/internal/data/native_balances.go
@@ -73,53 +73,71 @@ func (m *NativeBalanceModel) GetByAccount(ctx context.Context, accountAddress st
 	return &nb, nil
 }
 
-// BatchUpsert upserts and deletes native balances in batch.
+// BatchUpsert upserts and deletes native balances using UNNEST for efficiency.
 func (m *NativeBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts []NativeBalance, deletes []types.AddressBytea) error {
 	if len(upserts) == 0 && len(deletes) == 0 {
 		return nil
 	}
 
 	start := time.Now()
-	batch := &pgx.Batch{}
 
-	const upsertQuery = `
-		INSERT INTO native_balances (account_id, balance, minimum_balance, buying_liabilities, selling_liabilities, last_modified_ledger)
-		VALUES ($1, $2, $3, $4, $5, $6)
-		ON CONFLICT (account_id) DO UPDATE SET
-			balance = EXCLUDED.balance,
-			minimum_balance = EXCLUDED.minimum_balance,
-			buying_liabilities = EXCLUDED.buying_liabilities,
-			selling_liabilities = EXCLUDED.selling_liabilities,
-			last_modified_ledger = EXCLUDED.last_modified_ledger`
+	if len(upserts) > 0 {
+		accountIDs := make([][]byte, len(upserts))
+		balances := make([]int64, len(upserts))
+		minimumBalances := make([]int64, len(upserts))
+		buyingLiabilities := make([]int64, len(upserts))
+		sellingLiabilities := make([]int64, len(upserts))
+		ledgerNumbers := make([]int64, len(upserts))
 
-	for _, nb := range upserts {
-		batch.Queue(upsertQuery, nb.AccountID, nb.Balance, nb.MinimumBalance, nb.BuyingLiabilities, nb.SellingLiabilities, nb.LedgerNumber)
-	}
+		for i, nb := range upserts {
+			raw, err := nb.AccountID.Value()
+			if err != nil {
+				return fmt.Errorf("converting account address to bytes for upsert: %w", err)
+			}
+			accountIDs[i] = raw.([]byte)
+			balances[i] = nb.Balance
+			minimumBalances[i] = nb.MinimumBalance
+			buyingLiabilities[i] = nb.BuyingLiabilities
+			sellingLiabilities[i] = nb.SellingLiabilities
+			ledgerNumbers[i] = int64(nb.LedgerNumber)
+		}
 
-	const deleteQuery = `DELETE FROM native_balances WHERE account_id = $1`
-	for _, addr := range deletes {
-		batch.Queue(deleteQuery, addr)
-	}
+		const upsertQuery = `
+			INSERT INTO native_balances (account_id, balance, minimum_balance, buying_liabilities, selling_liabilities, last_modified_ledger)
+			SELECT * FROM UNNEST($1::bytea[], $2::bigint[], $3::bigint[], $4::bigint[], $5::bigint[], $6::bigint[])
+			ON CONFLICT (account_id) DO UPDATE SET
+				balance = EXCLUDED.balance,
+				minimum_balance = EXCLUDED.minimum_balance,
+				buying_liabilities = EXCLUDED.buying_liabilities,
+				selling_liabilities = EXCLUDED.selling_liabilities,
+				last_modified_ledger = EXCLUDED.last_modified_ledger`
 
-	if batch.Len() == 0 {
-		return nil
-	}
-
-	br := dbTx.SendBatch(ctx, batch)
-	for i := 0; i < batch.Len(); i++ {
-		if _, err := br.Exec(); err != nil {
-			_ = br.Close() //nolint:errcheck // cleanup on error path
+		if _, err := dbTx.Exec(ctx, upsertQuery, accountIDs, balances, minimumBalances, buyingLiabilities, sellingLiabilities, ledgerNumbers); err != nil {
 			m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", "native_balances").Observe(time.Since(start).Seconds())
 			m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", "native_balances").Inc()
 			m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", "native_balances", utils.GetDBErrorType(err)).Inc()
 			return fmt.Errorf("upserting native balances: %w", err)
 		}
 	}
-	if err := br.Close(); err != nil {
-		m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", "native_balances").Observe(time.Since(start).Seconds())
-		m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", "native_balances").Inc()
-		m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", "native_balances", utils.GetDBErrorType(err)).Inc()
-		return fmt.Errorf("closing native balance batch: %w", err)
+
+	if len(deletes) > 0 {
+		deleteIDs := make([][]byte, len(deletes))
+		for i, addr := range deletes {
+			raw, err := addr.Value()
+			if err != nil {
+				return fmt.Errorf("converting account address to bytes for delete: %w", err)
+			}
+			deleteIDs[i] = raw.([]byte)
+		}
+
+		const deleteQuery = `DELETE FROM native_balances WHERE account_id = ANY($1::bytea[])`
+
+		if _, err := dbTx.Exec(ctx, deleteQuery, deleteIDs); err != nil {
+			m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", "native_balances").Observe(time.Since(start).Seconds())
+			m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", "native_balances").Inc()
+			m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", "native_balances", utils.GetDBErrorType(err)).Inc()
+			return fmt.Errorf("deleting native balances: %w", err)
+		}
 	}
 
 	m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", "native_balances").Observe(time.Since(start).Seconds())

--- a/internal/data/native_balances.go
+++ b/internal/data/native_balances.go
@@ -94,7 +94,11 @@ func (m *NativeBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upser
 			if err != nil {
 				return fmt.Errorf("converting account address to bytes for upsert: %w", err)
 			}
-			accountIDs[i] = raw.([]byte)
+			rawBytes, ok := raw.([]byte)
+			if !ok {
+				return fmt.Errorf("converting account address to bytes for upsert: expected []byte, got %T", raw)
+			}
+			accountIDs[i] = rawBytes
 			balances[i] = nb.Balance
 			minimumBalances[i] = nb.MinimumBalance
 			buyingLiabilities[i] = nb.BuyingLiabilities
@@ -127,7 +131,11 @@ func (m *NativeBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upser
 			if err != nil {
 				return fmt.Errorf("converting account address to bytes for delete: %w", err)
 			}
-			deleteIDs[i] = raw.([]byte)
+			rawBytes, ok := raw.([]byte)
+			if !ok {
+				return fmt.Errorf("converting account address to bytes for delete: expected []byte, got %T", raw)
+			}
+			deleteIDs[i] = rawBytes
 		}
 
 		const deleteQuery = `DELETE FROM native_balances WHERE account_id = ANY($1::bytea[])`

--- a/internal/data/native_balances.go
+++ b/internal/data/native_balances.go
@@ -12,13 +12,14 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
 	"github.com/stellar/wallet-backend/internal/metrics"
 	"github.com/stellar/wallet-backend/internal/utils"
 )
 
 // NativeBalance contains native XLM balance data for an account.
 type NativeBalance struct {
-	AccountAddress     string `db:"account_address"`
+	AccountID          types.AddressBytea `db:"account_id"`
 	Balance            int64  `db:"balance"`
 	MinimumBalance     int64  `db:"minimum_balance"`
 	BuyingLiabilities  int64  `db:"buying_liabilities"`
@@ -32,7 +33,7 @@ type NativeBalanceModelInterface interface {
 	GetByAccount(ctx context.Context, accountAddress string) (*NativeBalance, error)
 
 	// Write operations (for live ingestion)
-	BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts []NativeBalance, deletes []string) error
+	BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts []NativeBalance, deletes []types.AddressBytea) error
 
 	// Batch operations (for initial population)
 	BatchCopy(ctx context.Context, dbTx pgx.Tx, balances []NativeBalance) error
@@ -53,12 +54,12 @@ func (m *NativeBalanceModel) GetByAccount(ctx context.Context, accountAddress st
 	}
 
 	const query = `
-		SELECT account_address, balance, minimum_balance, buying_liabilities, selling_liabilities, last_modified_ledger
+		SELECT account_id, balance, minimum_balance, buying_liabilities, selling_liabilities, last_modified_ledger
 		FROM native_balances
-		WHERE account_address = $1`
+		WHERE account_id = $1`
 
 	start := time.Now()
-	nb, err := db.QueryOne[NativeBalance](ctx, m.DB, query, accountAddress)
+	nb, err := db.QueryOne[NativeBalance](ctx, m.DB, query, types.AddressBytea(accountAddress))
 	duration := time.Since(start).Seconds()
 	m.Metrics.QueryDuration.WithLabelValues("GetByAccount", "native_balances").Observe(duration)
 	m.Metrics.QueriesTotal.WithLabelValues("GetByAccount", "native_balances").Inc()
@@ -73,7 +74,7 @@ func (m *NativeBalanceModel) GetByAccount(ctx context.Context, accountAddress st
 }
 
 // BatchUpsert upserts and deletes native balances in batch.
-func (m *NativeBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts []NativeBalance, deletes []string) error {
+func (m *NativeBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts []NativeBalance, deletes []types.AddressBytea) error {
 	if len(upserts) == 0 && len(deletes) == 0 {
 		return nil
 	}
@@ -82,9 +83,9 @@ func (m *NativeBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upser
 	batch := &pgx.Batch{}
 
 	const upsertQuery = `
-		INSERT INTO native_balances (account_address, balance, minimum_balance, buying_liabilities, selling_liabilities, last_modified_ledger)
+		INSERT INTO native_balances (account_id, balance, minimum_balance, buying_liabilities, selling_liabilities, last_modified_ledger)
 		VALUES ($1, $2, $3, $4, $5, $6)
-		ON CONFLICT (account_address) DO UPDATE SET
+		ON CONFLICT (account_id) DO UPDATE SET
 			balance = EXCLUDED.balance,
 			minimum_balance = EXCLUDED.minimum_balance,
 			buying_liabilities = EXCLUDED.buying_liabilities,
@@ -92,10 +93,10 @@ func (m *NativeBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upser
 			last_modified_ledger = EXCLUDED.last_modified_ledger`
 
 	for _, nb := range upserts {
-		batch.Queue(upsertQuery, nb.AccountAddress, nb.Balance, nb.MinimumBalance, nb.BuyingLiabilities, nb.SellingLiabilities, nb.LedgerNumber)
+		batch.Queue(upsertQuery, nb.AccountID, nb.Balance, nb.MinimumBalance, nb.BuyingLiabilities, nb.SellingLiabilities, nb.LedgerNumber)
 	}
 
-	const deleteQuery = `DELETE FROM native_balances WHERE account_address = $1`
+	const deleteQuery = `DELETE FROM native_balances WHERE account_id = $1`
 	for _, addr := range deletes {
 		batch.Queue(deleteQuery, addr)
 	}
@@ -137,10 +138,14 @@ func (m *NativeBalanceModel) BatchCopy(ctx context.Context, dbTx pgx.Tx, balance
 	copyCount, err := dbTx.CopyFrom(
 		ctx,
 		pgx.Identifier{"native_balances"},
-		[]string{"account_address", "balance", "minimum_balance", "buying_liabilities", "selling_liabilities", "last_modified_ledger"},
+		[]string{"account_id", "balance", "minimum_balance", "buying_liabilities", "selling_liabilities", "last_modified_ledger"},
 		pgx.CopyFromSlice(len(balances), func(i int) ([]any, error) {
 			nb := balances[i]
-			return []any{nb.AccountAddress, nb.Balance, nb.MinimumBalance, nb.BuyingLiabilities, nb.SellingLiabilities, nb.LedgerNumber}, nil
+			accountIDBytes, err := nb.AccountID.Value()
+			if err != nil {
+				return nil, fmt.Errorf("converting account address to bytes: %w", err)
+			}
+			return []any{accountIDBytes, nb.Balance, nb.MinimumBalance, nb.BuyingLiabilities, nb.SellingLiabilities, nb.LedgerNumber}, nil
 		}),
 	)
 	if err != nil {

--- a/internal/data/native_balances.go
+++ b/internal/data/native_balances.go
@@ -20,11 +20,11 @@ import (
 // NativeBalance contains native XLM balance data for an account.
 type NativeBalance struct {
 	AccountID          types.AddressBytea `db:"account_id"`
-	Balance            int64  `db:"balance"`
-	MinimumBalance     int64  `db:"minimum_balance"`
-	BuyingLiabilities  int64  `db:"buying_liabilities"`
-	SellingLiabilities int64  `db:"selling_liabilities"`
-	LedgerNumber       uint32 `db:"last_modified_ledger"`
+	Balance            int64              `db:"balance"`
+	MinimumBalance     int64              `db:"minimum_balance"`
+	BuyingLiabilities  int64              `db:"buying_liabilities"`
+	SellingLiabilities int64              `db:"selling_liabilities"`
+	LedgerNumber       uint32             `db:"last_modified_ledger"`
 }
 
 // NativeBalanceModelInterface defines the interface for native balance operations.

--- a/internal/data/native_balances_test.go
+++ b/internal/data/native_balances_test.go
@@ -6,10 +6,12 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/wallet-backend/internal/db"
 	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
 	"github.com/stellar/wallet-backend/internal/metrics"
 )
 
@@ -50,7 +52,7 @@ func TestNativeBalanceModel_GetByAccount(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		balance, err := m.GetByAccount(ctx, "GNOTEXIST")
+		balance, err := m.GetByAccount(ctx, keypair.MustRandom().Address())
 		require.NoError(t, err)
 		require.Nil(t, balance)
 	})
@@ -63,19 +65,19 @@ func TestNativeBalanceModel_GetByAccount(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		accountAddr := "GACCOUNT1"
+		accountAddr := keypair.MustRandom().Address()
 		_, err := dbConnectionPool.Exec(ctx, `
 			INSERT INTO native_balances
-			(account_address, balance, buying_liabilities, selling_liabilities, last_modified_ledger)
+			(account_id, balance, buying_liabilities, selling_liabilities, last_modified_ledger)
 			VALUES ($1, 1000000000, 100, 200, 12345)
-		`, accountAddr)
+		`, types.AddressBytea(accountAddr))
 		require.NoError(t, err)
 
 		balance, err := m.GetByAccount(ctx, accountAddr)
 		require.NoError(t, err)
 		require.NotNil(t, balance)
 
-		require.Equal(t, accountAddr, balance.AccountAddress)
+		require.Equal(t, types.AddressBytea(accountAddr), balance.AccountID)
 		require.Equal(t, int64(1000000000), balance.Balance)
 		require.Equal(t, int64(100), balance.BuyingLiabilities)
 		require.Equal(t, int64(200), balance.SellingLiabilities)
@@ -122,12 +124,13 @@ func TestNativeBalanceModel_BatchUpsert(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
+		accountAddr := keypair.MustRandom().Address()
 		pgxTx, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 
 		upserts := []NativeBalance{
 			{
-				AccountAddress:     "GACCOUNT1",
+				AccountID:          types.AddressBytea(accountAddr),
 				Balance:            1000000000,
 				BuyingLiabilities:  100,
 				SellingLiabilities: 200,
@@ -141,7 +144,7 @@ func TestNativeBalanceModel_BatchUpsert(t *testing.T) {
 
 		// Verify insert
 		var count int
-		err = dbConnectionPool.QueryRow(ctx, `SELECT COUNT(*) FROM native_balances WHERE account_address = $1`, "GACCOUNT1").Scan(&count)
+		err = dbConnectionPool.QueryRow(ctx, `SELECT COUNT(*) FROM native_balances WHERE account_id = $1`, types.AddressBytea(accountAddr)).Scan(&count)
 		require.NoError(t, err)
 		require.Equal(t, 1, count)
 	})
@@ -154,14 +157,16 @@ func TestNativeBalanceModel_BatchUpsert(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
+		accountAddr := keypair.MustRandom().Address()
+
 		// First insert
 		pgxTx1, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 		upserts := []NativeBalance{
 			{
-				AccountAddress: "GACCOUNT1",
-				Balance:        1000,
-				LedgerNumber:   100,
+				AccountID:    types.AddressBytea(accountAddr),
+				Balance:      1000,
+				LedgerNumber: 100,
 			},
 		}
 		err = m.BatchUpsert(ctx, pgxTx1, upserts, nil)
@@ -181,8 +186,8 @@ func TestNativeBalanceModel_BatchUpsert(t *testing.T) {
 		var balance int64
 		var ledger uint32
 		err = dbConnectionPool.QueryRow(ctx,
-			`SELECT balance, last_modified_ledger FROM native_balances WHERE account_address = $1`,
-			"GACCOUNT1").Scan(&balance, &ledger)
+			`SELECT balance, last_modified_ledger FROM native_balances WHERE account_id = $1`,
+			types.AddressBytea(accountAddr)).Scan(&balance, &ledger)
 		require.NoError(t, err)
 		require.Equal(t, int64(2000), balance)
 		require.Equal(t, uint32(200), ledger)
@@ -196,11 +201,13 @@ func TestNativeBalanceModel_BatchUpsert(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
+		accountAddr := keypair.MustRandom().Address()
+
 		// First insert
 		pgxTx1, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 		upserts := []NativeBalance{
-			{AccountAddress: "GACCOUNT1", Balance: 1000, LedgerNumber: 100},
+			{AccountID: types.AddressBytea(accountAddr), Balance: 1000, LedgerNumber: 100},
 		}
 		err = m.BatchUpsert(ctx, pgxTx1, upserts, nil)
 		require.NoError(t, err)
@@ -209,14 +216,14 @@ func TestNativeBalanceModel_BatchUpsert(t *testing.T) {
 		// Delete
 		pgxTx2, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
-		deletes := []string{"GACCOUNT1"}
+		deletes := []types.AddressBytea{types.AddressBytea(accountAddr)}
 		err = m.BatchUpsert(ctx, pgxTx2, nil, deletes)
 		require.NoError(t, err)
 		require.NoError(t, pgxTx2.Commit(ctx))
 
 		// Verify delete
 		var count int
-		err = dbConnectionPool.QueryRow(ctx, `SELECT COUNT(*) FROM native_balances WHERE account_address = $1`, "GACCOUNT1").Scan(&count)
+		err = dbConnectionPool.QueryRow(ctx, `SELECT COUNT(*) FROM native_balances WHERE account_id = $1`, types.AddressBytea(accountAddr)).Scan(&count)
 		require.NoError(t, err)
 		require.Equal(t, 0, count)
 	})
@@ -229,12 +236,16 @@ func TestNativeBalanceModel_BatchUpsert(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
+		accountAddr1 := keypair.MustRandom().Address()
+		accountAddr2 := keypair.MustRandom().Address()
+		accountAddr3 := keypair.MustRandom().Address()
+
 		// Insert two balances
 		pgxTx1, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 		upserts := []NativeBalance{
-			{AccountAddress: "GACCOUNT1", Balance: 1000, LedgerNumber: 100},
-			{AccountAddress: "GACCOUNT2", Balance: 2000, LedgerNumber: 100},
+			{AccountID: types.AddressBytea(accountAddr1), Balance: 1000, LedgerNumber: 100},
+			{AccountID: types.AddressBytea(accountAddr2), Balance: 2000, LedgerNumber: 100},
 		}
 		err = m.BatchUpsert(ctx, pgxTx1, upserts, nil)
 		require.NoError(t, err)
@@ -244,10 +255,10 @@ func TestNativeBalanceModel_BatchUpsert(t *testing.T) {
 		pgxTx2, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 		newUpserts := []NativeBalance{
-			{AccountAddress: "GACCOUNT1", Balance: 1500, LedgerNumber: 200}, // update
-			{AccountAddress: "GACCOUNT3", Balance: 3000, LedgerNumber: 200}, // new
+			{AccountID: types.AddressBytea(accountAddr1), Balance: 1500, LedgerNumber: 200}, // update
+			{AccountID: types.AddressBytea(accountAddr3), Balance: 3000, LedgerNumber: 200}, // new
 		}
-		deletes := []string{"GACCOUNT2"} // delete
+		deletes := []types.AddressBytea{types.AddressBytea(accountAddr2)} // delete
 		err = m.BatchUpsert(ctx, pgxTx2, newUpserts, deletes)
 		require.NoError(t, err)
 		require.NoError(t, pgxTx2.Commit(ctx))
@@ -256,12 +267,12 @@ func TestNativeBalanceModel_BatchUpsert(t *testing.T) {
 		var count int
 		err = dbConnectionPool.QueryRow(ctx, `SELECT COUNT(*) FROM native_balances`).Scan(&count)
 		require.NoError(t, err)
-		require.Equal(t, 2, count) // GACCOUNT1 (updated) + GACCOUNT3 (new)
+		require.Equal(t, 2, count)
 
 		var balance int64
 		err = dbConnectionPool.QueryRow(ctx,
-			`SELECT balance FROM native_balances WHERE account_address = $1`,
-			"GACCOUNT1").Scan(&balance)
+			`SELECT balance FROM native_balances WHERE account_id = $1`,
+			types.AddressBytea(accountAddr1)).Scan(&balance)
 		require.NoError(t, err)
 		require.Equal(t, int64(1500), balance)
 	})
@@ -306,12 +317,13 @@ func TestNativeBalanceModel_BatchCopy(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
+		accountAddr := keypair.MustRandom().Address()
 		pgxTx, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 
 		balances := []NativeBalance{
 			{
-				AccountAddress:     "GACCOUNT1",
+				AccountID:          types.AddressBytea(accountAddr),
 				Balance:            1000000000,
 				BuyingLiabilities:  100,
 				SellingLiabilities: 200,
@@ -326,11 +338,11 @@ func TestNativeBalanceModel_BatchCopy(t *testing.T) {
 		// Verify all fields
 		var b NativeBalance
 		err = dbConnectionPool.QueryRow(ctx, `
-			SELECT account_address, balance, buying_liabilities, selling_liabilities, last_modified_ledger
-			FROM native_balances WHERE account_address = $1
-		`, "GACCOUNT1").Scan(&b.AccountAddress, &b.Balance, &b.BuyingLiabilities, &b.SellingLiabilities, &b.LedgerNumber)
+			SELECT account_id, balance, buying_liabilities, selling_liabilities, last_modified_ledger
+			FROM native_balances WHERE account_id = $1
+		`, types.AddressBytea(accountAddr)).Scan(&b.AccountID, &b.Balance, &b.BuyingLiabilities, &b.SellingLiabilities, &b.LedgerNumber)
 		require.NoError(t, err)
-		require.Equal(t, balances[0].AccountAddress, b.AccountAddress)
+		require.Equal(t, balances[0].AccountID, b.AccountID)
 		require.Equal(t, balances[0].Balance, b.Balance)
 		require.Equal(t, balances[0].BuyingLiabilities, b.BuyingLiabilities)
 		require.Equal(t, balances[0].SellingLiabilities, b.SellingLiabilities)
@@ -345,13 +357,16 @@ func TestNativeBalanceModel_BatchCopy(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
+		accountAddr1 := keypair.MustRandom().Address()
+		accountAddr2 := keypair.MustRandom().Address()
+		accountAddr3 := keypair.MustRandom().Address()
 		pgxTx, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 
 		balances := []NativeBalance{
-			{AccountAddress: "GACCOUNT1", Balance: 1000, LedgerNumber: 100},
-			{AccountAddress: "GACCOUNT2", Balance: 2000, LedgerNumber: 100},
-			{AccountAddress: "GACCOUNT3", Balance: 3000, LedgerNumber: 100},
+			{AccountID: types.AddressBytea(accountAddr1), Balance: 1000, LedgerNumber: 100},
+			{AccountID: types.AddressBytea(accountAddr2), Balance: 2000, LedgerNumber: 100},
+			{AccountID: types.AddressBytea(accountAddr3), Balance: 3000, LedgerNumber: 100},
 		}
 
 		err = m.BatchCopy(ctx, pgxTx, balances)

--- a/internal/data/sac_balances.go
+++ b/internal/data/sac_balances.go
@@ -132,7 +132,11 @@ func (m *SACBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts 
 			if err != nil {
 				return fmt.Errorf("converting account address to bytes for upsert: %w", err)
 			}
-			accountIDs[i] = raw.([]byte)
+			rawBytes, ok := raw.([]byte)
+			if !ok {
+				return fmt.Errorf("converting account address to bytes for upsert: expected []byte, got %T", raw)
+			}
+			accountIDs[i] = rawBytes
 			contractIDs[i] = bal.ContractID
 			balances[i] = bal.Balance
 			isAuthorized[i] = bal.IsAuthorized
@@ -168,7 +172,11 @@ func (m *SACBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts 
 			if err != nil {
 				return fmt.Errorf("converting account address to bytes for delete: %w", err)
 			}
-			deleteAccountIDs[i] = raw.([]byte)
+			rawBytes, ok := raw.([]byte)
+			if !ok {
+				return fmt.Errorf("converting account address to bytes for delete: expected []byte, got %T", raw)
+			}
+			deleteAccountIDs[i] = rawBytes
 			deleteContractIDs[i] = bal.ContractID
 		}
 

--- a/internal/data/sac_balances.go
+++ b/internal/data/sac_balances.go
@@ -21,12 +21,12 @@ import (
 // Only contract addresses (C...) have SAC balances stored here; G-addresses use trustlines.
 // Includes contract metadata from JOIN with contract_tokens table for API responses.
 type SACBalance struct {
-	AccountID         types.AddressBytea `db:"account_id"` // Contract address (C...) of the holder
-	ContractID        uuid.UUID `db:"contract_id"`     // Deterministic UUID for the SAC contract
-	Balance           string    `db:"balance"`         // Balance as string (handles i128 values)
-	IsAuthorized      bool      `db:"is_authorized"`
-	IsClawbackEnabled bool      `db:"is_clawback_enabled"`
-	LedgerNumber      uint32    `db:"last_modified_ledger"`
+	AccountID         types.AddressBytea `db:"account_id"`  // Contract address (C...) of the holder
+	ContractID        uuid.UUID          `db:"contract_id"` // Deterministic UUID for the SAC contract
+	Balance           string             `db:"balance"`     // Balance as string (handles i128 values)
+	IsAuthorized      bool               `db:"is_authorized"`
+	IsClawbackEnabled bool               `db:"is_clawback_enabled"`
+	LedgerNumber      uint32             `db:"last_modified_ledger"`
 	// Contract metadata from JOIN with contract_tokens
 	TokenID  string `db:"token_id"` // SAC contract address (C...) used as token identifier in API; aliased from ct.contract_id
 	Code     string `db:"code"`     // Asset code (e.g., "USDC")

--- a/internal/data/sac_balances.go
+++ b/internal/data/sac_balances.go
@@ -109,7 +109,7 @@ func (m *SACBalanceModel) GetByAccount(ctx context.Context, accountAddress strin
 	return balances, nil
 }
 
-// BatchUpsert performs upserts and deletes for SAC balances.
+// BatchUpsert performs upserts and deletes for SAC balances using UNNEST for efficiency.
 // For upserts (ADD/UPDATE): inserts or updates balance with authorization flags.
 // For deletes (REMOVE): removes the balance row.
 func (m *SACBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts []SACBalance, deletes []SACBalance) error {
@@ -118,56 +118,72 @@ func (m *SACBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts 
 	}
 
 	start := time.Now()
-	batch := &pgx.Batch{}
 
-	// Upsert query: insert or update all fields
-	const upsertQuery = `
-		INSERT INTO sac_balances (
-			account_id, contract_id, balance, is_authorized, is_clawback_enabled, last_modified_ledger
-		) VALUES ($1, $2, $3, $4, $5, $6)
-		ON CONFLICT (account_id, contract_id) DO UPDATE SET
-			balance = EXCLUDED.balance,
-			is_authorized = EXCLUDED.is_authorized,
-			is_clawback_enabled = EXCLUDED.is_clawback_enabled,
-			last_modified_ledger = EXCLUDED.last_modified_ledger`
+	if len(upserts) > 0 {
+		accountIDs := make([][]byte, len(upserts))
+		contractIDs := make([]uuid.UUID, len(upserts))
+		balances := make([]string, len(upserts))
+		isAuthorized := make([]bool, len(upserts))
+		isClawbackEnabled := make([]bool, len(upserts))
+		ledgerNumbers := make([]int32, len(upserts))
 
-	for _, bal := range upserts {
-		batch.Queue(upsertQuery,
-			bal.AccountID,
-			bal.ContractID,
-			bal.Balance,
-			bal.IsAuthorized,
-			bal.IsClawbackEnabled,
-			bal.LedgerNumber,
-		)
-	}
+		for i, bal := range upserts {
+			raw, err := bal.AccountID.Value()
+			if err != nil {
+				return fmt.Errorf("converting account address to bytes for upsert: %w", err)
+			}
+			accountIDs[i] = raw.([]byte)
+			contractIDs[i] = bal.ContractID
+			balances[i] = bal.Balance
+			isAuthorized[i] = bal.IsAuthorized
+			isClawbackEnabled[i] = bal.IsClawbackEnabled
+			ledgerNumbers[i] = int32(bal.LedgerNumber)
+		}
 
-	// Delete query
-	const deleteQuery = `DELETE FROM sac_balances WHERE account_id = $1 AND contract_id = $2`
+		const upsertQuery = `
+			INSERT INTO sac_balances (
+				account_id, contract_id, balance, is_authorized, is_clawback_enabled, last_modified_ledger
+			)
+			SELECT * FROM UNNEST($1::bytea[], $2::uuid[], $3::text[], $4::boolean[], $5::boolean[], $6::int[])
+			ON CONFLICT (account_id, contract_id) DO UPDATE SET
+				balance = EXCLUDED.balance,
+				is_authorized = EXCLUDED.is_authorized,
+				is_clawback_enabled = EXCLUDED.is_clawback_enabled,
+				last_modified_ledger = EXCLUDED.last_modified_ledger`
 
-	for _, bal := range deletes {
-		batch.Queue(deleteQuery, bal.AccountID, bal.ContractID)
-	}
-
-	if batch.Len() == 0 {
-		return nil
-	}
-
-	br := dbTx.SendBatch(ctx, batch)
-	for i := 0; i < batch.Len(); i++ {
-		if _, err := br.Exec(); err != nil {
-			_ = br.Close() //nolint:errcheck // cleanup on error path
+		if _, err := dbTx.Exec(ctx, upsertQuery, accountIDs, contractIDs, balances, isAuthorized, isClawbackEnabled, ledgerNumbers); err != nil {
 			m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", "sac_balances").Observe(time.Since(start).Seconds())
 			m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", "sac_balances").Inc()
 			m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", "sac_balances", utils.GetDBErrorType(err)).Inc()
 			return fmt.Errorf("upserting SAC balances: %w", err)
 		}
 	}
-	if err := br.Close(); err != nil {
-		m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", "sac_balances").Observe(time.Since(start).Seconds())
-		m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", "sac_balances").Inc()
-		m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", "sac_balances", utils.GetDBErrorType(err)).Inc()
-		return fmt.Errorf("closing SAC balance batch: %w", err)
+
+	if len(deletes) > 0 {
+		deleteAccountIDs := make([][]byte, len(deletes))
+		deleteContractIDs := make([]uuid.UUID, len(deletes))
+
+		for i, bal := range deletes {
+			raw, err := bal.AccountID.Value()
+			if err != nil {
+				return fmt.Errorf("converting account address to bytes for delete: %w", err)
+			}
+			deleteAccountIDs[i] = raw.([]byte)
+			deleteContractIDs[i] = bal.ContractID
+		}
+
+		const deleteQuery = `
+			DELETE FROM sac_balances
+			WHERE (account_id, contract_id) IN (
+				SELECT * FROM UNNEST($1::bytea[], $2::uuid[])
+			)`
+
+		if _, err := dbTx.Exec(ctx, deleteQuery, deleteAccountIDs, deleteContractIDs); err != nil {
+			m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", "sac_balances").Observe(time.Since(start).Seconds())
+			m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", "sac_balances").Inc()
+			m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", "sac_balances", utils.GetDBErrorType(err)).Inc()
+			return fmt.Errorf("deleting SAC balances: %w", err)
+		}
 	}
 
 	m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", "sac_balances").Observe(time.Since(start).Seconds())

--- a/internal/data/sac_balances.go
+++ b/internal/data/sac_balances.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
 	"github.com/stellar/wallet-backend/internal/metrics"
 	"github.com/stellar/wallet-backend/internal/utils"
 )
@@ -20,7 +21,7 @@ import (
 // Only contract addresses (C...) have SAC balances stored here; G-addresses use trustlines.
 // Includes contract metadata from JOIN with contract_tokens table for API responses.
 type SACBalance struct {
-	AccountAddress    string    `db:"account_address"` // Contract address (C...) of the holder
+	AccountID         types.AddressBytea `db:"account_id"` // Contract address (C...) of the holder
 	ContractID        uuid.UUID `db:"contract_id"`     // Deterministic UUID for the SAC contract
 	Balance           string    `db:"balance"`         // Balance as string (handles i128 values)
 	IsAuthorized      bool      `db:"is_authorized"`
@@ -65,13 +66,13 @@ func (m *SACBalanceModel) GetByAccount(ctx context.Context, accountAddress strin
 	}
 
 	query := `
-		SELECT asb.account_address, asb.contract_id, asb.balance, asb.is_authorized,
+		SELECT asb.account_id, asb.contract_id, asb.balance, asb.is_authorized,
 		       asb.is_clawback_enabled, asb.last_modified_ledger,
 		       ct.contract_id AS token_id, ct.code, ct.issuer, ct.decimals
 		FROM sac_balances asb
 		INNER JOIN contract_tokens ct ON ct.id = asb.contract_id
-		WHERE asb.account_address = $1`
-	args := []interface{}{accountAddress}
+		WHERE asb.account_id = $1`
+	args := []interface{}{types.AddressBytea(accountAddress)}
 	argIndex := 2
 
 	if cursor != nil {
@@ -122,9 +123,9 @@ func (m *SACBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts 
 	// Upsert query: insert or update all fields
 	const upsertQuery = `
 		INSERT INTO sac_balances (
-			account_address, contract_id, balance, is_authorized, is_clawback_enabled, last_modified_ledger
+			account_id, contract_id, balance, is_authorized, is_clawback_enabled, last_modified_ledger
 		) VALUES ($1, $2, $3, $4, $5, $6)
-		ON CONFLICT (account_address, contract_id) DO UPDATE SET
+		ON CONFLICT (account_id, contract_id) DO UPDATE SET
 			balance = EXCLUDED.balance,
 			is_authorized = EXCLUDED.is_authorized,
 			is_clawback_enabled = EXCLUDED.is_clawback_enabled,
@@ -132,7 +133,7 @@ func (m *SACBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts 
 
 	for _, bal := range upserts {
 		batch.Queue(upsertQuery,
-			bal.AccountAddress,
+			bal.AccountID,
 			bal.ContractID,
 			bal.Balance,
 			bal.IsAuthorized,
@@ -142,10 +143,10 @@ func (m *SACBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts 
 	}
 
 	// Delete query
-	const deleteQuery = `DELETE FROM sac_balances WHERE account_address = $1 AND contract_id = $2`
+	const deleteQuery = `DELETE FROM sac_balances WHERE account_id = $1 AND contract_id = $2`
 
 	for _, bal := range deletes {
-		batch.Queue(deleteQuery, bal.AccountAddress, bal.ContractID)
+		batch.Queue(deleteQuery, bal.AccountID, bal.ContractID)
 	}
 
 	if batch.Len() == 0 {
@@ -186,7 +187,7 @@ func (m *SACBalanceModel) BatchCopy(ctx context.Context, dbTx pgx.Tx, balances [
 		ctx,
 		pgx.Identifier{"sac_balances"},
 		[]string{
-			"account_address",
+			"account_id",
 			"contract_id",
 			"balance",
 			"is_authorized",
@@ -195,8 +196,12 @@ func (m *SACBalanceModel) BatchCopy(ctx context.Context, dbTx pgx.Tx, balances [
 		},
 		pgx.CopyFromSlice(len(balances), func(i int) ([]any, error) {
 			bal := balances[i]
+			accountIDBytes, err := bal.AccountID.Value()
+			if err != nil {
+				return nil, fmt.Errorf("converting account address to bytes: %w", err)
+			}
 			return []any{
-				bal.AccountAddress,
+				accountIDBytes,
 				bal.ContractID,
 				bal.Balance,
 				bal.IsAuthorized,

--- a/internal/data/sac_balances_test.go
+++ b/internal/data/sac_balances_test.go
@@ -3,11 +3,12 @@ package data
 
 import (
 	"context"
+	"crypto/rand"
 	"slices"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/wallet-backend/internal/db"
@@ -15,6 +16,18 @@ import (
 	"github.com/stellar/wallet-backend/internal/indexer/types"
 	"github.com/stellar/wallet-backend/internal/metrics"
 )
+
+// randomContractAddress generates a random valid C-address for testing.
+// SAC balances store contract holder addresses which are C-addresses (not G-addresses).
+func randomContractAddress(t *testing.T) string {
+	t.Helper()
+	var raw [32]byte
+	_, err := rand.Read(raw[:])
+	require.NoError(t, err)
+	addr, err := strkey.Encode(strkey.VersionByteContract, raw[:])
+	require.NoError(t, err)
+	return addr
+}
 
 func TestSACBalanceModel_GetByAccount(t *testing.T) {
 	ctx := context.Background()
@@ -68,7 +81,7 @@ func TestSACBalanceModel_GetByAccount(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		balances, err := m.GetByAccount(ctx, keypair.MustRandom().Address(), nil, nil, ASC)
+		balances, err := m.GetByAccount(ctx, randomContractAddress(t), nil, nil, ASC)
 		require.NoError(t, err)
 		require.Empty(t, balances)
 	})
@@ -81,7 +94,7 @@ func TestSACBalanceModel_GetByAccount(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		accountAddr := keypair.MustRandom().Address()
+		accountAddr := randomContractAddress(t)
 		_, err := dbConnectionPool.Exec(ctx, `
 			INSERT INTO sac_balances
 			(account_id, contract_id, balance, is_authorized, is_clawback_enabled, last_modified_ledger)
@@ -115,7 +128,7 @@ func TestSACBalanceModel_GetByAccount(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		accountAddr := keypair.MustRandom().Address()
+		accountAddr := randomContractAddress(t)
 		_, err := dbConnectionPool.Exec(ctx, `
 			INSERT INTO sac_balances
 			(account_id, contract_id, balance, is_authorized, is_clawback_enabled, last_modified_ledger)
@@ -143,7 +156,7 @@ func TestSACBalanceModel_GetByAccount(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		accountAddr := keypair.MustRandom().Address()
+		accountAddr := randomContractAddress(t)
 		_, err := dbConnectionPool.Exec(ctx, `
 			INSERT INTO sac_balances
 			(account_id, contract_id, balance, is_authorized, is_clawback_enabled, last_modified_ledger)
@@ -229,7 +242,7 @@ func TestSACBalanceModel_BatchUpsert(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		accountAddr := keypair.MustRandom().Address()
+		accountAddr := randomContractAddress(t)
 		pgxTx, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 
@@ -265,7 +278,7 @@ func TestSACBalanceModel_BatchUpsert(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		accountAddr := keypair.MustRandom().Address()
+		accountAddr := randomContractAddress(t)
 
 		// First insert
 		pgxTx1, err := dbConnectionPool.Begin(ctx)
@@ -315,7 +328,7 @@ func TestSACBalanceModel_BatchUpsert(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		accountAddr := keypair.MustRandom().Address()
+		accountAddr := randomContractAddress(t)
 
 		// First insert
 		pgxTx1, err := dbConnectionPool.Begin(ctx)
@@ -359,8 +372,8 @@ func TestSACBalanceModel_BatchUpsert(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		accountAddr1 := keypair.MustRandom().Address()
-		accountAddr2 := keypair.MustRandom().Address()
+		accountAddr1 := randomContractAddress(t)
+		accountAddr2 := randomContractAddress(t)
 
 		// Insert two balances
 		pgxTx1, err := dbConnectionPool.Begin(ctx)
@@ -453,7 +466,7 @@ func TestSACBalanceModel_BatchCopy(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		accountAddr := keypair.MustRandom().Address()
+		accountAddr := randomContractAddress(t)
 		pgxTx, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 
@@ -496,8 +509,8 @@ func TestSACBalanceModel_BatchCopy(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		accountAddr1 := keypair.MustRandom().Address()
-		accountAddr2 := keypair.MustRandom().Address()
+		accountAddr1 := randomContractAddress(t)
+		accountAddr2 := randomContractAddress(t)
 		pgxTx, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 

--- a/internal/data/sac_balances_test.go
+++ b/internal/data/sac_balances_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/wallet-backend/internal/db"
 	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
 	"github.com/stellar/wallet-backend/internal/metrics"
 )
 
@@ -66,7 +68,7 @@ func TestSACBalanceModel_GetByAccount(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		balances, err := m.GetByAccount(ctx, "CNOTEXISTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", nil, nil, ASC)
+		balances, err := m.GetByAccount(ctx, keypair.MustRandom().Address(), nil, nil, ASC)
 		require.NoError(t, err)
 		require.Empty(t, balances)
 	})
@@ -79,12 +81,12 @@ func TestSACBalanceModel_GetByAccount(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		accountAddr := "CACCOUNT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+		accountAddr := keypair.MustRandom().Address()
 		_, err := dbConnectionPool.Exec(ctx, `
 			INSERT INTO sac_balances
-			(account_address, contract_id, balance, is_authorized, is_clawback_enabled, last_modified_ledger)
+			(account_id, contract_id, balance, is_authorized, is_clawback_enabled, last_modified_ledger)
 			VALUES ($1, $2, '1000000000', true, false, 12345)
-		`, accountAddr, contractID1)
+		`, types.AddressBytea(accountAddr), contractID1)
 		require.NoError(t, err)
 
 		balances, err := m.GetByAccount(ctx, accountAddr, nil, nil, ASC)
@@ -92,7 +94,7 @@ func TestSACBalanceModel_GetByAccount(t *testing.T) {
 		require.Len(t, balances, 1)
 
 		// Verify all fields including JOIN data
-		require.Equal(t, accountAddr, balances[0].AccountAddress)
+		require.Equal(t, types.AddressBytea(accountAddr), balances[0].AccountID)
 		require.Equal(t, contractID1, balances[0].ContractID)
 		require.Equal(t, "1000000000", balances[0].Balance)
 		require.True(t, balances[0].IsAuthorized)
@@ -113,14 +115,14 @@ func TestSACBalanceModel_GetByAccount(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		accountAddr := "CACCOUNT2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+		accountAddr := keypair.MustRandom().Address()
 		_, err := dbConnectionPool.Exec(ctx, `
 			INSERT INTO sac_balances
-			(account_address, contract_id, balance, is_authorized, is_clawback_enabled, last_modified_ledger)
+			(account_id, contract_id, balance, is_authorized, is_clawback_enabled, last_modified_ledger)
 			VALUES
 			($1, $2, '1000', true, false, 100),
 			($1, $3, '2000', true, true, 101)
-		`, accountAddr, contractID1, contractID2)
+		`, types.AddressBytea(accountAddr), contractID1, contractID2)
 		require.NoError(t, err)
 
 		balances, err := m.GetByAccount(ctx, accountAddr, nil, nil, ASC)
@@ -129,7 +131,7 @@ func TestSACBalanceModel_GetByAccount(t *testing.T) {
 
 		// Verify both balances belong to the correct account
 		for _, b := range balances {
-			require.Equal(t, accountAddr, b.AccountAddress)
+			require.Equal(t, types.AddressBytea(accountAddr), b.AccountID)
 		}
 	})
 
@@ -141,15 +143,15 @@ func TestSACBalanceModel_GetByAccount(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		accountAddr := "CACCOUNT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+		accountAddr := keypair.MustRandom().Address()
 		_, err := dbConnectionPool.Exec(ctx, `
 			INSERT INTO sac_balances
-			(account_address, contract_id, balance, is_authorized, is_clawback_enabled, last_modified_ledger)
+			(account_id, contract_id, balance, is_authorized, is_clawback_enabled, last_modified_ledger)
 			VALUES
 			($1, $2, '1000', true, false, 100),
 			($1, $3, '2000', true, false, 101),
 			($1, $4, '3000', true, false, 102)
-		`, accountAddr, contractID1, contractID2, contractID3)
+		`, types.AddressBytea(accountAddr), contractID1, contractID2, contractID3)
 		require.NoError(t, err)
 
 		expectedOrder := []string{contractID1.String(), contractID2.String(), contractID3.String()}
@@ -227,12 +229,13 @@ func TestSACBalanceModel_BatchUpsert(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
+		accountAddr := keypair.MustRandom().Address()
 		pgxTx, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 
 		upserts := []SACBalance{
 			{
-				AccountAddress:    "CACCOUNT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+				AccountID:         types.AddressBytea(accountAddr),
 				ContractID:        contractID1,
 				Balance:           "1000000000",
 				IsAuthorized:      true,
@@ -248,8 +251,8 @@ func TestSACBalanceModel_BatchUpsert(t *testing.T) {
 		// Verify insert
 		var count int
 		err = dbConnectionPool.QueryRow(ctx,
-			`SELECT COUNT(*) FROM sac_balances WHERE account_address = $1`,
-			"CACCOUNT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").Scan(&count)
+			`SELECT COUNT(*) FROM sac_balances WHERE account_id = $1`,
+			types.AddressBytea(accountAddr)).Scan(&count)
 		require.NoError(t, err)
 		require.Equal(t, 1, count)
 	})
@@ -262,12 +265,14 @@ func TestSACBalanceModel_BatchUpsert(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
+		accountAddr := keypair.MustRandom().Address()
+
 		// First insert
 		pgxTx1, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 		upserts := []SACBalance{
 			{
-				AccountAddress:    "CACCOUNT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+				AccountID:         types.AddressBytea(accountAddr),
 				ContractID:        contractID1,
 				Balance:           "1000",
 				IsAuthorized:      true,
@@ -294,8 +299,8 @@ func TestSACBalanceModel_BatchUpsert(t *testing.T) {
 		var isAuthorized bool
 		var ledger uint32
 		err = dbConnectionPool.QueryRow(ctx,
-			`SELECT balance, is_authorized, last_modified_ledger FROM sac_balances WHERE account_address = $1 AND contract_id = $2`,
-			"CACCOUNT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", contractID1).Scan(&balance, &isAuthorized, &ledger)
+			`SELECT balance, is_authorized, last_modified_ledger FROM sac_balances WHERE account_id = $1 AND contract_id = $2`,
+			types.AddressBytea(accountAddr), contractID1).Scan(&balance, &isAuthorized, &ledger)
 		require.NoError(t, err)
 		require.Equal(t, "2000", balance)
 		require.False(t, isAuthorized)
@@ -310,15 +315,17 @@ func TestSACBalanceModel_BatchUpsert(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
+		accountAddr := keypair.MustRandom().Address()
+
 		// First insert
 		pgxTx1, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 		upserts := []SACBalance{
 			{
-				AccountAddress: "CACCOUNT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-				ContractID:     contractID1,
-				Balance:        "1000",
-				LedgerNumber:   100,
+				AccountID:    types.AddressBytea(accountAddr),
+				ContractID:   contractID1,
+				Balance:      "1000",
+				LedgerNumber: 100,
 			},
 		}
 		err = m.BatchUpsert(ctx, pgxTx1, upserts, nil)
@@ -329,7 +336,7 @@ func TestSACBalanceModel_BatchUpsert(t *testing.T) {
 		pgxTx2, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 		deletes := []SACBalance{
-			{AccountAddress: "CACCOUNT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", ContractID: contractID1},
+			{AccountID: types.AddressBytea(accountAddr), ContractID: contractID1},
 		}
 		err = m.BatchUpsert(ctx, pgxTx2, nil, deletes)
 		require.NoError(t, err)
@@ -338,8 +345,8 @@ func TestSACBalanceModel_BatchUpsert(t *testing.T) {
 		// Verify delete
 		var count int
 		err = dbConnectionPool.QueryRow(ctx,
-			`SELECT COUNT(*) FROM sac_balances WHERE account_address = $1`,
-			"CACCOUNT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").Scan(&count)
+			`SELECT COUNT(*) FROM sac_balances WHERE account_id = $1`,
+			types.AddressBytea(accountAddr)).Scan(&count)
 		require.NoError(t, err)
 		require.Equal(t, 0, count)
 	})
@@ -352,12 +359,15 @@ func TestSACBalanceModel_BatchUpsert(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
+		accountAddr1 := keypair.MustRandom().Address()
+		accountAddr2 := keypair.MustRandom().Address()
+
 		// Insert two balances
 		pgxTx1, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 		upserts := []SACBalance{
-			{AccountAddress: "CACCOUNT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", ContractID: contractID1, Balance: "1000", LedgerNumber: 100},
-			{AccountAddress: "CACCOUNT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", ContractID: contractID2, Balance: "2000", LedgerNumber: 100},
+			{AccountID: types.AddressBytea(accountAddr1), ContractID: contractID1, Balance: "1000", LedgerNumber: 100},
+			{AccountID: types.AddressBytea(accountAddr1), ContractID: contractID2, Balance: "2000", LedgerNumber: 100},
 		}
 		err = m.BatchUpsert(ctx, pgxTx1, upserts, nil)
 		require.NoError(t, err)
@@ -367,11 +377,11 @@ func TestSACBalanceModel_BatchUpsert(t *testing.T) {
 		pgxTx2, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 		newUpserts := []SACBalance{
-			{AccountAddress: "CACCOUNT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", ContractID: contractID1, Balance: "1500", LedgerNumber: 200}, // update
-			{AccountAddress: "CACCOUNT2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", ContractID: contractID1, Balance: "3000", LedgerNumber: 200}, // new
+			{AccountID: types.AddressBytea(accountAddr1), ContractID: contractID1, Balance: "1500", LedgerNumber: 200}, // update
+			{AccountID: types.AddressBytea(accountAddr2), ContractID: contractID1, Balance: "3000", LedgerNumber: 200}, // new
 		}
 		deletes := []SACBalance{
-			{AccountAddress: "CACCOUNT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", ContractID: contractID2}, // delete
+			{AccountID: types.AddressBytea(accountAddr1), ContractID: contractID2}, // delete
 		}
 		err = m.BatchUpsert(ctx, pgxTx2, newUpserts, deletes)
 		require.NoError(t, err)
@@ -381,12 +391,12 @@ func TestSACBalanceModel_BatchUpsert(t *testing.T) {
 		var count int
 		err = dbConnectionPool.QueryRow(ctx, `SELECT COUNT(*) FROM sac_balances`).Scan(&count)
 		require.NoError(t, err)
-		require.Equal(t, 2, count) // CACCOUNT1:contractID1 (updated) + CACCOUNT2:contractID1 (new)
+		require.Equal(t, 2, count)
 
 		var balance string
 		err = dbConnectionPool.QueryRow(ctx,
-			`SELECT balance FROM sac_balances WHERE account_address = $1 AND contract_id = $2`,
-			"CACCOUNT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", contractID1).Scan(&balance)
+			`SELECT balance FROM sac_balances WHERE account_id = $1 AND contract_id = $2`,
+			types.AddressBytea(accountAddr1), contractID1).Scan(&balance)
 		require.NoError(t, err)
 		require.Equal(t, "1500", balance)
 	})
@@ -443,12 +453,13 @@ func TestSACBalanceModel_BatchCopy(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
+		accountAddr := keypair.MustRandom().Address()
 		pgxTx, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 
 		balances := []SACBalance{
 			{
-				AccountAddress:    "CACCOUNT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+				AccountID:         types.AddressBytea(accountAddr),
 				ContractID:        contractID1,
 				Balance:           "1000000000",
 				IsAuthorized:      true,
@@ -464,12 +475,12 @@ func TestSACBalanceModel_BatchCopy(t *testing.T) {
 		// Verify all fields
 		var b SACBalance
 		err = dbConnectionPool.QueryRow(ctx, `
-			SELECT account_address, contract_id, balance, is_authorized, is_clawback_enabled, last_modified_ledger
-			FROM sac_balances WHERE account_address = $1
-		`, "CACCOUNT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").Scan(
-			&b.AccountAddress, &b.ContractID, &b.Balance, &b.IsAuthorized, &b.IsClawbackEnabled, &b.LedgerNumber)
+			SELECT account_id, contract_id, balance, is_authorized, is_clawback_enabled, last_modified_ledger
+			FROM sac_balances WHERE account_id = $1
+		`, types.AddressBytea(accountAddr)).Scan(
+			&b.AccountID, &b.ContractID, &b.Balance, &b.IsAuthorized, &b.IsClawbackEnabled, &b.LedgerNumber)
 		require.NoError(t, err)
-		require.Equal(t, balances[0].AccountAddress, b.AccountAddress)
+		require.Equal(t, balances[0].AccountID, b.AccountID)
 		require.Equal(t, balances[0].ContractID, b.ContractID)
 		require.Equal(t, balances[0].Balance, b.Balance)
 		require.Equal(t, balances[0].IsAuthorized, b.IsAuthorized)
@@ -485,13 +496,15 @@ func TestSACBalanceModel_BatchCopy(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
+		accountAddr1 := keypair.MustRandom().Address()
+		accountAddr2 := keypair.MustRandom().Address()
 		pgxTx, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 
 		balances := []SACBalance{
-			{AccountAddress: "CACCOUNT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", ContractID: contractID1, Balance: "1000", LedgerNumber: 100},
-			{AccountAddress: "CACCOUNT1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", ContractID: contractID2, Balance: "2000", LedgerNumber: 100},
-			{AccountAddress: "CACCOUNT2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", ContractID: contractID1, Balance: "3000", LedgerNumber: 100},
+			{AccountID: types.AddressBytea(accountAddr1), ContractID: contractID1, Balance: "1000", LedgerNumber: 100},
+			{AccountID: types.AddressBytea(accountAddr1), ContractID: contractID2, Balance: "2000", LedgerNumber: 100},
+			{AccountID: types.AddressBytea(accountAddr2), ContractID: contractID1, Balance: "3000", LedgerNumber: 100},
 		}
 
 		err = m.BatchCopy(ctx, pgxTx, balances)

--- a/internal/data/trustline_balances.go
+++ b/internal/data/trustline_balances.go
@@ -12,13 +12,14 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
 	"github.com/stellar/wallet-backend/internal/metrics"
 	"github.com/stellar/wallet-backend/internal/utils"
 )
 
 // TrustlineBalance contains all fields for a trustline including asset metadata from JOIN.
 type TrustlineBalance struct {
-	AccountAddress     string    `db:"account_address"`
+	AccountID          types.AddressBytea `db:"account_id"`
 	AssetID            uuid.UUID `db:"asset_id"`
 	Code               string    `db:"code"`   // Asset code from trustline_assets table
 	Issuer             string    `db:"issuer"` // Asset issuer from trustline_assets table
@@ -61,13 +62,13 @@ func (m *TrustlineBalanceModel) GetByAccount(ctx context.Context, accountAddress
 	}
 
 	query := `
-		SELECT atb.account_address, atb.asset_id, ta.code, ta.issuer,
+		SELECT atb.account_id, atb.asset_id, ta.code, ta.issuer,
 		       atb.balance, atb.trust_limit, atb.buying_liabilities,
 		       atb.selling_liabilities, atb.flags, atb.last_modified_ledger
 		FROM trustline_balances atb
 		INNER JOIN trustline_assets ta ON ta.id = atb.asset_id
-		WHERE atb.account_address = $1`
-	args := []interface{}{accountAddress}
+		WHERE atb.account_id = $1`
+	args := []interface{}{types.AddressBytea(accountAddress)}
 	argIndex := 2
 
 	if cursor != nil {
@@ -120,10 +121,10 @@ func (m *TrustlineBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, up
 	// Upsert query: insert or update all fields
 	const upsertQuery = `
 		INSERT INTO trustline_balances (
-			account_address, asset_id, balance, trust_limit,
+			account_id, asset_id, balance, trust_limit,
 			buying_liabilities, selling_liabilities, flags, last_modified_ledger
 		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-		ON CONFLICT (account_address, asset_id) DO UPDATE SET
+		ON CONFLICT (account_id, asset_id) DO UPDATE SET
 			balance = EXCLUDED.balance,
 			trust_limit = EXCLUDED.trust_limit,
 			buying_liabilities = EXCLUDED.buying_liabilities,
@@ -133,7 +134,7 @@ func (m *TrustlineBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, up
 
 	for _, tl := range upserts {
 		batch.Queue(upsertQuery,
-			tl.AccountAddress,
+			tl.AccountID,
 			tl.AssetID,
 			tl.Balance,
 			tl.Limit,
@@ -145,10 +146,10 @@ func (m *TrustlineBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, up
 	}
 
 	// Delete query
-	const deleteQuery = `DELETE FROM trustline_balances WHERE account_address = $1 AND asset_id = $2`
+	const deleteQuery = `DELETE FROM trustline_balances WHERE account_id = $1 AND asset_id = $2`
 
 	for _, tl := range deletes {
-		batch.Queue(deleteQuery, tl.AccountAddress, tl.AssetID)
+		batch.Queue(deleteQuery, tl.AccountID, tl.AssetID)
 	}
 
 	if batch.Len() == 0 {
@@ -189,7 +190,7 @@ func (m *TrustlineBalanceModel) BatchCopy(ctx context.Context, dbTx pgx.Tx, bala
 		ctx,
 		pgx.Identifier{"trustline_balances"},
 		[]string{
-			"account_address",
+			"account_id",
 			"asset_id",
 			"balance",
 			"trust_limit",
@@ -200,8 +201,12 @@ func (m *TrustlineBalanceModel) BatchCopy(ctx context.Context, dbTx pgx.Tx, bala
 		},
 		pgx.CopyFromSlice(len(balances), func(i int) ([]any, error) {
 			tl := balances[i]
+			accountIDBytes, err := tl.AccountID.Value()
+			if err != nil {
+				return nil, fmt.Errorf("converting account address to bytes: %w", err)
+			}
 			return []any{
-				tl.AccountAddress,
+				accountIDBytes,
 				tl.AssetID,
 				tl.Balance,
 				tl.Limit,

--- a/internal/data/trustline_balances.go
+++ b/internal/data/trustline_balances.go
@@ -132,7 +132,11 @@ func (m *TrustlineBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, up
 			if err != nil {
 				return fmt.Errorf("converting account address to bytes for upsert: %w", err)
 			}
-			accountIDs[i] = raw.([]byte)
+			rawBytes, ok := raw.([]byte)
+			if !ok {
+				return fmt.Errorf("converting account address to bytes for upsert: expected []byte, got %T", raw)
+			}
+			accountIDs[i] = rawBytes
 			assetIDs[i] = tl.AssetID
 			balances[i] = tl.Balance
 			limits[i] = tl.Limit
@@ -173,7 +177,11 @@ func (m *TrustlineBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, up
 			if err != nil {
 				return fmt.Errorf("converting account address to bytes for delete: %w", err)
 			}
-			deleteAccountIDs[i] = raw.([]byte)
+			rawBytes, ok := raw.([]byte)
+			if !ok {
+				return fmt.Errorf("converting account address to bytes for delete: expected []byte, got %T", raw)
+			}
+			deleteAccountIDs[i] = rawBytes
 			deleteAssetIDs[i] = tl.AssetID
 		}
 

--- a/internal/data/trustline_balances.go
+++ b/internal/data/trustline_balances.go
@@ -20,15 +20,15 @@ import (
 // TrustlineBalance contains all fields for a trustline including asset metadata from JOIN.
 type TrustlineBalance struct {
 	AccountID          types.AddressBytea `db:"account_id"`
-	AssetID            uuid.UUID `db:"asset_id"`
-	Code               string    `db:"code"`   // Asset code from trustline_assets table
-	Issuer             string    `db:"issuer"` // Asset issuer from trustline_assets table
-	Balance            int64     `db:"balance"`
-	Limit              int64     `db:"trust_limit"`
-	BuyingLiabilities  int64     `db:"buying_liabilities"`
-	SellingLiabilities int64     `db:"selling_liabilities"`
-	Flags              uint32    `db:"flags"`
-	LedgerNumber       uint32    `db:"last_modified_ledger"`
+	AssetID            uuid.UUID          `db:"asset_id"`
+	Code               string             `db:"code"`   // Asset code from trustline_assets table
+	Issuer             string             `db:"issuer"` // Asset issuer from trustline_assets table
+	Balance            int64              `db:"balance"`
+	Limit              int64              `db:"trust_limit"`
+	BuyingLiabilities  int64              `db:"buying_liabilities"`
+	SellingLiabilities int64              `db:"selling_liabilities"`
+	Flags              uint32             `db:"flags"`
+	LedgerNumber       uint32             `db:"last_modified_ledger"`
 }
 
 // TrustlineBalanceModelInterface defines the interface for trustline balance operations.

--- a/internal/data/trustline_balances.go
+++ b/internal/data/trustline_balances.go
@@ -107,7 +107,7 @@ func (m *TrustlineBalanceModel) GetByAccount(ctx context.Context, accountAddress
 	return balances, nil
 }
 
-// BatchUpsert performs upserts and deletes with full XDR fields.
+// BatchUpsert performs upserts and deletes using UNNEST for efficiency.
 // For upserts (ADD/UPDATE): inserts or updates all trustline fields.
 // For deletes (REMOVE): removes the trustline row.
 func (m *TrustlineBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts []TrustlineBalance, deletes []TrustlineBalance) error {
@@ -116,61 +116,79 @@ func (m *TrustlineBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, up
 	}
 
 	start := time.Now()
-	batch := &pgx.Batch{}
 
-	// Upsert query: insert or update all fields
-	const upsertQuery = `
-		INSERT INTO trustline_balances (
-			account_id, asset_id, balance, trust_limit,
-			buying_liabilities, selling_liabilities, flags, last_modified_ledger
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-		ON CONFLICT (account_id, asset_id) DO UPDATE SET
-			balance = EXCLUDED.balance,
-			trust_limit = EXCLUDED.trust_limit,
-			buying_liabilities = EXCLUDED.buying_liabilities,
-			selling_liabilities = EXCLUDED.selling_liabilities,
-			flags = EXCLUDED.flags,
-			last_modified_ledger = EXCLUDED.last_modified_ledger`
+	if len(upserts) > 0 {
+		accountIDs := make([][]byte, len(upserts))
+		assetIDs := make([]uuid.UUID, len(upserts))
+		balances := make([]int64, len(upserts))
+		limits := make([]int64, len(upserts))
+		buyingLiabilities := make([]int64, len(upserts))
+		sellingLiabilities := make([]int64, len(upserts))
+		flags := make([]int32, len(upserts))
+		ledgerNumbers := make([]int64, len(upserts))
 
-	for _, tl := range upserts {
-		batch.Queue(upsertQuery,
-			tl.AccountID,
-			tl.AssetID,
-			tl.Balance,
-			tl.Limit,
-			tl.BuyingLiabilities,
-			tl.SellingLiabilities,
-			tl.Flags,
-			tl.LedgerNumber,
-		)
-	}
+		for i, tl := range upserts {
+			raw, err := tl.AccountID.Value()
+			if err != nil {
+				return fmt.Errorf("converting account address to bytes for upsert: %w", err)
+			}
+			accountIDs[i] = raw.([]byte)
+			assetIDs[i] = tl.AssetID
+			balances[i] = tl.Balance
+			limits[i] = tl.Limit
+			buyingLiabilities[i] = tl.BuyingLiabilities
+			sellingLiabilities[i] = tl.SellingLiabilities
+			flags[i] = int32(tl.Flags)
+			ledgerNumbers[i] = int64(tl.LedgerNumber)
+		}
 
-	// Delete query
-	const deleteQuery = `DELETE FROM trustline_balances WHERE account_id = $1 AND asset_id = $2`
+		const upsertQuery = `
+			INSERT INTO trustline_balances (
+				account_id, asset_id, balance, trust_limit,
+				buying_liabilities, selling_liabilities, flags, last_modified_ledger
+			)
+			SELECT * FROM UNNEST($1::bytea[], $2::uuid[], $3::bigint[], $4::bigint[], $5::bigint[], $6::bigint[], $7::int[], $8::bigint[])
+			ON CONFLICT (account_id, asset_id) DO UPDATE SET
+				balance = EXCLUDED.balance,
+				trust_limit = EXCLUDED.trust_limit,
+				buying_liabilities = EXCLUDED.buying_liabilities,
+				selling_liabilities = EXCLUDED.selling_liabilities,
+				flags = EXCLUDED.flags,
+				last_modified_ledger = EXCLUDED.last_modified_ledger`
 
-	for _, tl := range deletes {
-		batch.Queue(deleteQuery, tl.AccountID, tl.AssetID)
-	}
-
-	if batch.Len() == 0 {
-		return nil
-	}
-
-	br := dbTx.SendBatch(ctx, batch)
-	for i := 0; i < batch.Len(); i++ {
-		if _, err := br.Exec(); err != nil {
-			_ = br.Close() //nolint:errcheck // cleanup on error path
+		if _, err := dbTx.Exec(ctx, upsertQuery, accountIDs, assetIDs, balances, limits, buyingLiabilities, sellingLiabilities, flags, ledgerNumbers); err != nil {
 			m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", "trustline_balances").Observe(time.Since(start).Seconds())
 			m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", "trustline_balances").Inc()
 			m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", "trustline_balances", utils.GetDBErrorType(err)).Inc()
 			return fmt.Errorf("upserting trustline balances: %w", err)
 		}
 	}
-	if err := br.Close(); err != nil {
-		m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", "trustline_balances").Observe(time.Since(start).Seconds())
-		m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", "trustline_balances").Inc()
-		m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", "trustline_balances", utils.GetDBErrorType(err)).Inc()
-		return fmt.Errorf("closing trustline balance batch: %w", err)
+
+	if len(deletes) > 0 {
+		deleteAccountIDs := make([][]byte, len(deletes))
+		deleteAssetIDs := make([]uuid.UUID, len(deletes))
+
+		for i, tl := range deletes {
+			raw, err := tl.AccountID.Value()
+			if err != nil {
+				return fmt.Errorf("converting account address to bytes for delete: %w", err)
+			}
+			deleteAccountIDs[i] = raw.([]byte)
+			deleteAssetIDs[i] = tl.AssetID
+		}
+
+		const deleteQuery = `
+			DELETE FROM trustline_balances
+			WHERE (account_id, asset_id) IN (
+				SELECT * FROM UNNEST($1::bytea[], $2::uuid[])
+			)`
+
+		if _, err := dbTx.Exec(ctx, deleteQuery, deleteAccountIDs, deleteAssetIDs); err != nil {
+			m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", "trustline_balances").Observe(time.Since(start).Seconds())
+			m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", "trustline_balances").Inc()
+			m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", "trustline_balances", utils.GetDBErrorType(err)).Inc()
+			return fmt.Errorf("deleting trustline balances: %w", err)
+		}
 	}
 
 	m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", "trustline_balances").Observe(time.Since(start).Seconds())

--- a/internal/data/trustline_balances_test.go
+++ b/internal/data/trustline_balances_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/wallet-backend/internal/db"
 	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
 	"github.com/stellar/wallet-backend/internal/metrics"
 )
 
@@ -63,7 +65,7 @@ func TestTrustlineBalanceModel_GetByAccount(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		balances, err := m.GetByAccount(ctx, "GNOTEXIST", nil, nil, ASC)
+		balances, err := m.GetByAccount(ctx, keypair.MustRandom().Address(), nil, nil, ASC)
 		require.NoError(t, err)
 		require.Empty(t, balances)
 	})
@@ -76,12 +78,12 @@ func TestTrustlineBalanceModel_GetByAccount(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		accountAddr := "GACCOUNT1"
+		accountAddr := keypair.MustRandom().Address()
 		_, err := dbConnectionPool.Exec(ctx, `
 			INSERT INTO trustline_balances
-			(account_address, asset_id, balance, trust_limit, buying_liabilities, selling_liabilities, flags, last_modified_ledger)
+			(account_id, asset_id, balance, trust_limit, buying_liabilities, selling_liabilities, flags, last_modified_ledger)
 			VALUES ($1, $2, 1000, 10000, 100, 50, 1, 12345)
-		`, accountAddr, assetID1)
+		`, types.AddressBytea(accountAddr), assetID1)
 		require.NoError(t, err)
 
 		balances, err := m.GetByAccount(ctx, accountAddr, nil, nil, ASC)
@@ -89,7 +91,7 @@ func TestTrustlineBalanceModel_GetByAccount(t *testing.T) {
 		require.Len(t, balances, 1)
 
 		// Verify all fields including JOIN data
-		require.Equal(t, accountAddr, balances[0].AccountAddress)
+		require.Equal(t, types.AddressBytea(accountAddr), balances[0].AccountID)
 		require.Equal(t, assetID1, balances[0].AssetID)
 		require.Equal(t, "USDC", balances[0].Code)
 		require.Equal(t, "ISSUER1", balances[0].Issuer)
@@ -109,14 +111,14 @@ func TestTrustlineBalanceModel_GetByAccount(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
-		accountAddr := "GACCOUNT2"
+		accountAddr := keypair.MustRandom().Address()
 		_, err := dbConnectionPool.Exec(ctx, `
 			INSERT INTO trustline_balances
-			(account_address, asset_id, balance, trust_limit, buying_liabilities, selling_liabilities, flags, last_modified_ledger)
+			(account_id, asset_id, balance, trust_limit, buying_liabilities, selling_liabilities, flags, last_modified_ledger)
 			VALUES
 			($1, $2, 1000, 10000, 0, 0, 0, 100),
 			($1, $3, 2000, 20000, 0, 0, 0, 101)
-		`, accountAddr, assetID1, assetID2)
+		`, types.AddressBytea(accountAddr), assetID1, assetID2)
 		require.NoError(t, err)
 
 		balances, err := m.GetByAccount(ctx, accountAddr, nil, nil, ASC)
@@ -125,7 +127,7 @@ func TestTrustlineBalanceModel_GetByAccount(t *testing.T) {
 
 		// Verify both trustlines belong to the correct account
 		for _, b := range balances {
-			require.Equal(t, accountAddr, b.AccountAddress)
+			require.Equal(t, types.AddressBytea(accountAddr), b.AccountID)
 		}
 	})
 
@@ -137,33 +139,34 @@ func TestTrustlineBalanceModel_GetByAccount(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
+		accountAddr := keypair.MustRandom().Address()
 		_, err := dbConnectionPool.Exec(ctx, `
 			INSERT INTO trustline_balances
-			(account_address, asset_id, balance, trust_limit, buying_liabilities, selling_liabilities, flags, last_modified_ledger)
+			(account_id, asset_id, balance, trust_limit, buying_liabilities, selling_liabilities, flags, last_modified_ledger)
 			VALUES
-			('GACCOUNT1', $1, 1000, 10000, 0, 0, 0, 100),
-			('GACCOUNT1', $2, 2000, 20000, 0, 0, 0, 101),
-			('GACCOUNT1', $3, 3000, 30000, 0, 0, 0, 102)
-		`, assetID1, assetID2, assetID3)
+			($1, $2, 1000, 10000, 0, 0, 0, 100),
+			($1, $3, 2000, 20000, 0, 0, 0, 101),
+			($1, $4, 3000, 30000, 0, 0, 0, 102)
+		`, types.AddressBytea(accountAddr), assetID1, assetID2, assetID3)
 		require.NoError(t, err)
 
 		expectedOrder := []string{assetID1.String(), assetID2.String(), assetID3.String()}
 		slices.Sort(expectedOrder)
 
 		limit := int32(2)
-		page, err := m.GetByAccount(ctx, "GACCOUNT1", &limit, nil, ASC)
+		page, err := m.GetByAccount(ctx, accountAddr, &limit, nil, ASC)
 		require.NoError(t, err)
 		require.Len(t, page, 2)
 		require.Equal(t, expectedOrder[0], page[0].AssetID.String())
 		require.Equal(t, expectedOrder[1], page[1].AssetID.String())
 
 		cursor := page[1].AssetID
-		nextPage, err := m.GetByAccount(ctx, "GACCOUNT1", &limit, &cursor, ASC)
+		nextPage, err := m.GetByAccount(ctx, accountAddr, &limit, &cursor, ASC)
 		require.NoError(t, err)
 		require.Len(t, nextPage, 1)
 		require.Equal(t, expectedOrder[2], nextPage[0].AssetID.String())
 
-		descPage, err := m.GetByAccount(ctx, "GACCOUNT1", &limit, nil, DESC)
+		descPage, err := m.GetByAccount(ctx, accountAddr, &limit, nil, DESC)
 		require.NoError(t, err)
 		require.Len(t, descPage, 2)
 		require.Equal(t, expectedOrder[2], descPage[0].AssetID.String())
@@ -220,12 +223,13 @@ func TestTrustlineBalanceModel_BatchUpsert(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
+		accountAddr := keypair.MustRandom().Address()
 		pgxTx, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 
 		upserts := []TrustlineBalance{
 			{
-				AccountAddress:     "GACCOUNT1",
+				AccountID:          types.AddressBytea(accountAddr),
 				AssetID:            assetID1,
 				Balance:            1000,
 				Limit:              10000,
@@ -242,7 +246,7 @@ func TestTrustlineBalanceModel_BatchUpsert(t *testing.T) {
 
 		// Verify insert
 		var count int
-		err = dbConnectionPool.QueryRow(ctx, `SELECT COUNT(*) FROM trustline_balances WHERE account_address = $1`, "GACCOUNT1").Scan(&count)
+		err = dbConnectionPool.QueryRow(ctx, `SELECT COUNT(*) FROM trustline_balances WHERE account_id = $1`, types.AddressBytea(accountAddr)).Scan(&count)
 		require.NoError(t, err)
 		require.Equal(t, 1, count)
 	})
@@ -255,16 +259,18 @@ func TestTrustlineBalanceModel_BatchUpsert(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
+		accountAddr := keypair.MustRandom().Address()
+
 		// First insert
 		pgxTx1, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 		upserts := []TrustlineBalance{
 			{
-				AccountAddress: "GACCOUNT1",
-				AssetID:        assetID1,
-				Balance:        1000,
-				Limit:          10000,
-				LedgerNumber:   100,
+				AccountID:    types.AddressBytea(accountAddr),
+				AssetID:      assetID1,
+				Balance:      1000,
+				Limit:        10000,
+				LedgerNumber: 100,
 			},
 		}
 		err = m.BatchUpsert(ctx, pgxTx1, upserts, nil)
@@ -284,8 +290,8 @@ func TestTrustlineBalanceModel_BatchUpsert(t *testing.T) {
 		var balance int64
 		var ledger uint32
 		err = dbConnectionPool.QueryRow(ctx,
-			`SELECT balance, last_modified_ledger FROM trustline_balances WHERE account_address = $1 AND asset_id = $2`,
-			"GACCOUNT1", assetID1).Scan(&balance, &ledger)
+			`SELECT balance, last_modified_ledger FROM trustline_balances WHERE account_id = $1 AND asset_id = $2`,
+			types.AddressBytea(accountAddr), assetID1).Scan(&balance, &ledger)
 		require.NoError(t, err)
 		require.Equal(t, int64(2000), balance)
 		require.Equal(t, uint32(200), ledger)
@@ -299,11 +305,13 @@ func TestTrustlineBalanceModel_BatchUpsert(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
+		accountAddr := keypair.MustRandom().Address()
+
 		// First insert
 		pgxTx1, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 		upserts := []TrustlineBalance{
-			{AccountAddress: "GACCOUNT1", AssetID: assetID1, Balance: 1000, LedgerNumber: 100},
+			{AccountID: types.AddressBytea(accountAddr), AssetID: assetID1, Balance: 1000, LedgerNumber: 100},
 		}
 		err = m.BatchUpsert(ctx, pgxTx1, upserts, nil)
 		require.NoError(t, err)
@@ -313,7 +321,7 @@ func TestTrustlineBalanceModel_BatchUpsert(t *testing.T) {
 		pgxTx2, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 		deletes := []TrustlineBalance{
-			{AccountAddress: "GACCOUNT1", AssetID: assetID1},
+			{AccountID: types.AddressBytea(accountAddr), AssetID: assetID1},
 		}
 		err = m.BatchUpsert(ctx, pgxTx2, nil, deletes)
 		require.NoError(t, err)
@@ -321,7 +329,7 @@ func TestTrustlineBalanceModel_BatchUpsert(t *testing.T) {
 
 		// Verify delete
 		var count int
-		err = dbConnectionPool.QueryRow(ctx, `SELECT COUNT(*) FROM trustline_balances WHERE account_address = $1`, "GACCOUNT1").Scan(&count)
+		err = dbConnectionPool.QueryRow(ctx, `SELECT COUNT(*) FROM trustline_balances WHERE account_id = $1`, types.AddressBytea(accountAddr)).Scan(&count)
 		require.NoError(t, err)
 		require.Equal(t, 0, count)
 	})
@@ -334,12 +342,15 @@ func TestTrustlineBalanceModel_BatchUpsert(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
+		accountAddr1 := keypair.MustRandom().Address()
+		accountAddr2 := keypair.MustRandom().Address()
+
 		// Insert two trustlines
 		pgxTx1, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 		upserts := []TrustlineBalance{
-			{AccountAddress: "GACCOUNT1", AssetID: assetID1, Balance: 1000, LedgerNumber: 100},
-			{AccountAddress: "GACCOUNT1", AssetID: assetID2, Balance: 2000, LedgerNumber: 100},
+			{AccountID: types.AddressBytea(accountAddr1), AssetID: assetID1, Balance: 1000, LedgerNumber: 100},
+			{AccountID: types.AddressBytea(accountAddr1), AssetID: assetID2, Balance: 2000, LedgerNumber: 100},
 		}
 		err = m.BatchUpsert(ctx, pgxTx1, upserts, nil)
 		require.NoError(t, err)
@@ -349,11 +360,11 @@ func TestTrustlineBalanceModel_BatchUpsert(t *testing.T) {
 		pgxTx2, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 		newUpserts := []TrustlineBalance{
-			{AccountAddress: "GACCOUNT1", AssetID: assetID1, Balance: 1500, LedgerNumber: 200}, // update
-			{AccountAddress: "GACCOUNT2", AssetID: assetID1, Balance: 3000, LedgerNumber: 200}, // new
+			{AccountID: types.AddressBytea(accountAddr1), AssetID: assetID1, Balance: 1500, LedgerNumber: 200}, // update
+			{AccountID: types.AddressBytea(accountAddr2), AssetID: assetID1, Balance: 3000, LedgerNumber: 200}, // new
 		}
 		deletes := []TrustlineBalance{
-			{AccountAddress: "GACCOUNT1", AssetID: assetID2}, // delete
+			{AccountID: types.AddressBytea(accountAddr1), AssetID: assetID2}, // delete
 		}
 		err = m.BatchUpsert(ctx, pgxTx2, newUpserts, deletes)
 		require.NoError(t, err)
@@ -363,12 +374,12 @@ func TestTrustlineBalanceModel_BatchUpsert(t *testing.T) {
 		var count int
 		err = dbConnectionPool.QueryRow(ctx, `SELECT COUNT(*) FROM trustline_balances`).Scan(&count)
 		require.NoError(t, err)
-		require.Equal(t, 2, count) // GACCOUNT1:assetID1 (updated) + GACCOUNT2:assetID1 (new)
+		require.Equal(t, 2, count)
 
 		var balance int64
 		err = dbConnectionPool.QueryRow(ctx,
-			`SELECT balance FROM trustline_balances WHERE account_address = $1 AND asset_id = $2`,
-			"GACCOUNT1", assetID1).Scan(&balance)
+			`SELECT balance FROM trustline_balances WHERE account_id = $1 AND asset_id = $2`,
+			types.AddressBytea(accountAddr1), assetID1).Scan(&balance)
 		require.NoError(t, err)
 		require.Equal(t, int64(1500), balance)
 	})
@@ -423,12 +434,13 @@ func TestTrustlineBalanceModel_BatchCopy(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
+		accountAddr := keypair.MustRandom().Address()
 		pgxTx, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 
 		balances := []TrustlineBalance{
 			{
-				AccountAddress:     "GACCOUNT1",
+				AccountID:          types.AddressBytea(accountAddr),
 				AssetID:            assetID1,
 				Balance:            1000,
 				Limit:              10000,
@@ -446,11 +458,11 @@ func TestTrustlineBalanceModel_BatchCopy(t *testing.T) {
 		// Verify all fields
 		var b TrustlineBalance
 		err = dbConnectionPool.QueryRow(ctx, `
-			SELECT account_address, asset_id, balance, trust_limit, buying_liabilities, selling_liabilities, flags, last_modified_ledger
-			FROM trustline_balances WHERE account_address = $1
-		`, "GACCOUNT1").Scan(&b.AccountAddress, &b.AssetID, &b.Balance, &b.Limit, &b.BuyingLiabilities, &b.SellingLiabilities, &b.Flags, &b.LedgerNumber)
+			SELECT account_id, asset_id, balance, trust_limit, buying_liabilities, selling_liabilities, flags, last_modified_ledger
+			FROM trustline_balances WHERE account_id = $1
+		`, types.AddressBytea(accountAddr)).Scan(&b.AccountID, &b.AssetID, &b.Balance, &b.Limit, &b.BuyingLiabilities, &b.SellingLiabilities, &b.Flags, &b.LedgerNumber)
 		require.NoError(t, err)
-		require.Equal(t, balances[0].AccountAddress, b.AccountAddress)
+		require.Equal(t, balances[0].AccountID, b.AccountID)
 		require.Equal(t, balances[0].AssetID, b.AssetID)
 		require.Equal(t, balances[0].Balance, b.Balance)
 		require.Equal(t, balances[0].Limit, b.Limit)
@@ -468,13 +480,15 @@ func TestTrustlineBalanceModel_BatchCopy(t *testing.T) {
 			Metrics: dbMetrics,
 		}
 
+		accountAddr1 := keypair.MustRandom().Address()
+		accountAddr2 := keypair.MustRandom().Address()
 		pgxTx, err := dbConnectionPool.Begin(ctx)
 		require.NoError(t, err)
 
 		balances := []TrustlineBalance{
-			{AccountAddress: "GACCOUNT1", AssetID: assetID1, Balance: 1000, Limit: 10000, LedgerNumber: 100},
-			{AccountAddress: "GACCOUNT1", AssetID: assetID2, Balance: 2000, Limit: 20000, LedgerNumber: 100},
-			{AccountAddress: "GACCOUNT2", AssetID: assetID1, Balance: 3000, Limit: 30000, LedgerNumber: 100},
+			{AccountID: types.AddressBytea(accountAddr1), AssetID: assetID1, Balance: 1000, Limit: 10000, LedgerNumber: 100},
+			{AccountID: types.AddressBytea(accountAddr1), AssetID: assetID2, Balance: 2000, Limit: 20000, LedgerNumber: 100},
+			{AccountID: types.AddressBytea(accountAddr2), AssetID: assetID1, Balance: 3000, Limit: 30000, LedgerNumber: 100},
 		}
 
 		err = m.BatchCopy(ctx, pgxTx, balances)

--- a/internal/db/migrations/2026-01-12.0-trustline_balances.sql
+++ b/internal/db/migrations/2026-01-12.0-trustline_balances.sql
@@ -5,9 +5,9 @@
 
 -- Storage parameters tuned for heavy UPSERT/DELETE during ledger ingestion.
 -- UPSERTs only modify non-indexed columns (balance, trust_limit, liabilities, flags,
--- last_modified_ledger) while PK columns (account_address, asset_id) are never changed.
+-- last_modified_ledger) while PK columns (account_id, asset_id) are never changed.
 CREATE TABLE trustline_balances (
-    account_address TEXT NOT NULL,
+    account_id BYTEA NOT NULL,
     asset_id UUID NOT NULL,
     balance BIGINT NOT NULL DEFAULT 0,
     trust_limit BIGINT NOT NULL DEFAULT 0,
@@ -15,7 +15,7 @@ CREATE TABLE trustline_balances (
     selling_liabilities BIGINT NOT NULL DEFAULT 0,
     flags INTEGER NOT NULL DEFAULT 0,
     last_modified_ledger BIGINT NOT NULL DEFAULT 0,
-    PRIMARY KEY (account_address, asset_id),
+    PRIMARY KEY (account_id, asset_id),
     CONSTRAINT fk_trustline_asset
         FOREIGN KEY (asset_id) REFERENCES trustline_assets(id)
         DEFERRABLE INITIALLY DEFERRED

--- a/internal/db/migrations/2026-01-15.0-native_balances.sql
+++ b/internal/db/migrations/2026-01-15.0-native_balances.sql
@@ -4,9 +4,9 @@
 -- Stores native XLM balance data for accounts during ingestion.
 -- Storage parameters tuned for heavy UPSERT/DELETE during ledger ingestion.
 -- UPSERTs only modify non-indexed columns (balance, minimum_balance, liabilities,
--- last_modified_ledger) while the PK column (account_address) is never changed.
+-- last_modified_ledger) while the PK column (account_id) is never changed.
 CREATE TABLE native_balances (
-    account_address TEXT PRIMARY KEY,
+    account_id BYTEA PRIMARY KEY,
     balance BIGINT NOT NULL DEFAULT 0,
     minimum_balance BIGINT NOT NULL DEFAULT 0,
     buying_liabilities BIGINT NOT NULL DEFAULT 0,

--- a/internal/db/migrations/2026-01-16.0-sac-balances.sql
+++ b/internal/db/migrations/2026-01-16.0-sac-balances.sql
@@ -5,15 +5,15 @@
 -- Classic Stellar accounts (G...) have SAC balances in their trustlines, so only contract holders are stored here.
 -- Storage parameters tuned for heavy UPSERT/DELETE during ledger ingestion.
 -- UPSERTs only modify non-indexed columns (balance, is_authorized, is_clawback_enabled,
--- last_modified_ledger) while PK columns (account_address, contract_id) are never changed.
+-- last_modified_ledger) while PK columns (account_id, contract_id) are never changed.
 CREATE TABLE sac_balances (
-    account_address TEXT NOT NULL,
+    account_id BYTEA NOT NULL,
     contract_id UUID NOT NULL,
     balance TEXT NOT NULL DEFAULT '0',
     is_authorized BOOLEAN NOT NULL DEFAULT true,
     is_clawback_enabled BOOLEAN NOT NULL DEFAULT false,
     last_modified_ledger INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (account_address, contract_id),
+    PRIMARY KEY (account_id, contract_id),
     CONSTRAINT fk_contract_token
         FOREIGN KEY (contract_id) REFERENCES contract_tokens(id)
         DEFERRABLE INITIALLY DEFERRED

--- a/internal/serve/graphql/resolvers/account_balances_test.go
+++ b/internal/serve/graphql/resolvers/account_balances_test.go
@@ -132,7 +132,7 @@ func TestAccountResolver_Balances(t *testing.T) {
 		sep41Contract := createSEP41Contract(testSEP41ContractAddress, "CustomToken", "CTK", 6)
 
 		mockNativeBalanceModel.On("GetByAccount", ctx, testAccountAddress).
-			Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 2000000000}, nil)
+			Return(&data.NativeBalance{AccountID: types.AddressBytea(testAccountAddress), Balance: 2000000000}, nil)
 		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress, limitMatcher(50), (*uuid.UUID)(nil), data.ASC).
 			Return([]data.TrustlineBalance{{
 				AssetID:      trustlineID,
@@ -193,7 +193,7 @@ func TestAccountResolver_Balances(t *testing.T) {
 
 		mockSACBalanceModel.On("GetByAccount", ctx, testContractAddress, limitMatcher(51), (*uuid.UUID)(nil), data.ASC).
 			Return([]data.SACBalance{{
-				AccountAddress:    testContractAddress,
+				AccountID:         types.AddressBytea(testContractAddress),
 				ContractID:        sacContractID,
 				TokenID:           testSACContractAddress,
 				Balance:           "2500.0000000",
@@ -241,7 +241,7 @@ func TestAccountResolver_Balances(t *testing.T) {
 		sep41Contract2 := createSEP41Contract(testSEP41ContractAddress2, "TokenTwo", "TWO", 7)
 
 		mockNativeBalanceModel.On("GetByAccount", ctx, testAccountAddress).
-			Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 1000000000}, nil).
+			Return(&data.NativeBalance{AccountID: types.AddressBytea(testAccountAddress), Balance: 1000000000}, nil).
 			Once()
 		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress, limitMatcher(2), (*uuid.UUID)(nil), data.ASC).
 			Return([]data.TrustlineBalance{{
@@ -326,7 +326,7 @@ func TestAccountResolver_Balances(t *testing.T) {
 				LedgerNumber: 12345,
 			}}, nil)
 		mockNativeBalanceModel.On("GetByAccount", ctx, testAccountAddress).
-			Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 1000000000}, nil)
+			Return(&data.NativeBalance{AccountID: types.AddressBytea(testAccountAddress), Balance: 1000000000}, nil)
 		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)
 		mockContractMetadataService.On("FetchSingleField", ctx, testSEP41ContractAddress, "balance", mock.Anything).
 			Return(createI128ScVal(10000000000), nil)
@@ -372,7 +372,7 @@ func TestAccountResolver_Balances(t *testing.T) {
 		mockRPCService := services.NewRPCServiceMock(t)
 
 		mockNativeBalanceModel.On("GetByAccount", ctx, testAccountAddress).
-			Return(&data.NativeBalance{AccountAddress: testAccountAddress, Balance: 1000000000}, nil)
+			Return(&data.NativeBalance{AccountID: types.AddressBytea(testAccountAddress), Balance: 1000000000}, nil)
 		mockTrustlineBalanceModel.On("GetByAccount", ctx, testAccountAddress, limitMatcher(50), (*uuid.UUID)(nil), data.ASC).
 			Return(nil, errors.New("database query failed"))
 		mockRPCService.On("NetworkPassphrase").Return(testNetworkPassphrase)

--- a/internal/services/token_ingestion.go
+++ b/internal/services/token_ingestion.go
@@ -81,7 +81,7 @@ func newBatch(
 func (b *batch) addTrustline(accountAddress string, asset wbdata.TrustlineAsset, balance, limit, buyingLiabilities, sellingLiabilities int64, flags uint32, ledger uint32) {
 	// Add trustline balance with all XDR fields
 	b.trustlineBalances = append(b.trustlineBalances, wbdata.TrustlineBalance{
-		AccountAddress:     accountAddress,
+		AccountID:          types.AddressBytea(accountAddress),
 		AssetID:            wbdata.DeterministicAssetID(asset.Code, asset.Issuer),
 		Balance:            balance,
 		Limit:              limit,
@@ -94,7 +94,7 @@ func (b *batch) addTrustline(accountAddress string, asset wbdata.TrustlineAsset,
 
 func (b *batch) addNativeBalance(accountAddress string, balance, minimumBalance, buyingLiabilities, sellingLiabilities int64, ledger uint32) {
 	b.nativeBalances = append(b.nativeBalances, wbdata.NativeBalance{
-		AccountAddress:     accountAddress,
+		AccountID:          types.AddressBytea(accountAddress),
 		Balance:            balance,
 		MinimumBalance:     minimumBalance,
 		BuyingLiabilities:  buyingLiabilities,
@@ -378,7 +378,7 @@ func (s *tokenIngestionService) processTrustlineChanges(ctx context.Context, dbT
 	var deletes []wbdata.TrustlineBalance
 	for key, change := range changesByKey {
 		fullData := wbdata.TrustlineBalance{
-			AccountAddress:     change.AccountID,
+			AccountID:          types.AddressBytea(change.AccountID),
 			AssetID:            key.TrustlineID,
 			Balance:            change.Balance,
 			Limit:              change.Limit,
@@ -438,13 +438,13 @@ func (s *tokenIngestionService) processNativeBalanceChanges(ctx context.Context,
 	}
 
 	var upserts []wbdata.NativeBalance
-	var deletes []string
+	var deletes []types.AddressBytea
 	for _, change := range changesByAccountID {
 		if change.Operation == types.AccountOpRemove {
-			deletes = append(deletes, change.AccountID)
+			deletes = append(deletes, types.AddressBytea(change.AccountID))
 		} else {
 			upserts = append(upserts, wbdata.NativeBalance{
-				AccountAddress:     change.AccountID,
+				AccountID:          types.AddressBytea(change.AccountID),
 				Balance:            change.Balance,
 				MinimumBalance:     change.MinimumBalance,
 				BuyingLiabilities:  change.BuyingLiabilities,
@@ -474,7 +474,7 @@ func (s *tokenIngestionService) processSACBalanceChanges(ctx context.Context, db
 	for _, change := range changesByKey {
 		contractID := wbdata.DeterministicContractID(change.ContractID)
 		sacBal := wbdata.SACBalance{
-			AccountAddress:    change.AccountID,
+			AccountID:         types.AddressBytea(change.AccountID),
 			ContractID:        contractID,
 			Balance:           change.Balance,
 			IsAuthorized:      change.IsAuthorized,
@@ -725,7 +725,7 @@ func (s *tokenIngestionService) streamCheckpointData(
 					// Extract balance fields and stream to batch
 					balanceStr, authorized, clawback := s.extractSACBalanceFields(contractDataEntry.Val)
 					batch.addSACBalance(wbdata.SACBalance{
-						AccountAddress:    holderAddress,
+						AccountID:         types.AddressBytea(holderAddress),
 						ContractID:        contractUUID,
 						Balance:           balanceStr,
 						IsAuthorized:      authorized,

--- a/internal/services/token_ingestion_test.go
+++ b/internal/services/token_ingestion_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -263,7 +264,7 @@ func TestGetAccountTrustlineBalances(t *testing.T) {
 
 		trustlineBalanceModel := &wbdata.TrustlineBalanceModel{DB: dbConnectionPool, Metrics: dbMetrics}
 
-		got, err := trustlineBalanceModel.GetByAccount(ctx, "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB", nil, nil, wbdata.ASC)
+		got, err := trustlineBalanceModel.GetByAccount(ctx, keypair.MustRandom().Address(), nil, nil, wbdata.ASC)
 		assert.NoError(t, err)
 		assert.Empty(t, got)
 	})

--- a/internal/services/token_ingestion_test.go
+++ b/internal/services/token_ingestion_test.go
@@ -289,7 +289,7 @@ func TestGetAccountTrustlineBalances(t *testing.T) {
 		// Insert account trustline balances
 		err = db.RunInTransaction(ctx, dbConnectionPool, func(dbTx pgx.Tx) error {
 			return trustlineBalanceModel.BatchCopy(ctx, dbTx, []wbdata.TrustlineBalance{
-				{AccountAddress: accountAddress, AssetID: assetID, Balance: 0, Limit: 0, BuyingLiabilities: 0, SellingLiabilities: 0, Flags: 0, LedgerNumber: 100},
+				{AccountID: types.AddressBytea(accountAddress), AssetID: assetID, Balance: 0, Limit: 0, BuyingLiabilities: 0, SellingLiabilities: 0, Flags: 0, LedgerNumber: 100},
 			})
 		})
 		require.NoError(t, err)


### PR DESCRIPTION
Closes #582 

I also changed the Upsert methods to use an `UNNEST` query instead of `Batch.Queue` for better efficiency. The batch method makes N individual calls to postgres vs UNNEST which upserts in 1 single call