### PR TITLE
fix(internal): tighten SEP-41 validator signature matching

### DIFF
--- a/ai-summary/.metrics.json
+++ b/ai-summary/.metrics.json
@@ -1,0 +1,124 @@
+{
+  "hypothesis_viable": 5,
+  "hypothesis_not_viable": 1,
+  "review_viable": 1,
+  "review_not_viable": 2,
+  "poc_viable": 0,
+  "poc_not_viable": 0,
+  "final_review_viable": 0,
+  "final_review_not_viable": 0,
+  "final_review_revisions": 0,
+  "condensations": 0,
+  "publishes": 0,
+  "agent_failures": 0,
+  "agent_timeouts": 0,
+  "total_spawned": 7,
+  "input_tokens": 0,
+  "output_tokens": 40854,
+  "cache_read_tokens": 0,
+  "per_subsystem": {
+    "request-lifecycle": {
+      "review_not_viable": 2
+    },
+    "data-pipeline": {
+      "hypothesis_viable": 5,
+      "hypothesis_not_viable": 1,
+      "review_viable": 1
+    }
+  },
+  "per_model": {
+    "claude-opus-4-6": {
+      "review_not_viable": 2,
+      "review_viable": 1
+    },
+    "gpt-5.4": {
+      "hypothesis_viable": 5
+    }
+  },
+  "tokens_by_stage": {
+    "reviewer": {
+      "input": 0,
+      "output": 20003,
+      "cache_read": 0
+    },
+    "hypothesis": {
+      "input": 0,
+      "output": 20851,
+      "cache_read": 0
+    }
+  },
+  "tokens_by_model": {
+    "claude-opus-4-6": {
+      "input": 0,
+      "output": 20003,
+      "cache_read": 0
+    },
+    "gpt-5.4": {
+      "input": 0,
+      "output": 20851,
+      "cache_read": 0
+    }
+  },
+  "agent_durations": [
+    [
+      "reviewer",
+      "claude-opus-4-6",
+      126.1
+    ],
+    [
+      "reviewer",
+      "claude-opus-4-6",
+      160.1
+    ],
+    [
+      "hypothesis",
+      "gpt-5.4",
+      591.2
+    ],
+    [
+      "reviewer",
+      "claude-opus-4-6",
+      219.9
+    ]
+  ],
+  "costs": {
+    "providers": {
+      "copilot": {
+        "models": {
+          "claude-opus-4-6": {
+            "input_tokens": 0,
+            "output_tokens": 20003,
+            "cache_read_tokens": 0,
+            "total_cost": 0.27,
+            "premium_requests": 9
+          },
+          "gpt-5.4": {
+            "input_tokens": 0,
+            "output_tokens": 20851,
+            "cache_read_tokens": 0,
+            "total_cost": 0.03,
+            "premium_requests": 1
+          }
+        },
+        "provider_cost": 0.3
+      }
+    },
+    "total_cost": 0.3,
+    "stages": {
+      "reviewer": {
+        "copilot": {
+          "input_tokens": 0,
+          "output_tokens": 20003,
+          "premium_requests": 9
+        }
+      },
+      "hypothesis": {
+        "copilot": {
+          "input_tokens": 0,
+          "output_tokens": 20851,
+          "premium_requests": 1
+        }
+      }
+    }
+  }
+}

--- a/ai-summary/fail/apptracker/001-account-balances-authz-bypass.md
+++ b/ai-summary/fail/apptracker/001-account-balances-authz-bypass.md
@@ -1,0 +1,80 @@
+# H001: AccountByAddress exposes arbitrary account balances to any valid JWT holder
+
+**Date**: 2026-04-21
+**Subsystem**: apptracker / serve-graphql / auth
+**Severity**: High
+**Impact**: GraphQL authz bypass / cross-tenant balance disclosure
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+A valid Ed25519 JWT should authorize account-scoped GraphQL reads only for the Stellar address bound to that JWT. When a caller asks for another account's balances, the server should reject the request instead of returning native, trustline, SAC, or SEP-41 balance rows for the victim address.
+
+## Mechanism
+
+`AuthenticationMiddleware` only verifies that the request carries *some* valid JWT; it never stores the verified subject in request context or compares it against GraphQL targets. `Query.AccountByAddress` accepts any syntactically valid address and `Account.Balances` forwards that address straight into `getAccountBalances`, so a caller with their own valid keypair can read another account's balance inventory.
+
+## Trigger
+
+1. Authenticate as attacker account `GA...ATTACKER` with a valid JWT.
+2. Send:
+   ```graphql
+   query {
+     accountByAddress(address: "GA...VICTIM") {
+       address
+       balances(first: 10) {
+         edges { node { __typename } }
+       }
+     }
+   }
+   ```
+3. Observe the victim account's balance collection instead of an authorization failure.
+
+## Target Code
+
+- `internal/serve/middleware/middleware.go:16-44` — request auth only verifies signature validity
+- `internal/serve/serve.go:185-236` — GraphQL route is gated by middleware but no identity is propagated to resolvers
+- `internal/serve/graphql/resolvers/queries.resolvers.go:70-81` — `AccountByAddress` constructs an account object for any requested address
+- `internal/serve/graphql/resolvers/account.resolvers.go:25-28` — `Balances` blindly resolves the parent account
+- `internal/serve/graphql/resolvers/account_balances.go:200-259` — balance fetch path uses the supplied account address directly
+
+## Evidence
+
+There is no `context.WithValue` or equivalent subject-binding step anywhere in the request auth or GraphQL stack. `AccountByAddress` does not consult caller identity; it only validates address syntax, then hands the chosen address to the balance resolver.
+
+## Anti-Evidence
+
+The endpoint is not anonymous: the caller still needs a valid JWT from one of the configured public keys. Address parsing and balance pagination validation are present, but neither enforces ownership of the target account.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: PASS — not previously investigated
+**Failed At**: reviewer
+
+### Trace Summary
+
+Traced the complete authentication and GraphQL resolution chain from HTTP middleware through JWT verification to the `AccountByAddress` resolver and balance fetching. The JWT auth model uses `ClientAuthPublicKeys` — a server-configured list of trusted client application public keys. The JWT `Subject` claim is the client application's key, NOT an end-user Stellar address. The authentication model is service-to-service: "Is this request from a trusted client app?" All GraphQL queries (transactions, operations, accounts, state changes) are intentionally accessible to any authenticated client for any address.
+
+### Code Paths Examined
+
+- `cmd/serve.go:41-47` — `client-auth-public-keys` config: "A comma-separated list of public keys whose private keys are authorized to sign the payloads when making HTTP requests to this server."
+- `internal/serve/serve.go:142` — `NewMultiJWTTokenParser` built from `cfg.ClientAuthPublicKeys`, confirming app-level auth
+- `pkg/wbclient/auth/jwt_manager.go:47-49` — `JWTManager.ParseJWT` checks `claims.Subject != m.PublicKey`, verifying against the *client app key*, not any user address
+- `pkg/wbclient/auth/jwt_manager.go:152-165` — `MultiJWTTokenParser.ParseJWT` routes by `claims.Subject` to one of the pre-configured client parsers
+- `pkg/wbclient/auth/jwt_http_signer_verifier.go:67-103` — `VerifyHTTPRequest` returns nil on success, discarding the parsed claims and subject entirely
+- `internal/serve/middleware/middleware.go:16-44` — `AuthenticationMiddleware` only checks `err == nil` from verify; stores nothing in context
+- `internal/serve/graphql/resolvers/queries.resolvers.go:71-82` — `AccountByAddress` validates address syntax only, returns `Account` for any valid address
+- `internal/serve/graphql/schema/queries.graphqls` — No auth directives on any query fields
+
+### Why It Failed
+
+The hypothesis misunderstands the authentication model. The JWT does not represent an end-user Stellar account — its `Subject` is a **client application's public key** from the server's `client-auth-public-keys` configuration. There is no concept of "the Stellar address bound to this JWT." The wallet-backend authenticates trusted client applications (service-to-service), not individual end-users. All GraphQL queries (`accountByAddress`, `transactions`, `operations`, `stateChanges`) are designed to serve data for any requested address to any authenticated client. Furthermore, Stellar ledger data (account balances, transactions) is inherently public on the blockchain — the wallet-backend is an indexer caching this public data. This is working-as-designed behavior, not an authorization bypass.
+
+### Lesson Learned
+
+The wallet-backend JWT auth model is client-application-level, not per-user. The `Subject` claim identifies the calling application, not an end-user. Any hypothesis claiming "cross-tenant" data access must first verify that the auth model actually binds tokens to individual user identities — in this codebase, it does not. Additionally, since Stellar blockchain data is publicly queryable, per-account access control would provide no real security benefit.

--- a/ai-summary/fail/apptracker/001-mutable-sentry-hooks-require-inprocess-code.md
+++ b/ai-summary/fail/apptracker/001-mutable-sentry-hooks-require-inprocess-code.md
@@ -1,0 +1,51 @@
+# H001: Mutable Sentry hook globals allow runtime capture hijacking
+
+**Date**: 2026-04-21
+**Subsystem**: apptracker
+**Severity**: High
+**Impact**: telemetry integrity
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Runtime telemetry hooks should not be replaceable by untrusted actors. If an attacker can redirect `CaptureException` or `Init`, they could suppress error reporting or exfiltrate captured exceptions to an attacker-controlled sink.
+
+## Mechanism
+
+`internal/apptracker/sentry/sentry_tracker.go` exposes mutable package-level function variables for `Init`, `Flush`, `Recover`, and capture calls. In principle, reassigning those globals at runtime would let later capture paths execute attacker-controlled code instead of the Sentry SDK.
+
+## Trigger
+
+1. Import `internal/apptracker/sentry` from attacker-controlled in-process code.
+2. Reassign `InitFunc`, `FlushFunc`, `RecoverFunc`, or the capture function vars.
+3. Wait for application startup or an error-reporting path.
+
+## Target Code
+
+- `internal/apptracker/sentry/sentry_tracker.go:12-18` — mutable package-level hook variables
+- `internal/apptracker/sentry/sentry_tracker.go:22-39` — runtime call sites that trust those hooks
+
+## Evidence
+
+The package-level vars are explicitly designed to be swapped in tests, and no synchronization or immutability guard exists around them.
+
+## Anti-Evidence
+
+The trust model for this scan is a network client, not an in-process adversary. Reaching these assignments already requires code execution inside the wallet-backend process, which is out of scope and strictly stronger than the vulnerability itself.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Failed At**: hypothesis
+**Novelty**: PASS — not previously investigated
+
+### Why It Failed
+
+This issue only exists for an attacker who can already run arbitrary Go code in-process, which is outside the stated threat model.
+
+### Lesson Learned
+
+For `apptracker`, mutable test seams are only security-relevant if a network-reachable path can mutate them or if the threat model includes malicious plugins/in-process code.

--- a/ai-summary/fail/apptracker/002-account-transactions-authz-bypass.md
+++ b/ai-summary/fail/apptracker/002-account-transactions-authz-bypass.md
@@ -1,0 +1,74 @@
+# H002: AccountByAddress exposes arbitrary account transaction history to any valid JWT holder
+
+**Date**: 2026-04-21
+**Subsystem**: apptracker / serve-graphql / auth
+**Severity**: High
+**Impact**: GraphQL authz bypass / cross-tenant transaction-history disclosure
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Transaction history under `Account.transactions` should be returned only when the authenticated caller is authorized for that account. Requests for another account's transaction timeline should be denied rather than translated into a DB lookup keyed by the victim address.
+
+## Mechanism
+
+The same missing identity propagation that affects balances also affects the transaction connection. `AccountByAddress` lets the caller mint an in-memory `*types.Account` for any target address, and `accountResolver.Transactions` immediately executes `BatchGetByAccountAddress` for that address without any subject-vs-target comparison.
+
+## Trigger
+
+1. Authenticate as attacker account `GA...ATTACKER`.
+2. Send:
+   ```graphql
+   query {
+     accountByAddress(address: "GA...VICTIM") {
+       transactions(first: 5) {
+         edges { node { hash ledgerNumber } }
+       }
+     }
+   }
+   ```
+3. Observe the victim account's transaction history instead of an authorization error.
+
+## Target Code
+
+- `internal/serve/middleware/middleware.go:16-44` — JWT validity check only
+- `internal/serve/serve.go:185-236` — no caller identity is threaded into the GraphQL context
+- `internal/serve/graphql/resolvers/queries.resolvers.go:70-81` — arbitrary target account selection
+- `internal/serve/graphql/resolvers/account.resolvers.go:30-67` — `Transactions` queries by `obj.StellarAddress`
+
+## Evidence
+
+`accountResolver.Transactions` computes pagination, then calls `r.models.Transactions.BatchGetByAccountAddress(ctx, string(obj.StellarAddress), ...)`. The only provenance of `obj.StellarAddress` on this path is the caller-controlled `accountByAddress(address: ...)` argument.
+
+## Anti-Evidence
+
+The resolver validates pagination and optional time filters, which limits malformed requests but does not restrict who may inspect a given account's history. Authentication still requires a valid JWT, so this is an authorization gap rather than full anonymous access.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: FAIL — duplicate of 001-account-balances-authz-bypass
+**Failed At**: reviewer
+
+### Trace Summary
+
+This hypothesis is substantively identical to H001 (account-balances-authz-bypass), which was already reviewed and rejected. Both hypotheses claim that `AccountByAddress` enables cross-tenant data access because no caller identity is propagated into the GraphQL context. The only difference is the target field (`transactions` vs `balances`). The same auth model analysis that invalidated H001 applies here: the JWT `Subject` is a client application public key, not an end-user Stellar address, so there is no per-account authorization to bypass.
+
+### Code Paths Examined
+
+- `internal/serve/middleware/middleware.go:16-44` — `AuthenticationMiddleware` verifies JWT validity only, stores nothing in context (same as H001)
+- `internal/serve/serve.go:185-236` — GraphQL route gated by middleware, no identity propagated (same as H001)
+- `internal/serve/graphql/resolvers/queries.resolvers.go:70-81` — `AccountByAddress` validates address syntax, returns `Account` for any valid address (same as H001)
+- `internal/serve/graphql/resolvers/account.resolvers.go:30-67` — `Transactions` resolver calls `BatchGetByAccountAddress` using `obj.StellarAddress` from the parent account object
+
+### Why It Failed
+
+Duplicate of H001. The hypothesis itself states "The same missing identity propagation that affects balances also affects the transaction connection," explicitly acknowledging it is the same root cause. The wallet-backend JWT auth model authenticates trusted client applications (service-to-service), not individual end-users. The JWT `Subject` claim is a client app's public key from `client-auth-public-keys`, not a Stellar account address. All GraphQL queries are designed to serve data for any requested address to any authenticated client. Additionally, Stellar transaction data is publicly available on the blockchain, so per-account access control provides no security benefit.
+
+### Lesson Learned
+
+When a hypothesis explicitly cites another hypothesis as sharing the same root mechanism ("the same missing identity propagation that affects balances"), it is almost certainly a duplicate and should be rejected on novelty grounds without further investigation.

--- a/ai-summary/fail/apptracker/002-constructor-flush-gap-not-network-reachable.md
+++ b/ai-summary/fail/apptracker/002-constructor-flush-gap-not-network-reachable.md
@@ -1,0 +1,51 @@
+# H002: Constructor-scoped Flush/Recover defer lets attackers drop runtime Sentry events
+
+**Date**: 2026-04-21
+**Subsystem**: apptracker
+**Severity**: Medium
+**Impact**: telemetry availability
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Error events captured late in process lifetime should be flushed on orderly shutdown so operational telemetry is durable. A remote attacker should not be able to exploit tracker lifecycle mistakes to suppress evidence of their activity.
+
+## Mechanism
+
+`NewSentryTracker` defers `FlushFunc` and `RecoverFunc` inside the constructor, so the defers run immediately on return instead of at process shutdown. That means the apptracker package itself installs no shutdown-time flush, and late exceptions could be lost if the process exits quickly.
+
+## Trigger
+
+1. Start the server with Sentry enabled.
+2. Cause an exception shortly before process termination.
+3. Observe that apptracker itself has no later flush hook.
+
+## Target Code
+
+- `internal/apptracker/sentry/sentry_tracker.go:30-39` — `FlushFunc` and `RecoverFunc` are deferred in the constructor
+- `cmd/serve.go:88-93` — constructor return value is stored and reused; no shutdown flush is added here
+
+## Evidence
+
+The only explicit `FlushFunc` call in this subsystem is deferred inside `NewSentryTracker`, so it fires at construction time rather than shutdown.
+
+## Anti-Evidence
+
+The consequence is observability loss, not a direct confidentiality, integrity, or availability failure for wallet data. A network client also cannot deterministically force process exit from this subsystem alone, so the issue does not reach the minimum Medium security bar for this objective.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Failed At**: hypothesis
+**Novelty**: PASS — not previously investigated
+
+### Why It Failed
+
+This is an operational telemetry durability bug, not an exploitable network-reachable security vulnerability under the stated severity scale.
+
+### Lesson Learned
+
+For apptracker lifecycle issues, require a clear attacker-controlled path from network input to wallet data loss, auth bypass, or a qualifying crash/DoS before filing.

--- a/ai-summary/fail/apptracker/003-account-operations-authz-bypass.md
+++ b/ai-summary/fail/apptracker/003-account-operations-authz-bypass.md
@@ -1,0 +1,74 @@
+# H003: AccountByAddress exposes arbitrary account operations to any valid JWT holder
+
+**Date**: 2026-04-21
+**Subsystem**: apptracker / serve-graphql / auth
+**Severity**: High
+**Impact**: GraphQL authz bypass / cross-tenant operation-history disclosure
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+`Account.operations` should only resolve for the account that the authenticated JWT represents, or for an explicitly authorized delegate. A caller should not be able to request another account's operation stream simply by naming a different address in GraphQL.
+
+## Mechanism
+
+No resolver-layer authorization exists between `AccountByAddress` and `accountResolver.Operations`. Once the caller chooses a victim address, the resolver converts that address into a database lookup over `BatchGetByAccountAddress`, disclosing operation records for the victim while the JWT proves only that the caller controls *some* allowed keypair.
+
+## Trigger
+
+1. Authenticate as attacker account `GA...ATTACKER`.
+2. Send:
+   ```graphql
+   query {
+     accountByAddress(address: "GA...VICTIM") {
+       operations(first: 5) {
+         edges { node { id operationType successful } }
+       }
+     }
+   }
+   ```
+3. Observe operations associated with `GA...VICTIM`.
+
+## Target Code
+
+- `internal/serve/middleware/middleware.go:16-44` — middleware verifies token validity but never binds subject to context
+- `internal/serve/serve.go:185-236` — GraphQL handler receives no requester identity
+- `internal/serve/graphql/resolvers/queries.resolvers.go:70-81` — root query accepts arbitrary account addresses
+- `internal/serve/graphql/resolvers/account.resolvers.go:70-105` — operations resolver queries by the parent account address directly
+
+## Evidence
+
+`accountResolver.Operations` derives `string(obj.StellarAddress)` from the root-selected account object and passes it to `r.models.Operations.BatchGetByAccountAddress(...)`. There is no call site in this path that reads JWT claims, compares addresses, or enforces per-account ownership.
+
+## Anti-Evidence
+
+The operation resolver includes pagination and time-range handling, so it is not a raw unbounded dump. Those checks do not change the core issue that the target account is fully caller-chosen.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: FAIL — duplicate of 001-account-balances-authz-bypass and 002-account-transactions-authz-bypass
+**Failed At**: reviewer
+
+### Trace Summary
+
+This hypothesis is substantively identical to H001 (account-balances-authz-bypass) and H002 (account-transactions-authz-bypass), both of which were already reviewed and rejected. All three hypotheses claim the same root mechanism: `AccountByAddress` enables cross-tenant data access because the JWT auth middleware does not propagate caller identity into the GraphQL context. The only variation is the target resolver field — `balances` (H001), `transactions` (H002), and now `operations` (H003). The auth model analysis from H001 applies identically here.
+
+### Code Paths Examined
+
+- `internal/serve/middleware/middleware.go:16-44` — `AuthenticationMiddleware` verifies JWT validity only, stores nothing in context (same as H001/H002)
+- `internal/serve/serve.go:185-236` — GraphQL route gated by middleware, no identity propagated (same as H001/H002)
+- `internal/serve/graphql/resolvers/queries.resolvers.go:70-81` — `AccountByAddress` validates address syntax, returns `Account` for any valid address (same as H001/H002)
+- `internal/serve/graphql/resolvers/account.resolvers.go:70-105` — `Operations` resolver calls `BatchGetByAccountAddress` using `obj.StellarAddress` from the parent account object
+
+### Why It Failed
+
+Duplicate of H001 and H002. The wallet-backend JWT auth model authenticates trusted client applications (service-to-service), not individual end-users. The JWT `Subject` claim is a client application's public key from the `client-auth-public-keys` server configuration, not a Stellar account address. There is no concept of "the account that the authenticated JWT represents" — the JWT represents a trusted client app, and all GraphQL queries are designed to serve data for any requested address to any authenticated client. Additionally, Stellar operation data is publicly available on the blockchain, so per-account access control provides no security benefit. This is working-as-designed behavior, not an authorization bypass.
+
+### Lesson Learned
+
+The same "any authenticated caller can query any address" pattern has now been hypothesized three times across different resolver fields (balances, transactions, operations). All share the identical root cause misunderstanding: the auth model is app-level, not user-level. Future hypotheses targeting GraphQL field-level authz should be immediately checked against H001's finding that the JWT subject is a client app key, not a user identity.

--- a/ai-summary/fail/apptracker/003-health-error-reflection-needs-preexisting-outage.md
+++ b/ai-summary/fail/apptracker/003-health-error-reflection-needs-preexisting-outage.md
@@ -1,0 +1,52 @@
+# H003: Unauthenticated health checks exfiltrate RPC and DB errors to Sentry
+
+**Date**: 2026-04-21
+**Subsystem**: apptracker / serve-api
+**Severity**: Medium
+**Impact**: confidentiality
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+The unauthenticated `/health` endpoint should reduce backend failures to coarse health states instead of reflecting detailed upstream or database errors into both the HTTP response and Sentry. A random network client should not be able to trigger third-party telemetry emission of internal diagnostics.
+
+## Mechanism
+
+`HealthHandler.GetHealth` wraps RPC and ingest-store failures with `err.Error()` and passes the same error into `InternalServerError`/`ServiceUnavailable`, which forwards it to `CaptureException`. `rpcService.sendRPCRequest` also embeds raw RPC response bodies in several error strings, so detailed diagnostics would propagate if the health dependencies fail.
+
+## Trigger
+
+1. Put the backend into a degraded state where `RPCService.GetHealth()` or `IngestStore.Get()` fails.
+2. Call `GET /health`.
+3. Observe the detailed error reflected to the client and captured by apptracker.
+
+## Target Code
+
+- `internal/serve/httphandler/health.go:27-53` — health handler forwards backend errors directly
+- `internal/serve/httperror/errors.go:65-89` — internal/service-unavailable handlers call `appTracker.CaptureException`
+- `internal/services/rpc_service.go:355-377` — raw RPC bodies are interpolated into error strings
+
+## Evidence
+
+The health handler uses `err.Error()` as the client-facing message on both RPC and DB failure branches, and the same `err` is sent to apptracker without redaction.
+
+## Anti-Evidence
+
+The attacker does not control the upstream RPC or DB error content under the trust model, and exploitation depends on a preexisting degraded infrastructure state. Because the same details are already returned directly in the `/health` response, the apptracker path does not create a new attacker capability on its own.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Failed At**: hypothesis
+**Novelty**: PASS — not previously investigated
+
+### Why It Failed
+
+This path is real but relies on an outage condition outside attacker control, and the exploitable disclosure is already in the HTTP response rather than being introduced by apptracker itself.
+
+### Lesson Learned
+
+For tracker-backed egress findings, prefer cases where apptracker uniquely crosses a trust boundary or materially amplifies attacker control, not ones where the same data is already returned to the caller.

