### PR TITLE
Add balance pagination parameters to the Go client

### DIFF
--- a/internal/integrationtests/account_balances_test.go
+++ b/internal/integrationtests/account_balances_test.go
@@ -176,11 +176,11 @@ func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_HolderContr
 	}
 }
 
-// TestCheckpoint_Account1_ForwardPagination exercises the SDK's forward
-// pagination round-trip. Pre-fix the SDK ignored caller-supplied first/after
-// args (issue #608); this test guards against any regression that drops
-// them again. Account1 has 3 balances, so first=1 plus a follow-up call
-// using the returned EndCursor must return a different edge.
+// TestCheckpoint_Account1_ForwardPagination verifies that GetAccountBalances
+// honors the first and after pagination args. Account1 has 3 balances at
+// checkpoint, so calling with first=1 must return a single edge with
+// HasNextPage=true; passing the returned EndCursor as after on the next
+// call must return a different edge.
 func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account1_ForwardPagination() {
 	pageSize := int32(1)
 	address := suite.testEnv.BalanceTestAccount1KP.Address()
@@ -207,10 +207,11 @@ func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account1_Fo
 		"Second page must return a different edge than the first; equal cursors imply the after arg was ignored")
 }
 
-// TestCheckpoint_Account1_BackwardPagination exercises the SDK's backward
-// pagination round-trip. The pre-fix SDK query string did not declare
-// $last or $before at all, so a forward-only test would not catch a
-// regression where these args are silently dropped.
+// TestCheckpoint_Account1_BackwardPagination verifies that GetAccountBalances
+// honors the last and before pagination args. Account1 has 3 balances at
+// checkpoint, so calling with last=1 must return a single edge with
+// HasPreviousPage=true; passing the returned StartCursor as before on the
+// next call must return a different edge.
 func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account1_BackwardPagination() {
 	pageSize := int32(1)
 	address := suite.testEnv.BalanceTestAccount1KP.Address()

--- a/internal/integrationtests/account_balances_test.go
+++ b/internal/integrationtests/account_balances_test.go
@@ -32,6 +32,12 @@ import (
 	"github.com/stellar/wallet-backend/pkg/wbclient/types"
 )
 
+// fetchAllBalancesPageSize is the explicit `first` arg used by tests that
+// expect every fixture balance to fit in a single page. The server defaults
+// to 50 when pagination args are omitted (internal/serve/graphql/utils.go),
+// so we set a larger value to keep these tests robust as fixtures grow.
+const fetchAllBalancesPageSize int32 = 100
+
 // AccountBalancesAfterCheckpointTestSuite validates that balances are correctly calculated
 // using tokens populated from the checkpoint ledger before any fixture transactions are submitted.
 //
@@ -48,18 +54,20 @@ type AccountBalancesAfterCheckpointTestSuite struct {
 // - USDC trustline (100)
 // - EURC trustline (100)
 func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account1_HasInitialBalances() {
-	balances, err := suite.testEnv.WBClient.GetAccountBalances(
+	first := fetchAllBalancesPageSize
+	connection, err := suite.testEnv.WBClient.GetAccountBalances(
 		context.Background(),
 		suite.testEnv.BalanceTestAccount1KP.Address(),
+		&first, nil, nil, nil,
 	)
 	suite.Require().NoError(err)
-	suite.Require().NotNil(balances)
-	suite.Require().NotEmpty(balances)
+	suite.Require().NotNil(connection)
+	suite.Require().NotEmpty(connection.Edges)
 
-	suite.Require().Equal(3, len(balances), "Expected 3 balances: native XLM, USDC trustline, EURC trustline")
+	suite.Require().Equal(3, len(connection.Edges), "Expected 3 balances: native XLM, USDC trustline, EURC trustline")
 
-	for _, balance := range balances {
-		switch b := balance.(type) {
+	for _, edge := range connection.Edges {
+		switch b := edge.Node.(type) {
 		case *types.NativeBalance:
 			suite.Require().Equal("10000.0000000", b.GetBalance())
 			suite.Require().Equal(types.TokenTypeNative, b.GetTokenType())
@@ -87,7 +95,7 @@ func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account1_Ha
 			}
 
 		default:
-			suite.Fail("Unexpected balance type: %T", balance)
+			suite.Fail("Unexpected balance type: %T", edge.Node)
 		}
 	}
 }
@@ -97,18 +105,20 @@ func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account1_Ha
 // - Native XLM (~10000)
 // - USDC trustline (100)
 func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account2_HasInitialBalances() {
-	balances, err := suite.testEnv.WBClient.GetAccountBalances(
+	first := fetchAllBalancesPageSize
+	connection, err := suite.testEnv.WBClient.GetAccountBalances(
 		context.Background(),
 		suite.testEnv.BalanceTestAccount2KP.Address(),
+		&first, nil, nil, nil,
 	)
 	suite.Require().NoError(err)
-	suite.Require().NotNil(balances)
-	suite.Require().NotEmpty(balances)
+	suite.Require().NotNil(connection)
+	suite.Require().NotEmpty(connection.Edges)
 
-	suite.Require().Equal(2, len(balances), "Expected 2 balances: native XLM and USDC trustline")
+	suite.Require().Equal(2, len(connection.Edges), "Expected 2 balances: native XLM and USDC trustline")
 
-	for _, balance := range balances {
-		switch b := balance.(type) {
+	for _, edge := range connection.Edges {
+		switch b := edge.Node.(type) {
 		case *types.NativeBalance:
 			suite.Require().Equal("10000.0000000", b.GetBalance())
 			suite.Require().Equal(types.TokenTypeNative, b.GetTokenType())
@@ -129,7 +139,7 @@ func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account2_Ha
 			suite.Require().Equal(suite.testEnv.USDCContractAddress, b.GetTokenID())
 
 		default:
-			suite.Fail("Unexpected balance type: %T", balance)
+			suite.Fail("Unexpected balance type: %T", edge.Node)
 		}
 	}
 }
@@ -138,18 +148,20 @@ func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account2_Ha
 // has the expected initial balances from checkpoint setup:
 // - USDC SAC tokens (200)
 func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_HolderContract_HasInitialBalances() {
-	balances, err := suite.testEnv.WBClient.GetAccountBalances(
+	first := fetchAllBalancesPageSize
+	connection, err := suite.testEnv.WBClient.GetAccountBalances(
 		context.Background(),
 		suite.testEnv.HolderContractAddress,
+		&first, nil, nil, nil,
 	)
 	suite.Require().NoError(err)
-	suite.Require().NotNil(balances)
-	suite.Require().NotEmpty(balances)
+	suite.Require().NotNil(connection)
+	suite.Require().NotEmpty(connection.Edges)
 
-	suite.Require().Equal(1, len(balances), "Expected 1 balance: USDC SAC")
+	suite.Require().Equal(1, len(connection.Edges), "Expected 1 balance: USDC SAC")
 
-	for _, balance := range balances {
-		switch b := balance.(type) {
+	for _, edge := range connection.Edges {
+		switch b := edge.Node.(type) {
 		case *types.SACBalance:
 			suite.Require().Equal("200.0000000", b.GetBalance())
 			suite.Require().Equal(suite.testEnv.USDCContractAddress, b.GetTokenID())
@@ -159,7 +171,7 @@ func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_HolderContr
 			suite.Require().Equal(int32(7), b.Decimals)
 
 		default:
-			suite.Fail("Unexpected balance type: %T", balance)
+			suite.Fail("Unexpected balance type: %T", edge.Node)
 		}
 	}
 }
@@ -181,18 +193,20 @@ type AccountBalancesAfterLiveIngestionTestSuite struct {
 // - USDC trustline (100) - unchanged
 // - EURC trustline (50) - reduced from 100 after transfer to contract
 func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_Account1_HasUpdatedBalances() {
-	balances, err := suite.testEnv.WBClient.GetAccountBalances(
+	first := fetchAllBalancesPageSize
+	connection, err := suite.testEnv.WBClient.GetAccountBalances(
 		context.Background(),
 		suite.testEnv.BalanceTestAccount1KP.Address(),
+		&first, nil, nil, nil,
 	)
 	suite.Require().NoError(err)
-	suite.Require().NotNil(balances)
-	suite.Require().NotEmpty(balances)
+	suite.Require().NotNil(connection)
+	suite.Require().NotEmpty(connection.Edges)
 
-	suite.Require().Equal(3, len(balances), "Expected 3 balances: native XLM, USDC, and EURC")
+	suite.Require().Equal(3, len(connection.Edges), "Expected 3 balances: native XLM, USDC, and EURC")
 
-	for _, balance := range balances {
-		switch b := balance.(type) {
+	for _, edge := range connection.Edges {
+		switch b := edge.Node.(type) {
 		case *types.NativeBalance:
 			parsedBalance, err := strconv.ParseFloat(b.GetBalance(), 64)
 			suite.Require().NoError(err)
@@ -222,7 +236,7 @@ func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_Accou
 			}
 
 		default:
-			suite.Fail("Unexpected balance type: %T", balance)
+			suite.Fail("Unexpected balance type: %T", edge.Node)
 		}
 	}
 }
@@ -233,18 +247,20 @@ func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_Accou
 // - USDC trustline (100) - unchanged
 // - EURC trustline (75) - NEW from trustline creation and payment
 func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_Account2_HasNewBalances() {
-	balances, err := suite.testEnv.WBClient.GetAccountBalances(
+	first := fetchAllBalancesPageSize
+	connection, err := suite.testEnv.WBClient.GetAccountBalances(
 		context.Background(),
 		suite.testEnv.BalanceTestAccount2KP.Address(),
+		&first, nil, nil, nil,
 	)
 	suite.Require().NoError(err)
-	suite.Require().NotNil(balances)
-	suite.Require().NotEmpty(balances)
+	suite.Require().NotNil(connection)
+	suite.Require().NotEmpty(connection.Edges)
 
-	suite.Require().Equal(3, len(balances), "Expected 3 balances: native XLM, USDC, and EURC")
+	suite.Require().Equal(3, len(connection.Edges), "Expected 3 balances: native XLM, USDC, and EURC")
 
-	for _, balance := range balances {
-		switch b := balance.(type) {
+	for _, edge := range connection.Edges {
+		switch b := edge.Node.(type) {
 		case *types.NativeBalance:
 			parsedBalance, err := strconv.ParseFloat(b.GetBalance(), 64)
 			suite.Require().NoError(err)
@@ -274,7 +290,7 @@ func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_Accou
 			}
 
 		default:
-			suite.Fail("Unexpected balance type: %T", balance)
+			suite.Fail("Unexpected balance type: %T", edge.Node)
 		}
 	}
 }
@@ -284,18 +300,20 @@ func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_Accou
 // - USDC SAC tokens (200) - unchanged
 // - EURC SAC tokens (50) - NEW from transfer from account 1
 func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_HolderContract_HasNewEURC() {
-	balances, err := suite.testEnv.WBClient.GetAccountBalances(
+	first := fetchAllBalancesPageSize
+	connection, err := suite.testEnv.WBClient.GetAccountBalances(
 		context.Background(),
 		suite.testEnv.HolderContractAddress,
+		&first, nil, nil, nil,
 	)
 	suite.Require().NoError(err)
-	suite.Require().NotNil(balances)
-	suite.Require().NotEmpty(balances)
+	suite.Require().NotNil(connection)
+	suite.Require().NotEmpty(connection.Edges)
 
-	suite.Require().Equal(2, len(balances), "Expected 2 balances: USDC SAC and EURC SAC")
+	suite.Require().Equal(2, len(connection.Edges), "Expected 2 balances: USDC SAC and EURC SAC")
 
-	for _, balance := range balances {
-		switch b := balance.(type) {
+	for _, edge := range connection.Edges {
+		switch b := edge.Node.(type) {
 		case *types.SACBalance:
 			suite.Require().Equal(types.TokenTypeSAC, b.GetTokenType())
 			suite.Require().Equal(suite.testEnv.MasterAccountAddress, b.Issuer)
@@ -313,7 +331,7 @@ func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_Holde
 			}
 
 		default:
-			suite.Fail("Unexpected balance type: %T", balance)
+			suite.Fail("Unexpected balance type: %T", edge.Node)
 		}
 	}
 }

--- a/internal/integrationtests/account_balances_test.go
+++ b/internal/integrationtests/account_balances_test.go
@@ -176,6 +176,67 @@ func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_HolderContr
 	}
 }
 
+// TestCheckpoint_Account1_ForwardPagination exercises the SDK's forward
+// pagination round-trip. Pre-fix the SDK ignored caller-supplied first/after
+// args (issue #608); this test guards against any regression that drops
+// them again. Account1 has 3 balances, so first=1 plus a follow-up call
+// using the returned EndCursor must return a different edge.
+func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account1_ForwardPagination() {
+	pageSize := int32(1)
+	address := suite.testEnv.BalanceTestAccount1KP.Address()
+
+	page1, err := suite.testEnv.WBClient.GetAccountBalances(
+		context.Background(), address,
+		&pageSize, nil, nil, nil,
+	)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(page1)
+	suite.Require().Len(page1.Edges, 1, "Expected exactly 1 edge on the first page when first=1")
+	suite.Require().NotNil(page1.PageInfo)
+	suite.Require().True(page1.PageInfo.HasNextPage, "HasNextPage should be true with 3 balances and first=1")
+	suite.Require().NotNil(page1.PageInfo.EndCursor, "EndCursor should be populated when HasNextPage is true")
+
+	page2, err := suite.testEnv.WBClient.GetAccountBalances(
+		context.Background(), address,
+		&pageSize, nil, page1.PageInfo.EndCursor, nil,
+	)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(page2)
+	suite.Require().Len(page2.Edges, 1, "Expected exactly 1 edge on the second page when first=1")
+	suite.Require().NotEqual(page1.Edges[0].Cursor, page2.Edges[0].Cursor,
+		"Second page must return a different edge than the first; equal cursors imply the after arg was ignored")
+}
+
+// TestCheckpoint_Account1_BackwardPagination exercises the SDK's backward
+// pagination round-trip. The pre-fix SDK query string did not declare
+// $last or $before at all, so a forward-only test would not catch a
+// regression where these args are silently dropped.
+func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account1_BackwardPagination() {
+	pageSize := int32(1)
+	address := suite.testEnv.BalanceTestAccount1KP.Address()
+
+	lastPage, err := suite.testEnv.WBClient.GetAccountBalances(
+		context.Background(), address,
+		nil, &pageSize, nil, nil,
+	)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(lastPage)
+	suite.Require().Len(lastPage.Edges, 1, "Expected exactly 1 edge on the last page when last=1")
+	suite.Require().NotNil(lastPage.PageInfo)
+	suite.Require().True(lastPage.PageInfo.HasPreviousPage, "HasPreviousPage should be true with 3 balances and last=1")
+	suite.Require().NotNil(lastPage.PageInfo.StartCursor, "StartCursor should be populated when HasPreviousPage is true")
+
+	prevPage, err := suite.testEnv.WBClient.GetAccountBalances(
+		context.Background(), address,
+		nil, &pageSize, nil, lastPage.PageInfo.StartCursor,
+	)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(prevPage)
+	suite.Require().Len(prevPage.Edges, 1, "Expected exactly 1 edge on the page before the last")
+	suite.Require().NotEqual(lastPage.Edges[0].Cursor, prevPage.Edges[0].Cursor,
+		"Previous page must return a different edge than the last; equal cursors imply the before arg was ignored")
+}
+
 // AccountBalancesAfterLiveIngestionTestSuite validates that balances are correctly calculated
 // after fixture transactions are submitted and processed by the live ingestion pipeline. These new transactions
 // will lead to new tokens being inserted into the token cache and new balances being calculated.

--- a/internal/integrationtests/account_balances_test.go
+++ b/internal/integrationtests/account_balances_test.go
@@ -32,12 +32,6 @@ import (
 	"github.com/stellar/wallet-backend/pkg/wbclient/types"
 )
 
-// fetchAllBalancesPageSize is the explicit `first` arg used by tests that
-// expect every fixture balance to fit in a single page. The server defaults
-// to 50 when pagination args are omitted (internal/serve/graphql/utils.go),
-// so we set a larger value to keep these tests robust as fixtures grow.
-const fetchAllBalancesPageSize int32 = 100
-
 // AccountBalancesAfterCheckpointTestSuite validates that balances are correctly calculated
 // using tokens populated from the checkpoint ledger before any fixture transactions are submitted.
 //
@@ -54,20 +48,17 @@ type AccountBalancesAfterCheckpointTestSuite struct {
 // - USDC trustline (100)
 // - EURC trustline (100)
 func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account1_HasInitialBalances() {
-	first := fetchAllBalancesPageSize
-	connection, err := suite.testEnv.WBClient.GetAccountBalances(
+	balances, err := suite.testEnv.WBClient.GetAllAccountBalances(
 		context.Background(),
 		suite.testEnv.BalanceTestAccount1KP.Address(),
-		&first, nil, nil, nil,
 	)
 	suite.Require().NoError(err)
-	suite.Require().NotNil(connection)
-	suite.Require().NotEmpty(connection.Edges)
+	suite.Require().NotEmpty(balances)
 
-	suite.Require().Equal(3, len(connection.Edges), "Expected 3 balances: native XLM, USDC trustline, EURC trustline")
+	suite.Require().Equal(3, len(balances), "Expected 3 balances: native XLM, USDC trustline, EURC trustline")
 
-	for _, edge := range connection.Edges {
-		switch b := edge.Node.(type) {
+	for _, balance := range balances {
+		switch b := balance.(type) {
 		case *types.NativeBalance:
 			suite.Require().Equal("10000.0000000", b.GetBalance())
 			suite.Require().Equal(types.TokenTypeNative, b.GetTokenType())
@@ -95,7 +86,7 @@ func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account1_Ha
 			}
 
 		default:
-			suite.Fail("Unexpected balance type: %T", edge.Node)
+			suite.Fail("Unexpected balance type: %T", balance)
 		}
 	}
 }
@@ -105,20 +96,17 @@ func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account1_Ha
 // - Native XLM (~10000)
 // - USDC trustline (100)
 func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account2_HasInitialBalances() {
-	first := fetchAllBalancesPageSize
-	connection, err := suite.testEnv.WBClient.GetAccountBalances(
+	balances, err := suite.testEnv.WBClient.GetAllAccountBalances(
 		context.Background(),
 		suite.testEnv.BalanceTestAccount2KP.Address(),
-		&first, nil, nil, nil,
 	)
 	suite.Require().NoError(err)
-	suite.Require().NotNil(connection)
-	suite.Require().NotEmpty(connection.Edges)
+	suite.Require().NotEmpty(balances)
 
-	suite.Require().Equal(2, len(connection.Edges), "Expected 2 balances: native XLM and USDC trustline")
+	suite.Require().Equal(2, len(balances), "Expected 2 balances: native XLM and USDC trustline")
 
-	for _, edge := range connection.Edges {
-		switch b := edge.Node.(type) {
+	for _, balance := range balances {
+		switch b := balance.(type) {
 		case *types.NativeBalance:
 			suite.Require().Equal("10000.0000000", b.GetBalance())
 			suite.Require().Equal(types.TokenTypeNative, b.GetTokenType())
@@ -139,7 +127,7 @@ func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account2_Ha
 			suite.Require().Equal(suite.testEnv.USDCContractAddress, b.GetTokenID())
 
 		default:
-			suite.Fail("Unexpected balance type: %T", edge.Node)
+			suite.Fail("Unexpected balance type: %T", balance)
 		}
 	}
 }
@@ -148,20 +136,17 @@ func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_Account2_Ha
 // has the expected initial balances from checkpoint setup:
 // - USDC SAC tokens (200)
 func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_HolderContract_HasInitialBalances() {
-	first := fetchAllBalancesPageSize
-	connection, err := suite.testEnv.WBClient.GetAccountBalances(
+	balances, err := suite.testEnv.WBClient.GetAllAccountBalances(
 		context.Background(),
 		suite.testEnv.HolderContractAddress,
-		&first, nil, nil, nil,
 	)
 	suite.Require().NoError(err)
-	suite.Require().NotNil(connection)
-	suite.Require().NotEmpty(connection.Edges)
+	suite.Require().NotEmpty(balances)
 
-	suite.Require().Equal(1, len(connection.Edges), "Expected 1 balance: USDC SAC")
+	suite.Require().Equal(1, len(balances), "Expected 1 balance: USDC SAC")
 
-	for _, edge := range connection.Edges {
-		switch b := edge.Node.(type) {
+	for _, balance := range balances {
+		switch b := balance.(type) {
 		case *types.SACBalance:
 			suite.Require().Equal("200.0000000", b.GetBalance())
 			suite.Require().Equal(suite.testEnv.USDCContractAddress, b.GetTokenID())
@@ -171,7 +156,7 @@ func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_HolderContr
 			suite.Require().Equal(int32(7), b.Decimals)
 
 		default:
-			suite.Fail("Unexpected balance type: %T", edge.Node)
+			suite.Fail("Unexpected balance type: %T", balance)
 		}
 	}
 }
@@ -255,20 +240,17 @@ type AccountBalancesAfterLiveIngestionTestSuite struct {
 // - USDC trustline (100) - unchanged
 // - EURC trustline (50) - reduced from 100 after transfer to contract
 func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_Account1_HasUpdatedBalances() {
-	first := fetchAllBalancesPageSize
-	connection, err := suite.testEnv.WBClient.GetAccountBalances(
+	balances, err := suite.testEnv.WBClient.GetAllAccountBalances(
 		context.Background(),
 		suite.testEnv.BalanceTestAccount1KP.Address(),
-		&first, nil, nil, nil,
 	)
 	suite.Require().NoError(err)
-	suite.Require().NotNil(connection)
-	suite.Require().NotEmpty(connection.Edges)
+	suite.Require().NotEmpty(balances)
 
-	suite.Require().Equal(3, len(connection.Edges), "Expected 3 balances: native XLM, USDC, and EURC")
+	suite.Require().Equal(3, len(balances), "Expected 3 balances: native XLM, USDC, and EURC")
 
-	for _, edge := range connection.Edges {
-		switch b := edge.Node.(type) {
+	for _, balance := range balances {
+		switch b := balance.(type) {
 		case *types.NativeBalance:
 			parsedBalance, err := strconv.ParseFloat(b.GetBalance(), 64)
 			suite.Require().NoError(err)
@@ -298,7 +280,7 @@ func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_Accou
 			}
 
 		default:
-			suite.Fail("Unexpected balance type: %T", edge.Node)
+			suite.Fail("Unexpected balance type: %T", balance)
 		}
 	}
 }
@@ -309,20 +291,17 @@ func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_Accou
 // - USDC trustline (100) - unchanged
 // - EURC trustline (75) - NEW from trustline creation and payment
 func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_Account2_HasNewBalances() {
-	first := fetchAllBalancesPageSize
-	connection, err := suite.testEnv.WBClient.GetAccountBalances(
+	balances, err := suite.testEnv.WBClient.GetAllAccountBalances(
 		context.Background(),
 		suite.testEnv.BalanceTestAccount2KP.Address(),
-		&first, nil, nil, nil,
 	)
 	suite.Require().NoError(err)
-	suite.Require().NotNil(connection)
-	suite.Require().NotEmpty(connection.Edges)
+	suite.Require().NotEmpty(balances)
 
-	suite.Require().Equal(3, len(connection.Edges), "Expected 3 balances: native XLM, USDC, and EURC")
+	suite.Require().Equal(3, len(balances), "Expected 3 balances: native XLM, USDC, and EURC")
 
-	for _, edge := range connection.Edges {
-		switch b := edge.Node.(type) {
+	for _, balance := range balances {
+		switch b := balance.(type) {
 		case *types.NativeBalance:
 			parsedBalance, err := strconv.ParseFloat(b.GetBalance(), 64)
 			suite.Require().NoError(err)
@@ -352,7 +331,7 @@ func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_Accou
 			}
 
 		default:
-			suite.Fail("Unexpected balance type: %T", edge.Node)
+			suite.Fail("Unexpected balance type: %T", balance)
 		}
 	}
 }
@@ -362,20 +341,17 @@ func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_Accou
 // - USDC SAC tokens (200) - unchanged
 // - EURC SAC tokens (50) - NEW from transfer from account 1
 func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_HolderContract_HasNewEURC() {
-	first := fetchAllBalancesPageSize
-	connection, err := suite.testEnv.WBClient.GetAccountBalances(
+	balances, err := suite.testEnv.WBClient.GetAllAccountBalances(
 		context.Background(),
 		suite.testEnv.HolderContractAddress,
-		&first, nil, nil, nil,
 	)
 	suite.Require().NoError(err)
-	suite.Require().NotNil(connection)
-	suite.Require().NotEmpty(connection.Edges)
+	suite.Require().NotEmpty(balances)
 
-	suite.Require().Equal(2, len(connection.Edges), "Expected 2 balances: USDC SAC and EURC SAC")
+	suite.Require().Equal(2, len(balances), "Expected 2 balances: USDC SAC and EURC SAC")
 
-	for _, edge := range connection.Edges {
-		switch b := edge.Node.(type) {
+	for _, balance := range balances {
+		switch b := balance.(type) {
 		case *types.SACBalance:
 			suite.Require().Equal(types.TokenTypeSAC, b.GetTokenType())
 			suite.Require().Equal(suite.testEnv.MasterAccountAddress, b.Issuer)
@@ -393,7 +369,7 @@ func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_Holde
 			}
 
 		default:
-			suite.Fail("Unexpected balance type: %T", edge.Node)
+			suite.Fail("Unexpected balance type: %T", balance)
 		}
 	}
 }

--- a/pkg/wbclient/client.go
+++ b/pkg/wbclient/client.go
@@ -529,21 +529,20 @@ func (c *Client) GetAccountBalances(ctx context.Context, address string, first, 
 
 // GetAllAccountBalances returns every balance for the given address by
 // driving GetAccountBalances forward through the cursor sequence in
-// fixed-size pages. Use this when you want a flat list of balances for
-// an account; use GetAccountBalances directly when you need explicit
+// fixed-size pages. Returns a non-nil empty slice when the account has
+// no balances. Use this when you want a flat list of balances for an
+// account; use GetAccountBalances directly when you need explicit
 // control over page size or position.
 func (c *Client) GetAllAccountBalances(ctx context.Context, address string) ([]types.Balance, error) {
 	first := int32(100)
 
-	var (
-		after    *string
-		balances []types.Balance
-	)
+	var after *string
+	balances := make([]types.Balance, 0)
 
 	for {
 		connection, err := c.GetAccountBalances(ctx, address, &first, nil, after, nil)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("getting account balances page: %w", err)
 		}
 		if connection == nil {
 			break

--- a/pkg/wbclient/client.go
+++ b/pkg/wbclient/client.go
@@ -527,6 +527,37 @@ func (c *Client) GetAccountBalances(ctx context.Context, address string, first, 
 	return data.AccountByAddress.Balances, nil
 }
 
+// GetAllAccountBalances returns every balance for the given address by
+// driving GetAccountBalances forward through the cursor sequence in
+// fixed-size pages. Use this when you want a flat list of balances for
+// an account; use GetAccountBalances directly when you need explicit
+// control over page size or position.
+func (c *Client) GetAllAccountBalances(ctx context.Context, address string) ([]types.Balance, error) {
+	first := int32(100)
+
+	var (
+		after    *string
+		balances []types.Balance
+	)
+
+	for {
+		connection, err := c.GetAccountBalances(ctx, address, &first, nil, after, nil)
+		if err != nil {
+			return nil, err
+		}
+		if connection == nil {
+			break
+		}
+		balances = append(balances, connection.Balances()...)
+		if connection.PageInfo == nil || !connection.PageInfo.HasNextPage || connection.PageInfo.EndCursor == nil {
+			break
+		}
+		after = connection.PageInfo.EndCursor
+	}
+
+	return balances, nil
+}
+
 func (c *Client) request(ctx context.Context, bodyObj any) (*http.Response, error) {
 	reqBody, err := json.Marshal(bodyObj)
 	if err != nil {

--- a/pkg/wbclient/client.go
+++ b/pkg/wbclient/client.go
@@ -92,12 +92,7 @@ type OperationStateChangesData struct {
 
 type AccountBalancesData struct {
 	AccountByAddress struct {
-		Balances struct {
-			Edges []struct {
-				Node json.RawMessage `json:"node"`
-			} `json:"edges"`
-			PageInfo *types.PageInfo `json:"pageInfo"`
-		} `json:"balances"`
+		Balances *types.BalanceConnection `json:"balances"`
 	} `json:"accountByAddress"`
 }
 
@@ -513,42 +508,23 @@ func (c *Client) GetOperationStateChanges(ctx context.Context, id int64, first, 
 	return data.OperationByID.StateChanges, nil
 }
 
-func (c *Client) GetAccountBalances(ctx context.Context, address string) ([]types.Balance, error) {
-	const pageSize int32 = 100
-
-	var (
-		after    *string
-		balances []types.Balance
-	)
-
-	for {
-		variables := map[string]any{
-			"address": address,
-			"first":   pageSize,
-			"after":   after,
-		}
-
-		data, err := executeGraphQL[AccountBalancesData](c, ctx, buildAccountBalancesQuery(), variables)
-		if err != nil {
-			return nil, err
-		}
-
-		for i, edge := range data.AccountByAddress.Balances.Edges {
-			balance, unmarshalErr := types.UnmarshalBalance(edge.Node)
-			if unmarshalErr != nil {
-				return nil, fmt.Errorf("unmarshaling balance %d: %w", len(balances)+i, unmarshalErr)
-			}
-			balances = append(balances, balance)
-		}
-
-		pageInfo := data.AccountByAddress.Balances.PageInfo
-		if pageInfo == nil || !pageInfo.HasNextPage || pageInfo.EndCursor == nil {
-			break
-		}
-		after = pageInfo.EndCursor
+func (c *Client) GetAccountBalances(ctx context.Context, address string, first, last *int32, after, before *string) (*types.BalanceConnection, error) {
+	paginationVars, err := buildPaginationVars(first, last, after, before)
+	if err != nil {
+		return nil, fmt.Errorf("building pagination variables: %w", err)
 	}
 
-	return balances, nil
+	variables := mergeVariables(
+		map[string]interface{}{"address": address},
+		paginationVars,
+	)
+
+	data, err := executeGraphQL[AccountBalancesData](c, ctx, buildAccountBalancesQuery(), variables)
+	if err != nil {
+		return nil, err
+	}
+
+	return data.AccountByAddress.Balances, nil
 }
 
 func (c *Client) request(ctx context.Context, bodyObj any) (*http.Response, error) {

--- a/pkg/wbclient/queries.go
+++ b/pkg/wbclient/queries.go
@@ -374,17 +374,20 @@ const balanceFragments = `
 // buildAccountBalancesQuery builds the GraphQL query for fetching account balances.
 func buildAccountBalancesQuery() string {
 	return fmt.Sprintf(`
-		query GetAccountBalances($address: String!, $first: Int, $after: String) {
+		query GetAccountBalances($address: String!, $first: Int, $after: String, $last: Int, $before: String) {
 			accountByAddress(address: $address) {
-				balances(first: $first, after: $after) {
+				balances(first: $first, after: $after, last: $last, before: $before) {
 					edges {
 						node {
 							%s
 						}
+						cursor
 					}
 					pageInfo {
+						startCursor
 						endCursor
 						hasNextPage
+						hasPreviousPage
 					}
 				}
 			}

--- a/pkg/wbclient/types/types.go
+++ b/pkg/wbclient/types/types.go
@@ -338,22 +338,27 @@ type BalanceConnection struct {
 }
 
 // UnmarshalJSON implements custom JSON unmarshaling for BalanceConnection
-// to reject null entries in the edges array. The GraphQL schema declares
-// edges as [BalanceEdge!]!, so a null edge is a server bug; failing fast
-// at decode time surfaces it instead of silently dropping data downstream.
+// and enforces the schema's non-null guarantees. The GraphQL schema declares
+// edges as [BalanceEdge!]! — both the field itself and each element are
+// non-null — so each of the following is a server bug and is rejected here:
+//   - a missing or null edges field on the connection
+//   - a null entry within the edges array
 //
-// Null nodes inside an edge are caught by BalanceEdge.UnmarshalJSON;
-// this method covers the array-element case that the standard library
-// never routes through that decoder.
+// Null nodes inside an edge object are caught separately by
+// BalanceEdge.UnmarshalJSON.
 func (c *BalanceConnection) UnmarshalJSON(data []byte) error {
 	type tempConnection struct {
-		Edges    []*BalanceEdge `json:"edges,omitempty"`
+		Edges    []*BalanceEdge `json:"edges"`
 		PageInfo *PageInfo      `json:"pageInfo"`
 	}
 
 	var temp tempConnection
 	if err := json.Unmarshal(data, &temp); err != nil {
 		return fmt.Errorf("unmarshaling balance connection: %w", err)
+	}
+
+	if temp.Edges == nil {
+		return fmt.Errorf("balance connection missing required edges field: the GraphQL schema declares edges as non-null")
 	}
 
 	for i, edge := range temp.Edges {

--- a/pkg/wbclient/types/types.go
+++ b/pkg/wbclient/types/types.go
@@ -319,8 +319,7 @@ func (e *BalanceEdge) UnmarshalJSON(data []byte) error {
 	e.Cursor = temp.Cursor
 
 	if len(temp.Node) == 0 || string(temp.Node) == "null" {
-		e.Node = nil
-		return nil
+		return fmt.Errorf("balance edge missing required node (cursor=%q): the GraphQL schema declares Balance as non-null", temp.Cursor)
 	}
 
 	node, err := UnmarshalBalance(temp.Node)
@@ -336,4 +335,22 @@ func (e *BalanceEdge) UnmarshalJSON(data []byte) error {
 type BalanceConnection struct {
 	Edges    []*BalanceEdge `json:"edges,omitempty"`
 	PageInfo *PageInfo      `json:"pageInfo"`
+}
+
+// Balances returns the connection's balance nodes as a flat slice.
+// Returns nil if the receiver is nil or has no edges. Combined with the
+// strict UnmarshalJSON on BalanceEdge, callers using this helper can
+// trust that every returned Balance is non-nil.
+func (c *BalanceConnection) Balances() []Balance {
+	if c == nil || len(c.Edges) == 0 {
+		return nil
+	}
+	balances := make([]Balance, 0, len(c.Edges))
+	for _, edge := range c.Edges {
+		if edge == nil {
+			continue
+		}
+		balances = append(balances, edge.Node)
+	}
+	return balances
 }

--- a/pkg/wbclient/types/types.go
+++ b/pkg/wbclient/types/types.go
@@ -337,10 +337,44 @@ type BalanceConnection struct {
 	PageInfo *PageInfo      `json:"pageInfo"`
 }
 
+// UnmarshalJSON implements custom JSON unmarshaling for BalanceConnection
+// to reject null entries in the edges array. The GraphQL schema declares
+// edges as [BalanceEdge!]!, so a null edge is a server bug; failing fast
+// at decode time surfaces it instead of silently dropping data downstream.
+//
+// Null nodes inside an edge are caught by BalanceEdge.UnmarshalJSON;
+// this method covers the array-element case that the standard library
+// never routes through that decoder.
+func (c *BalanceConnection) UnmarshalJSON(data []byte) error {
+	type tempConnection struct {
+		Edges    []*BalanceEdge `json:"edges,omitempty"`
+		PageInfo *PageInfo      `json:"pageInfo"`
+	}
+
+	var temp tempConnection
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return fmt.Errorf("unmarshaling balance connection: %w", err)
+	}
+
+	for i, edge := range temp.Edges {
+		if edge == nil {
+			return fmt.Errorf("balance connection edge at index %d is null: the GraphQL schema declares BalanceEdge as non-null", i)
+		}
+	}
+
+	c.Edges = temp.Edges
+	c.PageInfo = temp.PageInfo
+	return nil
+}
+
 // Balances returns the connection's balance nodes as a flat slice.
 // Returns nil if the receiver is nil or has no edges. Combined with the
-// strict UnmarshalJSON on BalanceEdge, callers using this helper can
-// trust that every returned Balance is non-nil.
+// strict UnmarshalJSON on BalanceEdge and BalanceConnection, callers
+// using this helper can trust that every returned Balance is non-nil.
+//
+// The defensive nil-edge skip protects against connections constructed
+// directly in Go code (not via JSON decode); JSON-derived connections
+// never reach this branch because UnmarshalJSON rejects null edges.
 func (c *BalanceConnection) Balances() []Balance {
 	if c == nil || len(c.Edges) == 0 {
 		return nil

--- a/pkg/wbclient/types/types.go
+++ b/pkg/wbclient/types/types.go
@@ -295,3 +295,45 @@ type StateChangeConnection struct {
 	Edges    []*StateChangeEdge `json:"edges,omitempty"`
 	PageInfo *PageInfo          `json:"pageInfo"`
 }
+
+// BalanceEdge represents an edge in the balance connection
+type BalanceEdge struct {
+	Node   Balance `json:"node,omitempty"`
+	Cursor string  `json:"cursor"`
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling for BalanceEdge
+// to properly handle polymorphic balance types (NativeBalance,
+// TrustlineBalance, SACBalance) discriminated by __typename.
+func (e *BalanceEdge) UnmarshalJSON(data []byte) error {
+	type tempEdge struct {
+		Node   json.RawMessage `json:"node,omitempty"`
+		Cursor string          `json:"cursor"`
+	}
+
+	var temp tempEdge
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return fmt.Errorf("unmarshaling balance edge: %w", err)
+	}
+
+	e.Cursor = temp.Cursor
+
+	if len(temp.Node) == 0 || string(temp.Node) == "null" {
+		e.Node = nil
+		return nil
+	}
+
+	node, err := UnmarshalBalance(temp.Node)
+	if err != nil {
+		return err
+	}
+
+	e.Node = node
+	return nil
+}
+
+// BalanceConnection represents a paginated list of balances
+type BalanceConnection struct {
+	Edges    []*BalanceEdge `json:"edges,omitempty"`
+	PageInfo *PageInfo      `json:"pageInfo"`
+}

--- a/pkg/wbclient/types/types_test.go
+++ b/pkg/wbclient/types/types_test.go
@@ -99,3 +99,56 @@ func Test_BalanceConnection_Balances(t *testing.T) {
 		})
 	}
 }
+
+func Test_BalanceConnection_UnmarshalJSON_RejectsNullEdge(t *testing.T) {
+	payload := []byte(`{
+		"edges": [
+			{
+				"cursor": "c1",
+				"node": {
+					"__typename": "NativeBalance",
+					"balance": "1",
+					"tokenId": "native",
+					"tokenType": "NATIVE"
+				}
+			},
+			null
+		],
+		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+	}`)
+
+	var conn BalanceConnection
+	err := json.Unmarshal(payload, &conn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "edge at index 1 is null")
+}
+
+func Test_BalanceConnection_UnmarshalJSON_DecodesValidConnection(t *testing.T) {
+	payload := []byte(`{
+		"edges": [
+			{
+				"cursor": "c1",
+				"node": {
+					"__typename": "NativeBalance",
+					"balance": "100",
+					"tokenId": "native",
+					"tokenType": "NATIVE"
+				}
+			}
+		],
+		"pageInfo": {"hasNextPage": true, "hasPreviousPage": false, "endCursor": "c1"}
+	}`)
+
+	var conn BalanceConnection
+	err := json.Unmarshal(payload, &conn)
+	require.NoError(t, err)
+	require.Len(t, conn.Edges, 1)
+	require.NotNil(t, conn.Edges[0])
+	require.NotNil(t, conn.Edges[0].Node)
+	assert.Equal(t, "c1", conn.Edges[0].Cursor)
+
+	require.NotNil(t, conn.PageInfo)
+	assert.True(t, conn.PageInfo.HasNextPage)
+	require.NotNil(t, conn.PageInfo.EndCursor)
+	assert.Equal(t, "c1", *conn.PageInfo.EndCursor)
+}

--- a/pkg/wbclient/types/types_test.go
+++ b/pkg/wbclient/types/types_test.go
@@ -1,0 +1,101 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_BalanceEdge_UnmarshalJSON_RejectsNullNode(t *testing.T) {
+	var edge BalanceEdge
+	err := json.Unmarshal([]byte(`{"node": null, "cursor": "abc"}`), &edge)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required node")
+	assert.Contains(t, err.Error(), `cursor="abc"`)
+}
+
+func Test_BalanceEdge_UnmarshalJSON_RejectsMissingNode(t *testing.T) {
+	var edge BalanceEdge
+	err := json.Unmarshal([]byte(`{"cursor": "abc"}`), &edge)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required node")
+}
+
+func Test_BalanceEdge_UnmarshalJSON_DecodesNativeBalance(t *testing.T) {
+	payload := []byte(`{
+		"cursor": "cur-1",
+		"node": {
+			"__typename": "NativeBalance",
+			"balance": "10000.0000000",
+			"tokenId": "native",
+			"tokenType": "NATIVE",
+			"minimumBalance": "10",
+			"buyingLiabilities": "0",
+			"sellingLiabilities": "0",
+			"lastModifiedLedger": 12345
+		}
+	}`)
+
+	var edge BalanceEdge
+	err := json.Unmarshal(payload, &edge)
+	require.NoError(t, err)
+	require.Equal(t, "cur-1", edge.Cursor)
+	require.NotNil(t, edge.Node)
+
+	native, ok := edge.Node.(*NativeBalance)
+	require.True(t, ok, "expected node to decode into *NativeBalance, got %T", edge.Node)
+	assert.Equal(t, "10000.0000000", native.BalanceValue)
+	assert.Equal(t, "native", native.TokenID)
+	assert.Equal(t, TokenTypeNative, native.TokenType)
+	assert.Equal(t, "10", native.MinimumBalance)
+	assert.Equal(t, uint32(12345), native.LastModifiedLedger)
+}
+
+func Test_BalanceConnection_Balances(t *testing.T) {
+	cursor1, cursor2 := "c1", "c2"
+	native := &NativeBalance{BalanceValue: "100", TokenID: "native", TokenType: TokenTypeNative}
+	trustline := &TrustlineBalance{BalanceValue: "50", TokenID: "USDC", TokenType: TokenTypeClassic}
+
+	testCases := []struct {
+		name string
+		conn *BalanceConnection
+		want []Balance
+	}{
+		{
+			name: "nil receiver returns nil",
+			conn: nil,
+			want: nil,
+		},
+		{
+			name: "empty edges returns nil",
+			conn: &BalanceConnection{Edges: nil},
+			want: nil,
+		},
+		{
+			name: "populated edges flatten in order",
+			conn: &BalanceConnection{Edges: []*BalanceEdge{
+				{Node: native, Cursor: cursor1},
+				{Node: trustline, Cursor: cursor2},
+			}},
+			want: []Balance{native, trustline},
+		},
+		{
+			name: "nil edge entries are skipped",
+			conn: &BalanceConnection{Edges: []*BalanceEdge{
+				{Node: native, Cursor: cursor1},
+				nil,
+				{Node: trustline, Cursor: cursor2},
+			}},
+			want: []Balance{native, trustline},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.conn.Balances()
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/wbclient/types/types_test.go
+++ b/pkg/wbclient/types/types_test.go
@@ -100,6 +100,42 @@ func Test_BalanceConnection_Balances(t *testing.T) {
 	}
 }
 
+func Test_BalanceConnection_UnmarshalJSON_RejectsMissingEdgesField(t *testing.T) {
+	payload := []byte(`{
+		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+	}`)
+
+	var conn BalanceConnection
+	err := json.Unmarshal(payload, &conn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required edges field")
+}
+
+func Test_BalanceConnection_UnmarshalJSON_RejectsNullEdgesField(t *testing.T) {
+	payload := []byte(`{
+		"edges": null,
+		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+	}`)
+
+	var conn BalanceConnection
+	err := json.Unmarshal(payload, &conn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required edges field")
+}
+
+func Test_BalanceConnection_UnmarshalJSON_AcceptsEmptyEdgesArray(t *testing.T) {
+	payload := []byte(`{
+		"edges": [],
+		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+	}`)
+
+	var conn BalanceConnection
+	err := json.Unmarshal(payload, &conn)
+	require.NoError(t, err)
+	require.NotNil(t, conn.Edges)
+	assert.Empty(t, conn.Edges)
+}
+
 func Test_BalanceConnection_UnmarshalJSON_RejectsNullEdge(t *testing.T) {
 	payload := []byte(`{
 		"edges": [


### PR DESCRIPTION
## Summary

Closes #608.

The `Account.balances` GraphQL query has supported full Relay-style pagination (`first`/`after`/`last`/`before`) since #577. However, the Go SDK method `GetAccountBalances` was never updated — it hardcoded `first: 100`, looped internally to fetch every page, and returned a flat `[]types.Balance`. That made it the only paginated query in the SDK without pagination args.

This PR closes that gap and ships two follow-ups (a convenience helper and a tightening of the polymorphic decode trust boundary) on top.

## What changed

### Core: paginated `GetAccountBalances`

- **New types** in `pkg/wbclient/types/types.go`: `BalanceEdge` and `BalanceConnection`. `BalanceEdge` has a custom `UnmarshalJSON` that dispatches the polymorphic `Balance` node through `UnmarshalBalance` — same pattern as the existing `StateChangeEdge`.
- **GraphQL query string** in `pkg/wbclient/queries.go`: declares all four Relay pagination variables (`$first`, `$after`, `$last`, `$before`) and requests the per-edge `cursor` plus full `PageInfo` (`startCursor`, `endCursor`, `hasNextPage`, `hasPreviousPage`).
- **`GetAccountBalances` signature** in `pkg/wbclient/client.go`:
  ```go
  func (c *Client) GetAccountBalances(
      ctx context.Context,
      address string,
      first, last *int32,
      after, before *string,
  ) (*types.BalanceConnection, error)
  ```
  Internal pagination loop is removed. Pagination args go through the existing `buildPaginationVars` helper, which validates them with the same rules as every other paginated method.

### Follow-ups in this PR

- **`GetAllAccountBalances` convenience helper** in `pkg/wbclient/client.go`. Drives forward pagination internally with a fixed page size and returns a flat `[]types.Balance` — the one-call "fetch every balance for this address" path, for callers that don't need page-level control. Returns a **non-nil empty slice** when the account has no balances (so callers that JSON-marshal the result get `[]` on the wire, not `null`). Pagination errors are wrapped with `"getting account balances page: %w"` so failures partway through the loop are distinguishable from a single-page error.
- **Strict polymorphic decode at both layers.** The schema declares `edges: [BalanceEdge!]!` and `node: Balance!` — both non-null. Two custom `UnmarshalJSON` methods enforce that contract:
  - `BalanceEdge.UnmarshalJSON` rejects null/missing `node` fields inside an edge object (was previously absorbed silently as `Node = nil`).
  - `BalanceConnection.UnmarshalJSON` rejects `null` array elements in `edges` — the case that `BalanceEdge.UnmarshalJSON` cannot catch because Go's `encoding/json` never routes a null array element through a custom decoder.

  Together they guarantee that any successfully-decoded `*BalanceConnection` has non-nil edges *and* non-nil `edge.Node` values, so callers can drop defensive nil-checks (the freighter-backend currently has these).
- **`(*BalanceConnection).Balances() []Balance` helper** for callers that want the flat slice without writing the edge-iteration loop themselves. This is a thin low-level transformation and returns `nil` for an empty connection; the public `GetAllAccountBalances` owns the stable non-nil empty contract.
- **Pinned the new contracts** with unit tests in `pkg/wbclient/types/types_test.go` (rejects null/missing node, rejects null edge slot in an array, decodes a valid native balance, decodes a full valid connection, helper covers nil-receiver / empty / populated / nil-edge-skip cases).

`StateChangeEdge` and `StateChangeConnection` are intentionally untouched in this PR — that surface has its own consumers and tightening it is a separate refactor.

### Tests

- The six existing checkpoint and live-ingestion integration tests (the "fetch all balances for an account" cases) now call `GetAllAccountBalances` and iterate `[]Balance` directly.
- Two new pagination integration tests: `TestCheckpoint_Account1_ForwardPagination` and `TestCheckpoint_Account1_BackwardPagination`. These call `GetAccountBalances` explicitly and round-trip cursors via `EndCursor`/`after` and `StartCursor`/`before` respectively. The backward test is the most important regression-defense: the previous SDK query did not even declare `\$last`/`\$before`, so a forward-only test would have missed that whole class of bug.

## Breaking change

This is a deliberate breaking change to the Go SDK. The signature change cannot be hidden behind a backwards-compatible wrapper without keeping two methods around, and the auto-pagination behavior is being removed from `GetAccountBalances` by design — every other paginated SDK method requires the caller to drive pagination explicitly, and `GetAccountBalances` should match. Consumers that want one-call "fetch all" semantics use the new `GetAllAccountBalances`.

The only internal caller (`internal/integrationtests/account_balances_test.go`) is updated in this PR.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./pkg/wbclient/... -timeout 2m` — 63 tests pass (53 prior + 10 new types tests)
- [ ] Integration tests (Docker required, run locally before merge):
  ```bash
  ENABLE_INTEGRATION_TESTS=true go test -v -race \
    ./internal/integrationtests/ \
    -run 'TestIntegrationTests/AccountBalancesAfterCheckpointTestSuite' \
    -timeout 30m
  ```
  Note: integration suites are subtests of a single `TestIntegrationTests` function (`internal/integrationtests/main_test.go:17`), so `-run` patterns must be slash-qualified.
- [ ] `make check` (lint, vet, etc.)