### PR TITLE
fix(ingest): harden SEP-41 metadata surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,7 +808,7 @@ CREATE TABLE contract_tokens (
     issuer TEXT NULL,              -- Asset issuer (for SAC tokens)
     name TEXT NULL,                -- Token name from contract
     symbol TEXT NULL,              -- Token symbol from contract
-    decimals SMALLINT NOT NULL,    -- Token decimals
+    decimals INTEGER NOT NULL,     -- Token decimals (SEP-41 u32)
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/internal/data/contract_tokens.go
+++ b/internal/data/contract_tokens.go
@@ -107,7 +107,7 @@ func (m *ContractModel) BatchInsert(ctx context.Context, dbTx pgx.Tx, contracts 
 
 	const query = `
 		INSERT INTO contract_tokens (id, contract_id, type, code, issuer, name, symbol, decimals)
-		SELECT * FROM UNNEST($1::uuid[], $2::text[], $3::text[], $4::text[], $5::text[], $6::text[], $7::text[], $8::smallint[])
+		SELECT * FROM UNNEST($1::uuid[], $2::text[], $3::text[], $4::text[], $5::text[], $6::text[], $7::text[], $8::integer[])
 		ON CONFLICT (contract_id) DO NOTHING
 	`
 

--- a/internal/data/contract_tokens_test.go
+++ b/internal/data/contract_tokens_test.go
@@ -244,6 +244,44 @@ func TestContractModel_BatchInsert(t *testing.T) {
 		cleanUpDB()
 	})
 
+	t.Run("accepts SEP-41 decimals values above SMALLINT range", func(t *testing.T) {
+		cleanUpDB()
+
+		m := &ContractModel{
+			DB:      dbConnectionPool,
+			Metrics: dbMetrics,
+		}
+
+		name := "Wide Decimals"
+		symbol := "WIDE"
+		// 40000 exceeds PostgreSQL SMALLINT max (32767) but is a valid SEP-41 u32.
+		// Before widening contract_tokens.decimals to INTEGER, this insert would
+		// fail with "40000 is greater than maximum value for int2" and roll back
+		// the whole ledger-persistence transaction.
+		const wideDecimals uint32 = 40000
+		contracts := []*Contract{
+			{
+				ID:         DeterministicContractID("wide_contract"),
+				ContractID: "wide_contract",
+				Type:       "sep41",
+				Name:       &name,
+				Symbol:     &symbol,
+				Decimals:   wideDecimals,
+			},
+		}
+
+		err := db.RunInTransaction(ctx, dbConnectionPool, func(dbTx pgx.Tx) error {
+			return m.BatchInsert(ctx, dbTx, contracts)
+		})
+		require.NoError(t, err)
+
+		stored, err := db.QueryOne[Contract](ctx, dbConnectionPool, `SELECT * FROM contract_tokens WHERE contract_id = $1`, "wide_contract")
+		require.NoError(t, err)
+		require.Equal(t, wideDecimals, stored.Decimals)
+
+		cleanUpDB()
+	})
+
 	t.Run("skips duplicate contracts with ON CONFLICT DO NOTHING", func(t *testing.T) {
 		cleanUpDB()
 

--- a/internal/db/migrations/2025-06-13.0-contract_tokens.sql
+++ b/internal/db/migrations/2025-06-13.0-contract_tokens.sql
@@ -10,7 +10,7 @@ CREATE TABLE contract_tokens (
     issuer TEXT NULL,
     name TEXT NULL,
     symbol TEXT NULL,
-    decimals SMALLINT NOT NULL,
+    decimals INTEGER NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/internal/serve/graphql/resolvers/statechange.resolvers.go
+++ b/internal/serve/graphql/resolvers/statechange.resolvers.go
@@ -431,14 +431,12 @@ func (r *Resolver) TrustlineChange() graphql1.TrustlineChangeResolver {
 	return &trustlineChangeResolver{r}
 }
 
-type (
-	accountChangeResolver              struct{ *Resolver }
-	balanceAuthorizationChangeResolver struct{ *Resolver }
-	flagsChangeResolver                struct{ *Resolver }
-	metadataChangeResolver             struct{ *Resolver }
-	reservesChangeResolver             struct{ *Resolver }
-	signerChangeResolver               struct{ *Resolver }
-	signerThresholdsChangeResolver     struct{ *Resolver }
-	standardBalanceChangeResolver      struct{ *Resolver }
-	trustlineChangeResolver            struct{ *Resolver }
-)
+type accountChangeResolver struct{ *Resolver }
+type balanceAuthorizationChangeResolver struct{ *Resolver }
+type flagsChangeResolver struct{ *Resolver }
+type metadataChangeResolver struct{ *Resolver }
+type reservesChangeResolver struct{ *Resolver }
+type signerChangeResolver struct{ *Resolver }
+type signerThresholdsChangeResolver struct{ *Resolver }
+type standardBalanceChangeResolver struct{ *Resolver }
+type trustlineChangeResolver struct{ *Resolver }

--- a/internal/services/contract_metadata.go
+++ b/internal/services/contract_metadata.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/alitto/pond/v2"
 	"github.com/stellar/go-stellar-sdk/keypair"
@@ -22,6 +23,24 @@ import (
 	"github.com/stellar/wallet-backend/internal/indexer/types"
 )
 
+// validateTokenString enforces the invariants a SEP-41 string field must satisfy
+// before it can be safely persisted to a Postgres TEXT column: bounded length,
+// valid UTF-8, and no NUL bytes. PG TEXT (in a UTF-8 DB) rejects both invalid
+// UTF-8 and 0x00, so letting either through would wedge the whole ledger-persist
+// transaction.
+func validateTokenString(fieldName, value string, maxLen int) error {
+	if len(value) > maxLen {
+		return fmt.Errorf("%s exceeds %d byte cap (got %d)", fieldName, maxLen, len(value))
+	}
+	if !utf8.ValidString(value) {
+		return fmt.Errorf("%s is not valid UTF-8", fieldName)
+	}
+	if strings.IndexByte(value, 0) >= 0 {
+		return fmt.Errorf("%s contains NUL byte", fieldName)
+	}
+	return nil
+}
+
 const (
 	// simulateTransactionBatchSize is the number of contracts to process in parallel
 	// when fetching metadata via RPC simulation.
@@ -29,6 +48,16 @@ const (
 
 	// batchSleepDuration is the delay between batches to avoid overwhelming the RPC.
 	batchSleepDuration = 2 * time.Second
+
+	// maxTokenDecimals caps SEP-41 decimals() at a realistic upper bound. Real tokens
+	// use ≤ 18; this also keeps the value inside Postgres INTEGER range, since SEP-41
+	// technically permits a u32 that exceeds INT32_MAX.
+	maxTokenDecimals uint32 = 70
+
+	// maxTokenNameLength / maxTokenSymbolLength bound attacker-controlled strings from
+	// SEP-41 name() and symbol(), measured in bytes. Real tokens are well under these.
+	maxTokenNameLength   = 128
+	maxTokenSymbolLength = 32
 )
 
 // ContractMetadata holds the metadata for a SEP-41 contract token (name, symbol, decimals).
@@ -251,6 +280,10 @@ func (s *contractMetadataService) fetchMetadata(ctx context.Context, contractID 
 			appendError(fmt.Errorf("name value is not a string"))
 			return
 		}
+		if vErr := validateTokenString("name", string(nameStr), maxTokenNameLength); vErr != nil {
+			appendError(vErr)
+			return
+		}
 		mu.Lock()
 		name = string(nameStr)
 		mu.Unlock()
@@ -268,6 +301,10 @@ func (s *contractMetadataService) fetchMetadata(ctx context.Context, contractID 
 			appendError(fmt.Errorf("symbol value is not a string"))
 			return
 		}
+		if vErr := validateTokenString("symbol", string(symbolStr), maxTokenSymbolLength); vErr != nil {
+			appendError(vErr)
+			return
+		}
 		mu.Lock()
 		symbol = string(symbolStr)
 		mu.Unlock()
@@ -283,6 +320,10 @@ func (s *contractMetadataService) fetchMetadata(ctx context.Context, contractID 
 		decimalsU32, ok := decimalsVal.GetU32()
 		if !ok {
 			appendError(fmt.Errorf("decimals value is not a uint32"))
+			return
+		}
+		if uint32(decimalsU32) > maxTokenDecimals {
+			appendError(fmt.Errorf("decimals exceeds cap of %d (got %d)", maxTokenDecimals, decimalsU32))
 			return
 		}
 		mu.Lock()

--- a/internal/services/contract_metadata_test.go
+++ b/internal/services/contract_metadata_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stellar/wallet-backend/internal/data"
 	"github.com/stellar/wallet-backend/internal/entities"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
 )
 
 // Helper functions for creating test XDR values
@@ -875,4 +876,60 @@ func TestFetchBatch(t *testing.T) {
 		assert.Equal(t, "", result[contractID1].Symbol)
 		assert.Equal(t, uint32(0), result[contractID1].Decimals)
 	})
+}
+
+// TestFetchSep41Metadata_ReturnsSentinelsForMaliciousContract exercises the public
+// FetchSep41Metadata entry point with a contract whose decimals response is above
+// the cap. The batch must swallow the validation error, log a warning, and still
+// return a *data.Contract for the offending ID with sentinel fields — otherwise a
+// single malicious token could wedge the whole ledger-persist transaction.
+func TestFetchSep41Metadata_ReturnsSentinelsForMaliciousContract(t *testing.T) {
+	ctx := context.Background()
+
+	mockRPCService := NewRPCServiceMock(t)
+	mockContractModel := data.NewContractModelMock(t)
+	pool := pond.NewPool(5)
+	defer pool.Stop()
+
+	contractID := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
+
+	nameScVal := xdr.ScVal{Type: xdr.ScValTypeScvString, Str: ptrToScString("Legit")}
+	symbolScVal := xdr.ScVal{Type: xdr.ScValTypeScvString, Str: ptrToScString("LGT")}
+	// 40000 exceeds the 70 cap — mirrors the PoC used in "rejects decimals above cap".
+	decimalsScVal := xdr.ScVal{Type: xdr.ScValTypeScvU32, U32: ptrToXdrUint32(40000)}
+
+	mockRPCService.On("SimulateTransaction", mock.MatchedBy(func(txXDR string) bool {
+		return containsFunction(txXDR, "name")
+	}), mock.Anything).Return(
+		entities.RPCSimulateTransactionResult{Results: []entities.RPCSimulateHostFunctionResult{{XDR: nameScVal}}}, nil,
+	)
+	mockRPCService.On("SimulateTransaction", mock.MatchedBy(func(txXDR string) bool {
+		return containsFunction(txXDR, "symbol")
+	}), mock.Anything).Return(
+		entities.RPCSimulateTransactionResult{Results: []entities.RPCSimulateHostFunctionResult{{XDR: symbolScVal}}}, nil,
+	)
+	mockRPCService.On("SimulateTransaction", mock.MatchedBy(func(txXDR string) bool {
+		return containsFunction(txXDR, "decimals")
+	}), mock.Anything).Return(
+		entities.RPCSimulateTransactionResult{Results: []entities.RPCSimulateHostFunctionResult{{XDR: decimalsScVal}}}, nil,
+	)
+
+	service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
+	require.NoError(t, err)
+
+	contracts, err := service.FetchSep41Metadata(ctx, []string{contractID})
+
+	require.NoError(t, err)
+	require.Len(t, contracts, 1)
+
+	got := contracts[0]
+	assert.Equal(t, contractID, got.ContractID)
+	assert.Equal(t, data.DeterministicContractID(contractID), got.ID)
+	assert.Equal(t, string(types.ContractTypeSEP41), got.Type)
+
+	require.NotNil(t, got.Name)
+	require.NotNil(t, got.Symbol)
+	assert.Equal(t, "", *got.Name)
+	assert.Equal(t, "", *got.Symbol)
+	assert.Equal(t, uint32(0), got.Decimals)
 }

--- a/internal/services/contract_metadata_test.go
+++ b/internal/services/contract_metadata_test.go
@@ -238,6 +238,202 @@ func TestFetchSep41Metadata(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "not a uint32")
 	})
+
+	t.Run("rejects decimals above cap", func(t *testing.T) {
+		mockRPCService := NewRPCServiceMock(t)
+		mockContractModel := data.NewContractModelMock(t)
+		pool := pond.NewPool(5)
+		defer pool.Stop()
+
+		contractID := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
+
+		nameScVal := xdr.ScVal{Type: xdr.ScValTypeScvString, Str: ptrToScString("TestName")}
+		symbolScVal := xdr.ScVal{Type: xdr.ScValTypeScvString, Str: ptrToScString("TST")}
+		// 40000 is the original PoC value; well above our 70 cap and also above SMALLINT.
+		decimalsScVal := xdr.ScVal{Type: xdr.ScValTypeScvU32, U32: ptrToXdrUint32(40000)}
+
+		mockRPCService.On("SimulateTransaction", mock.MatchedBy(func(txXDR string) bool {
+			return containsFunction(txXDR, "name")
+		}), mock.Anything).Return(
+			entities.RPCSimulateTransactionResult{Results: []entities.RPCSimulateHostFunctionResult{{XDR: nameScVal}}}, nil,
+		)
+		mockRPCService.On("SimulateTransaction", mock.MatchedBy(func(txXDR string) bool {
+			return containsFunction(txXDR, "symbol")
+		}), mock.Anything).Return(
+			entities.RPCSimulateTransactionResult{Results: []entities.RPCSimulateHostFunctionResult{{XDR: symbolScVal}}}, nil,
+		)
+		mockRPCService.On("SimulateTransaction", mock.MatchedBy(func(txXDR string) bool {
+			return containsFunction(txXDR, "decimals")
+		}), mock.Anything).Return(
+			entities.RPCSimulateTransactionResult{Results: []entities.RPCSimulateHostFunctionResult{{XDR: decimalsScVal}}}, nil,
+		)
+
+		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
+		require.NoError(t, err)
+
+		cms := service.(*contractMetadataService)
+		_, err = cms.fetchMetadata(ctx, contractID)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "decimals exceeds cap")
+	})
+
+	t.Run("rejects name longer than cap", func(t *testing.T) {
+		mockRPCService := NewRPCServiceMock(t)
+		mockContractModel := data.NewContractModelMock(t)
+		pool := pond.NewPool(5)
+		defer pool.Stop()
+
+		contractID := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
+
+		oversizedName := strings.Repeat("A", maxTokenNameLength+1)
+		nameScVal := xdr.ScVal{Type: xdr.ScValTypeScvString, Str: ptrToScString(oversizedName)}
+		symbolScVal := xdr.ScVal{Type: xdr.ScValTypeScvString, Str: ptrToScString("TST")}
+		decimalsScVal := xdr.ScVal{Type: xdr.ScValTypeScvU32, U32: ptrToXdrUint32(7)}
+
+		mockRPCService.On("SimulateTransaction", mock.MatchedBy(func(txXDR string) bool {
+			return containsFunction(txXDR, "name")
+		}), mock.Anything).Return(
+			entities.RPCSimulateTransactionResult{Results: []entities.RPCSimulateHostFunctionResult{{XDR: nameScVal}}}, nil,
+		)
+		mockRPCService.On("SimulateTransaction", mock.MatchedBy(func(txXDR string) bool {
+			return containsFunction(txXDR, "symbol")
+		}), mock.Anything).Return(
+			entities.RPCSimulateTransactionResult{Results: []entities.RPCSimulateHostFunctionResult{{XDR: symbolScVal}}}, nil,
+		)
+		mockRPCService.On("SimulateTransaction", mock.MatchedBy(func(txXDR string) bool {
+			return containsFunction(txXDR, "decimals")
+		}), mock.Anything).Return(
+			entities.RPCSimulateTransactionResult{Results: []entities.RPCSimulateHostFunctionResult{{XDR: decimalsScVal}}}, nil,
+		)
+
+		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
+		require.NoError(t, err)
+
+		cms := service.(*contractMetadataService)
+		_, err = cms.fetchMetadata(ctx, contractID)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "name exceeds")
+	})
+
+	t.Run("rejects name containing NUL byte", func(t *testing.T) {
+		mockRPCService := NewRPCServiceMock(t)
+		mockContractModel := data.NewContractModelMock(t)
+		pool := pond.NewPool(5)
+		defer pool.Stop()
+
+		contractID := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
+
+		// NUL byte is legal UTF-8 (U+0000) but Postgres TEXT rejects it, so our
+		// validator must too — otherwise the whole ledger-persist tx rolls back.
+		nameScVal := xdr.ScVal{Type: xdr.ScValTypeScvString, Str: ptrToScString("evil\x00token")}
+		symbolScVal := xdr.ScVal{Type: xdr.ScValTypeScvString, Str: ptrToScString("TST")}
+		decimalsScVal := xdr.ScVal{Type: xdr.ScValTypeScvU32, U32: ptrToXdrUint32(7)}
+
+		mockRPCService.On("SimulateTransaction", mock.MatchedBy(func(txXDR string) bool {
+			return containsFunction(txXDR, "name")
+		}), mock.Anything).Return(
+			entities.RPCSimulateTransactionResult{Results: []entities.RPCSimulateHostFunctionResult{{XDR: nameScVal}}}, nil,
+		)
+		mockRPCService.On("SimulateTransaction", mock.MatchedBy(func(txXDR string) bool {
+			return containsFunction(txXDR, "symbol")
+		}), mock.Anything).Return(
+			entities.RPCSimulateTransactionResult{Results: []entities.RPCSimulateHostFunctionResult{{XDR: symbolScVal}}}, nil,
+		)
+		mockRPCService.On("SimulateTransaction", mock.MatchedBy(func(txXDR string) bool {
+			return containsFunction(txXDR, "decimals")
+		}), mock.Anything).Return(
+			entities.RPCSimulateTransactionResult{Results: []entities.RPCSimulateHostFunctionResult{{XDR: decimalsScVal}}}, nil,
+		)
+
+		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
+		require.NoError(t, err)
+
+		cms := service.(*contractMetadataService)
+		_, err = cms.fetchMetadata(ctx, contractID)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "NUL byte")
+	})
+
+	t.Run("rejects symbol with invalid UTF-8", func(t *testing.T) {
+		mockRPCService := NewRPCServiceMock(t)
+		mockContractModel := data.NewContractModelMock(t)
+		pool := pond.NewPool(5)
+		defer pool.Stop()
+
+		contractID := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
+
+		// Lone continuation byte — invalid UTF-8. Postgres UTF-8 DB rejects.
+		nameScVal := xdr.ScVal{Type: xdr.ScValTypeScvString, Str: ptrToScString("TestName")}
+		symbolScVal := xdr.ScVal{Type: xdr.ScValTypeScvString, Str: ptrToScString("\xc3\x28")}
+		decimalsScVal := xdr.ScVal{Type: xdr.ScValTypeScvU32, U32: ptrToXdrUint32(7)}
+
+		mockRPCService.On("SimulateTransaction", mock.MatchedBy(func(txXDR string) bool {
+			return containsFunction(txXDR, "name")
+		}), mock.Anything).Return(
+			entities.RPCSimulateTransactionResult{Results: []entities.RPCSimulateHostFunctionResult{{XDR: nameScVal}}}, nil,
+		)
+		mockRPCService.On("SimulateTransaction", mock.MatchedBy(func(txXDR string) bool {
+			return containsFunction(txXDR, "symbol")
+		}), mock.Anything).Return(
+			entities.RPCSimulateTransactionResult{Results: []entities.RPCSimulateHostFunctionResult{{XDR: symbolScVal}}}, nil,
+		)
+		mockRPCService.On("SimulateTransaction", mock.MatchedBy(func(txXDR string) bool {
+			return containsFunction(txXDR, "decimals")
+		}), mock.Anything).Return(
+			entities.RPCSimulateTransactionResult{Results: []entities.RPCSimulateHostFunctionResult{{XDR: decimalsScVal}}}, nil,
+		)
+
+		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
+		require.NoError(t, err)
+
+		cms := service.(*contractMetadataService)
+		_, err = cms.fetchMetadata(ctx, contractID)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "valid UTF-8")
+	})
+
+	t.Run("rejects symbol longer than cap", func(t *testing.T) {
+		mockRPCService := NewRPCServiceMock(t)
+		mockContractModel := data.NewContractModelMock(t)
+		pool := pond.NewPool(5)
+		defer pool.Stop()
+
+		contractID := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
+
+		oversizedSymbol := strings.Repeat("S", maxTokenSymbolLength+1)
+		nameScVal := xdr.ScVal{Type: xdr.ScValTypeScvString, Str: ptrToScString("TestName")}
+		symbolScVal := xdr.ScVal{Type: xdr.ScValTypeScvString, Str: ptrToScString(oversizedSymbol)}
+		decimalsScVal := xdr.ScVal{Type: xdr.ScValTypeScvU32, U32: ptrToXdrUint32(7)}
+
+		mockRPCService.On("SimulateTransaction", mock.MatchedBy(func(txXDR string) bool {
+			return containsFunction(txXDR, "name")
+		}), mock.Anything).Return(
+			entities.RPCSimulateTransactionResult{Results: []entities.RPCSimulateHostFunctionResult{{XDR: nameScVal}}}, nil,
+		)
+		mockRPCService.On("SimulateTransaction", mock.MatchedBy(func(txXDR string) bool {
+			return containsFunction(txXDR, "symbol")
+		}), mock.Anything).Return(
+			entities.RPCSimulateTransactionResult{Results: []entities.RPCSimulateHostFunctionResult{{XDR: symbolScVal}}}, nil,
+		)
+		mockRPCService.On("SimulateTransaction", mock.MatchedBy(func(txXDR string) bool {
+			return containsFunction(txXDR, "decimals")
+		}), mock.Anything).Return(
+			entities.RPCSimulateTransactionResult{Results: []entities.RPCSimulateHostFunctionResult{{XDR: decimalsScVal}}}, nil,
+		)
+
+		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
+		require.NoError(t, err)
+
+		cms := service.(*contractMetadataService)
+		_, err = cms.fetchMetadata(ctx, contractID)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "symbol exceeds")
+	})
 }
 
 func TestFetchSingleField(t *testing.T) {


### PR DESCRIPTION
### What

Harden SEP-41 contract metadata ingest against contracts that can wedge ledger persistence.

- Widen `contract_tokens.decimals` from `SMALLINT` to `INTEGER` (edit the existing `2025-06-13.0-contract_tokens.sql` migration in place — service isn't in production yet, so no new migration).
- In `services.fetchMetadata`, reject `decimals > 70`, `name > 128 bytes`, `symbol > 32 bytes`, non-UTF-8 strings, and strings containing NUL bytes. Violations flow through the existing warning path so the contract persists with sentinels (`decimals=0`, `name=""`, `symbol=""`) instead of poisoning the batch.

### Why

SEP-41 defines `decimals() -> u32`, but `contract_tokens.decimals` was `SMALLINT` with the batch insert casting to `$8::smallint[]`. A contract returning `decimals > 32767` would fail pgx encoding, roll back the atomic ledger-persistence transaction, and stall the ingest cursor on that ledger indefinitely. The same wedge class applies to `name()` / `symbol()` strings that violate Postgres `TEXT` constraints in a UTF-8 database (NUL bytes, invalid UTF-8) or grow to unreasonable sizes. Reported via HackerOne.

The bounds (70 / 128 / 32) sit well above any realistic token while keeping values inside ranges Postgres can encode, and the fall-through-to-warning behavior preserves the existing contract of "bad metadata doesn't block the ledger."

### Known limitations

N/A

### Issue that this PR addresses

[TODO: Attach the link to the GitHub issue or task. Include the priority of the task here in addition to the link.]

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.