--- a/ai-summary/fail/apptracker/004-account-statechanges-authz-bypass.md
+++ b/ai-summary/fail/apptracker/004-account-statechanges-authz-bypass.md
@@ -1,0 +1,81 @@
+# H004: AccountByAddress exposes arbitrary account state changes to any valid JWT holder
+
+**Date**: 2026-04-21
+**Subsystem**: apptracker / serve-graphql / auth
+**Severity**: High
+**Impact**: GraphQL authz bypass / cross-tenant state-change disclosure
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Account-scoped state-change feeds should be restricted to the JWT subject's own account, because they expose a richer history than raw balances alone: change categories, reasons, linked operations/transactions, and account metadata transitions. A caller asking for another address's state changes should receive an authorization failure.
+
+## Mechanism
+
+`Account.stateChanges` repeats the same ownership gap as the other `Account` field resolvers. After `AccountByAddress` accepts an arbitrary target address, `accountResolver.StateChanges` passes that address into `BatchGetByAccountAddress` and returns the resulting change records without ever consulting the authenticated subject.
+
+## Trigger
+
+1. Authenticate as attacker account `GA...ATTACKER`.
+2. Send:
+   ```graphql
+   query {
+     accountByAddress(address: "GA...VICTIM") {
+       stateChanges(first: 5) {
+         edges {
+           node {
+             __typename
+             type
+             reason
+           }
+         }
+       }
+     }
+   }
+   ```
+3. Observe the victim account's state-change history.
+
+## Target Code
+
+- `internal/serve/middleware/middleware.go:16-44` — auth verifies only that a JWT is valid
+- `internal/serve/serve.go:185-236` — no subject is propagated into GraphQL execution context
+- `internal/serve/graphql/resolvers/queries.resolvers.go:70-81` — arbitrary account selection by address
+- `internal/serve/graphql/resolvers/account.resolvers.go:108-172` — state changes are fetched by the parent account address
+- `internal/serve/graphql/schema/statechange.graphqls:1-18` — the exposed interface includes linked account/operation/transaction context
+
+## Evidence
+
+The resolver extracts optional filters, then executes `r.models.StateChanges.BatchGetByAccountAddress(ctx, string(obj.StellarAddress), ...)`. The `BaseStateChange` schema shows that successful exploitation reveals structured account-linked history, not just one scalar field.
+
+## Anti-Evidence
+
+Input validation exists for transaction-hash filters and pagination cursors. Those checks prevent malformed requests, but they do not enforce that the caller owns the account whose state changes are being queried.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: FAIL — duplicate of 001-account-balances-authz-bypass, 002-account-transactions-authz-bypass, and 003-account-operations-authz-bypass
+**Failed At**: reviewer
+
+### Trace Summary
+
+This hypothesis is the fourth iteration of the same root mechanism already rejected in H001, H002, and H003. All four hypotheses claim that `AccountByAddress` enables cross-tenant data access because the JWT auth middleware does not propagate caller identity into the GraphQL context. The only variation is the target resolver field — `balances` (H001), `transactions` (H002), `operations` (H003), and now `stateChanges` (H004). The comprehensive auth model analysis from H001 applies identically here.
+
+### Code Paths Examined
+
+- `internal/serve/middleware/middleware.go:16-44` — `AuthenticationMiddleware` verifies JWT validity only, stores nothing in context (same as H001/H002/H003)
+- `internal/serve/serve.go:185-236` — GraphQL route gated by middleware, no identity propagated (same as H001/H002/H003)
+- `internal/serve/graphql/resolvers/queries.resolvers.go:70-81` — `AccountByAddress` validates address syntax, returns `Account` for any valid address (same as H001/H002/H003)
+- `internal/serve/graphql/resolvers/account.resolvers.go:108-172` — `StateChanges` resolver calls `BatchGetByAccountAddress` using `obj.StellarAddress` from the parent account object
+
+### Why It Failed
+
+Duplicate of H001, H002, and H003. The wallet-backend JWT auth model authenticates trusted client applications (service-to-service), not individual end-users. The JWT `Subject` claim is a client application's public key from the `client-auth-public-keys` server configuration, not a Stellar account address. There is no concept of "the JWT subject's own account" — the JWT subject identifies a trusted client app, and all GraphQL queries are designed to serve data for any requested address to any authenticated client. Additionally, Stellar state-change data derives from publicly available blockchain data, so per-account access control provides no security benefit. This is working-as-designed behavior, not an authorization bypass.
+
+### Lesson Learned
+
+The same "any authenticated caller can query any address" pattern has now been hypothesized four times across different resolver fields (balances, transactions, operations, state changes). All share the identical root cause misunderstanding: the auth model is app-level, not user-level. Any future hypothesis claiming per-account authz bypass on any `Account` field resolver should be immediately rejected as a duplicate of H001 without further code tracing.

--- a/ai-summary/fail/apptracker/004-auth-body-read-errors-dont-cross-medium.md
+++ b/ai-summary/fail/apptracker/004-auth-body-read-errors-dont-cross-medium.md
@@ -1,0 +1,52 @@
+# H004: Broken request bodies force Sentry exception traffic through auth middleware
+
+**Date**: 2026-04-21
+**Subsystem**: apptracker / auth / serve-api
+**Severity**: Medium
+**Impact**: availability
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Malformed or aborted request bodies on authenticated endpoints should be rejected as bad input without being promoted to internal exceptions. A client that disconnects mid-upload should not be able to manufacture apptracker traffic from the edge of the API.
+
+## Mechanism
+
+`VerifyHTTPRequest` reads the request body before signature verification, and any `io.ReadAll` failure is returned as a plain error rather than `ErrUnauthorized`. `AuthenticationMiddleware` treats non-`ErrUnauthorized` failures as internal errors and passes them to `InternalServerError`, which in turn reports them through apptracker.
+
+## Trigger
+
+1. Send a request into `/graphql/query` with an `Authorization: Bearer ...` header.
+2. Abort the body upload mid-stream so `io.ReadAll(io.LimitReader(...))` fails.
+3. Let middleware route the resulting error through `InternalServerError`.
+
+## Target Code
+
+- `pkg/wbclient/auth/jwt_http_signer_verifier.go:79-89` — body-read failure path
+- `internal/serve/middleware/middleware.go:25-35` — non-`ErrUnauthorized` auth failures become internal errors
+- `internal/serve/httperror/errors.go:65-74` — apptracker capture on internal errors
+
+## Evidence
+
+The verifier returns `fmt.Errorf("reading request body: %w", err)` without wrapping `ErrUnauthorized`, and middleware explicitly routes that branch to `InternalServerError`.
+
+## Anti-Evidence
+
+This produces logged exception traffic, but I did not find a concrete path from that behavior to a qualifying crash, permanent desync, or cross-tenant disclosure. In practice it looks closer to noisy telemetry / rate-limit pressure than to a Medium security issue under the project rubric.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Failed At**: hypothesis
+**Novelty**: PASS — not previously investigated
+
+### Why It Failed
+
+The attacker can likely generate exception noise, but the impact does not clearly rise above operational log spam within this objective's severity thresholds.
+
+### Lesson Learned
+
+For auth-to-apptracker paths, require a demonstrable crash, auth bypass, or durable availability failure rather than generic exception amplification.

--- a/ai-summary/fail/apptracker/005-broken-pipe-recovery-is-just-telemetry-noise.md
+++ b/ai-summary/fail/apptracker/005-broken-pipe-recovery-is-just-telemetry-noise.md
@@ -1,0 +1,52 @@
+# H005: Client disconnects during UInt32 serialization cause recovered panics that hit Sentry
+
+**Date**: 2026-04-21
+**Subsystem**: apptracker / serve-graphql
+**Severity**: Medium
+**Impact**: availability
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Client disconnects during response serialization should be treated as aborted requests, not as application panics that generate stack traces and apptracker events. An attacker closing the socket should not be able to force panic-reporting paths.
+
+## Mechanism
+
+`MarshalUInt32` panics on `io.WriteString` failure, and `RecoverHandler` only special-cases `http.ErrAbortHandler`, not broken-pipe / connection-reset write errors. A caller who disconnects while GraphQL is serializing `UInt32` fields could therefore induce recovered panics and `CaptureException` calls.
+
+## Trigger
+
+1. Authenticate and request a GraphQL object that includes `UInt32` fields such as `ledgerNumber`.
+2. Close the TCP connection while the response body is being written.
+3. Let `RecoverHandler` catch the resulting write-error panic.
+
+## Target Code
+
+- `internal/serve/graphql/scalars/uint32.go:16-24` — marshaler panics on writer error
+- `internal/serve/middleware/middleware.go:49-70` — recover path reports non-`http.ErrAbortHandler` panics
+- `internal/serve/httperror/errors.go:65-74` — recovered panic is sent to apptracker
+
+## Evidence
+
+The marshaler explicitly `panic(err)` on any write failure, and the recover middleware converts arbitrary panic values into `error`s before reporting them.
+
+## Anti-Evidence
+
+The panic is recovered inside middleware, so I did not identify a path to process crash or persistent service degradation. The remaining effect is exception noise rather than a clear Medium-impact vulnerability.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Failed At**: hypothesis
+**Novelty**: PASS — not previously investigated
+
+### Why It Failed
+
+This path likely exists, but it stops at a recovered 500 and telemetry event, which is not enough by itself for the accepted severity bar.
+
+### Lesson Learned
+
+Recovered panics need a follow-on consequence such as process crash, connection desync, or durable resource exhaustion to qualify for this objective.

--- a/ai-summary/fail/apptracker/005-transaction-account-pivot-authz-bypass.md
+++ b/ai-summary/fail/apptracker/005-transaction-account-pivot-authz-bypass.md
@@ -1,0 +1,84 @@
+# H005: Transaction-to-account traversal bypasses any address-knowledge barrier for cross-tenant reads
+
+**Date**: 2026-04-21
+**Subsystem**: apptracker / serve-graphql / auth
+**Severity**: High
+**Impact**: GraphQL authz bypass / graph-traversal-based cross-tenant disclosure
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Even if the API exposes transaction-level data, nested account relationships should not let a caller pivot from a public ledger object into private account-scoped reads for unrelated accounts. Once a transaction returns related accounts, any subsequent `Account` subfields should still enforce that the requester is authorized for each account.
+
+## Mechanism
+
+`Query.transactions` returns arbitrary transactions to any valid JWT holder, and `Transaction.accounts` materializes the participating accounts with no ownership check. Those nested `Account` objects can immediately resolve `balances`, `transactions`, `operations`, or `stateChanges`, so an attacker does not even need to know a victim address ahead of time: they can harvest addresses from transaction relationships and pivot into account-scoped data inside the same query.
+
+## Trigger
+
+1. Authenticate as attacker account `GA...ATTACKER`.
+2. Send:
+   ```graphql
+   query {
+     transactions(first: 10) {
+       edges {
+         node {
+           hash
+           accounts {
+             address
+             balances(first: 1) {
+               edges { node { __typename } }
+             }
+           }
+         }
+       }
+     }
+   }
+   ```
+3. Observe balances for accounts discovered through unrelated transactions.
+
+## Target Code
+
+- `internal/serve/graphql/schema/queries.graphqls:3-10` — any valid JWT can start from the `transactions` root
+- `internal/serve/graphql/resolvers/queries.resolvers.go:36-68` — root transaction listing has no subject-based filtering
+- `internal/serve/graphql/resolvers/transaction.resolvers.go:66-84` — `Transaction.accounts` returns related accounts without authz
+- `internal/serve/graphql/resolvers/account.resolvers.go:25-28` — nested `Account.balances` trusts the parent account object
+- `internal/serve/middleware/middleware.go:16-44` — middleware verifies only validity, not target ownership
+
+## Evidence
+
+The transaction root query fetches global transaction records, `Transaction.accounts` loads all related account rows via dataloaders, and the nested `Account` resolver surface is identical to the direct `accountByAddress` path. There is still no request-context identity available anywhere in that chain to stop the pivot.
+
+## Anti-Evidence
+
+This path still requires a valid JWT and the attacker only learns accounts that already appear in returned transaction data. That limits the issue to authenticated callers, but it does not prevent cross-tenant access once the graph traversal begins.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: FAIL — duplicate of 001-account-balances-authz-bypass (and 002, 003)
+**Failed At**: reviewer
+
+### Trace Summary
+
+Traced the `Query.Transactions` → `Transaction.Accounts` → `Account.Balances` path through the resolver chain. The `Transactions` root query calls `r.models.Transactions.GetAll` with no caller filter. `Transaction.Accounts` uses `AccountsByToIDLoader` to batch-load related accounts. Nested `Account.Balances` calls `getAccountBalances` on the parent address. All code paths are real and reachable — but the auth model is service-to-service, not per-user, so there is no "cross-tenant" boundary to bypass.
+
+### Code Paths Examined
+
+- `internal/serve/graphql/resolvers/queries.resolvers.go:36-68` — `Transactions` root query fetches global transactions via `GetAll`, no caller identity filter
+- `internal/serve/graphql/resolvers/transaction.resolvers.go:66-84` — `Transaction.Accounts` loads related accounts via `AccountsByToIDLoader` dataloader, no authz check
+- `internal/serve/graphql/resolvers/account.resolvers.go:25-28` — `Balances` resolves via `getAccountBalances(ctx, string(obj.StellarAddress), ...)`, trusts parent object
+- `internal/serve/middleware/middleware.go:16-44` — `AuthenticationMiddleware` verifies JWT validity only, stores nothing in context
+- `pkg/wbclient/auth/jwt_manager.go:47-49` — JWT `Subject` is a client application public key, not an end-user Stellar address (established in H001 review)
+
+### Why It Failed
+
+This is the same root cause as H001, H002, and H003: the hypothesis assumes the JWT binds to an individual Stellar account and that "cross-tenant" access controls should exist. In reality, the wallet-backend JWT auth model authenticates **trusted client applications** (service-to-service), not individual end-users. The JWT `Subject` claim is a client app's public key from the server's `client-auth-public-keys` config — there is no concept of "the account this JWT represents." All GraphQL queries (root-level and nested) are designed to serve data for any address to any authenticated client. The "graph traversal pivot" from transactions to accounts is simply a different entry path to the same by-design behavior already analyzed in H001. Additionally, Stellar ledger data (accounts, balances, transactions) is inherently public on the blockchain — the wallet-backend is an indexer caching this public data, so per-account access control would provide no real security benefit.
+
+### Lesson Learned
+
+This is the fourth hypothesis (H001 balances, H002 transactions, H003 operations, H005 transaction-account pivot) claiming cross-tenant authz bypass through different GraphQL traversal paths. All share the identical misunderstanding: the auth model is app-level, not user-level. The "pivot through transactions" angle does not change the fundamental analysis — if there is no per-user identity binding, there is no tenant boundary to cross regardless of which resolver chain is used as the entry point.

--- a/ai-summary/fail/data-pipeline/001-graphql-sql-injection-not-reachable.md
+++ b/ai-summary/fail/data-pipeline/001-graphql-sql-injection-not-reachable.md
@@ -1,0 +1,51 @@
+# H001: GraphQL Column/Sort SQL Injection Through Dynamic SELECT Clauses
+
+**Date**: 2026-04-23
+**Subsystem**: data-pipeline
+**Severity**: High
+**Impact**: Integrity
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Only statically known database column names and sort directions should ever reach the SQL-building helpers. An attacker-controlled GraphQL request should not be able to splice arbitrary SQL into the `SELECT` list or `ORDER BY` clause.
+
+## Mechanism
+
+`prepareColumnsWithID` splices the caller-supplied `columns` string directly into SQL, and several query builders interpolate `SortOrder` with `fmt.Sprintf`. If a GraphQL request could smuggle raw text into either value, it would turn the read path into an injection primitive.
+
+## Trigger
+
+Attempt to supply malicious field names or sort-direction text through GraphQL so the generated `columns` string or `SortOrder` contains SQL metacharacters.
+
+## Target Code
+
+- `internal/data/query_utils.go:162-184` — direct column-list splicing sink
+- `internal/data/operations.go:124-149` — `SortOrder` interpolation sink
+- `internal/serve/graphql/resolvers/utils.go:167-183,229-267` — GraphQL field-to-column mapping
+- `internal/serve/graphql/resolvers/utils.go:288-341` — pagination parsing sets sort order
+
+## Evidence
+
+The data layer really does splice `columns` and `SortOrder` into query strings. At first glance that looks like a classic SQL-injection surface.
+
+## Anti-Evidence
+
+The GraphQL layer does not forward raw user strings into either value. `GetDBColumnsForFields` maps collected schema field names through hard-coded struct tags, and `parsePaginationParams` only emits the typed constants `ASC` or `DESC`.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-23
+**Failed At**: hypothesis
+**Novelty**: PASS — not previously investigated
+
+### Why It Failed
+
+The dangerous SQL-building helpers are present, but the active GraphQL call path feeds them only schema-derived column names and fixed sort constants, not attacker-controlled text.
+
+### Lesson Learned
+
+For this repository, dynamic SQL sinks in `internal/data` must be paired with a concrete caller that converts network input into `columns` or `SortOrder`. The sink alone is not enough because the resolver layer currently closes those values over gqlgen metadata and typed enums.

--- a/ai-summary/fail/data-pipeline/002-protocol-state-path-dormant-on-main.md
+++ b/ai-summary/fail/data-pipeline/002-protocol-state-path-dormant-on-main.md
@@ -1,0 +1,50 @@
+# H002: Protocol Catchup/Cache Desync Corrupts Live Protocol State
+
+**Date**: 2026-04-23
+**Subsystem**: data-pipeline
+**Severity**: High
+**Impact**: Integrity
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+If live ingest is producing protocol state, optimized catchup and the protocol-contract cache should keep those processor paths synchronized with the ledgers being ingested. Falling behind should not silently skip protocol history or current-state updates.
+
+## Mechanism
+
+The live-ingest path has explicit protocol cursor CAS logic and a stale-by-100-ledgers contract cache, while catchup batching only persists fact tables and token balances. That looked like it could let newly classified contracts or catchup-ledgers bypass protocol processors and corrupt downstream protocol state.
+
+## Trigger
+
+Run live ingest with protocol processors enabled, let the node fall behind into catchup, and submit activity to a protocol-tracked contract during the stale-cache window or catchup range.
+
+## Target Code
+
+- `internal/ingest/ingest.go:217-243` — live ingest only wires processors from the registry
+- `internal/services/processor_registry.go:11-35` — processor registry definition
+- `internal/services/validator_registry.go:11-24` — validator registry definition
+
+## Evidence
+
+There is substantial protocol-processing code in `internal/services`, including live CAS gating, migration services, and protocol setup. That makes the catchup/cache surface look important at first pass.
+
+## Anti-Evidence
+
+I found no in-tree production `RegisterProcessor(...)` or `RegisterValidator(...)` call sites on `main`; only the registries, tests, and command wiring remain. Without any registered processor or validator, the suspected corruption path is dormant rather than attacker-reachable in the current tree.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-23
+**Failed At**: hypothesis
+**Novelty**: PASS — not previously investigated
+
+### Why It Failed
+
+The protocol-state machinery appears unwired on `main`, so the catchup/cache desync concern is not presently reachable through an active production processor path.
+
+### Lesson Learned
+
+For this repo, protocol-state bugs need an explicit in-tree registration path before they qualify as live security findings. Registry-driven subsystems can look hot in isolation while being effectively dead code in the current build.

--- a/ai-summary/fail/ingest/001-admin-pprof-exposure.md
+++ b/ai-summary/fail/ingest/001-admin-pprof-exposure.md
@@ -1,0 +1,72 @@
+# H001: Unauthenticated ingest pprof endpoints are exposed on every interface
+
+**Date**: 2026-04-21
+**Subsystem**: ingest
+**Severity**: Medium
+**Impact**: availability / confidentiality
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Profiling and tracing endpoints should not be reachable by arbitrary network clients. If ingest exposes pprof at all, it should either bind only to loopback/private admin infrastructure or enforce authentication before serving goroutine dumps, heap snapshots, CPU profiles, and execution traces.
+
+## Mechanism
+
+When `AdminPort > 0`, `startServers` binds `adminServer` to `:%d` and mounts the standard library pprof handlers directly, with no auth or network scoping. Any client that can reach that port can dump runtime state (`/debug/pprof/goroutine`, `/debug/pprof/heap`) or force expensive profiling work (`/debug/pprof/profile`, `/debug/pprof/trace`), creating both an information-disclosure surface and a request-driven DoS primitive against the ingest process.
+
+## Trigger
+
+1. Run ingest with `AdminPort` configured on a reachable interface.
+2. Send unauthenticated requests such as:
+   - `GET /debug/pprof/goroutine?debug=2`
+   - `GET /debug/pprof/heap`
+   - `GET /debug/pprof/profile?seconds=30`
+3. Observe that profiling data is returned or CPU profiling work is started without any auth gate.
+
+## Target Code
+
+- `internal/ingest/ingest.go:startServers:300-317` — starts an admin HTTP server on `:%d`
+- `internal/ingest/ingest.go:registerAdminHandlers:323-329` — mounts raw pprof handlers
+
+## Evidence
+
+The admin server is created with `Addr: fmt.Sprintf(":%d", cfg.AdminPort)` and `Handler: adminMux`, then `registerAdminHandlers(adminMux)` wires `/debug/pprof/*` directly. There is no auth middleware, IP restriction, or loopback-only bind in this path.
+
+## Anti-Evidence
+
+The surface is only enabled when `AdminPort > 0`, and it is split onto a separate port rather than the main ingest port. Operators who keep that port unreachable reduce exposure, but the code itself does not enforce that boundary.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: PASS — not previously investigated
+**Failed At**: reviewer
+
+### Trace Summary
+
+Traced the full admin server startup path in `internal/ingest/ingest.go`. Confirmed that `startServers` (lines 274-321) creates an admin HTTP server binding to all interfaces on `AdminPort` when configured, and `registerAdminHandlers` (lines 324-330) mounts the five standard `net/http/pprof` handlers (`Index`, `Cmdline`, `Profile`, `Symbol`, `Trace`) with no authentication middleware. The code exactly matches what the hypothesis describes.
+
+### Code Paths Examined
+
+- `internal/ingest/ingest.go:startServers:274-321` — confirmed admin server binds `0.0.0.0:AdminPort` with no auth
+- `internal/ingest/ingest.go:registerAdminHandlers:324-330` — confirmed raw pprof handler mounting
+- `internal/ingest/ingest.go:Configs:50-103` — confirmed `AdminPort` is opt-in (default zero)
+- `internal/ingest/ingest.go:setupDeps:137-270` — confirmed admin server is only started via `startServers` call
+
+### Why It Failed
+
+The finding is real but does not meet the minimum **Medium** severity threshold required by the objective. The actual impact is Informational/Low:
+
+1. **No crash/panic**: Go's `net/http/pprof` handlers do not crash or panic the process. They consume bounded resources during profiling but return normally.
+2. **No OOM**: Heap dumps, goroutine dumps, and CPU profiles produce output proportional to existing process state, not attacker-controlled amplification. No realistic path to OOM the ingest process through these endpoints.
+3. **Information disclosure is Low-severity**: Goroutine stacks and heap profiles reveal internal function names and memory layout — useful for reconnaissance but not directly exploitable against wallet-backend's security model (no secrets in heap, no auth tokens leaked via pprof).
+4. **Operator-deployment concern**: The admin port is opt-in (`AdminPort > 0`), deliberately separated from the main ingest port, and follows standard Go service patterns. This is analogous to the objective's explicit OUT_OF_SCOPE: "Missing rate limits, missing WAF, missing TLS configuration — these are operator-deployment concerns, not wallet-backend code bugs."
+5. **Cannot argue to Medium**: None of the Medium criteria (crash/panic from unauth input, Redis desync, migration CAS violation, JWT replay, Soroban sim crash, RPC-induced OOM) apply to unauthenticated pprof access.
+
+### Lesson Learned
+
+Unauthenticated pprof on a dedicated admin port is standard Go operational practice and is an operator-deployment concern, not a code-level security bug. Only flag pprof exposure if the endpoints are on the main API port (bypassing auth middleware) or if a specific pprof handler can be shown to crash/OOM the process under realistic conditions.

--- a/ai-summary/fail/ingest/001-catchup-protocol-production.md
+++ b/ai-summary/fail/ingest/001-catchup-protocol-production.md
@@ -1,0 +1,51 @@
+# H001: Catchup mode skips protocol state production after a lagged restart
+
+**Date**: 2026-04-21
+**Subsystem**: ingest
+**Severity**: High
+**Impact**: persistent state corruption
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+If protocol processors are active in production, the catchup path should either run their per-ledger production logic or prove that no protocol state is lost while `latest_ingest_ledger` advances across the catchup range.
+
+## Mechanism
+
+`startLiveIngestion` can call `startBackfilling(..., BackfillModeCatchup)` before resuming live ingestion, and the catchup batch path never calls `protocolProcessorsEligibleForProduction` or `produceProtocolStateForProcessors`. That looks like a gap where protocol history/current-state production could be skipped for ledgers processed during catchup.
+
+## Trigger
+
+1. Let live ingest fall behind far enough to enter catchup mode.
+2. Ensure protocol processors are expected to persist state for ledgers in the catchup range.
+3. Restart ingest and watch catchup advance the latest cursor without invoking the live protocol-production path.
+
+## Target Code
+
+- `internal/services/ingest_live.go:startLiveIngestion:277-290` — enters catchup mode before live streaming
+- `internal/services/ingest_backfill.go:processLedgersInBatch:506-585` — catchup batch path that skips protocol production
+
+## Evidence
+
+The live path calls `produceProtocolStateForProcessors`, but the catchup batch path only processes ledger/indexer data and post-merges token/cache changes. There is no equivalent protocol-production call in catchup mode.
+
+## Anti-Evidence
+
+The current tree has no production `RegisterProcessor(...)` call sites or production `ProtocolProcessor` implementation files, so `GetAllProcessors()` resolves to an empty registry on main. That makes the apparent omission unreachable today.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Failed At**: hypothesis
+**Novelty**: PASS — not previously investigated
+
+### Why It Failed
+
+The bug only becomes real after protocol processors are registered in production. On the current main branch, the processor registry is empty, so catchup is not skipping any reachable protocol-production work.
+
+### Lesson Learned
+
+Recent protocol-infrastructure code in `internal/services` is partially dormant on main. Before filing a protocol-state hypothesis, confirm there is an actual production `ProtocolProcessor` registration path.

--- a/ai-summary/fail/ingest/002-ledger-goroutine-fanout.md
+++ b/ai-summary/fail/ingest/002-ledger-goroutine-fanout.md
@@ -1,0 +1,74 @@
+# H002: Unbounded per-ledger transaction fan-out lets on-chain load exhaust ingest workers
+
+**Date**: 2026-04-21
+**Subsystem**: ingest
+**Severity**: Medium
+**Impact**: availability
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Ledger ingestion should cap in-process transaction parallelism so one large ledger cannot create an unbounded number of concurrent buffers and worker goroutines. The ingest service should apply backpressure at the worker-pool boundary rather than scaling linearly with the raw transaction count in a single ledger.
+
+## Mechanism
+
+`NewIngestService` creates `ledgerIndexerPool := pond.NewPool(0)`, and `Indexer.ProcessLedgerTransactions` submits one job per transaction in the ledger. Each submitted job allocates a fresh `IndexerBuffer` and runs the full participant/state-change pipeline, so a ledger with many transactions turns directly into many concurrent goroutines and buffers with no local concurrency ceiling, giving an attacker an on-chain CPU/RAM amplification path.
+
+## Trigger
+
+1. Submit enough transactions to pack a ledger near the network's maximum transaction count.
+2. Let ingest process that ledger in live mode.
+3. Observe one `group.Submit` per transaction and matching per-transaction buffer allocation while the unbounded pond pool executes them concurrently.
+
+## Target Code
+
+- `internal/services/ingest.go:135-183` — creates the unbounded `ledgerIndexerPool`
+- `internal/indexer/indexer.go:111-147` — submits one task per ledger transaction
+- `internal/indexer/indexer.go:122-133` — allocates a new `IndexerBuffer` inside each task
+
+## Evidence
+
+The pool is initialized with `pond.NewPool(0)`, which removes the worker cap. `ProcessLedgerTransactions` iterates every transaction and immediately schedules a goroutine for it, rather than chunking or bounding concurrency.
+
+## Anti-Evidence
+
+Ledger size is bounded by Stellar protocol limits, so the fan-out is not literally infinite. But there is still no ingest-side guardrail that converts those protocol limits into a safe local concurrency limit for this process.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: PASS — not previously investigated
+**Failed At**: reviewer
+
+### Trace Summary
+
+Traced from `NewIngestService` (ingest.go:135-183) through `ingestLiveLedgers` (ingest_live.go:321-380) to `processLedger` → `indexer.ProcessLedger` → `Indexer.ProcessLedgerTransactions` (indexer.go:111-151). Confirmed `pond.NewPool(0)` creates an unbounded pool and `ProcessLedgerTransactions` submits one goroutine per transaction. However, the live loop processes ledgers sequentially (one at a time), and the fan-out per ledger is bounded by Stellar protocol limits on transactions per ledger close.
+
+### Code Paths Examined
+
+- `internal/services/ingest.go:135-137` — `pond.NewPool(0)` creates unbounded pool; backfill pool at line 146 IS bounded (`pond.NewPool(backfillWorkers)`) showing deliberate design choice
+- `internal/services/ingest_live.go:321-380` — live ingestion loop processes ledgers sequentially in a `for` loop, one at a time
+- `internal/indexer/indexer.go:111-151` — `ProcessLedgerTransactions` submits one goroutine per transaction via `group.Submit`
+- `internal/indexer/indexer_buffer.go:77-92` — `NewIndexerBuffer` allocates empty maps with no pre-sized capacity; lightweight per-goroutine footprint
+
+### Why It Failed
+
+The hypothesis fails the viability checklist on multiple grounds:
+
+1. **No concrete attacker capability against the wallet-backend.** The trigger requires submitting transactions to the Stellar network (a separate system), not sending a request to the wallet-backend's client-facing interface (GraphQL/HTTP). The viability checklist requires "a specific request shape a network client can send" to the wallet-backend itself.
+
+2. **Trust model excludes this attack vector.** The objective context states "The upstream Stellar RPC and history archives are **trusted**." Ledger contents — including the number of transactions per ledger — are trusted data from the upstream. An attack that requires influencing ledger contents falls outside the trust boundary.
+
+3. **Protocol-bounded fan-out, not unbounded.** Stellar protocol limits cap the maximum transactions per ledger (typically ~200 operations on mainnet, set by validator consensus). While `pond.NewPool(0)` is technically unbounded, the actual concurrency is bounded by the network's `max_tx_set_size`. Go routinely handles hundreds or even thousands of concurrent goroutines without issue.
+
+4. **Each `IndexerBuffer` is lightweight.** `NewIndexerBuffer()` creates a struct of empty maps — no pre-allocated data. The per-goroutine memory footprint is trivially small at the scale the protocol allows.
+
+5. **Intentional design.** The code explicitly bounds the backfill pool (`pond.NewPool(backfillWorkers)` with a comment "bounded size to control memory usage") while leaving the per-ledger indexer pool unbounded. This is a deliberate throughput optimization for single-ledger processing, not an oversight.
+
+### Lesson Learned
+
+When assessing resource-amplification hypotheses against ingestion pipelines, verify that the amplification input is attacker-controlled within the trust model. Data volumes determined by the trusted upstream (Stellar network consensus) are not attacker-controlled inputs to the wallet-backend — they are the expected workload the service must handle.

--- a/ai-summary/fail/ingest/002-short-asset-code-trim.md
+++ b/ai-summary/fail/ingest/002-short-asset-code-trim.md
@@ -1,0 +1,50 @@
+# H002: Short trustline asset codes suppress inherited authorization state on trustline creation
+
+**Date**: 2026-04-21
+**Subsystem**: ingest
+**Severity**: Medium
+**Impact**: wallet-data integrity
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+When a new trustline is created, ingest should derive the correct inherited authorization/clawback flags regardless of whether the asset code is shorter than the fixed XDR width for AlphaNum4/AlphaNum12 assets.
+
+## Mechanism
+
+`getTrustlineFlagsFromChanges` compares the asset code extracted from effect details against the code reconstructed from the trustline entry. If the trustline-side code retained its NUL padding, short asset codes could fail to match and the inherited balance-authorization state change would be skipped.
+
+## Trigger
+
+1. Create a trustline for a short asset code (for example, `USD`).
+2. Let ingest generate the synthetic balance-authorization state change for trustline creation.
+3. Check whether the trustline lookup fails because the trustline-side code still contains fixed-width padding.
+
+## Target Code
+
+- `internal/indexer/processors/effects.go:getTrustlineFlagsFromChanges:520-576` — trustline lookup by `(trustor, assetCode, assetIssuer)`
+
+## Evidence
+
+The code reconstructs `entryAssetCode` from fixed-width XDR asset-code arrays before matching it against the effect detail values. That initially looks vulnerable to padded-string mismatches for short codes.
+
+## Anti-Evidence
+
+Right before the comparison, the code strips NUL bytes from `entryAssetCode` (`for i, c := range entryAssetCode { if c == 0 { entryAssetCode = entryAssetCode[:i]; break } }`). The normalized value is then compared against `assetCode`, preventing the mismatch.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Failed At**: hypothesis
+**Novelty**: PASS — not previously investigated
+
+### Why It Failed
+
+The suspected short-code mismatch is already handled by explicit NUL-byte trimming before the asset-code equality check. Short AlphaNum4/12 assets should therefore still match correctly.
+
+### Lesson Learned
+
+In this codebase, several XDR fixed-width string paths already normalize padding before comparison. Confirm the normalization step before filing asset-code mismatch hypotheses.

--- a/ai-summary/fail/ingest/003-dead-details-panic-path.md
+++ b/ai-summary/fail/ingest/003-dead-details-panic-path.md
@@ -1,0 +1,51 @@
+# H003: Unknown Soroban enum values panic operation-detail generation and crash ingest
+
+**Date**: 2026-04-21
+**Subsystem**: ingest
+**Severity**: Medium
+**Impact**: availability
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Unknown or newly introduced Soroban operation/host-function enum values should be surfaced as ordinary errors or ignored fields, not trigger a process panic during ingest.
+
+## Mechanism
+
+`TransactionOperationWrapper.Details()` still panics on unknown operation, host-function, or contract-preimage enum arms. If ingest used this serializer in production, a future valid ledger enum could crash the process instead of producing a degraded-but-safe record.
+
+## Trigger
+
+1. Feed ingest a Soroban operation whose enum arm is not handled by `Details()`.
+2. Ensure the ingest pipeline calls `TransactionOperationWrapper.Details()`.
+3. Observe the `panic(...)` on the default switch branch.
+
+## Target Code
+
+- `internal/indexer/processors/transaction_operation_wrapper.go:164-355` — panics on unknown operation/host-function type
+- `internal/indexer/processors/transaction_operation_wrapper.go:644-660` — panics on unknown contract-id preimage type
+
+## Evidence
+
+The serializer has explicit `panic(fmt.Errorf(...))` defaults rather than returning an error for unknown enum arms.
+
+## Anti-Evidence
+
+There are no in-tree production call sites for `TransactionOperationWrapper.Details()` on main. The ingest persistence path stores raw operation XDR and never invokes this serializer, so the panic path is currently dead code.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Failed At**: hypothesis
+**Novelty**: PASS — not previously investigated
+
+### Why It Failed
+
+The panic branches are real, but the method is not exercised by any production ingest path on main. Without a reachable caller, this is a dormant code smell rather than an exploitable ingest crash.
+
+### Lesson Learned
+
+Enum-panic scans need a call-graph check. Several scary `panic` sites in the indexer live behind unused helper methods and are out of scope until a production caller appears.

--- a/ai-summary/fail/ingest/003-sac-schema-spoofing.md
+++ b/ai-summary/fail/ingest/003-sac-schema-spoofing.md
@@ -1,0 +1,67 @@
+# H003: SAC indexing trusts storage shape without verifying the contract ID matches the embedded asset
+
+**Date**: 2026-04-21
+**Subsystem**: ingest
+**Severity**: High
+**Impact**: balance integrity / wrong-asset attribution
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Ingest should only classify a contract as a Stellar Asset Contract when the contract's address matches the deterministic asset-contract ID derived from the embedded classic asset. Merely matching the SAC storage schema should not be enough to create `contract_tokens` or `sac_balances` rows for a contract.
+
+## Mechanism
+
+Both `SACInstanceProcessor` and `SACBalancesProcessor` trust the SDK helpers as sufficient proof that a ledger entry belongs to an SAC, but neither cross-checks `contractID == asset.ContractID(networkPassphrase)`. A custom contract that mimics SAC instance/balance storage for a victim `code:issuer` pair can therefore be indexed as a real SAC and populate attacker-controlled balances under an unrelated contract address, poisoning wallet data for that fake asset contract.
+
+## Trigger
+
+1. Deploy a custom Soroban contract at an attacker-controlled contract ID.
+2. Write contract instance and balance entries that satisfy the SAC helpers' expected schema for a victim asset, e.g. `USDC:G...`.
+3. Let ingest process the ledger and observe it inserting `contract_tokens`/`sac_balances` rows for the attacker contract as if it were the real asset contract.
+
+## Target Code
+
+- `internal/indexer/processors/sac_instances.go:47-85` — classifies any matching instance entry as `ContractTypeSAC`
+- `internal/indexer/processors/sac_balances.go:96-137` — accepts matching balance storage and persists it as SAC balance data
+- `internal/services/checkpoint.go:349-360` — checkpoint path also trusts SAC-shaped balance storage
+- `internal/indexer/processors/contracts/sac.go:isSACContract:292-299` — shows the stricter contract-ID equality check used elsewhere
+
+## Evidence
+
+The SAC ingest paths call `sac.AssetFromContractData` / `sac.ContractBalanceFromContractData` and immediately persist derived metadata, but do not derive the expected asset contract ID and compare it to the actual contract being indexed. In contrast, `SACEventsProcessor` explicitly performs that equality check before treating an event as SAC-specific.
+
+## Anti-Evidence
+
+The SDK helpers already reject malformed schemas, the native asset contract, and G-address holders for balance entries. The exploit therefore depends on crafting a contract whose storage looks SAC-valid enough to pass those helpers.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: PASS — not previously investigated
+**Failed At**: reviewer
+
+### Trace Summary
+
+The hypothesis claims neither `SACInstanceProcessor` nor `SACBalancesProcessor` cross-checks the contract ID against the deterministic asset contract ID. This is factually incorrect for the instance path. The SDK function `sac.AssetFromContractData` (go-stellar-sdk@v0.1.0, `ingest/sac/contract_data.go:170-176`) explicitly derives the expected contract ID from the embedded asset and rejects entries where `expectedID != *contractData.Contract.ContractId`. The balance path (`ContractBalanceFromContractData`) does lack this check, but balance entries carry no asset identity to derive an expected ID from, and any mislabeling is cosmetic with no corruption of real SAC data.
+
+### Code Paths Examined
+
+- `go-stellar-sdk@v0.1.0/ingest/sac/contract_data.go:AssetFromContractData:170-176` — **performs the exact contract ID equality check the hypothesis claims is missing**: `expectedID, err := asset.ContractID(passphrase); ... if expectedID != *(contractData.Contract.ContractId) { return false }`
+- `go-stellar-sdk@v0.1.0/ingest/sac/contract_data.go:ContractBalanceFromContractData:203-275` — validates balance schema (key=["Balance", address], value={amount, authorized, clawback}) and rejects native asset, but does NOT verify contract ID against a derived asset contract ID (balance entries don't carry asset identity)
+- `internal/indexer/processors/sac_instances.go:ProcessOperation:40-88` — calls `sac.AssetFromContractData` which includes the contract ID check; forged instances are rejected
+- `internal/indexer/processors/sac_balances.go:processSACBalanceChange:74-138` — calls `sac.ContractBalanceFromContractData`; stores balance under the entry's own contract ID (not a victim's)
+- `internal/services/checkpoint.go:316-371` — checkpoint balance path labels contract as SAC (line 356) if `ContractBalanceFromContractData` passes and no instance entry was processed first; but instance path at line 331 unconditionally overwrites, and balance path at line 352 only writes if not exists
+- `internal/indexer/processors/contracts/sac.go:isSACContract:292-299` — `SACEventsProcessor` also checks contract ID; this is the check the hypothesis cites as "stricter" but the same defense exists in the SDK's `AssetFromContractData`
+
+### Why It Failed
+
+The hypothesis's core mechanism is disproven. `sac.AssetFromContractData` already performs the `contractID == asset.ContractID(passphrase)` check (SDK lines 170-176), making the instance classification path immune to spoofing by a custom contract. The balance path (`ContractBalanceFromContractData`) does lack a contract ID check, but: (a) balance entries inherently cannot carry asset identity to derive an expected contract ID from, (b) any mislabeling of contract type in the checkpoint path is either prevented (instance processed first) or overwritten (instance processed after), and (c) no real SAC's balance data is corrupted since the fake contract has its own distinct contract ID. The worst-case impact is a cosmetic mislabeling of an attacker's own contract as SAC type with no code/issuer/name, which is Informational severity — below the Medium filing threshold.
+
+### Lesson Learned
+
+Always read the actual SDK source for helper functions before claiming they lack validation. `AssetFromContractData`'s doc comment explicitly states it "will ignore forged asset info entries by deriving the Stellar Asset Contract ID from the asset info entry and comparing it to the contract ID found in the ledger entry." The hypothesis missed this because it only examined the wallet-backend callers, not the SDK implementation.

--- a/ai-summary/fail/ingest/004-checkpoint-mustinstance-reachability.md
+++ b/ai-summary/fail/ingest/004-checkpoint-mustinstance-reachability.md
@@ -1,0 +1,51 @@
+# H004: Checkpoint bootstrap panics on instance-key / non-instance-value contract data
+
+**Date**: 2026-04-21
+**Subsystem**: ingest
+**Severity**: Medium
+**Impact**: availability
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Checkpoint bootstrap should tolerate unexpected `ContractData` union combinations and either skip them or return an ordinary error, matching the safer `GetInstance()+ok` pattern already present in adjacent ingest code.
+
+## Mechanism
+
+`processContractInstanceChange` calls `contractDataEntry.Val.MustInstance()` after checking only that the key arm is `ScvLedgerKeyContractInstance`. If a checkpoint snapshot ever contains the same key arm paired with a different value arm, bootstrap would panic during initial population.
+
+## Trigger
+
+1. Start ingest from an empty DB so `PopulateFromCheckpoint` runs.
+2. Feed it a checkpoint snapshot containing a `ContractData` entry whose key is `ScvLedgerKeyContractInstance` but whose value is not an instance.
+3. Observe the `MustInstance()` panic in checkpoint processing.
+
+## Target Code
+
+- `internal/services/checkpoint.go:326-340` — routes instance-key entries into `processContractInstanceChange`
+- `internal/services/checkpoint.go:502-545` — uses `Val.MustInstance()` without checking the union arm
+
+## Evidence
+
+The sibling `ProtocolContractsProcessor` already documents this exact malformed shape and switched to `GetInstance()+ok` to avoid panicking on it.
+
+## Anti-Evidence
+
+I could not tie this snapshot shape to a client-controlled, honest-upstream ledger path in the current trust model. Without proof that a network client can actually get such an entry into checkpoint state, the hypothesis remains speculative.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Failed At**: hypothesis
+**Novelty**: PASS — not previously investigated
+
+### Why It Failed
+
+The code smell is real, but reachability from attacker-controlled ledger input is unproven under the trusted-upstream model. I could not show how a normal network client can force this specific union mismatch into checkpoint state.
+
+### Lesson Learned
+
+Checkpoint-only panic candidates need both code evidence and a credible path from client-controlled ledger state into the checkpoint snapshot. A nearby defensive fix alone is not enough.

--- a/ai-summary/fail/ingest/004-sac-balance-map-order.md
+++ b/ai-summary/fail/ingest/004-sac-balance-map-order.md
@@ -1,0 +1,65 @@
+# H004: Live SAC balance ingestion assumes ScMap order and can misparse or panic on reordered balance values
+
+**Date**: 2026-04-21
+**Subsystem**: ingest
+**Severity**: High
+**Impact**: balance integrity / availability
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+SAC balance ingestion should read `amount`, `authorized`, and `clawback` by key name and should not depend on the serialized order of `ScMap` entries. Live ingestion and checkpoint ingestion should parse the same on-ledger balance value identically.
+
+## Mechanism
+
+After `sac.ContractBalanceFromContractData` returns success, the live path dereferences `val.MustMap()` and assumes `entries[0]` is `amount` and `entries[1:2]` are booleans. A valid SAC-like map serialized in another order can make `MustI128` / `MustB` read the wrong union arm and panic, or can silently swap persisted balance/authorization fields; the checkpoint path does not share this assumption because it scans the map by symbol key.
+
+## Trigger
+
+1. Produce a contract-data balance value whose keys are ordered differently from `[amount, authorized, clawback]`, such as `[authorized, amount, clawback]`.
+2. Let live ingest process that ledger update.
+3. Observe either a panic during `MustI128` / `MustB` or incorrect persisted `balance`, `is_authorized`, or `is_clawback_enabled` values.
+
+## Target Code
+
+- `internal/indexer/processors/sac_balances.go:96-145` — validates with SDK, then extracts fields positionally
+- `internal/services/token_ingestion.go:139-170` — persists the extracted SAC fields directly
+- `internal/services/checkpoint.go:619-655` — checkpoint counterpart parses the same value by key name
+
+## Evidence
+
+`extractSACBalanceFields` does `entries := *val.MustMap()` and returns `entries[0].Val.MustI128(), entries[1].Val.MustB(), entries[2].Val.MustB()`. The safer checkpoint implementation iterates the map and switches on `"amount"`, `"authorized"`, and `"clawback"` instead, which shows the codebase already has a non-order-dependent parser for the same shape.
+
+## Anti-Evidence
+
+If upstream Soroban serialization canonically preserves this exact field order for all SAC balance values, practical reachability is reduced. But the live parser itself does not enforce or re-check that invariant before using positional `Must*` accessors.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: PASS — not previously investigated
+**Failed At**: reviewer
+
+### Trace Summary
+
+Traced the full code path from `processSACBalanceChange` (sac_balances.go:74) through the SDK's `sac.ContractBalanceFromContractData` (go-stellar-sdk/ingest/sac/contract_data.go) and into `extractSACBalanceFields` (sac_balances.go:142-145). The SDK validation function explicitly checks positional order of map entries — `balanceMap[0].Key` must be `"amount"`, `balanceMap[1].Key` must be `"authorized"`, `balanceMap[2].Key` must be `"clawback"` — returning `false` for any other order. This means a reordered map never reaches the positional extraction code.
+
+### Code Paths Examined
+
+- `internal/indexer/processors/sac_balances.go:96-104` — calls `sac.ContractBalanceFromContractData(*entry, p.networkPassphrase)` and returns `skip=true` if `ok` is false
+- `go-stellar-sdk@v0.1.0/ingest/sac/contract_data.go:ContractBalanceFromContractData` — validates `len(balanceMap) == 3`, then checks `balanceMap[0].Key == "amount"`, `balanceMap[1].Key == "authorized"` (with IsBool), `balanceMap[2].Key == "clawback"` (with IsBool); returns `false` if any positional check fails
+- `internal/indexer/processors/sac_balances.go:142-145` — `extractSACBalanceFields` uses positional access `entries[0]`, `entries[1]`, `entries[2]`; only reachable after SDK validation passes
+
+### Why It Failed
+
+The SDK's `ContractBalanceFromContractData` acts as a positional-order gate. It explicitly validates that `balanceMap[0]` is `"amount"`, `balanceMap[1]` is `"authorized"`, and `balanceMap[2]` is `"clawback"` — using the exact same positional assumption the live parser uses. A map with reordered entries would fail the SDK check (returning `ok=false`), causing the live processor to skip the entry at line 103 before `extractSACBalanceFields` is ever called. The hypothesis's mechanism — that positional access can misparse or panic on reordered maps — is impossible because the SDK precondition guarantees the order.
+
+Additionally, the Soroban runtime's SAC implementation always serializes balance maps in canonical `[amount, authorized, clawback]` order, making non-canonical ordering unreachable from honest upstream (which is the trust model).
+
+### Lesson Learned
+
+When a hypothesis claims positional access is unsafe, check whether upstream validation functions enforce the same positional invariant. The SDK's `ContractBalanceFromContractData` and the live processor's `extractSACBalanceFields` share the same positional assumption — the SDK validates it, and the processor relies on it. The checkpoint path's key-name iteration is more defensive but functionally equivalent given the SDK gate.

--- a/ai-summary/fail/ingest/005-checkpoint-protocol-memory-oom.md
+++ b/ai-summary/fail/ingest/005-checkpoint-protocol-memory-oom.md
@@ -1,0 +1,69 @@
+# H005: Checkpoint bootstrap retains all contract/WASM protocol bookkeeping in memory until EOF
+
+**Date**: 2026-04-21
+**Subsystem**: ingest
+**Severity**: Medium
+**Impact**: availability
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Checkpoint population should stream or batch protocol bookkeeping so a fresh node does not need to hold every unique contract token, WASM hash, and contract-to-WASM mapping in RAM until the entire checkpoint snapshot finishes. Large public chain state should degrade bootstrap linearly, not create a single in-memory accumulation point.
+
+## Mechanism
+
+`PopulateFromCheckpoint` processes the entire snapshot in one transaction and stores protocol-related state in process-local maps (`uniqueContractTokens`, `wasmClassifications`, `contractAddressesByWasmHash`) until `finalize` runs at EOF. An attacker who fills chain state with many uploaded WASMs and deployed contracts can therefore turn public ledger state into a deterministic bootstrap OOM / slow-start vector for any new or rebuilt ingest node.
+
+## Trigger
+
+1. Upload and deploy a large number of distinct contract bytecodes/contracts on chain.
+2. Start a fresh ingest instance with an empty DB so `PopulateFromCheckpoint` runs.
+3. Observe checkpoint processing retain all unique protocol bookkeeping entries in memory until the reader reaches EOF and `finalize` executes.
+
+## Target Code
+
+- `internal/services/checkpoint.go:101-115` — long-lived `uniqueContractTokens` checkpoint maps
+- `internal/services/checkpoint.go:195-203,232-240` — in-memory `wasmClassifications` and `contractAddressesByWasmHash`
+- `internal/services/checkpoint.go:334-338,375-377` — every matching contract/WASM is accumulated into those maps
+- `internal/services/checkpoint.go:408-441` — persistence happens only once, during finalization
+
+## Evidence
+
+Balances are streamed in batches, but protocol bookkeeping is not: new hashes and contract mappings are appended to maps throughout the full reader loop and are only written after EOF. There is no intermediate flush, spill-to-disk, or configurable cap on those maps.
+
+## Anti-Evidence
+
+The attack is most effective against empty-DB bootstrap and rebuild flows rather than steady-state live ingestion. It also requires enough on-chain contract state to make the in-memory accumulation materially large.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: PASS — not previously investigated
+**Failed At**: reviewer
+
+### Trace Summary
+
+Traced the full `PopulateFromCheckpoint` flow in `internal/services/checkpoint.go`. Confirmed that `checkpointProcessor` accumulates three unbounded maps (`wasmClassifications`, `contractAddressesByWasmHash`, `uniqueContractTokens`/`uniqueAssets`) throughout the entire checkpoint read loop (lines 243-268), flushing them only at `finalize` (lines 408-441). Meanwhile, balance data IS streamed via the `batch` struct with `flushBatchSize = 250_000` (lines 381-391). The asymmetry described in the hypothesis is real.
+
+### Code Paths Examined
+
+- `internal/services/checkpoint.go:101-115` — `checkpointData` struct holds `uniqueAssets` and `uniqueContractTokens` maps, confirmed unbounded
+- `internal/services/checkpoint.go:194-205` — `checkpointProcessor` struct holds `wasmClassifications` (map[xdr.Hash]types.ContractType) and `contractAddressesByWasmHash` (map[xdr.Hash][]xdr.Hash), confirmed unbounded
+- `internal/services/checkpoint.go:232-240` — maps initialized empty at start of `PopulateFromCheckpoint`
+- `internal/services/checkpoint.go:258-260` — `processContractCode` appends to `wasmClassifications` for every ContractCode entry
+- `internal/services/checkpoint.go:326-338` — `processEntry` appends to `uniqueContractTokens` and `contractAddressesByWasmHash` for contract instances
+- `internal/services/checkpoint.go:375-377` — `processContractCode` unconditionally inserts every WASM hash into `wasmClassifications`
+- `internal/services/checkpoint.go:408-441` — `finalize` is the sole consumer of these maps, called only after EOF
+- `internal/services/checkpoint.go:381-391` — `flushBatchIfNeeded` streams balances at 250K threshold — protocol maps have no equivalent flush
+
+### Why It Failed
+
+The code pattern is real but the worst-case impact cannot reach Medium severity. Per-entry memory overhead is approximately 340 bytes (100 for wasmClassifications + 90 for contractAddressesByWasmHash + 150 for uniqueContractTokens). To consume 1GB of RAM requires ~3M unique deployed contracts; to reach a typical 4-8GB OOM threshold requires 12-24M contracts. Current Stellar mainnet has on the order of tens of thousands of contracts. Deploying millions of contracts on-chain to create the OOM payload would require enormous transaction fees, making the attack economically infeasible. Furthermore, the vulnerability only manifests during fresh bootstrap (empty-DB) flows, not steady-state operation, and operators can provision sufficient RAM for bootstrap. The finding is a legitimate design improvement suggestion (Informational severity) but falls below the Medium minimum threshold required by the objective's severity scale.
+
+### Lesson Learned
+
+Unbounded in-memory accumulation during checkpoint processing is a real pattern worth noting for future design reviews, but the economic cost of inflating Stellar chain state (contract deployment fees) creates a natural bound that makes OOM from this path impractical at current and foreseeable chain sizes. Future hypotheses about checkpoint OOM should quantify the on-chain cost to reach meaningful memory pressure.

--- a/ai-summary/fail/request-lifecycle/001-account-by-address-cross-account-read.md
+++ b/ai-summary/fail/request-lifecycle/001-account-by-address-cross-account-read.md
@@ -1,0 +1,76 @@
+# H001: accountByAddress allows arbitrary cross-account reads with any valid JWT
+
+**Date**: 2026-04-21
+**Subsystem**: request-lifecycle
+**Severity**: High
+**Impact**: Confidentiality / GraphQL authz bypass returning cross-tenant account data
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+A JWT that proves control of one whitelisted Stellar key should only authorize reads for that caller's own account data, or for some explicitly authorized account set. A request for `accountByAddress(address: "<victim>")` should be rejected when the verified JWT subject does not match `<victim>`.
+
+## Mechanism
+
+The HTTP auth layer only answers the boolean question "is this request signed by any configured key" and then discards the verified claims. `accountByAddress` accepts any syntactically valid Stellar address, constructs an `Account` object for that address, and the `Account` field resolvers then read balances, transactions, operations, and state changes for that user-controlled address without comparing it to the authenticated subject.
+
+## Trigger
+
+1. Obtain a valid JWT for an attacker-controlled whitelisted key.
+2. Send `POST /graphql/query` with `query { accountByAddress(address: "<victim G-address>") { balances(first: 10) { edges { node { ... on NativeBalance { balance } ... on TrustlineBalance { code issuer balance } } } } transactions(first: 10) { edges { node { hash } } } } }`.
+3. Observe that the server returns the victim account's balance and history instead of rejecting the cross-account read.
+
+## Target Code
+
+- `pkg/wbclient/auth/jwt_http_signer_verifier.go:VerifyHTTPRequest:95-103` — verifies the signature but returns only success/failure, not the caller identity
+- `internal/serve/middleware/middleware.go:AuthenticationMiddleware:25-27` — forwards the request after a successful boolean auth check without attaching claims to context
+- `internal/serve/graphql/resolvers/queries.resolvers.go:AccountByAddress:70-82` — accepts any valid address supplied by the caller
+- `internal/serve/graphql/resolvers/account.resolvers.go:Balances/Transactions/Operations/StateChanges:25-173` — reads account-scoped data keyed solely by `obj.StellarAddress`
+
+## Evidence
+
+`VerifyHTTPRequest` discards the parsed claims (`_, _, err := s.parser.ParseJWT(...)`), so no verified subject survives into GraphQL execution. `AuthenticationMiddleware` simply calls `next.ServeHTTP` on success, while `AccountByAddress` returns `&types.Account{StellarAddress: types.AddressBytea(address)}` for any valid address and each `Account` resolver uses that user-controlled address directly in database reads.
+
+## Anti-Evidence
+
+The JWT still provides strong proof that the caller controls some whitelisted key, so this is not an unauthenticated bypass. Invalid Stellar addresses and malformed transaction hashes are rejected, which limits the issue to authorization rather than input validation.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: PASS — not previously investigated
+**Failed At**: reviewer
+
+### Trace Summary
+
+Traced the full request lifecycle from `VerifyHTTPRequest` through `AuthenticationMiddleware` into the `accountByAddress` resolver and its child resolvers (`Balances`, `Transactions`, `Operations`, `StateChanges`). Confirmed that the JWT claims are discarded after verification and no caller identity is propagated to the resolver layer. However, also confirmed that this is intentional design, not a bug, because the wallet-backend indexes public Stellar blockchain data and provides unrestricted read access to any authenticated client.
+
+### Code Paths Examined
+
+- `pkg/wbclient/auth/jwt_http_signer_verifier.go:VerifyHTTPRequest:95-103` — confirmed `_, _, err := s.parser.ParseJWT(...)` discards claims; returns only error
+- `internal/serve/middleware/middleware.go:AuthenticationMiddleware:22-28` — confirmed boolean auth gate with no claims propagated to context
+- `internal/serve/graphql/resolvers/queries.resolvers.go:AccountByAddress:71-82` — confirmed returns `Account` for any valid address
+- `internal/serve/graphql/resolvers/queries.resolvers.go:Transactions:39-68` — root query returns ALL transactions with no account scoping
+- `internal/serve/graphql/resolvers/queries.resolvers.go:Operations:86-115` — root query returns ALL operations with no account scoping
+- `internal/serve/graphql/resolvers/queries.resolvers.go:StateChanges:124-154` — root query returns ALL state changes with no account scoping
+- `internal/serve/graphql/resolvers/account.resolvers.go:25-173` — account resolvers use `obj.StellarAddress` directly
+
+### Why It Failed
+
+The hypothesis describes **working-as-designed behavior** and incorrectly states the expected behavior. The wallet-backend is a read-only indexer over public Stellar blockchain data — all account balances, transactions, operations, and state changes on the Stellar ledger are inherently public and queryable by anyone via Horizon or stellar-rpc. The JWT authentication gates access to the API service itself, not to specific accounts' data.
+
+Three pieces of evidence confirm this is by-design:
+
+1. **Root queries expose all data without scoping.** The `Transactions`, `Operations`, and `StateChanges` root queries return ALL indexed data with pagination but no account filter. If per-account authorization were intended, these queries would also need scoping — their existence proves the API deliberately exposes all indexed ledger data.
+
+2. **The subsystem's own security surface documentation states this explicitly**: "Any valid token signed by any whitelisted public key can query any account, transaction, or state change. Resolver-level authorization does not exist."
+
+3. **Trust model alignment.** The objective's trust model states "The server custodies no funds but gates access to account metadata" — meaning the auth gates API access, not per-account data. Per the severity criteria, "GraphQL auth/authz bypass" requires bypassing authorization that exists. There is no per-account authorization to bypass.
+
+### Lesson Learned
+
+When evaluating cross-account read hypotheses against blockchain indexers, always check whether the underlying data is inherently public. A read-only index over a public ledger has no confidentiality boundary between accounts — the JWT authentication is an API-access gate, not a data-isolation mechanism. Also check for unscoped root queries (e.g., `Transactions` without account filter) as evidence that the API intentionally exposes all data to any authenticated caller.

--- a/ai-summary/fail/request-lifecycle/001-cross-origin-jwt-replay-needs-shared-trust-domain.md
+++ b/ai-summary/fail/request-lifecycle/001-cross-origin-jwt-replay-needs-shared-trust-domain.md
@@ -1,0 +1,52 @@
+# H001: Cross-origin JWT replay via missing host or audience binding
+
+**Date**: 2026-04-21
+**Subsystem**: request-lifecycle
+**Severity**: Medium
+**Impact**: Authentication / replay across deployments
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+A JWT minted for one wallet-backend deployment should not be accepted by a different deployment unless the server explicitly intends those deployments to share an authorization domain. A verifier that wants origin isolation should bind the token to deployment identity via `aud`, `iss`, host, or another origin-specific claim.
+
+## Mechanism
+
+The generated JWT contains only `sub`, `iat`, `exp`, `bodyHash`, and `methodAndPath`, and verification checks only those fields against the current request. That initially suggests a replay path where a signed `/graphql/query` request could be reused against another deployment that shares the same allowlisted key.
+
+## Trigger
+
+1. Capture or mint a valid JWT for `POST /graphql/query` on deployment A.
+2. Replay the same method, URI, and body to deployment B.
+3. Check whether deployment B accepts it when both deployments trust the same client key.
+
+## Target Code
+
+- `pkg/wbclient/auth/jwt_manager.go:GenerateJWT:70-80` — only sets `Subject`, `IssuedAt`, and `ExpiresAt` in `RegisteredClaims`
+- `pkg/wbclient/auth/claims.go:Validate:19-50` — validates `sub`, `bodyHash`, and `methodAndPath`, but not host or audience
+- `pkg/wbclient/auth/jwt_http_signer_verifier.go:VerifyHTTPRequest:92-99` — binds the signature to `req.URL.RequestURI()` rather than a broader origin
+
+## Evidence
+
+There is no `Audience`, `Issuer`, or host binding in the token format, and `VerifyHTTPRequest` compares only method, `RequestURI`, and body hash. On the surface, that means the same signed request could verify anywhere that accepts the same public key and exposes the same path.
+
+## Anti-Evidence
+
+The trust model for this scan does not give the attacker passive network visibility to steal someone else's JWT, and a second deployment must already be configured to trust the same public key before acceptance is even possible. Under that shared-trust configuration, the second deployment has explicitly authorized the same caller, so the missing host/audience claim does not create a new in-scope unauthorized capability by itself.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Failed At**: hypothesis
+**Novelty**: PASS — not previously investigated
+
+### Why It Failed
+
+This attack only materializes when another deployment already trusts the same client key, and the stated attacker model does not include stealing somebody else's signed request in transit. Without a separate trust domain boundary enforced elsewhere, the missing host or audience binding is a deployment-design concern rather than an exploitable in-scope auth bypass on `main`.
+
+### Lesson Learned
+
+For this repo and threat model, replay findings need a concrete path that gives the attacker a token they otherwise could not mint themselves, or a way to cross a trust boundary that the server code actually distinguishes. "No audience claim" is not enough on its own when the verifier's only authorization primitive is the shared public-key allowlist.

--- a/ai-summary/fail/request-lifecycle/002-global-ledger-queries-ignore-caller-identity.md
+++ b/ai-summary/fail/request-lifecycle/002-global-ledger-queries-ignore-caller-identity.md
@@ -1,0 +1,66 @@
+# H002: root ledger queries expose global history to any whitelisted JWT
+
+**Date**: 2026-04-21
+**Subsystem**: request-lifecycle
+**Severity**: High
+**Impact**: Confidentiality / GraphQL authz bypass returning global transaction and state-change data
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Authenticated callers should not be able to enumerate the entire indexed ledger unless the API explicitly defines a privileged role for that subject. Root queries that return transactions, operations, or state changes should either scope results to the verified caller or reject the request for non-privileged identities.
+
+## Mechanism
+
+The request lifecycle never propagates the verified JWT subject into resolver authorization, and the root GraphQL schema exposes global collection queries plus direct object lookups. As a result, any valid JWT can call `transactions`, `operations`, `stateChanges`, `transactionByHash`, or `operationById` and receive records unrelated to the caller, enabling broad cross-tenant history extraction without even knowing a victim address up front.
+
+## Trigger
+
+1. Obtain a valid JWT for any configured client key.
+2. Send `query { transactions(first: 50) { edges { node { hash ledgerNumber accounts { address } } } } }` or `query { stateChanges(first: 50) { edges { node { account { address } type reason } } } }`.
+3. Observe that the API returns globally indexed ledger data rather than data scoped to the JWT subject.
+
+## Target Code
+
+- `internal/serve/graphql/schema/queries.graphqls:3-10` — exposes global `transactions`, `operations`, `stateChanges`, `transactionByHash`, and `operationById` entry points
+- `pkg/wbclient/auth/jwt_http_signer_verifier.go:VerifyHTTPRequest:95-103` — verifies but discards the caller identity
+- `internal/serve/middleware/middleware.go:AuthenticationMiddleware:25-27` — does not attach claims or role information to the request context
+- `internal/serve/graphql/resolvers/queries.resolvers.go:TransactionByHash/Transactions/Operations/OperationByID/StateChanges:19-154` — serves global records with no subject-based filtering
+
+## Evidence
+
+The schema exposes global root collections and direct object lookups. The corresponding resolvers call `r.models.Transactions.GetAll`, `r.models.Operations.GetAll`, `r.models.StateChanges.GetAll`, `r.models.Transactions.GetByHash`, and `r.models.Operations.GetByID` directly, and none of those resolver paths read any authenticated identity from context because none was stored there.
+
+## Anti-Evidence
+
+The GraphQL endpoint is not public: requests still require a valid JWT from a configured public key. Complexity limits and pagination restrict query volume, but they do not reduce the authorization gap once a caller is authenticated.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: PASS — not previously investigated
+**Failed At**: reviewer
+
+### Trace Summary
+
+Traced the full request lifecycle from JWT verification through GraphQL resolution. Confirmed that `VerifyHTTPRequest` (line 97) discards the parsed token and claims (`_, _, err := s.parser.ParseJWT(...)`), `AuthenticationMiddleware` does not attach identity to context, and all root query resolvers (`Transactions`, `Operations`, `StateChanges`, `TransactionByHash`, `OperationByID`) call unscoped model methods. However, this is the intended architecture of the system.
+
+### Code Paths Examined
+
+- `pkg/wbclient/auth/jwt_http_signer_verifier.go:VerifyHTTPRequest:95-103` — confirmed token/claims return values are discarded; only error is checked
+- `internal/serve/middleware/middleware.go:AuthenticationMiddleware:22-29` — confirmed no context enrichment with caller identity; just pass/fail gate
+- `internal/serve/graphql/schema/queries.graphqls:3-10` — confirmed global root queries including `transactions`, `operations`, `stateChanges` with no caller-scoping parameters
+- `internal/serve/graphql/resolvers/queries.resolvers.go:19-154` — confirmed all resolvers call unscoped `GetAll`/`GetByHash`/`GetByID` with no identity filtering
+- `internal/serve/graphql/resolvers/queries.resolvers.go:71-82` — `AccountByAddress` takes an explicit `address` parameter, confirming the design intent is for clients to look up arbitrary accounts
+
+### Why It Failed
+
+This describes **working-as-designed behavior**, not a bug. The wallet-backend is a Stellar blockchain indexer, and all Stellar ledger data is inherently public — anyone can query any transaction, account, or operation on the public Stellar network via Horizon or any block explorer. The system has no multi-tenant concept: there is no "your data" vs "someone else's data" because the underlying blockchain is a public ledger. The JWT authentication gates API access (only trusted clients may use the indexer), not data visibility. The `accountByAddress(address: String!)` query takes an explicit address argument — confirming the design intent that callers look up data about any account, not just "their" account. The hypothesis's "Expected Behavior" asserts a per-caller data-scoping model that the system was never designed to implement.
+
+### Lesson Learned
+
+When evaluating authorization gaps on a blockchain indexer, consider whether the underlying data has a meaningful confidentiality property. Stellar ledger data is public, so serving it to any authenticated client is not an authz bypass — it is the intended function of the service. A true authz finding here would require showing that the API exposes *non-public* data (e.g., server-internal state, private keys, or operator secrets) to unauthorized callers, not that it serves public blockchain records without per-caller scoping.

--- a/ai-summary/fail/request-lifecycle/003-batched-transaction-operations-hide-late-ops.md
+++ b/ai-summary/fail/request-lifecycle/003-batched-transaction-operations-hide-late-ops.md
@@ -1,0 +1,75 @@
+# H003: batched Transaction.operations silently hides operations after the tenth child
+
+**Date**: 2026-04-21
+**Subsystem**: request-lifecycle
+**Severity**: Medium
+**Impact**: Integrity / incomplete transaction rendering can hide malicious operations in nested GraphQL views
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+If a client asks for `operations(first: N)` on multiple transactions in one GraphQL response, each transaction should still honor the requested page size and return a correct `PageInfo` that signals whether more operations exist. A transaction with more than 10 operations should not be silently truncated to 10 while reporting that no further page exists.
+
+## Mechanism
+
+`transactionResolver.Operations` computes `queryLimit = first + 1` so Relay pagination can determine `hasNextPage`, but the multi-parent dataloader path clamps that value to `min(limit, 10)` and drops the per-transaction cursor entirely. When a query batches more than one transaction, a transaction with more than 10 operations can be rendered as if it were complete even though later operations were never fetched, letting a malicious transaction bury sensitive operations beyond the tenth child in a view the client believes is exhaustive.
+
+## Trigger
+
+1. Ensure the indexed data contains at least two transactions in the requested page, and one of them has more than 10 operations.
+2. Send `query { transactions(first: 2) { edges { node { hash operations(first: 50) { edges { node { id operationType } } pageInfo { hasNextPage endCursor } } } } } }`.
+3. Observe that the high-fanout transaction returns only 10 operations because the loader's multi-key path capped the per-parent query, and `pageInfo` can under-report the existence of later operations because the resolver expected `first + 1` rows but never received them.
+
+## Target Code
+
+- `internal/serve/graphql/resolvers/transaction.resolvers.go:Operations:26-63` — requests `first + 1` rows for Relay pagination
+- `internal/serve/graphql/dataloaders/operation_loaders.go:operationsByToIDLoader:39-58` — switches to a multi-key path when more than one transaction is present, clamps the limit to `MaxOperationsPerBatch = 10`, and drops `Cursor`
+- `internal/data/operations.go:BatchGetByToIDs:115-161` — enforces the reduced per-transaction row cap via `ROW_NUMBER() ... WHERE rn <= limit`
+- `internal/data/operations_test.go:320-380` — confirms the per-parent `ROW_NUMBER` limiting behavior
+
+## Evidence
+
+The resolver computes `queryLimit := *params.Limit + 1`, but `operationsByToIDLoader` replaces that with `maxLimit := min(*limit, MaxOperationsPerBatch)` whenever `len(keys) > 1`. The data-layer query then applies `WHERE rn <= <limit>` per `to_id`, so a request for `first: 50` across multiple parent transactions fetches at most 10 rows per transaction even though the GraphQL connection logic still assumes it asked for 51.
+
+## Anti-Evidence
+
+The truncation is intentional for batched performance, so this is not a random edge case. Single-transaction queries use `BatchGetByToID`, which honors the real cursor and limit, so the integrity issue depends on getting multiple parent transactions into the same GraphQL batch.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: PASS — not previously investigated
+**Failed At**: reviewer
+
+### Trace Summary
+
+Traced the full execution path from `transactionResolver.Operations` through the dataloader batching logic into `BatchGetByToIDs` and back through `NewConnectionWithRelayPagination`. Confirmed the bug is real: when multiple transactions batch together, operations are clamped to 10 per parent and `hasNextPage` incorrectly reports `false` because the relay pagination function compares `len(nodes)` (≤10) against the original `params.Limit` (e.g. 50). However, the impact does not reach the minimum Medium severity threshold for this security scan.
+
+### Code Paths Examined
+
+- `internal/serve/graphql/resolvers/transaction.resolvers.go:Operations:26-63` — confirmed `queryLimit = *params.Limit + 1` passed to loader, `params.Limit` (original) passed to `NewConnectionWithRelayPagination`
+- `internal/serve/graphql/dataloaders/operation_loaders.go:40-58` — confirmed `len(keys) > 1` triggers `maxLimit = min(*limit, MaxOperationsPerBatch=10)`, cursor dropped
+- `internal/data/operations.go:BatchGetByToIDs:115-162` — confirmed `ROW_NUMBER() OVER (PARTITION BY) ... WHERE rn <= limit` caps at 10 per parent
+- `internal/serve/graphql/resolvers/utils.go:NewConnectionWithRelayPagination:62-108` — confirmed `hasNextPage = int32(len(nodes)) > *params.Limit` evaluates to `10 > 50 = false`
+
+### Why It Failed
+
+The bug is confirmed real — batched operation queries silently truncate to 10 results per transaction with incorrect `hasNextPage: false`. However, the impact cannot be argued up to Medium severity per the objective's severity scale:
+
+1. **Not auth bypass** — no authentication or authorization boundary is crossed.
+2. **Not balance-integrity loss** — this affects operations (public blockchain data), not account balances or token attribution.
+3. **Not persistent state corruption** — the database is correct; only the API response is incomplete.
+4. **Not a crash/panic** — no denial of service from unauthenticated input.
+5. **Not cache desync** — Redis/DB consistency is unaffected.
+6. **The data is public** — all Stellar operations are publicly visible on-chain; a client can query individual transactions for full results via the single-key path.
+7. **Intentional design trade-off** — the code has a `TODO: this should be configurable via config` comment on `MaxOperationsPerBatch`, and the anti-evidence section of the hypothesis itself acknowledges this.
+
+The worst-case impact (incomplete rendering of public blockchain operations in nested GraphQL views) maps to Low/Informational severity, which is below the minimum Medium filing threshold for this security scan.
+
+### Lesson Learned
+
+API pagination accuracy bugs in read-only public-data indexers are real correctness issues but do not constitute security vulnerabilities when: (a) the underlying data has no confidentiality boundary, (b) the database state is unaffected, (c) alternative query paths exist to retrieve complete data, and (d) the truncation is a documented intentional design trade-off. When assessing "hidden data" claims, verify whether the data carries any trust or confidentiality requirement per the threat model.

--- a/ai-summary/fail/request-lifecycle/004-batched-transaction-state-changes-hide-late-changes.md
+++ b/ai-summary/fail/request-lifecycle/004-batched-transaction-state-changes-hide-late-changes.md
@@ -1,0 +1,74 @@
+# H004: batched Transaction.stateChanges truncates per-transaction evidence at ten rows
+
+**Date**: 2026-04-21
+**Subsystem**: request-lifecycle
+**Severity**: Medium
+**Impact**: Integrity / nested state-change views can omit later account mutations while appearing complete
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Nested `Transaction.stateChanges(first: N)` queries should honor the requested page size for every transaction in the response, and `PageInfo` should reliably indicate whether additional state changes exist. A transaction with dozens of state changes should not collapse to 10 rows merely because another transaction was fetched in the same GraphQL request.
+
+## Mechanism
+
+The transaction state-change resolver also asks for `first + 1` rows, but the multi-parent loader path rewrites that to `min(limit, 10)` and stops carrying the per-transaction cursor. The downstream SQL uses `ROW_NUMBER() OVER (PARTITION BY sc.to_id)` with the reduced limit, so later state changes for a high-fanout transaction disappear from the nested GraphQL connection even though the client asked for a much larger page and will build `PageInfo` from an artificially shortened slice.
+
+## Trigger
+
+1. Ensure the first page of `transactions(first: 2)` contains a transaction with more than 10 indexed state changes.
+2. Send `query { transactions(first: 2) { edges { node { hash stateChanges(first: 50) { edges { node { account { address } type reason } } pageInfo { hasNextPage endCursor } } } } } }`.
+3. Observe that the busy transaction returns at most 10 state changes when another transaction is present in the same response, allowing later mutations to be hidden from the client.
+
+## Target Code
+
+- `internal/serve/graphql/resolvers/transaction.resolvers.go:StateChanges:90-128` — requests `first + 1` rows for nested transaction state changes
+- `internal/serve/graphql/dataloaders/statechange_loaders.go:stateChangesByToIDLoader:31-55` — multi-key path caps the requested limit at `MaxStateChangesPerBatch = 10` and omits cursor handling
+- `internal/data/statechanges.go:BatchGetByToIDs:379-427` — applies `ROW_NUMBER() OVER (PARTITION BY sc.to_id)` and `WHERE rn <= limit`
+- `internal/data/statechanges_test.go:609-614` — demonstrates the per-`to_id` truncation behavior
+
+## Evidence
+
+The resolver's `queryLimit := *params.Limit + 1` is supposed to support Relay pagination, but `stateChangesByToIDLoader` substitutes `maxLimit := min(*limit, MaxStateChangesPerBatch)` whenever more than one transaction is batched. The SQL query then hard-limits each `to_id` partition with `WHERE rn <= <limit>`, so a client asking for 50 rows gets at most 10 rows per transaction without the connection layer knowing the fetch was truncated early.
+
+## Anti-Evidence
+
+Single-transaction requests use `BatchGetByToID`, which does accept a cursor and the real requested limit. The vulnerability therefore requires a multi-parent GraphQL batch, not a lone `transactionByHash { stateChanges(...) }` request.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-23
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: FAIL — duplicate of H003 (003-batched-transaction-operations-hide-late-ops.md)
+**Failed At**: reviewer
+
+### Trace Summary
+
+Traced the execution path from `transactionResolver.StateChanges` (line 90) through `StateChangesByToIDLoader.Load` into the `stateChangesByToIDLoader` fetcher (statechange_loaders.go:31-65), confirming the multi-key path at line 50 applies `maxLimit := min(*limit, MaxStateChangesPerBatch)` (capped at 10) and drops the cursor. The relay pagination function at `utils.go:69` then checks `int32(len(nodes)) > *params.Limit`, which evaluates to `10 > 50 = false`, incorrectly reporting `hasNextPage: false`. This is structurally identical to the operations truncation in H003.
+
+### Code Paths Examined
+
+- `internal/serve/graphql/resolvers/transaction.resolvers.go:StateChanges:90-128` — confirmed `queryLimit = *params.Limit + 1` passed to loader key, original `params` passed to `NewConnectionWithRelayPagination`
+- `internal/serve/graphql/dataloaders/statechange_loaders.go:31-65` — confirmed `len(keys) > 1` triggers `maxLimit = min(*limit, MaxStateChangesPerBatch=10)`, cursor dropped at line 54 (not passed to `BatchGetByToIDs`)
+- `internal/serve/graphql/resolvers/utils.go:NewConnectionWithRelayPagination:62-108` — confirmed `hasNextPage = int32(len(nodes)) > *params.Limit` evaluates to `false` when loader returns ≤10 nodes against a limit of 50
+
+### Why It Failed
+
+This is a **duplicate of H003** (003-batched-transaction-operations-hide-late-ops.md). H003 covered the identical bug pattern — multi-parent dataloader batching truncation with incorrect `hasNextPage` — for `Transaction.operations`. H004 applies the same pattern to `Transaction.stateChanges`. Both use the same architectural mechanism (`MaxXxxPerBatch = 10`, cursor drop, `ROW_NUMBER()` partition, relay pagination mismatch), and the severity assessment is identical.
+
+Even setting aside the duplicate status, the impact does not reach Medium severity per the objective's severity scale:
+
+1. **Not auth bypass** — no authentication or authorization boundary is crossed.
+2. **Not balance-integrity loss** — state changes are public blockchain event records, not account balances or token attribution.
+3. **Not persistent state corruption** — the database is correct; only the nested API response is incomplete.
+4. **Not a crash/panic** — no denial of service.
+5. **Not cache desync** — Redis/DB consistency is unaffected.
+6. **The data is public** — all Stellar state changes are publicly visible on-chain; clients can query individual transactions via the single-key path for complete results.
+7. **Intentional design trade-off** — the code has a `TODO: this should be configurable via config` comment on `MaxStateChangesPerBatch`.
+
+### Lesson Learned
+
+When a hypothesis restates an already-investigated pattern (multi-parent dataloader truncation) for a different child type (state changes vs operations), it is a duplicate regardless of which field is affected, because the mechanism, severity assessment, and mitigation are identical. The `TODO` comments on both `MaxOperationsPerBatch` and `MaxStateChangesPerBatch` confirm the truncation is a known intentional trade-off.

--- a/ai-summary/fail/request-lifecycle/005-batched-operation-state-changes-drop-per-field-cursors.md
+++ b/ai-summary/fail/request-lifecycle/005-batched-operation-state-changes-drop-per-field-cursors.md
@@ -1,0 +1,79 @@
+# H005: aliased Operation.stateChanges batches ignore each field's cursor
+
+**Date**: 2026-04-21
+**Subsystem**: request-lifecycle
+**Severity**: Medium
+**Impact**: Integrity / cursor-confused nested pagination can replay first-page state changes and hide later ones
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+If a GraphQL query asks for `stateChanges(first: 2, after: "<cursor>")` on two different operations in the same response, each operation's field should apply its own cursor and return the next page for that specific operation. Batched execution should preserve per-field cursor semantics even when the loads are coalesced.
+
+## Mechanism
+
+`operationResolver.StateChanges` includes the caller-supplied cursor in `StateChangeColumnsKey`, but the dataloader's multi-key path ignores every key's `Cursor` and calls `BatchGetByOperationIDs` with only `(operationIDs, columns, limit, sortOrder)`. Two aliased root lookups can therefore batch together and both receive first-page state changes again, even though each field supplied a later-page cursor, which lets an attacker or malicious dataset keep later state changes out of a client workflow that trusts nested pagination.
+
+## Trigger
+
+1. Pick two operations that each have at least three state changes and obtain a valid `after` cursor for page 2 of each operation.
+2. Send a single query such as:
+   `query { a: operationById(id: 101) { stateChanges(first: 2, after: "<cursor-a>") { edges { node { type reason } } pageInfo { endCursor } } } b: operationById(id: 202) { stateChanges(first: 2, after: "<cursor-b>") { edges { node { type reason } } pageInfo { endCursor } } } }`
+3. Observe that both aliased fields can return rows from the start of each operation instead of honoring the supplied page-2 cursors because the batched loader never forwards those cursors to SQL.
+
+## Target Code
+
+- `internal/serve/graphql/schema/queries.graphqls:3-10` — exposes `operationById`, which can be aliased to force multiple `Operation.stateChanges` loads in one request
+- `internal/serve/graphql/resolvers/operation.resolvers.go:StateChanges:74-113` — captures a per-field cursor in `StateChangeColumnsKey`
+- `internal/serve/graphql/dataloaders/statechange_loaders.go:stateChangesByOperationIDLoader:71-94` — ignores `keys[i].Cursor` when `len(keys) > 1`
+- `internal/data/statechanges.go:BatchGetByOperationID:429-485` — single-operation path supports decomposed cursor pagination
+- `internal/data/statechanges.go:BatchGetByOperationIDs:488-537` — batched path has no cursor parameter at all
+
+## Evidence
+
+The single-operation SQL path explicitly expands the supplied cursor into a decomposed `AND (...)` clause, but the multi-operation SQL path cannot do that because `BatchGetByOperationIDs` receives no cursor input. Since dataloadgen batches requests across the request with a 5 ms window, aliased `operationById` fields can land in the same batch and silently lose their per-field cursor boundaries.
+
+## Anti-Evidence
+
+If only one operation's `stateChanges` field is resolved in the request, the loader uses `BatchGetByOperationID` and pagination behaves correctly. The issue depends on coalescing multiple `Operation.stateChanges` loads into one dataloader batch.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-23
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: PASS — not previously investigated (related to H003 but targets a different loader/entity)
+**Failed At**: reviewer
+
+### Trace Summary
+
+Traced the full execution path from `operationResolver.StateChanges` (line 74) through the `StateChangeColumnsKey` construction (including `Cursor` at line 87), into `stateChangesByOperationIDLoader` (line 71), and through both the single-key path (`BatchGetByOperationID`, line 86, which supports cursor pagination) and the multi-key path (`BatchGetByOperationIDs`, line 93, which drops cursors entirely). Confirmed the bug is real: when multiple `Operation.stateChanges` fields batch together via dataloadgen's 5ms window, the per-field cursor is silently dropped and both fields receive first-page results. Also confirmed `BatchGetByOperationIDs` (line 488-537 in statechanges.go) has no cursor parameter — it uses only `ROW_NUMBER() OVER (PARTITION BY operation_id)` with a limit.
+
+### Code Paths Examined
+
+- `internal/serve/graphql/resolvers/operation.resolvers.go:StateChanges:74-113` — confirmed `StateChangeColumnsKey` includes `Cursor: params.StateChangeCursor` (line 87), but this cursor is only consumed by the single-key path
+- `internal/serve/graphql/dataloaders/statechange_loaders.go:stateChangesByOperationIDLoader:71-105` — confirmed `len(keys) > 1` triggers multi-key path (line 88-93) which passes only `operationIDs, columns, limit, sortOrder` — NO cursor
+- `internal/data/statechanges.go:BatchGetByOperationID:429-486` — confirmed single-key path supports decomposed cursor pagination via `buildDecomposedCursorCondition` (lines 444-453)
+- `internal/data/statechanges.go:BatchGetByOperationIDs:488-537` — confirmed batched path has no cursor parameter; uses `ROW_NUMBER() OVER (PARTITION BY operation_id)` with only a limit cap
+- `internal/serve/graphql/resolvers/utils.go:NewConnectionWithRelayPagination` — confirmed relay pagination function compares `len(nodes)` against `params.Limit` to compute `hasNextPage`
+
+### Why It Failed
+
+The bug is confirmed real — batched state-change queries via operation ID silently drop per-field cursors and return first-page results for all batched operations. However, the impact cannot be argued up to Medium severity per the objective's severity scale:
+
+1. **Not auth bypass** — no authentication or authorization boundary is crossed.
+2. **Not balance-integrity loss** — this affects state changes (public blockchain operation metadata), not account balances or token attribution. The `tokenIngestionService` and balance cache paths are entirely unaffected.
+3. **Not persistent state corruption** — the database is correct; only the API response is incorrect when batching occurs.
+4. **Not a crash/panic** — no denial of service.
+5. **Not cache desync** — Redis/DB consistency is unaffected.
+6. **The data is public** — all Stellar state changes are publicly visible on-chain; a client can query individual operations for correct paginated results via the single-key path.
+7. **Same class of bug as H003** — H003 documented the identical pattern for operations batched by transaction ID (truncation + cursor drop in `operationsByToIDLoader`). That finding was also marked NOT_VIABLE for identical severity reasons.
+8. **Intentional design trade-off** — the `TODO: this should be configurable via config` comment on `MaxStateChangesPerBatch` (line 14) and the code comments documenting the single-key vs multi-key split confirm this is a known limitation of the batching strategy.
+
+The worst-case impact (incorrect pagination of public blockchain state changes in nested GraphQL views) maps to Low/Informational severity, which is below the minimum Medium filing threshold for this security scan.
+
+### Lesson Learned
+
+DataLoader batching cursor-drop bugs are a systematic pattern across the wallet-backend's one-to-many loaders (operations-by-toID, state-changes-by-toID, state-changes-by-operationID). While they are real correctness bugs, they consistently fail to reach Medium severity in this threat model because: (a) the underlying data is public blockchain data with no confidentiality boundary, (b) the database state is unaffected, (c) the single-key query path provides a correct alternative, and (d) the batching trade-off is documented as intentional. Future hypotheses about dataloader cursor/limit handling in this codebase should be rejected early unless they can demonstrate balance-integrity corruption or persistent state divergence.

--- a/ai-summary/fail/sorobanauth/001-accountbyaddress-cross-account-read.md
+++ b/ai-summary/fail/sorobanauth/001-accountbyaddress-cross-account-read.md
@@ -1,0 +1,77 @@
+# H001: AccountByAddress Is Not Bound To JWT Subject
+
+**Date**: 2026-04-21
+**Subsystem**: sorobanauth
+**Severity**: High
+**Impact**: confidentiality / GraphQL authz bypass
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+After JWT verification succeeds, the GraphQL layer should know which Stellar address authenticated the request and reject `accountByAddress(address: ...)` requests for other accounts/contracts unless an explicit server-side authorization rule allows them. Account-scoped fields such as `balances`, `transactions`, `operations`, and `stateChanges` should only return data for the authenticated subject (or an authorized delegate), not for an arbitrary caller-supplied address.
+
+## Mechanism
+
+`VerifyHTTPRequest` only returns success/failure and discards the parsed JWT claims, while `AuthenticationMiddleware` forwards the request unchanged when verification succeeds. `AccountByAddress` then instantiates an account object directly from the caller-supplied `address`, and every account field resolver queries storage with that address without comparing it to any authenticated subject, so any holder of a valid Ed25519 JWT can read another account's indexed data.
+
+## Trigger
+
+1. Authenticate with any valid Stellar keypair accepted by `CLIENT_AUTH_PUBLIC_KEYS`.
+2. Send a GraphQL request like `accountByAddress(address: "G...victim...") { balances { edges { node { tokenId balance } } } transactions { edges { node { hash } } } operations { edges { node { id } } } stateChanges { edges { node { __typename } } } }`.
+3. Observe that the backend returns the victim account's data instead of rejecting the query as cross-account access.
+
+## Target Code
+
+- `pkg/wbclient/auth/jwt_http_signer_verifier.go:67-102` — verification succeeds/fails but does not propagate claims/subject.
+- `internal/serve/middleware/middleware.go:16-44` — authenticated requests are passed downstream without caller identity in context.
+- `internal/serve/graphql/resolvers/queries.resolvers.go:70-82` — `AccountByAddress` trusts the caller-supplied address.
+- `internal/serve/graphql/resolvers/account.resolvers.go:26-172` — account field resolvers query by `obj.StellarAddress` with no subject check.
+
+## Evidence
+
+The auth middleware calls `requestAuthVerifier.VerifyHTTPRequest(req)` and, on success, immediately executes `next.ServeHTTP(rw, req)` without attaching claims to the request context. `AccountByAddress` only validates StrKey syntax, returns `&types.Account{StellarAddress: ...}`, and the downstream resolvers use that raw address as the database lookup key.
+
+## Anti-Evidence
+
+The request must still carry a valid JWT signed by an allowed key, so this is not an unauthenticated bypass. Complexity limits and pagination validation reduce query size, but they do not enforce tenant scoping.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: PASS — not previously investigated
+**Failed At**: reviewer
+
+### Trace Summary
+
+Traced the full authentication and query path: JWT claims contain a `Subject` field that is validated as a Stellar public key, but this subject identifies the **client application** (from `CLIENT_AUTH_PUBLIC_KEYS`), not an end user. `VerifyHTTPRequest` returns only `error`; the middleware passes requests downstream without context enrichment. The GraphQL schema has no authorization directives and no per-account scoping. Root queries (`Transactions`, `Operations`, `StateChanges`) return ALL data without any account binding, confirming the system is designed as a client-app-authenticated data API, not a per-user-scoped service.
+
+### Code Paths Examined
+
+- `pkg/wbclient/auth/claims.go:13-17,38-39` — `customClaims.Subject` is validated as a Stellar public key, used to identify the client app
+- `pkg/wbclient/auth/jwt_manager.go:47,77,159-161` — `Subject` is matched against `CLIENT_AUTH_PUBLIC_KEYS`; it identifies the client application, not an end user
+- `pkg/wbclient/auth/jwt_http_signer_verifier.go:67-102` — `VerifyHTTPRequest` returns `error` only, discards claims (confirmed)
+- `internal/serve/middleware/middleware.go:16-44` — middleware calls `next.ServeHTTP(rw, req)` on success with no context enrichment (confirmed)
+- `internal/serve/serve.go:186-210` — auth middleware is conditionally applied; GraphQL routes are behind client-app auth, not user-scoped auth
+- `internal/serve/graphql/resolvers/queries.resolvers.go:36-68` — root `Transactions` query returns ALL transactions without account scoping
+- `internal/serve/graphql/resolvers/queries.resolvers.go:70-82` — `AccountByAddress` validates StrKey syntax only (confirmed)
+- `internal/serve/graphql/resolvers/account.resolvers.go:26-172` — account resolvers query by `obj.StellarAddress` (confirmed)
+- `internal/serve/graphql/schema/queries.graphqls:1-10` — no authorization directives; `accountByAddress` is a general query
+- `internal/serve/graphql/schema/directives.graphqls` — only `@goField` directive exists (code generation, not authorization)
+
+### Why It Failed
+
+This hypothesis describes **working-as-designed behavior**, not a security vulnerability. The JWT `Subject` identifies a **client application** (one of `CLIENT_AUTH_PUBLIC_KEYS`), not an individual end user. The system is intentionally designed as a client-app-authenticated blockchain data API where any authenticated client can query any account's indexed data — analogous to a blockchain explorer with API key authentication.
+
+Key evidence that this is by-design:
+1. Root queries (`Transactions`, `Operations`, `StateChanges`) return ALL data across all accounts without any address binding — there is no concept of tenant scoping anywhere in the system.
+2. The auth middleware is even optional (`if deps.RequestAuthVerifier != nil`), confirming it gates access to the API, not to specific data.
+3. The GraphQL schema has zero authorization directives — no `@auth`, `@hasRole`, or `@owner` patterns.
+4. Stellar blockchain data is inherently public; the backend indexes public ledger data and serves it to authorized client applications.
+
+### Lesson Learned
+
+The JWT subject in this system identifies a client application, not an end user. Any hypothesis claiming per-account authorization bypass must first verify that per-account authorization exists in the design. The presence of root-level unscoped queries (Transactions, Operations) is the fastest signal that the system does not implement tenant scoping.

--- a/ai-summary/fail/sorobanauth/001-authorizeentry-nil-address-panic.md
+++ b/ai-summary/fail/sorobanauth/001-authorizeentry-nil-address-panic.md
@@ -1,0 +1,50 @@
+# H001: AuthorizeEntry Panics On Address Credentials With Nil Address
+
+**Date**: 2026-04-21
+**Subsystem**: sorobanauth
+**Severity**: Medium
+**Impact**: availability
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+`AuthSigner.AuthorizeEntry` should return a descriptive error when it is asked to sign a `SorobanCredentialsTypeSorobanCredentialsAddress` entry whose `Credentials.Address` pointer is nil. Malformed authorization entries should not be able to crash a caller process.
+
+## Mechanism
+
+The function only checks `auth.Credentials.Type` and then immediately dereferences `auth.Credentials.Address.Address` while rebuilding the entry. A caller that feeds an address-typed entry with a nil `Address` pointer would hit a nil-pointer panic instead of receiving a typed error.
+
+## Trigger
+
+Call `(*AuthSigner).AuthorizeEntry` with:
+- `auth.Credentials.Type = xdr.SorobanCredentialsTypeSorobanCredentialsAddress`
+- `auth.Credentials.Address = nil`
+
+## Target Code
+
+- `pkg/sorobanauth/sorobanauth.go:33-50` — dereferences `auth.Credentials.Address.Address` without a nil guard.
+
+## Evidence
+
+Unlike `CheckForForbiddenSigners`, which explicitly checks `auth.Credentials.Address == nil`, `AuthorizeEntry` does not validate the pointer before dereferencing it.
+
+## Anti-Evidence
+
+The only in-repo callers are integration-test helpers that sign RPC simulation results, and there are no production imports of `pkg/sorobanauth` on `main`. I did not find a live server path that feeds attacker-controlled auth entries into this function.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Failed At**: hypothesis
+**Novelty**: PASS — not previously investigated
+
+### Why It Failed
+
+The panic is real at the package boundary, but I could not connect it to a production wallet-backend request path on `main`; the code is only imported by integration infrastructure in-tree.
+
+### Lesson Learned
+
+For this subsystem, exported-library robustness bugs are not enough on their own. They need a concrete production caller on `main` or an explicit server path that consumes attacker-controlled `SorobanAuthorizationEntry` values.

--- a/ai-summary/fail/sorobanauth/002-global-graphql-history-enumeration.md
+++ b/ai-summary/fail/sorobanauth/002-global-graphql-history-enumeration.md
@@ -1,0 +1,74 @@
+# H002: Root GraphQL History Queries Ignore Caller Identity
+
+**Date**: 2026-04-21
+**Subsystem**: sorobanauth
+**Severity**: High
+**Impact**: confidentiality / GraphQL authz bypass
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Authenticated GraphQL callers should only be able to enumerate transactions, operations, and state changes they are authorized to see. Root history queries should either be denied for end-user JWTs or filtered to records associated with the authenticated subject, rather than exposing the entire indexed ledger history to any valid keypair.
+
+## Mechanism
+
+The server treats JWT authentication as a binary "has any valid token" check and never binds the authenticated subject into GraphQL authorization. As a result, root resolvers call `GetAll`, `GetByHash`, and `GetByID` directly on global tables, letting any valid JWT enumerate or fetch arbitrary transactions, operations, and state changes across all tenants.
+
+## Trigger
+
+1. Authenticate with any valid Stellar keypair accepted by the server.
+2. Issue one of:
+   - `transactions(first: 50) { edges { node { hash ledgerNumber } } }`
+   - `operations(first: 50) { edges { node { id operationType } } }`
+   - `stateChanges(first: 50) { edges { node { __typename ledgerNumber } } }`
+   - `transactionByHash(hash: "<someone-else's-hash>") { hash }`
+   - `operationById(id: <someone-else's-id>) { id }`
+3. Observe that the backend returns global history instead of enforcing per-subject visibility.
+
+## Target Code
+
+- `internal/serve/middleware/middleware.go:16-44` — authentication is presence-only after verify.
+- `internal/serve/graphql/resolvers/queries.resolvers.go:22-33` — `TransactionByHash` reads by arbitrary hash.
+- `internal/serve/graphql/resolvers/queries.resolvers.go:39-67` — `Transactions` reads from `models.Transactions.GetAll`.
+- `internal/serve/graphql/resolvers/queries.resolvers.go:84-121` — `Operations` and `OperationByID` expose arbitrary operations.
+- `internal/serve/graphql/resolvers/queries.resolvers.go:123-154` — `StateChanges` exposes arbitrary state changes.
+
+## Evidence
+
+Every root history resolver obtains DB columns and then calls the corresponding model with no reference to request identity. There is no context value, subject extraction, or ownership filter between `AuthenticationMiddleware` and these resolver methods.
+
+## Anti-Evidence
+
+These endpoints are behind JWT authentication when auth is configured, so the attacker still needs one valid signing key. Pagination and complexity limits constrain volume per request but not access scope.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: FAIL — substantially equivalent to `ai-summary/fail/apptracker/001-account-balances-authz-bypass.md` (same auth-model misunderstanding applied to different query types)
+**Failed At**: reviewer
+
+### Trace Summary
+
+Traced the authentication middleware, JWT verification chain, and all root GraphQL resolvers for transactions, operations, and state changes. The JWT auth model uses `ClientAuthPublicKeys` — a server-configured list of trusted client application public keys. The JWT `Subject` claim identifies the calling **client application**, not an end-user Stellar address. Authentication is service-to-service: "Is this request from a trusted client app?" Once authenticated, all queries are intentionally accessible to any authorized client for all indexed data.
+
+### Code Paths Examined
+
+- `internal/serve/serve.go:142-146` — `NewMultiJWTTokenParser` built from `cfg.ClientAuthPublicKeys`, confirming app-level auth model
+- `pkg/wbclient/auth/jwt_manager.go:47-49` — `JWTManager.ParseJWT` checks `claims.Subject != m.PublicKey`, verifying against the *client app key*, not any user address
+- `pkg/wbclient/auth/jwt_manager.go:152-165` — `MultiJWTTokenParser.ParseJWT` routes by `claims.Subject` to pre-configured client parsers
+- `pkg/wbclient/auth/jwt_http_signer_verifier.go:67-103` — `VerifyHTTPRequest` returns nil on success, discarding parsed claims entirely
+- `internal/serve/middleware/middleware.go:16-44` — `AuthenticationMiddleware` only checks `err == nil`; stores nothing in context
+- `internal/serve/graphql/resolvers/queries.resolvers.go:22-154` — All root resolvers (TransactionByHash, Transactions, Operations, OperationByID, StateChanges) read from global tables with no identity filter
+- `internal/serve/serve.go:186-236` — GraphQL route gated by auth middleware, no identity propagation to resolvers
+
+### Why It Failed
+
+The hypothesis describes **working-as-designed behavior** based on a fundamental misunderstanding of the authentication model. The JWT does not represent an end-user Stellar account — its `Subject` is a **client application's public key** from the server's `client-auth-public-keys` configuration. There is no concept of "tenants" or "per-user data." The wallet-backend authenticates trusted client applications (service-to-service), and all GraphQL queries are designed to serve the full indexed ledger dataset to any authenticated client. Furthermore, Stellar ledger data (transactions, operations, state changes) is inherently **public on the blockchain** — the wallet-backend is an indexer caching this public data, so per-account access control would provide no security benefit. This is the identical reasoning that rejected `apptracker/001-account-balances-authz-bypass.md`.
+
+### Lesson Learned
+
+The wallet-backend JWT auth model is client-application-level, not per-user. Any hypothesis claiming "cross-tenant" or "cross-caller" data access across *any* GraphQL query type (balances, transactions, operations, state changes) is not viable because the system has no tenant boundaries. The `ClientAuthPublicKeys` config gates access to the entire API as a unit.

--- a/ai-summary/fail/sorobanauth/002-muxed-forbidden-list-bypass-is-caller-misuse.md
+++ b/ai-summary/fail/sorobanauth/002-muxed-forbidden-list-bypass-is-caller-misuse.md
@@ -1,0 +1,51 @@
+# H002: Muxed Forbidden Signer Aliases Can Miss G-Address Matches
+
+**Date**: 2026-04-21
+**Subsystem**: sorobanauth
+**Severity**: High
+**Impact**: integrity / forbidden-signer bypass
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+`CheckForForbiddenSigners` should canonicalize both the operation source account and the forbidden-signer blacklist so that `M...` and `G...` representations of the same underlying Ed25519 key are treated identically. A caller-supplied blacklist should not be bypassable by choosing a different StrKey representation for the same signer.
+
+## Mechanism
+
+The function canonicalizes `opSourceAccount` through `ResolveToGAddress`, but it compares address-credential signers directly against the raw `forbiddenSigners` slice. If a caller supplies a forbidden signer as an `M...` address while the auth entry stringifies to the underlying `G...` address, the `slices.Contains` test will miss the match.
+
+## Trigger
+
+1. Call `CheckForForbiddenSigners` with `forbiddenSigners = []string{"M...forbidden..."}`.
+2. Pass an address-credential auth entry whose signer is the same underlying account but stringifies as `G...`.
+3. Observe that the function does not flag the signer as forbidden.
+
+## Target Code
+
+- `pkg/sorobanauth/sorobanauth.go:135-167` — canonicalizes only `opSourceAccount`, not `forbiddenSigners`.
+- `pkg/utils/utils.go:121-131` — provides the canonicalization helper used on the source-account side.
+
+## Evidence
+
+The source-account branch calls `ResolveToGAddress(opSourceAccount)`, while the address-credentials branch compares `auth.Credentials.Address.Address.String()` directly against the caller-supplied strings. No normalization step is applied to the blacklist itself.
+
+## Anti-Evidence
+
+There are no in-tree production callers of `CheckForForbiddenSigners`, and the exploit requires the caller to build the blacklist from attacker-influenced `M...` input rather than from fixed privileged-account configuration.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Failed At**: hypothesis
+**Novelty**: PASS — not previously investigated
+
+### Why It Failed
+
+This is a caller-misuse hazard, not a wallet-backend server exploit on `main`: no production code invokes the function, and the attacker would need influence over the blacklist input itself.
+
+### Lesson Learned
+
+For `CheckForForbiddenSigners`, reachability matters more than theoretical mismatch behavior. A viable finding here needs a concrete submission path in production code that actually depends on this helper and accepts attacker-shaped blacklist input.

--- a/ai-summary/fail/sorobanauth/003-soroban-auth-participants-leak-via-nested-accounts.md
+++ b/ai-summary/fail/sorobanauth/003-soroban-auth-participants-leak-via-nested-accounts.md
@@ -1,0 +1,81 @@
+# H003: Soroban Auth Participants Leak Through Nested Transaction And Operation Accounts
+
+**Date**: 2026-04-21
+**Subsystem**: sorobanauth
+**Severity**: High
+**Impact**: confidentiality / cross-tenant Soroban auth metadata disclosure
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Nested GraphQL `accounts` fields should only expose true ledger participants that the caller is authorized to see. Soroban authorization metadata such as signer addresses and nested contract/auth-tree addresses should not be turned into globally readable account lists for arbitrary callers without an explicit authorization decision.
+
+## Mechanism
+
+For successful Soroban operations, `participantsForAuthEntries` unions the auth signer address with every contract/account address found in `RootInvocation` and all `SubInvocations`, and `Indexer.processTransaction` persists those derived addresses into `operations_accounts`. The GraphQL `Operation.accounts` and `Transaction.accounts` resolvers then batch-load and return those rows with no caller check, so any valid JWT can inspect Soroban auth participant graphs for operations it does not own.
+
+## Trigger
+
+1. Identify or submit a successful Soroban transaction that uses address-based auth and/or nested subinvocations.
+2. Authenticate with any valid JWT.
+3. Query either:
+   - `transactionByHash(hash: "...") { accounts { address } operations(first: 10) { edges { node { id accounts { address } } } } }`
+   - `operationById(id: ...) { accounts { address } }`
+4. Observe addresses/contracts that come from Soroban auth entries and subinvocations rather than caller-owned scope checks.
+
+## Target Code
+
+- `internal/indexer/processors/contract_operations.go:51-127` — recursively extracts signer and subinvocation addresses from auth entries.
+- `internal/indexer/processors/contract_operations.go:332-356` — `InvokeContractOpProcessor` unions auth participants into the operation participant set.
+- `internal/indexer/indexer.go:198-208` — persists every derived participant into `operations_accounts`.
+- `internal/serve/graphql/dataloaders/account_loaders.go:43-66` — batch-loads `operations_accounts` rows with no authz filter.
+- `internal/serve/graphql/resolvers/operation.resolvers.go:48-67` — returns `Operation.accounts` directly.
+- `internal/serve/graphql/resolvers/transaction.resolvers.go:66-84` — returns `Transaction.accounts` directly from participant tables.
+
+## Evidence
+
+The participant extractor does not distinguish "address appeared in Soroban auth metadata" from "address is authorized to view this operation"; it simply unions every discovered address into the participant set. The nested GraphQL account resolvers perform a straight dataloader lookup on the persisted mapping and never compare the result to the authenticated request subject.
+
+## Anti-Evidence
+
+Only successful Soroban transactions reach this path, so malformed or failed transactions do not create the leak. Some leaked addresses are contract IDs or already-on-ledger public accounts, which reduces secrecy for those specific values, but the cross-operation authorization graph is still disclosed server-side.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: FAIL — duplicate of H001 (001-accountbyaddress-cross-account-read.md)
+**Failed At**: reviewer
+
+### Trace Summary
+
+Traced all six target code paths. Confirmed that `participantsForAuthEntries` extracts signer and contract addresses from auth entries (lines 108-127), `InvokeContractOpProcessor.Participants()` unions these into the operation participant set (lines 332-356), and the indexer persists them into `operations_accounts` (lines 198-208). The GraphQL resolvers load and return these participants without per-caller filtering. However, this is identical to the working-as-designed behavior already investigated and rejected in H001.
+
+### Code Paths Examined
+
+- `internal/indexer/processors/contract_operations.go:108-127` — `participantsForAuthEntries` extracts signer addresses and recursively collects subinvocation participants; confirmed behavior matches hypothesis
+- `internal/indexer/processors/contract_operations.go:332-356` — `InvokeContractOpProcessor.Participants()` unions source account, contract ID, and auth participants into a single set; confirmed
+- `internal/indexer/indexer.go:198-208` — persists all participants into `operations_accounts` via `buffer.PushOperation`; confirmed
+- `internal/serve/graphql/dataloaders/account_loaders.go:43-66` — batch-loads accounts by operation ID with no authz filter; confirmed
+- `internal/serve/graphql/resolvers/operation.resolvers.go:48-67` — returns accounts directly from dataloader; no authz check; confirmed
+- `internal/serve/graphql/resolvers/transaction.resolvers.go:66-84` — returns accounts by ToID from dataloader; no authz check; confirmed
+
+### Why It Failed
+
+This hypothesis is a duplicate of H001 (001-accountbyaddress-cross-account-read.md), which was already investigated and rejected as **working-as-designed behavior**. The H001 review established conclusively that:
+
+1. **The JWT Subject identifies a client application, not an end user.** There is no per-user identity in the system to scope data against.
+2. **The system has no concept of tenant scoping.** Root queries (`Transactions`, `Operations`, `StateChanges`) return ALL data across all accounts without any address binding.
+3. **The GraphQL schema has zero authorization directives** — no `@auth`, `@hasRole`, or `@owner` patterns exist anywhere.
+4. **Stellar blockchain data is inherently public.** Soroban authorization entries are part of on-chain transaction metadata visible to anyone querying the Stellar network directly.
+
+H003 describes the same architectural property (no per-caller data scoping in GraphQL) applied to a specific data subset (Soroban auth participant addresses). The "leak" it describes is the system functioning exactly as designed — serving indexed public blockchain data to authenticated client applications.
+
+Additionally, even if evaluated independently, the impact cannot reach Medium severity: the data is already public on the Stellar blockchain, and the "cross-tenant" framing presupposes a tenant model that does not exist in the system's design.
+
+### Lesson Learned
+
+Any hypothesis claiming data disclosure through GraphQL resolvers must first verify that per-user data scoping exists in the system. The wallet-backend is a client-app-authenticated blockchain data API that intentionally serves all indexed ledger data (including Soroban auth metadata) to any authenticated client. The absence of per-resolver authz checks is a design choice, not a vulnerability. H001's lesson applies broadly to all data fields in the GraphQL schema.

--- a/ai-summary/fail/sorobanauth/004-muxed-soroban-source-poisons-operations-accounts.md
+++ b/ai-summary/fail/sorobanauth/004-muxed-soroban-source-poisons-operations-accounts.md
@@ -1,0 +1,83 @@
+# H004: Muxed Soroban Operation Sources Poison operations_accounts Rows
+
+**Date**: 2026-04-21
+**Subsystem**: sorobanauth
+**Severity**: Medium
+**Impact**: availability / persistent participant-table corruption
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+When a Soroban operation uses a muxed source account, participant persistence should canonicalize that source to the underlying `G...` address (or reject it consistently) before writing to `operations_accounts`. Stored account IDs must remain decodable so later GraphQL queries over `Operation.accounts` continue to work.
+
+## Mechanism
+
+`participantsForSorobanOp` seeds the participant set with `op.SourceAccount().Address()`, which preserves an `M...` source account verbatim. `AddressBytea.Value` then calls `strkey.DecodeAny`, allocates a fixed 33-byte buffer, and copies only the first 32 bytes of the decoded payload before `BatchCopy` writes the row; later reads scan the malformed 33-byte value back through `AddressBytea.Scan`, which expects a valid 33-byte `G.../C...` encoding, so queries that load `operations_accounts` for the poisoned operation can fail.
+
+## Trigger
+
+1. Submit a successful Soroban `InvokeHostFunction` operation with an operation-level muxed source account (`M...`) and a regular transaction source.
+2. Let ingestion persist the operation participants.
+3. Query `operationById(id: ...) { accounts { address } }` or `transactionByHash(hash: ...) { operations(first: 10) { edges { node { accounts { address } } } } }`.
+4. Observe loader/query failure caused by the malformed persisted account row.
+
+## Target Code
+
+- `internal/indexer/processors/transaction_operation_wrapper.go:55-63` — preserves the muxed operation source.
+- `internal/indexer/processors/contract_operations.go:146-183` — seeds Soroban participants with `op.SourceAccount().Address()`.
+- `internal/indexer/types/types.go:52-87` — `AddressBytea.Scan`/`Value` assume a fixed 33-byte storage shape.
+- `internal/data/operations.go:380-420` — writes participant rows into `operations_accounts`.
+- `internal/data/accounts.go:42-59` — reads `operations_accounts` rows back into `AddressBytea`.
+- `internal/serve/graphql/resolvers/operation.resolvers.go:48-67` — exposes the failing load path.
+
+## Evidence
+
+The muxed source is never normalized through `ResolveToGAddress` on the Soroban participant path. `AddressBytea.Value` does not reject non-33-byte decoded payloads before truncating them into a 33-byte buffer, which creates an asymmetry with `AddressBytea.Scan`, where only a correctly encoded 33-byte value is accepted.
+
+## Anti-Evidence
+
+The damage appears limited to the participant side-table and the GraphQL fields that load from it; root `accountByAddress` rejects `M...` input, so not every query surface is affected. The finding depends on Stellar permitting muxed operation sources on the specific Soroban host-function shape used.
+
+---
+
+## Review
+
+**Verdict**: NOT_VIABLE
+**Date**: 2026-04-21
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: PASS — not previously investigated (distinct from H002 muxed-forbidden-list-bypass which concerns `CheckForForbiddenSigners`, not participant persistence)
+**Failed At**: reviewer
+
+### Trace Summary
+
+Traced the full data flow from `MuxedAccount.Address()` through `participantsForSorobanOp` → `AddressBytea.Value()` → PostgreSQL BYTEA → `AddressBytea.Scan()` → GraphQL response. The silent truncation in `Value()` is real: `DecodeAny("M...")` returns 40 raw bytes (32 Ed25519 + 8 mux ID), but `copy(result[1:], rawBytes)` into a 33-byte buffer silently drops the last 8 bytes. However, `Scan()` does NOT fail — `strkey.Encode(VersionByteMuxedAccount, 32_bytes)` succeeds, producing a truncated but structurally valid 56-character M-address. Furthermore, the correct G-address is always present in the union from the parallel `Participants()` → `ToAccountId()` path.
+
+### Code Paths Examined
+
+- `xdr/muxed_account.go:GetAddress()` — for `CryptoKeyTypeKeyTypeMuxedEd25519`, encodes 32+8=40 raw bytes with `VersionByteMuxedAccount`; confirmed `Address()` returns `M...` for muxed accounts
+- `internal/indexer/processors/transaction_operation_wrapper.go:56-63` — `SourceAccount()` returns `*xdr.MuxedAccount`; `.Address()` preserves the M-address (confirmed)
+- `internal/indexer/processors/contract_operations.go:151` — `set.NewSet(op.SourceAccount().Address())` — adds the M-address verbatim to participants (confirmed)
+- `internal/indexer/processors/participants.go:167-173` — `op.Participants()` calls `SourceAccount().ToAccountId()` which resolves muxed → G-address; this G-address is added to the SAME set via union (confirmed)
+- `internal/indexer/types/types.go:76-87` — `AddressBytea.Value()`: `DecodeAny` returns 40 bytes for M-address; `copy(result[1:], rawBytes)` copies only 32 bytes into the 33-byte buffer, silently dropping 8 bytes (confirmed)
+- `internal/indexer/types/types.go:53-72` — `AddressBytea.Scan()`: reads 33 bytes, calls `strkey.Encode(VersionByteMuxedAccount, 32_bytes)` which SUCCEEDS (Encode does not validate payload size against version byte), producing a truncated 56-char M-address
+- `strkey/main.go:143-173` — `Encode()` validates only version byte validity and max payload size (100); does NOT reject 32-byte payload for muxed version byte
+- `internal/data/operations.go:390-404` — `AddressBytea(addr).Value()` is called per participant; no error for M-addresses (truncation is silent)
+- `internal/data/accounts.go:42-58` — `BatchGetByOperationIDs` reads `account_id` via `AddressBytea.Scan()` which succeeds (no query failure)
+
+### Why It Failed
+
+**Severity below Medium.** The truncation bug is real but the impact does not meet the minimum filing threshold:
+
+1. **No query failure**: The hypothesis claims "observe loader/query failure" but `AddressBytea.Scan()` succeeds — `strkey.Encode(VersionByteMuxedAccount, 32_bytes)` produces a valid (though wrong) StrKey. No crash, no panic, no error.
+
+2. **Correct G-address always present**: The non-Soroban participant path (`Participants()` → `ToAccountId().Address()`) adds the canonical G-address to the same union set. The corrupted M-address is an *additional* wrong row, not a replacement.
+
+3. **Impact is a spurious participant entry**: The only effect is that `operations_accounts` gets one extra row with a truncated M-address that doesn't correspond to any real account. GraphQL clients see one extra bogus participant address alongside the correct one.
+
+4. **Does not match any Medium criteria**: Not a crash/panic from unauth'd input; not a Redis desync; not a CAS violation; not a JWT replay; not an OOM. The closest match is "persistent state corruption from malicious ledger data" (High), but (a) muxed sources are valid protocol data, not malicious, and (b) the corruption is limited to an extra wrong row in a side table with the correct data also present.
+
+This is a genuine code quality bug (Low/Informational) but falls below the Medium minimum severity for this security scan.
+
+### Lesson Learned
+
+`AddressBytea` assumes all Stellar addresses decode to exactly 32 raw key bytes (+ 1 version byte = 33). Muxed accounts (`M...`) decode to 40 raw bytes, causing silent truncation. However, because the non-Soroban participant path (`ToAccountId()`) always adds the canonical G-address, the corruption only produces an extra wrong row rather than losing the correct participant. For a finding to reach Medium severity, the silent truncation would need to affect a data path where the correct address is NOT also stored — such as balance attribution or transaction source fields.

--- a/ai-summary/fail/sorobanauth/005-auth-subinvocations-can-forge-contract-deploy-history.md
+++ b/ai-summary/fail/sorobanauth/005-auth-subinvocations-can-forge-contract-deploy-history.md
@@ -1,0 +1,75 @@
+# H005: Contract Deploy History Is Derived From Auth Trees Instead Of Executed Ledger Effects
+
+**Date**: 2026-04-21
+**Subsystem**: sorobanauth
+**Severity**: High
+**Impact**: integrity / persistent state corruption
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Contract deployment state changes should only be emitted for contracts that were actually deployed by the executed host function and confirmed by ledger effects. Merely mentioning a `CreateContract*` preimage in a Soroban authorization tree should not be enough to create persistent deploy history for a contract/account address.
+
+## Mechanism
+
+`ContractDeployProcessor` recursively walks every `invokeHostOp.Auth[*].RootInvocation` and emits a deployment state change for each `CreateContractHostFn` or `CreateContractV2HostFn` it encounters, even though those invocations come from authorization metadata rather than the executed operation body or ledger diff. If Soroban accepts auth trees that are broader than the executed invocation tree, an attacker can get the backend to record phantom contract deployments for deterministic contract IDs that were never created on-chain.
+
+## Trigger
+
+1. Craft a successful Soroban transaction whose executed host function does **not** deploy a contract, but whose auth entry tree contains a `CreateContractHostFn`/`CreateContractV2HostFn` branch with a chosen `ContractIdPreimage`.
+2. Submit the transaction on-chain and wait for ingestion.
+3. Query state changes or contract/account history for the derived contract ID.
+4. Observe a create/deploy record even though no corresponding deployment ledger effect exists.
+
+## Target Code
+
+- `internal/indexer/processors/contract_deploy.go:31-127` — emits deploy state changes from auth-root and subinvocation traversal.
+- `internal/indexer/processors/contract_operations.go:51-105` — shows the same recursive trust in auth-tree subinvocations.
+- `internal/serve/graphql/resolvers/account.resolvers.go:108-172` — exposes persisted state changes for arbitrary account/contract addresses.
+- `internal/serve/graphql/resolvers/queries.resolvers.go:70-82` — allows callers to pivot directly to the chosen contract/account address.
+
+## Evidence
+
+The processor's `walkInvocation` function only inspects `SorobanAuthorizedInvocation` values and never consults the actual operation result meta before emitting a create state change. The main loop calls `walkInvocation(auth.RootInvocation)` for every auth entry on every successful invoke-host-function operation.
+
+## Anti-Evidence
+
+Soroban may require the authorization tree to match the executed invocation tree exactly, in which case extra create-contract branches would be rejected before the transaction reaches ingestion. If that invariant holds at the protocol layer, this specific corruption path closes.
+
+---
+
+## Review
+
+**Verdict**: NEEDS_REFINEMENT
+**Date**: 2026-04-21
+**Reviewed by**: claude-opus-4-6, high
+**Failed At**: reviewer
+
+### What's Wrong
+
+The hypothesis's specific trigger requires a **successful** Soroban transaction whose auth tree contains `CreateContractHostFn` branches that don't correspond to actual executed invocations. This is blocked by the Soroban protocol: Stellar Core enforces that auth entry invocation trees must match the actual execution trace. An auth entry with extra `CreateContractHostFn` subinvocations that were never executed would fail auth matching, causing the transaction to fail. For successful transactions, the auth tree and execution tree are consistent, so every `CreateContractHostFn` in the auth tree corresponds to a real deployment.
+
+However, the **underlying code deficiency is real**: `ContractDeployProcessor.ProcessOperation` (contract_deploy.go:32-127) has no `Transaction.Successful()` guard. The indexer's `processTransaction` (indexer.go:155) processes ALL transactions including failed ones. `GetOperationsParticipants` (participants.go:125) iterates ALL operations regardless of success. For failed Soroban transactions, `GetOperationParticipants` returns early at line 182 with just the source account (non-empty), so the operation IS included in the `opsParticipants` map. `getTransactionStateChanges` (indexer.go:287) then calls `ProcessOperation` on each processor for every operation in that map — including failed-transaction operations.
+
+### Alternative Angle
+
+The viable attack path is through **failed transactions**, not successful ones:
+
+1. Submit a Soroban `InvokeHostFunction` transaction with auth entries containing `CreateContractHostFn`/`CreateContractV2HostFn` invocations for chosen `ContractIdPreimage` values.
+2. Ensure the transaction FAILS (e.g., invoke a nonexistent contract, cause host function abort, insufficient resources). The transaction is still included in the ledger with fees charged.
+3. The `Auth` field is in the transaction envelope (not the result), so it's always present regardless of outcome.
+4. The indexer processes the failed transaction: `processTransaction` → `getTransactionStateChanges` → `ContractDeployProcessor.ProcessOperation` reads `invokeHostOp.Auth` from the envelope and walks invocations.
+5. Phantom contract deploy state changes (`StateChangeCategoryAccount`, `StateChangeReasonCreate`) are emitted and persisted via `buffer.PushStateChange`.
+6. Clients querying state changes or account history see phantom contract deployments that never occurred on-chain.
+
+This constitutes persistent state corruption (phantom deploy records in the indexer that don't reflect on-chain reality). Per the severity scale, "persistent state corruption from malicious ledger data" maps to **High**.
+
+Note: The `participantsFromInvocationAndSubInvocations` function in `contract_operations.go:51-105` has the same pattern — it trusts auth tree entries without a success check — which would also produce phantom participant records for the same failed transactions.
+
+### Additional Code Paths
+
+- `internal/indexer/processors/contract_deploy.go:116-120` — the `for _, auth := range invokeHostOp.Auth` loop with NO success guard; confirm this processes failed-tx auth entries.
+- `internal/indexer/processors/participants.go:165-190` — `GetOperationParticipants` returns early for failed Soroban txs at line 182, but the source-account-only result is non-empty, so the operation still enters the `opsParticipants` map.
+- `internal/indexer/indexer.go:287-300` — `getTransactionStateChanges` iterates ALL `opsParticipants` and calls `ProcessOperation` on each processor with no success filter.
+- `internal/indexer/processors/contract_operations.go:108-127` — `participantsForAuthEntries` also walks auth entries without a success check, creating phantom participant associations.
+- Verify that `ingest.LedgerTransaction` includes failed Soroban txs and that their envelope `Auth` field is populated with submitter-chosen entries.

--- a/ai-summary/hypothesis/data-pipeline/002-checkpoint-balance-only-sac-name-abort.md
+++ b/ai-summary/hypothesis/data-pipeline/002-checkpoint-balance-only-sac-name-abort.md
@@ -1,0 +1,36 @@
+# H002: Checkpoint bootstrap aborts if a balance-only fake SAC contract returns an invalid `name()`
+
+**Date**: 2026-04-23
+**Subsystem**: data-pipeline
+**Severity**: Medium
+**Impact**: availability / bootstrap halt
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Checkpoint bootstrap should not let one attacker-controlled contract block initialization of a fresh node. If a contract was only heuristically identified from balance storage, metadata lookup failures should be isolated to that contract instead of aborting the entire checkpoint transaction.
+
+## Mechanism
+
+During checkpoint processing, balance-shaped contract-data entries create placeholder `contract_tokens` rows of type `SAC` even when no validated SAC instance metadata was seen yet. `finalize()` then calls `FetchSACMetadata()` for every such placeholder, and `FetchSACMetadata()` is explicitly fail-fast: if one contract traps, returns a non-string, or returns a malformed `name()` value, the entire checkpoint transaction aborts, preventing fresh ingest startup or rebuild from completing.
+
+## Trigger
+
+1. Deploy a custom contract that writes SAC-looking balance entries so checkpoint adds it to `uniqueContractTokens` with `Type: SAC` but no code/issuer.
+2. Implement `name()` to return a non-string, a malformed string without `code:issuer`, or a value that causes simulation to fail.
+3. Start a fresh ingest node so `PopulateFromCheckpoint()` runs and observe checkpoint finalization abort when metadata fetch reaches that contract.
+
+## Target Code
+
+- `internal/services/checkpoint.go:349-358` — balance-only contract-data path creates placeholder `SAC` contracts with nil code/issuer
+- `internal/services/checkpoint.go:408-419` — `finalize()` fetches metadata for every placeholder SAC contract and fails the transaction on error
+- `internal/services/contract_metadata.go:83-129` — `FetchSACMetadata()` joins any per-contract error into a batch-fatal failure
+- `internal/services/contract_metadata.go:137-159` — malformed or non-`code:issuer` `name()` values are rejected
+
+## Evidence
+
+The checkpoint path treats balance-derived SAC detection as sufficient to enqueue RPC metadata lookup later, even before a validated instance row is seen. The metadata service does not downgrade or quarantine bad contracts: any single `fetchSACMetadataForContract()` failure bubbles out through `FetchSACMetadata()` and then through `checkpointProcessor.finalize()`.
+
+## Anti-Evidence
+
+If the balance-only placeholder path is unreachable for mainnet-valid ledger data, this becomes moot. If it is reachable, the remaining uncertainty is operational frequency: the bug primarily affects empty-DB bootstrap and rebuild flows, not already-synced steady-state nodes.

--- a/ai-summary/hypothesis/data-pipeline/003-checkpoint-simulate-metadata-oom.md
+++ b/ai-summary/hypothesis/data-pipeline/003-checkpoint-simulate-metadata-oom.md
@@ -1,0 +1,37 @@
+# H003: Checkpoint metadata fetch reads unbounded `simulateTransaction` responses into memory
+
+**Date**: 2026-04-23
+**Subsystem**: data-pipeline
+**Severity**: Medium
+**Impact**: availability / RPC-induced OOM
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Metadata simulation for checkpoint bootstrap should cap RPC response size before reading it into memory. A contract's `name()` implementation should not be able to force the wallet backend to buffer an arbitrarily large JSON/XDR simulation response during initialization.
+
+## Mechanism
+
+Once checkpoint finalization decides a contract needs metadata, `FetchSingleField()` calls `simulateTransaction` and `rpcService.sendRPCRequest()` immediately `io.ReadAll`s the entire HTTP body before any size check. A fake SAC-like contract can therefore turn on-chain-controlled `name()` output, events, or state changes into a large simulation payload that is fully materialized in memory and then decoded again through `json.Unmarshal`, producing an RPC-induced memory spike or OOM during bootstrap.
+
+## Trigger
+
+1. Make checkpoint enqueue a contract for metadata fetch (for example via the balance-only SAC placeholder path).
+2. Implement `name()` so simulation returns a very large value and/or large side-channel fields (`events`, `stateChanges`, auth).
+3. Start bootstrap and observe `simulateTransaction` response buffering in `sendRPCRequest()` before any limit or streaming decoder is applied.
+
+## Target Code
+
+- `internal/services/checkpoint.go:416-419` — checkpoint bootstrap invokes metadata simulation inside finalization
+- `internal/services/contract_metadata.go:96-123` — batches up to 20 metadata simulations in parallel
+- `internal/services/contract_metadata.go:178-237` — `FetchSingleField()` drives `simulateTransaction`
+- `internal/services/rpc_service.go:349-373` — reads the full RPC body with `io.ReadAll` and then unmarshals it
+- `internal/entities/rpc.go:247-284` — unmarshals full simulation results, including `events` and `stateChanges`
+
+## Evidence
+
+There is no response-size guard anywhere between `httpClient.Post(...)` and `io.ReadAll(resp.Body)`. The same raw bytes are then unmarshaled into structured Go values, so a single large response incurs at least two full in-memory representations before checkpoint can reject it.
+
+## Anti-Evidence
+
+Soroban and RPC may impose upstream limits on result size, so the practical ceiling depends on network configuration. But the wallet backend adds no local bound of its own, so any upstream-allowed payload is accepted wholesale by the bootstrap path.

--- a/ai-summary/hypothesis/data-pipeline/004-protocol-setup-getledgerentries-oom.md
+++ b/ai-summary/hypothesis/data-pipeline/004-protocol-setup-getledgerentries-oom.md
@@ -1,0 +1,35 @@
+# H004: Protocol setup batches 200 contract-code fetches into one unbounded `getLedgerEntries` response
+
+**Date**: 2026-04-23
+**Subsystem**: data-pipeline
+**Severity**: Medium
+**Impact**: availability / protocol-setup OOM
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Protocol classification should bound the size of each RPC response or reduce batch size based on byte volume, not just key count. An attacker should not be able to upload enough large WASM blobs that a single `getLedgerEntries` call forces the classifier to buffer a massive response body in RAM.
+
+## Mechanism
+
+`ProtocolSetupService.fetchWasmBytecodes()` batches up to 200 contract-code keys per RPC call and passes the response through `rpcService.GetLedgerEntries()`, which ultimately uses `sendRPCRequest()`'s unbounded `io.ReadAll`. If an attacker fills `protocol_wasms` with many large uploaded bytecodes, one classification run can fetch hundreds of base64-encoded WASM blobs in a single HTTP response, creating a memory-amplification path that can crash or stall the protocol-setup job.
+
+## Trigger
+
+1. Upload many large contract bytecodes so they appear in `protocol_wasms` as unclassified hashes.
+2. Run protocol setup for a validator set that scans those hashes.
+3. Observe `fetchWasmBytecodes()` sending `getLedgerEntries` requests with up to 200 keys and `sendRPCRequest()` reading the entire JSON payload into memory at once.
+
+## Target Code
+
+- `internal/services/protocol_setup.go:168-173` — classification fetches all unclassified bytecodes before validation
+- `internal/services/protocol_setup.go:241-271` — `fetchWasmBytecodes()` batches up to `rpcLedgerEntryBatchSize = 200` and decodes every returned `ContractCode`
+- `internal/services/rpc_service.go:349-373` — full-body buffering via `io.ReadAll` with no response-size cap
+
+## Evidence
+
+The classifier's batching threshold is a count-only constant (`rpcLedgerEntryBatchSize = 200`), not a byte budget. Each returned code entry includes base64-expanded bytecode inside JSON, and the transport layer has no mechanism to reject overlarge bodies before allocation.
+
+## Anti-Evidence
+
+Maximum contract-code size is bounded by Soroban network settings, so the exploit depends on those limits being large enough and enough uploaded contracts being available simultaneously. Even with those limits, though, the classifier's local memory use scales with `200 * max_code_size` rather than a bounded response target.

--- a/ai-summary/hypothesis/data-pipeline/005-protocol-setup-spec-extraction-exhaustion.md
+++ b/ai-summary/hypothesis/data-pipeline/005-protocol-setup-spec-extraction-exhaustion.md
@@ -1,0 +1,35 @@
+# H005: Protocol setup compiles and unmarshals `contractspecv0` without any local CPU or size limits
+
+**Date**: 2026-04-23
+**Subsystem**: data-pipeline
+**Severity**: Medium
+**Impact**: availability / WASM parser exhaustion
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+WASM classification should impose explicit limits on compile cost and `contractspecv0` decode volume before treating uploaded bytecode as safe to analyze. A single on-chain WASM blob should not be able to monopolize classifier CPU or memory simply by embedding a huge or pathological custom section.
+
+## Mechanism
+
+After fetching bytecode, `ProtocolSetupService.classify()` sends it straight into `wasmSpecExtractor.ExtractSpec()`, which compiles the full module with wazero and then repeatedly `xdr.Unmarshal`s spec entries until EOF. There is no limit on module size, custom-section length, or number of decoded `ScSpecEntry` values, so attacker-uploaded WASM can turn protocol classification into a CPU/memory exhaustion path even when the module is otherwise valid enough to compile.
+
+## Trigger
+
+1. Upload a WASM whose `contractspecv0` custom section is extremely large or contains a very large number of tiny spec entries.
+2. Run protocol setup so classification fetches that bytecode.
+3. Observe `ExtractSpec()` compile the module and iterate `xdr.Unmarshal` until the entire section is consumed, with no byte or entry cap.
+
+## Target Code
+
+- `internal/services/protocol_setup.go:175-180` — classification feeds every fetched bytecode into `ExtractSpec()`
+- `internal/services/protocol_validator.go:35-42` — creates a default wazero runtime with custom sections enabled but no explicit resource limits
+- `internal/services/protocol_validator.go:41-79` — compiles the full module and unmarshals spec entries until EOF
+
+## Evidence
+
+`ExtractSpec()` has only two structural checks: the module must compile, and it must contain a `contractspecv0` section. Once those pass, the decoder appends entries until the section is exhausted, and nothing in the call chain enforces a maximum section length or maximum entry count.
+
+## Anti-Evidence
+
+Wazero may reject some malformed modules early, and upstream network rules bound overall contract size. But valid large modules still reach the expensive compile-and-decode path, and there is no wallet-backend-side limit that turns those upstream bounds into a safe local resource budget.

--- a/ai-summary/hypothesis/data-pipeline/006-operation-transaction-alias-projection-bleed.md
+++ b/ai-summary/hypothesis/data-pipeline/006-operation-transaction-alias-projection-bleed.md
@@ -1,0 +1,34 @@
+# H006: Operation.transaction Aliases Reuse the First Projection
+
+**Date**: 2026-04-23
+**Subsystem**: data-pipeline
+**Severity**: Medium
+**Impact**: Integrity
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Two aliased `transaction` selections on the same `Operation` should each be resolved from the same canonical transaction row while honoring their own field projections. If one alias asks only for `ledgerNumber` and another alias asks for `hash`, the second alias should still receive the real transaction hash, not a zero-value placeholder.
+
+## Mechanism
+
+The resolver puts the requested DB columns into the dataloader key, but `transactionByOperationIDLoader` ignores every key except `keys[0].Columns` when a batch contains multiple loads. `newOneToOneLoader` then re-associates the fetched row only by `OperationID`, so every alias for that operation receives the same partially-populated `types.Transaction` built from whichever projection was batched first.
+
+## Trigger
+
+Issue one GraphQL request that asks for the same operation's transaction twice with different aliases and different sub-selections, for example: `operations(first: 1) { edges { node { txLite: transaction { ledgerNumber } txFull: transaction { hash } } } }`. If `txLite` is batched first, `txFull.hash` should come back empty or incorrect even though the backing row has a real hash.
+
+## Target Code
+
+- `internal/serve/graphql/resolvers/operation.resolvers.go:28-45` — builds a loader key whose `Columns` depend on the alias-local GraphQL selection set
+- `internal/serve/graphql/dataloaders/transaction_loaders.go:23-31` — multi-key batch path uses `keys[0].Columns` for every key
+- `internal/serve/graphql/dataloaders/loaders.go:156-166` — one-to-one loader groups results only by `OperationID`
+- `internal/data/transactions.go:181-204` — dynamic projection query returns sparse `Transaction` rows based on the supplied `columns`
+
+## Evidence
+
+`GetDBColumnsForFields` derives different column lists per resolver invocation, so aliased fields can legitimately produce distinct `Columns` values in the same request. The transaction loader's batch function drops per-key projections, and the generic one-to-one loader returns the fetched struct to every key sharing the same parent primary key.
+
+## Anti-Evidence
+
+If only one alias is present, or both aliases request the same transaction fields, the bug does not manifest. This also depends on the loads batching together within the dataloader wait window.

--- a/ai-summary/hypothesis/data-pipeline/007-statechange-operation-alias-projection-bleed.md
+++ b/ai-summary/hypothesis/data-pipeline/007-statechange-operation-alias-projection-bleed.md
@@ -1,0 +1,34 @@
+# H007: StateChange.operation Aliases Reuse the First Projection
+
+**Date**: 2026-04-23
+**Subsystem**: data-pipeline
+**Severity**: Medium
+**Impact**: Integrity
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Two aliased `operation` selections on the same `BaseStateChange` should both resolve against the real operation row while respecting their own requested fields. Asking for `id` under one alias must not cause a sibling alias requesting `operationXdr` or `resultCode` to receive zero values.
+
+## Mechanism
+
+`resolveStateChangeOperation` puts the alias-local DB column set into the loader key, but `operationByStateChangeIDLoader` fetches all batched keys with `keys[0].Columns`. `newOneToOneLoader` then maps the loaded `Operation` only by the synthetic `stateChangeID`, so both aliases for the same state change get the same sparse struct shaped by the first alias rather than their own selection.
+
+## Trigger
+
+Query a state change's parent operation twice in one request with different aliases and different sub-selections, for example: `stateChanges(first: 1) { edges { node { opLite: operation { id } opFull: operation { operationXdr resultCode } } } }`. When `opLite` is processed first, `opFull` should expose empty or incorrect operation data.
+
+## Target Code
+
+- `internal/serve/graphql/resolvers/resolver.go:124-139` — builds the `StateChangeID`/`Columns` loader key from the alias-local selection set
+- `internal/serve/graphql/dataloaders/operation_loaders.go:77-99` — state-change batch path uses only `keys[0].Columns`
+- `internal/serve/graphql/dataloaders/loaders.go:156-166` — one-to-one loader reuses one fetched row per synthetic `stateChangeID`
+- `internal/data/operations.go:295-323` — sparse projection query for operations by state-change tuple
+
+## Evidence
+
+The dataloader key intentionally carries `Columns`, proving the resolver expects projection-sensitive batching. The batch function discards that distinction, and the generic loader returns a single fetched struct to every matching key regardless of which alias asked for which operation fields.
+
+## Anti-Evidence
+
+Single-alias requests are safe, and matching alias projections would hide the problem. The issue also requires the duplicated aliased field loads to coalesce into the same dataloader batch.

--- a/ai-summary/hypothesis/data-pipeline/008-transaction-operations-alias-page-confusion.md
+++ b/ai-summary/hypothesis/data-pipeline/008-transaction-operations-alias-page-confusion.md
@@ -1,0 +1,35 @@
+# H008: Transaction.operations Aliases Collapse to One Page Definition
+
+**Date**: 2026-04-23
+**Subsystem**: data-pipeline
+**Severity**: Medium
+**Impact**: Integrity
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Two aliased `operations` connections on the same `Transaction` should honor their own `first`/`last`/cursor arguments and return distinct pages. A caller asking for `ops1: operations(first: 1)` and `ops2: operations(first: 25, after: "...")` should not get the same edge list for both aliases.
+
+## Mechanism
+
+The resolver includes `Limit`, `Cursor`, `SortOrder`, and `Columns` in the loader key, but the multi-key branch in `operationsByToIDLoader` reads only `keys[0]` and ignores the rest. `newOneToManyLoader` then groups results solely by `ToID`, so all aliased loads for that transaction reuse the same slice even when their page boundaries differ.
+
+## Trigger
+
+Issue a single GraphQL request such as `transactionByHash(...) { ops1: operations(first: 1) { edges { node { id } } } ops2: operations(first: 25, after: "<cursor>") { edges { node { id resultCode } } } }`. Both aliases should come back with the same page, determined by whichever loader key was first in the batch.
+
+## Target Code
+
+- `internal/serve/graphql/resolvers/transaction.resolvers.go:26-50` — puts per-alias pagination and projection values into the loader key
+- `internal/serve/graphql/dataloaders/operation_loaders.go:41-58` — multi-key path uses only `keys[0].Columns`, `keys[0].Limit`, and `keys[0].SortOrder`
+- `internal/serve/graphql/dataloaders/loaders.go:107-118` — one-to-many loader returns one grouped slice per `ToID`, not per full key
+- `internal/data/operations.go:115-161` — batched multi-parent query applies a single per-parent limit
+- `internal/data/operations.go:166-210` — single-parent query is the only path that respects cursor pagination
+
+## Evidence
+
+The code explicitly falls back to a separate single-key query because only that path can honor a cursor; once the batch has multiple keys, cursor and limit individuality are discarded. Because the generic loader groups by transaction `ToID` only, different aliased keys for the same transaction cannot remain distinct after fetch.
+
+## Anti-Evidence
+
+If only one `operations` field is requested, or if every alias uses identical pagination and projections, the results look correct. Different parent transactions are also less interesting here; the corruption is strongest when the same `ToID` appears multiple times in one batch.

--- a/ai-summary/hypothesis/data-pipeline/009-catchup-fact-balance-split-brain.md
+++ b/ai-summary/hypothesis/data-pipeline/009-catchup-fact-balance-split-brain.md
@@ -1,0 +1,36 @@
+# H009: Catchup Backfill Publishes History Before Balances Catch Up
+
+**Date**: 2026-04-23
+**Subsystem**: data-pipeline
+**Severity**: Medium
+**Impact**: Integrity
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+When optimized catchup is running, callers should never be able to observe transaction/state-change history from a ledger before the corresponding trustline/native/SAC balance tables reflect the same ledger. History and balance views should advance atomically from the perspective of concurrent API readers.
+
+## Mechanism
+
+Catchup batches periodically call `flushBatchBufferWithRetry`, which immediately commits transactions, operations, and state changes to PostgreSQL, but only stores token deltas in in-memory `BatchChanges`. The actual balance-table updates are deferred until `processBatchChanges` runs once after all parallel batches complete, so concurrent GraphQL readers can observe newer history rows from the fact tables while balance reads still come from pre-catchup cache tables.
+
+## Trigger
+
+Let the ingest service fall behind until it enters optimized catchup, then create or monitor a transfer affecting a target account during the catchup window. While catchup is still running, query `account.transactions` or `account.stateChanges` alongside `account.balances`; the history side should show the newer ledger while balances still reflect the older pre-catchup state.
+
+## Target Code
+
+- `internal/services/ingest_backfill.go:204-256` — catchup mode defers `processBatchChanges` and latest-cursor update until after all batches finish
+- `internal/services/ingest_backfill.go:426-475` — periodic batch flush commits fact tables immediately
+- `internal/services/ingest_backfill.go:558-575` — intermediate flushes happen before the final catchup merge
+- `internal/services/ingest_backfill.go:601-659` — token/balance tables are updated only in the final merged transaction
+- `internal/serve/graphql/resolvers/account.resolvers.go:34-49,108-154` — account history queries read directly from fact tables
+- `internal/serve/graphql/resolvers/balance_reader.go:31-58` — balances come from the separate balance tables
+
+## Evidence
+
+`flushBatchBufferWithRetry` calls `insertIntoDB` even when `batchChanges` is non-nil, and `insertIntoDB` does not touch the balance models. The only place catchup calls `ProcessTokenChanges` is `processBatchChanges`, which runs later after all parallel batch work has already committed the history rows.
+
+## Anti-Evidence
+
+The inconsistency window closes once the final merged catchup transaction succeeds, so this is not necessarily persistent corruption. It also requires a separate API reader process (or any concurrent DB reader) to observe the shared database while catchup is still in progress.

--- a/ai-summary/hypothesis/data-pipeline/010-checkpoint-contract-instance-mustinstance-panic.md
+++ b/ai-summary/hypothesis/data-pipeline/010-checkpoint-contract-instance-mustinstance-panic.md
@@ -1,0 +1,33 @@
+# H010: Checkpoint Cold Start Can Panic on Contract-Instance Union Mismatch
+
+**Date**: 2026-04-23
+**Subsystem**: data-pipeline
+**Severity**: Medium
+**Impact**: Availability
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Checkpoint population should defensively reject or skip semantically inconsistent contract-data entries instead of crashing the process. A malformed or unusual contract-data row should surface as a handled error, leaving the node able to continue startup or fail gracefully.
+
+## Mechanism
+
+`processContractInstanceChange` only checks that the key union says `ScvLedgerKeyContractInstance` before dereferencing `contractDataEntry.Val.MustInstance()`. If a checkpoint contains a contract-data entry whose key is `ContractInstance` but whose value union is not an instance, `MustInstance()` will panic and take down cold-start ingestion on a DB-empty node.
+
+## Trigger
+
+Start an ingest node against an empty database so it executes `PopulateFromCheckpoint`, and feed it a checkpoint containing a `LedgerEntryTypeContractData` row with `Key.Type == ScvLedgerKeyContractInstance` but `Val.Type != ScvInstance`. The service should panic during checkpoint processing instead of skipping the bad row.
+
+## Target Code
+
+- `internal/services/checkpoint.go:325-341` — routes contract-instance keys into `processContractInstanceChange`
+- `internal/services/checkpoint.go:503-548` — calls `contractDataEntry.Val.MustInstance()` without an `ok` check
+- `internal/indexer/processors/protocol_contracts.go:66-73` — same semantic boundary handled safely in the live indexer with `GetInstance()`
+
+## Evidence
+
+The live indexer already documents that `Key.Type` and `Val.Type` are independent XDR unions and intentionally uses `GetInstance()` to avoid panicking on a key/value mismatch. The checkpoint path does not apply the same guard, even though it parses the same contract-instance concept from raw ledger data.
+
+## Anti-Evidence
+
+Stellar Core may never emit this inconsistency in normal practice, so the trigger may require a rare-but-valid ledger shape or an edge-case archive artifact rather than a common contract. The bug is therefore strongest as a hardening hypothesis until a concrete checkpoint sample proves reachability.

--- a/ai-summary/reviewed/data-pipeline/001-balance-only-sac-fk-rollback.md
+++ b/ai-summary/reviewed/data-pipeline/001-balance-only-sac-fk-rollback.md
@@ -1,0 +1,82 @@
+# H001: Balance-only fake SAC entries can halt live and catchup ingestion at the SAC-balance foreign key
+
+**Date**: 2026-04-23
+**Subsystem**: data-pipeline
+**Severity**: Medium
+**Impact**: availability / ingestion halt
+**Hypothesis by**: gpt-5.4, high
+
+## Expected Behavior
+
+Live ingest and catchup backfill should reject non-SAC contract-data balance entries before they reach the `sac_balances` table, or they should ensure a matching `contract_tokens` row is created in the same transaction. A ledger containing attacker-controlled contract storage should not be able to make the ingestion loop roll back the ledger repeatedly and stop advancing cursors.
+
+## Mechanism
+
+`SACBalancesProcessor` can stage SAC balance changes from contract-data entries independently of `SACInstanceProcessor`, but `PersistLedgerData` / `processBatchChanges` only create `contract_tokens` rows from `buffer.GetSACContracts()` (instance-derived metadata). If an attacker writes balance-shaped storage under a non-SAC contract so the balance path fires without a matching instance-derived contract row, `tokenIngestionService.ProcessTokenChanges` upserts `sac_balances` against a deferred foreign key to `contract_tokens(id)`, causing the whole transaction to fail and the live/catchup loop to retry the same ledger until ingest stops.
+
+## Trigger
+
+1. Deploy a custom Soroban contract whose storage includes valid-looking `["Balance", <contract-address>] -> {amount, authorized, clawback}` entries but no SAC instance entry that `sac.AssetFromContractData` would accept.
+2. Cause a ledger to touch that contract data so the indexer sees a SAC balance change.
+3. Let live ingest or catchup process the ledger and observe `sac_balances` upserted for `DeterministicContractID(change.ContractID)` without a corresponding `contract_tokens` row, rolling back the transaction and wedging ingestion on that ledger.
+
+## Target Code
+
+- `internal/indexer/indexer.go:229-242` — stages SAC balance changes before SAC contract metadata and treats them as independent pipelines
+- `internal/services/ingest_live.go:96-107` — inserts only `buffer.GetSACContracts()` into `contract_tokens`
+- `internal/services/ingest_live.go:136-143` — applies SAC balance changes afterward inside the same transaction
+- `internal/services/ingest_backfill.go:625-659` — catchup merge path repeats the same contract-then-SAC-balance ordering with only instance-derived contracts
+- `internal/services/token_ingestion.go:145-167` — converts staged SAC balance changes directly into `sac_balances` upserts
+- `internal/db/migrations/2026-01-16.0-sac-balances.sql:9-19` — deferred FK from `sac_balances.contract_id` to `contract_tokens(id)`
+
+## Evidence
+
+The live and catchup persistence paths never synthesize contract metadata from SAC balance changes; they only insert rows returned by `GetSACContracts()`, which comes from `SACInstanceProcessor`. In contrast, the checkpoint path explicitly creates placeholder SAC contracts from balance-only entries at `internal/services/checkpoint.go:349-358`, which strongly suggests the codebase already expects the balance parser to succeed even when no instance-derived contract row is present.
+
+## Anti-Evidence
+
+If `sac.ContractBalanceFromContractData` is impossible to satisfy without a genuine SAC instance entry being processed in the same ledger, the missing-contract FK failure would not occur. The main uncertainty is therefore not the FK behavior itself, but whether attacker-controlled balance-only contract data can reach `SACBalancesProcessor` on mainnet-valid ledgers.
+
+---
+
+## Review
+
+**Verdict**: VIABLE
+**Severity**: Medium
+**Date**: 2026-04-23
+**Reviewed by**: claude-opus-4-6, high
+**Novelty**: PASS — not previously investigated
+
+### Trace Summary
+
+The SDK's `sac.ContractBalanceFromContractData` validates only the structural shape of contract-data entries (`["Balance", <C-address>]` key + `{amount, authorized, clawback}` value map) but does NOT verify the hosting contract is a genuine Stellar Asset Contract. In contrast, `sac.AssetFromContractData` (used by `SACInstanceProcessor`) re-derives the SAC contract ID from the asset info and compares it — rejecting non-SAC contracts. This asymmetry means a custom Soroban contract that writes balance-shaped persistent storage will pass the balance processor but produce no matching `contract_tokens` row, causing a deferred FK violation that rolls back the entire ledger transaction and halts ingestion after 5 retries.
+
+### Code Paths Examined
+
+- `go-stellar-sdk@v0.5.0/ingest/sac/contract_data.go:ContractBalanceFromContractData` — validates data shape only (durability, key vector `["Balance", ScAddress]`, value map `{amount:i128, authorized:bool, clawback:bool}`); does NOT derive or compare the SAC contract ID. Any non-native contract with this storage shape passes.
+- `go-stellar-sdk@v0.5.0/ingest/sac/contract_data.go:AssetFromContractData` — in contrast, re-derives `asset.ContractID(passphrase)` and compares against the entry's contract ID. Only genuine SACs pass.
+- `internal/indexer/processors/sac_balances.go:processSACBalanceChange:96-104` — calls `ContractBalanceFromContractData`; on `ok`, extracts `contractID` from the entry's `Contract` field and emits a `SACBalanceChange`.
+- `internal/indexer/processors/sac_instances.go:ProcessOperation:57-60` — calls `AssetFromContractData`; rejects non-SAC contracts, so no `contract_tokens` row is produced.
+- `internal/services/ingest_live.go:PersistLedgerData:87-143` — within one `RunInTransaction`: inserts `contract_tokens` from `buffer.GetSACContracts()` (instance-derived only, step 2), then calls `ProcessTokenChanges` which upserts `sac_balances` (step 4). The deferred FK on `sac_balances.contract_id → contract_tokens(id)` is checked at commit.
+- `internal/services/ingest_live.go:ingestProcessedDataWithRetry:467-501` — retries `PersistLedgerData` up to 5 times with exponential backoff; on exhaustion returns error.
+- `internal/services/ingest_live.go:ingestLiveLedgers:363-366` — on retry exhaustion, returns error to caller, which propagates to `log.Fatalf` (process exit). Restart hits the same ledger → infinite crash loop.
+- `internal/services/checkpoint.go:349-358` — the checkpoint path explicitly creates placeholder `contract_tokens` rows from balance-only entries, confirming the codebase knows this scenario is possible.
+- `internal/db/migrations/2026-01-16.0-sac-balances.sql:17-19` — `CONSTRAINT fk_contract_token FOREIGN KEY (contract_id) REFERENCES contract_tokens(id) DEFERRABLE INITIALLY DEFERRED`.
+
+### Findings
+
+1. **Root cause confirmed**: `ContractBalanceFromContractData` is a shape-only validator with no SAC-identity check. Any custom Soroban contract can write persistent data in the `["Balance", <C-addr>] → {amount, authorized, clawback}` shape, and the indexer will accept it.
+2. **FK violation path confirmed**: `PersistLedgerData` inserts `contract_tokens` only from `SACInstanceProcessor` output (genuine SACs). The subsequent `sac_balances` upsert references a `DeterministicContractID` for the attacker's contract, which has no `contract_tokens` row. The deferred FK fails at commit.
+3. **Retry exhaustion → crash loop confirmed**: After 5 failed attempts, the error propagates up and the process exits. On restart, it resumes from the same ledger (cursor was never advanced), creating an infinite crash loop.
+4. **Checkpoint path handles this correctly**: `checkpoint.go:349-358` creates placeholder `contract_tokens` rows from balance-only entries — the live and catchup paths omit this step.
+5. **Attacker capability is concrete**: Deploy a Soroban contract that writes the specific storage shape. This requires only a standard Soroban transaction — no privileged access.
+
+### PoC Guidance
+
+- **Test file**: `internal/services/ingest_test.go` (append new test)
+- **Setup**: Use the existing test infrastructure for `PersistLedgerData`. Build a mock `IndexerBuffer` where `GetSACBalanceChanges()` returns a change with a `ContractID` that does NOT appear in `GetSACContracts()`. Set up the real migration schema (with the FK constraint) using `dbtest`.
+- **Steps**:
+  1. Create a `SACBalanceChange` with `Operation=SACBalanceOpAdd`, `ContractID="C_ATTACKER..."`, `AccountID="C_HOLDER..."`.
+  2. Ensure `GetSACContracts()` returns an empty map (no matching instance entry).
+  3. Call `PersistLedgerData` within a real DB transaction.
+- **Assertion**: The transaction must fail with a foreign key violation error on `fk_contract_token`. Verify the cursor is NOT advanced (the ledger was not persisted). Then verify that calling `PersistLedgerData` again for the same ledger produces the same error (demonstrating the wedge).

--- a/internal/data/ingest_store_test.go
+++ b/internal/data/ingest_store_test.go
@@ -236,13 +236,13 @@ func Test_IngestStoreModel_CompareAndSwap(t *testing.T) {
 	defer dbConnectionPool.Close()
 
 	testCases := []struct {
-		name            string
-		setupDB         func(t *testing.T)
-		expectedValue   string
-		newValue        string
-		expectedSwap    bool
-		expectedErr     error  // sentinel error expected (nil means no error)
-		expectedDB      string // expected value in DB after CAS; empty means key should not exist
+		name          string
+		setupDB       func(t *testing.T)
+		expectedValue string
+		newValue      string
+		expectedSwap  bool
+		expectedErr   error  // sentinel error expected (nil means no error)
+		expectedDB    string // expected value in DB after CAS; empty means key should not exist
 	}{
 		{
 			name: "succeeds_when_value_matches",

--- a/internal/services/sep41_validator.go
+++ b/internal/services/sep41_validator.go
@@ -34,8 +34,13 @@ var scSpecTypeNames = map[xdr.ScSpecType]string{
 // sep41FunctionSpec defines the expected signature for a SEP-41 token function.
 type sep41FunctionSpec struct {
 	name            string
-	expectedInputs  map[string]string
+	expectedInputs  []sep41FunctionInputSpec
 	expectedOutputs []string
+}
+
+type sep41FunctionInputSpec struct {
+	name     string
+	typeName string
 }
 
 // sep41RequiredFunctions defines all required functions for SEP-41 token standard compliance.
@@ -43,80 +48,80 @@ type sep41FunctionSpec struct {
 var sep41RequiredFunctions = []sep41FunctionSpec{
 	{
 		name:            "balance",
-		expectedInputs:  map[string]string{"id": "Address"},
+		expectedInputs:  []sep41FunctionInputSpec{{name: "id", typeName: "Address"}},
 		expectedOutputs: []string{"i128"},
 	},
 	{
 		name:            "allowance",
-		expectedInputs:  map[string]string{"from": "Address", "spender": "Address"},
+		expectedInputs:  []sep41FunctionInputSpec{{name: "from", typeName: "Address"}, {name: "spender", typeName: "Address"}},
 		expectedOutputs: []string{"i128"},
 	},
 	{
 		name:            "decimals",
-		expectedInputs:  map[string]string{},
+		expectedInputs:  []sep41FunctionInputSpec{},
 		expectedOutputs: []string{"u32"},
 	},
 	{
 		name:            "name",
-		expectedInputs:  map[string]string{},
+		expectedInputs:  []sep41FunctionInputSpec{},
 		expectedOutputs: []string{"String"},
 	},
 	{
 		name:            "symbol",
-		expectedInputs:  map[string]string{},
+		expectedInputs:  []sep41FunctionInputSpec{},
 		expectedOutputs: []string{"String"},
 	},
 	{
 		name: "approve",
-		expectedInputs: map[string]string{
-			"from":              "Address",
-			"spender":           "Address",
-			"amount":            "i128",
-			"expiration_ledger": "u32",
+		expectedInputs: []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "spender", typeName: "Address"},
+			{name: "amount", typeName: "i128"},
+			{name: "expiration_ledger", typeName: "u32"},
 		},
 		expectedOutputs: []string{},
 	},
 	{
 		name: "transfer",
-		expectedInputs: map[string]string{
-			"from":   "Address",
-			"to":     "Address",
-			"amount": "i128",
+		expectedInputs: []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "to", typeName: "Address"},
+			{name: "amount", typeName: "i128"},
 		},
 	},
 	// transfer: (from: Address, to_muxed: MuxedAddress, amount: i128) -> () -> CAP-67
 	{
 		name: "transfer",
-		expectedInputs: map[string]string{
-			"from":     "Address",
-			"to_muxed": "MuxedAddress",
-			"amount":   "i128",
+		expectedInputs: []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "to_muxed", typeName: "MuxedAddress"},
+			{name: "amount", typeName: "i128"},
 		},
 	},
 	{
 		name: "transfer_from",
-		expectedInputs: map[string]string{
-			"spender": "Address",
-			"from":    "Address",
-			"to":      "Address",
-			"amount":  "i128",
+		expectedInputs: []sep41FunctionInputSpec{
+			{name: "spender", typeName: "Address"},
+			{name: "from", typeName: "Address"},
+			{name: "to", typeName: "Address"},
+			{name: "amount", typeName: "i128"},
 		},
 		expectedOutputs: []string{},
 	},
 	{
 		name: "burn",
-		expectedInputs: map[string]string{
-			"from":   "Address",
-			"amount": "i128",
+		expectedInputs: []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "amount", typeName: "i128"},
 		},
 		expectedOutputs: []string{},
 	},
 	{
 		name: "burn_from",
-		expectedInputs: map[string]string{
-			"spender": "Address",
-			"from":    "Address",
-			"amount":  "i128",
+		expectedInputs: []sep41FunctionInputSpec{
+			{name: "spender", typeName: "Address"},
+			{name: "from", typeName: "Address"},
+			{name: "amount", typeName: "i128"},
 		},
 		expectedOutputs: []string{},
 	},
@@ -166,24 +171,24 @@ func (v *SEP41ProtocolValidator) Validate(contractSpec []xdr.ScSpecEntry) bool {
 			continue
 		}
 
-		// Extract actual inputs from the contract function
-		actualInputs := make(map[string]any, len(function.Inputs))
+		// Extract actual inputs from the contract function, preserving order.
+		actualInputs := make([]sep41FunctionInputSpec, 0, len(function.Inputs))
 		for _, input := range function.Inputs {
-			actualInputs[input.Name] = getTypeName(input.Type.Type)
+			actualInputs = append(actualInputs, sep41FunctionInputSpec{
+				name:     input.Name,
+				typeName: getTypeName(input.Type.Type),
+			})
 		}
 
-		// Extract actual outputs from the contract function
-		actualOutputs := set.NewSet[string]()
+		// Extract actual outputs from the contract function, preserving order.
+		actualOutputs := make([]string, 0, len(function.Outputs))
 		for _, output := range function.Outputs {
-			actualOutputs.Add(getTypeName(output.Type))
+			actualOutputs = append(actualOutputs, getTypeName(output.Type))
 		}
 
 		for _, expectedSpec := range expectedSpecs {
-			// Convert expected outputs to set for comparison
-			expectedOutputs := set.NewSet(expectedSpec.expectedOutputs...)
-
 			// Validate the function signature matches SEP-41 requirements
-			if validateFunctionInputsAndOutputs(actualInputs, actualOutputs, expectedSpec.expectedInputs, expectedOutputs) {
+			if validateFunctionInputsAndOutputs(actualInputs, actualOutputs, expectedSpec.expectedInputs, expectedSpec.expectedOutputs) {
 				foundFunctions.Add(funcName)
 				break
 			}
@@ -195,25 +200,31 @@ func (v *SEP41ProtocolValidator) Validate(contractSpec []xdr.ScSpecEntry) bool {
 }
 
 // validateFunctionInputsAndOutputs checks if a function's signature matches the expected SEP-41 specification.
-// It compares input parameter names/types and output types, supporting both exact matches and sets of valid types
-// (e.g., for CAP-67 where "from" parameter accepts both Address and MuxedAddress).
-func validateFunctionInputsAndOutputs(inputs map[string]any, outputs set.Set[string], expectedInputs map[string]string, expectedOutputs set.Set[string]) bool {
+// It compares ordered input/output slices with exact arity and exact position-by-position matches.
+func validateFunctionInputsAndOutputs(
+	inputs []sep41FunctionInputSpec,
+	outputs []string,
+	expectedInputs []sep41FunctionInputSpec,
+	expectedOutputs []string,
+) bool {
 	if len(inputs) != len(expectedInputs) {
 		return false
 	}
 
-	for expectedInput, expectedInputType := range expectedInputs {
-		if inputs[expectedInput] != expectedInputType {
+	for i := range expectedInputs {
+		if inputs[i] != expectedInputs[i] {
 			return false
 		}
 	}
 
-	if expectedOutputs.Cardinality() != outputs.Cardinality() {
+	if len(outputs) != len(expectedOutputs) {
 		return false
 	}
 
-	if !expectedOutputs.Equal(outputs) {
-		return false
+	for i := range expectedOutputs {
+		if outputs[i] != expectedOutputs[i] {
+			return false
+		}
 	}
 	return true
 }

--- a/internal/services/sep41_validator.go
+++ b/internal/services/sep41_validator.go
@@ -34,11 +34,11 @@ var scSpecTypeNames = map[xdr.ScSpecType]string{
 // sep41FunctionSpec defines the expected signature for a SEP-41 token function.
 type sep41FunctionSpec struct {
 	name            string
-	expectedInputs  []sep41FunctionInputSpec
+	expectedInputs  []contractFunctionInputSpec
 	expectedOutputs []string
 }
 
-type sep41FunctionInputSpec struct {
+type contractFunctionInputSpec struct {
 	name     string
 	typeName string
 }
@@ -48,32 +48,32 @@ type sep41FunctionInputSpec struct {
 var sep41RequiredFunctions = []sep41FunctionSpec{
 	{
 		name:            "balance",
-		expectedInputs:  []sep41FunctionInputSpec{{name: "id", typeName: "Address"}},
+		expectedInputs:  []contractFunctionInputSpec{{name: "id", typeName: "Address"}},
 		expectedOutputs: []string{"i128"},
 	},
 	{
 		name:            "allowance",
-		expectedInputs:  []sep41FunctionInputSpec{{name: "from", typeName: "Address"}, {name: "spender", typeName: "Address"}},
+		expectedInputs:  []contractFunctionInputSpec{{name: "from", typeName: "Address"}, {name: "spender", typeName: "Address"}},
 		expectedOutputs: []string{"i128"},
 	},
 	{
 		name:            "decimals",
-		expectedInputs:  []sep41FunctionInputSpec{},
+		expectedInputs:  []contractFunctionInputSpec{},
 		expectedOutputs: []string{"u32"},
 	},
 	{
 		name:            "name",
-		expectedInputs:  []sep41FunctionInputSpec{},
+		expectedInputs:  []contractFunctionInputSpec{},
 		expectedOutputs: []string{"String"},
 	},
 	{
 		name:            "symbol",
-		expectedInputs:  []sep41FunctionInputSpec{},
+		expectedInputs:  []contractFunctionInputSpec{},
 		expectedOutputs: []string{"String"},
 	},
 	{
 		name: "approve",
-		expectedInputs: []sep41FunctionInputSpec{
+		expectedInputs: []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "spender", typeName: "Address"},
 			{name: "amount", typeName: "i128"},
@@ -83,7 +83,7 @@ var sep41RequiredFunctions = []sep41FunctionSpec{
 	},
 	{
 		name: "transfer",
-		expectedInputs: []sep41FunctionInputSpec{
+		expectedInputs: []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "to", typeName: "Address"},
 			{name: "amount", typeName: "i128"},
@@ -92,7 +92,7 @@ var sep41RequiredFunctions = []sep41FunctionSpec{
 	// transfer: (from: Address, to_muxed: MuxedAddress, amount: i128) -> () -> CAP-67
 	{
 		name: "transfer",
-		expectedInputs: []sep41FunctionInputSpec{
+		expectedInputs: []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "to_muxed", typeName: "MuxedAddress"},
 			{name: "amount", typeName: "i128"},
@@ -100,7 +100,7 @@ var sep41RequiredFunctions = []sep41FunctionSpec{
 	},
 	{
 		name: "transfer_from",
-		expectedInputs: []sep41FunctionInputSpec{
+		expectedInputs: []contractFunctionInputSpec{
 			{name: "spender", typeName: "Address"},
 			{name: "from", typeName: "Address"},
 			{name: "to", typeName: "Address"},
@@ -110,7 +110,7 @@ var sep41RequiredFunctions = []sep41FunctionSpec{
 	},
 	{
 		name: "burn",
-		expectedInputs: []sep41FunctionInputSpec{
+		expectedInputs: []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "amount", typeName: "i128"},
 		},
@@ -118,7 +118,7 @@ var sep41RequiredFunctions = []sep41FunctionSpec{
 	},
 	{
 		name: "burn_from",
-		expectedInputs: []sep41FunctionInputSpec{
+		expectedInputs: []contractFunctionInputSpec{
 			{name: "spender", typeName: "Address"},
 			{name: "from", typeName: "Address"},
 			{name: "amount", typeName: "i128"},
@@ -172,9 +172,9 @@ func (v *SEP41ProtocolValidator) Validate(contractSpec []xdr.ScSpecEntry) bool {
 		}
 
 		// Extract actual inputs from the contract function, preserving order.
-		actualInputs := make([]sep41FunctionInputSpec, 0, len(function.Inputs))
+		actualInputs := make([]contractFunctionInputSpec, 0, len(function.Inputs))
 		for _, input := range function.Inputs {
-			actualInputs = append(actualInputs, sep41FunctionInputSpec{
+			actualInputs = append(actualInputs, contractFunctionInputSpec{
 				name:     input.Name,
 				typeName: getTypeName(input.Type.Type),
 			})
@@ -202,9 +202,9 @@ func (v *SEP41ProtocolValidator) Validate(contractSpec []xdr.ScSpecEntry) bool {
 // validateFunctionInputsAndOutputs checks if a function's signature matches the expected SEP-41 specification.
 // It compares ordered input/output slices with exact arity and exact position-by-position matches.
 func validateFunctionInputsAndOutputs(
-	inputs []sep41FunctionInputSpec,
+	inputs []contractFunctionInputSpec,
 	outputs []string,
-	expectedInputs []sep41FunctionInputSpec,
+	expectedInputs []contractFunctionInputSpec,
 	expectedOutputs []string,
 ) bool {
 	if len(inputs) != len(expectedInputs) {

--- a/internal/services/sep41_validator_test.go
+++ b/internal/services/sep41_validator_test.go
@@ -328,13 +328,13 @@ func TestIsContractCodeSEP41(t *testing.T) {
 
 func TestValidateFunctionInputsAndOutputs(t *testing.T) {
 	t.Run("returns true for exact match", func(t *testing.T) {
-		inputs := []sep41FunctionInputSpec{
+		inputs := []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "to", typeName: "Address"},
 		}
 		outputs := []string{"i128"}
 
-		expectedInputs := []sep41FunctionInputSpec{
+		expectedInputs := []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "to", typeName: "Address"},
 		}
@@ -345,12 +345,12 @@ func TestValidateFunctionInputsAndOutputs(t *testing.T) {
 	})
 
 	t.Run("returns false for too few inputs", func(t *testing.T) {
-		inputs := []sep41FunctionInputSpec{
+		inputs := []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 		}
 		outputs := []string{"i128"}
 
-		expectedInputs := []sep41FunctionInputSpec{
+		expectedInputs := []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "to", typeName: "Address"},
 		}
@@ -361,14 +361,14 @@ func TestValidateFunctionInputsAndOutputs(t *testing.T) {
 	})
 
 	t.Run("returns false for too many inputs", func(t *testing.T) {
-		inputs := []sep41FunctionInputSpec{
+		inputs := []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "to", typeName: "Address"},
 			{name: "amount", typeName: "i128"},
 		}
 		outputs := []string{"i128"}
 
-		expectedInputs := []sep41FunctionInputSpec{
+		expectedInputs := []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "to", typeName: "Address"},
 		}
@@ -379,13 +379,13 @@ func TestValidateFunctionInputsAndOutputs(t *testing.T) {
 	})
 
 	t.Run("returns false for wrong input parameter name", func(t *testing.T) {
-		inputs := []sep41FunctionInputSpec{
+		inputs := []contractFunctionInputSpec{
 			{name: "sender", typeName: "Address"},
 			{name: "receiver", typeName: "Address"},
 		}
 		outputs := []string{"i128"}
 
-		expectedInputs := []sep41FunctionInputSpec{
+		expectedInputs := []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "to", typeName: "Address"},
 		}
@@ -396,13 +396,13 @@ func TestValidateFunctionInputsAndOutputs(t *testing.T) {
 	})
 
 	t.Run("returns false for wrong input parameter type", func(t *testing.T) {
-		inputs := []sep41FunctionInputSpec{
+		inputs := []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "to", typeName: "u32"},
 		}
 		outputs := []string{"i128"}
 
-		expectedInputs := []sep41FunctionInputSpec{
+		expectedInputs := []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "to", typeName: "Address"},
 		}
@@ -413,13 +413,13 @@ func TestValidateFunctionInputsAndOutputs(t *testing.T) {
 	})
 
 	t.Run("returns false for reordered inputs", func(t *testing.T) {
-		inputs := []sep41FunctionInputSpec{
+		inputs := []contractFunctionInputSpec{
 			{name: "to", typeName: "Address"},
 			{name: "from", typeName: "Address"},
 		}
 		outputs := []string{"i128"}
 
-		expectedInputs := []sep41FunctionInputSpec{
+		expectedInputs := []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "to", typeName: "Address"},
 		}
@@ -430,13 +430,13 @@ func TestValidateFunctionInputsAndOutputs(t *testing.T) {
 	})
 
 	t.Run("returns false for too few outputs", func(t *testing.T) {
-		inputs := []sep41FunctionInputSpec{
+		inputs := []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "to", typeName: "Address"},
 		}
 		outputs := []string{}
 
-		expectedInputs := []sep41FunctionInputSpec{
+		expectedInputs := []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "to", typeName: "Address"},
 		}
@@ -447,13 +447,13 @@ func TestValidateFunctionInputsAndOutputs(t *testing.T) {
 	})
 
 	t.Run("returns false for too many outputs", func(t *testing.T) {
-		inputs := []sep41FunctionInputSpec{
+		inputs := []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "to", typeName: "Address"},
 		}
 		outputs := []string{"i128", "u32"}
 
-		expectedInputs := []sep41FunctionInputSpec{
+		expectedInputs := []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "to", typeName: "Address"},
 		}
@@ -464,13 +464,13 @@ func TestValidateFunctionInputsAndOutputs(t *testing.T) {
 	})
 
 	t.Run("returns false for wrong output type", func(t *testing.T) {
-		inputs := []sep41FunctionInputSpec{
+		inputs := []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "to", typeName: "Address"},
 		}
 		outputs := []string{"u32"}
 
-		expectedInputs := []sep41FunctionInputSpec{
+		expectedInputs := []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "to", typeName: "Address"},
 		}
@@ -481,13 +481,13 @@ func TestValidateFunctionInputsAndOutputs(t *testing.T) {
 	})
 
 	t.Run("returns false for duplicate outputs", func(t *testing.T) {
-		inputs := []sep41FunctionInputSpec{
+		inputs := []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "to", typeName: "Address"},
 		}
 		outputs := []string{"i128", "i128"}
 
-		expectedInputs := []sep41FunctionInputSpec{
+		expectedInputs := []contractFunctionInputSpec{
 			{name: "from", typeName: "Address"},
 			{name: "to", typeName: "Address"},
 		}
@@ -498,10 +498,10 @@ func TestValidateFunctionInputsAndOutputs(t *testing.T) {
 	})
 
 	t.Run("returns true for empty inputs and outputs", func(t *testing.T) {
-		inputs := []sep41FunctionInputSpec{}
+		inputs := []contractFunctionInputSpec{}
 		outputs := []string{}
 
-		expectedInputs := []sep41FunctionInputSpec{}
+		expectedInputs := []contractFunctionInputSpec{}
 		expectedOutputs := []string{}
 
 		result := validateFunctionInputsAndOutputs(inputs, outputs, expectedInputs, expectedOutputs)

--- a/internal/services/sep41_validator_test.go
+++ b/internal/services/sep41_validator_test.go
@@ -3,7 +3,6 @@ package services
 import (
 	"testing"
 
-	set "github.com/deckarep/golang-set/v2"
 	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/assert"
 )
@@ -248,6 +247,42 @@ func TestIsContractCodeSEP41(t *testing.T) {
 		assert.False(t, result)
 	})
 
+	t.Run("returns false for transfer with reordered inputs", func(t *testing.T) {
+		addressType := createScSpecTypeDef(xdr.ScSpecTypeScSpecTypeAddress)
+		i128Type := createScSpecTypeDef(xdr.ScSpecTypeScSpecTypeI128)
+
+		transferFunc := createScSpecFunctionEntry("transfer",
+			[]xdr.ScSpecFunctionInputV0{
+				createFunctionInput("to", addressType),
+				createFunctionInput("from", addressType),
+				createFunctionInput("amount", i128Type),
+			},
+			[]xdr.ScSpecTypeDef{},
+		)
+
+		spec := createPartialSEP41Spec([]string{"transfer"})
+		spec = append(spec, transferFunc)
+
+		result := NewSEP41ProtocolValidator().Validate(spec)
+		assert.False(t, result)
+	})
+
+	t.Run("returns false for balance with duplicate outputs", func(t *testing.T) {
+		addressType := createScSpecTypeDef(xdr.ScSpecTypeScSpecTypeAddress)
+		i128Type := createScSpecTypeDef(xdr.ScSpecTypeScSpecTypeI128)
+
+		balanceFunc := createScSpecFunctionEntry("balance",
+			[]xdr.ScSpecFunctionInputV0{createFunctionInput("id", addressType)},
+			[]xdr.ScSpecTypeDef{i128Type, i128Type},
+		)
+
+		spec := createPartialSEP41Spec([]string{"balance"})
+		spec = append(spec, balanceFunc)
+
+		result := NewSEP41ProtocolValidator().Validate(spec)
+		assert.False(t, result)
+	})
+
 	t.Run("returns false for empty contract spec", func(t *testing.T) {
 		spec := []xdr.ScSpecEntry{}
 		result := NewSEP41ProtocolValidator().Validate(spec)
@@ -293,147 +328,181 @@ func TestIsContractCodeSEP41(t *testing.T) {
 
 func TestValidateFunctionInputsAndOutputs(t *testing.T) {
 	t.Run("returns true for exact match", func(t *testing.T) {
-		inputs := map[string]any{
-			"from": "Address",
-			"to":   "Address",
+		inputs := []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "to", typeName: "Address"},
 		}
-		outputs := set.NewSet("i128")
+		outputs := []string{"i128"}
 
-		expectedInputs := map[string]string{
-			"from": "Address",
-			"to":   "Address",
+		expectedInputs := []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "to", typeName: "Address"},
 		}
-		expectedOutputs := set.NewSet("i128")
+		expectedOutputs := []string{"i128"}
 
 		result := validateFunctionInputsAndOutputs(inputs, outputs, expectedInputs, expectedOutputs)
 		assert.True(t, result)
 	})
 
 	t.Run("returns false for too few inputs", func(t *testing.T) {
-		inputs := map[string]any{
-			"from": "Address",
+		inputs := []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
 		}
-		outputs := set.NewSet("i128")
+		outputs := []string{"i128"}
 
-		expectedInputs := map[string]string{
-			"from": "Address",
-			"to":   "Address",
+		expectedInputs := []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "to", typeName: "Address"},
 		}
-		expectedOutputs := set.NewSet("i128")
+		expectedOutputs := []string{"i128"}
 
 		result := validateFunctionInputsAndOutputs(inputs, outputs, expectedInputs, expectedOutputs)
 		assert.False(t, result)
 	})
 
 	t.Run("returns false for too many inputs", func(t *testing.T) {
-		inputs := map[string]any{
-			"from":   "Address",
-			"to":     "Address",
-			"amount": "i128",
+		inputs := []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "to", typeName: "Address"},
+			{name: "amount", typeName: "i128"},
 		}
-		outputs := set.NewSet("i128")
+		outputs := []string{"i128"}
 
-		expectedInputs := map[string]string{
-			"from": "Address",
-			"to":   "Address",
+		expectedInputs := []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "to", typeName: "Address"},
 		}
-		expectedOutputs := set.NewSet("i128")
+		expectedOutputs := []string{"i128"}
 
 		result := validateFunctionInputsAndOutputs(inputs, outputs, expectedInputs, expectedOutputs)
 		assert.False(t, result)
 	})
 
 	t.Run("returns false for wrong input parameter name", func(t *testing.T) {
-		inputs := map[string]any{
-			"sender":   "Address",
-			"receiver": "Address",
+		inputs := []sep41FunctionInputSpec{
+			{name: "sender", typeName: "Address"},
+			{name: "receiver", typeName: "Address"},
 		}
-		outputs := set.NewSet("i128")
+		outputs := []string{"i128"}
 
-		expectedInputs := map[string]string{
-			"from": "Address",
-			"to":   "Address",
+		expectedInputs := []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "to", typeName: "Address"},
 		}
-		expectedOutputs := set.NewSet("i128")
+		expectedOutputs := []string{"i128"}
 
 		result := validateFunctionInputsAndOutputs(inputs, outputs, expectedInputs, expectedOutputs)
 		assert.False(t, result)
 	})
 
 	t.Run("returns false for wrong input parameter type", func(t *testing.T) {
-		inputs := map[string]any{
-			"from": "Address",
-			"to":   "u32", // Wrong type
+		inputs := []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "to", typeName: "u32"},
 		}
-		outputs := set.NewSet("i128")
+		outputs := []string{"i128"}
 
-		expectedInputs := map[string]string{
-			"from": "Address",
-			"to":   "Address",
+		expectedInputs := []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "to", typeName: "Address"},
 		}
-		expectedOutputs := set.NewSet("i128")
+		expectedOutputs := []string{"i128"}
+
+		result := validateFunctionInputsAndOutputs(inputs, outputs, expectedInputs, expectedOutputs)
+		assert.False(t, result)
+	})
+
+	t.Run("returns false for reordered inputs", func(t *testing.T) {
+		inputs := []sep41FunctionInputSpec{
+			{name: "to", typeName: "Address"},
+			{name: "from", typeName: "Address"},
+		}
+		outputs := []string{"i128"}
+
+		expectedInputs := []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "to", typeName: "Address"},
+		}
+		expectedOutputs := []string{"i128"}
 
 		result := validateFunctionInputsAndOutputs(inputs, outputs, expectedInputs, expectedOutputs)
 		assert.False(t, result)
 	})
 
 	t.Run("returns false for too few outputs", func(t *testing.T) {
-		inputs := map[string]any{
-			"from": "Address",
-			"to":   "Address",
+		inputs := []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "to", typeName: "Address"},
 		}
-		outputs := set.NewSet[string]()
+		outputs := []string{}
 
-		expectedInputs := map[string]string{
-			"from": "Address",
-			"to":   "Address",
+		expectedInputs := []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "to", typeName: "Address"},
 		}
-		expectedOutputs := set.NewSet("i128")
+		expectedOutputs := []string{"i128"}
 
 		result := validateFunctionInputsAndOutputs(inputs, outputs, expectedInputs, expectedOutputs)
 		assert.False(t, result)
 	})
 
 	t.Run("returns false for too many outputs", func(t *testing.T) {
-		inputs := map[string]any{
-			"from": "Address",
-			"to":   "Address",
+		inputs := []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "to", typeName: "Address"},
 		}
-		outputs := set.NewSet("i128", "u32")
+		outputs := []string{"i128", "u32"}
 
-		expectedInputs := map[string]string{
-			"from": "Address",
-			"to":   "Address",
+		expectedInputs := []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "to", typeName: "Address"},
 		}
-		expectedOutputs := set.NewSet("i128")
+		expectedOutputs := []string{"i128"}
 
 		result := validateFunctionInputsAndOutputs(inputs, outputs, expectedInputs, expectedOutputs)
 		assert.False(t, result)
 	})
 
 	t.Run("returns false for wrong output type", func(t *testing.T) {
-		inputs := map[string]any{
-			"from": "Address",
-			"to":   "Address",
+		inputs := []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "to", typeName: "Address"},
 		}
-		outputs := set.NewSet("u32") // Wrong type
+		outputs := []string{"u32"}
 
-		expectedInputs := map[string]string{
-			"from": "Address",
-			"to":   "Address",
+		expectedInputs := []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "to", typeName: "Address"},
 		}
-		expectedOutputs := set.NewSet("i128")
+		expectedOutputs := []string{"i128"}
+
+		result := validateFunctionInputsAndOutputs(inputs, outputs, expectedInputs, expectedOutputs)
+		assert.False(t, result)
+	})
+
+	t.Run("returns false for duplicate outputs", func(t *testing.T) {
+		inputs := []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "to", typeName: "Address"},
+		}
+		outputs := []string{"i128", "i128"}
+
+		expectedInputs := []sep41FunctionInputSpec{
+			{name: "from", typeName: "Address"},
+			{name: "to", typeName: "Address"},
+		}
+		expectedOutputs := []string{"i128"}
 
 		result := validateFunctionInputsAndOutputs(inputs, outputs, expectedInputs, expectedOutputs)
 		assert.False(t, result)
 	})
 
 	t.Run("returns true for empty inputs and outputs", func(t *testing.T) {
-		inputs := map[string]any{}
-		outputs := set.NewSet[string]()
+		inputs := []sep41FunctionInputSpec{}
+		outputs := []string{}
 
-		expectedInputs := map[string]string{}
-		expectedOutputs := set.NewSet[string]()
+		expectedInputs := []sep41FunctionInputSpec{}
+		expectedOutputs := []string{}
 
 		result := validateFunctionInputsAndOutputs(inputs, outputs, expectedInputs, expectedOutputs)
 		assert.True(t, result)


### PR DESCRIPTION
### What

Tightens SEP-41 validation to require exact ordered input and output signatures when classifying contracts. The validator now compares ordered slices instead of normalizing inputs to a map and outputs to a set, and the test suite adds regression coverage for reordered transfer params and duplicate balance outputs.

### Why

The previous implementation could misclassify non-SEP-41 contracts as SEP-41 when function parameters were reordered or outputs were duplicated. That creates a security-sensitive false-positive path where attacker-controlled contracts can be pulled into SEP-41 indexing and state production.

### Known limitations
N/A

### Issue that this PR addresses
N/A

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (no queries changed).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production. (N/A - validator fix only.)
