### PR TITLE
fix(sep41): accept legacy 3-topic mint and clawback events

### DIFF
--- a/internal/services/sep41/events.go
+++ b/internal/services/sep41/events.go
@@ -70,7 +70,7 @@ func ContractIDString(event xdr.ContractEvent) (string, error) {
 // Topics: [sym("transfer"), from: Address, to: Address] — data = i128 amount (classic)
 // or map { amount: i128, to_muxed_id: u64 } (CAP-67).
 func ParseTransferEvent(event xdr.ContractEvent) (*TransferEvent, error) {
-	topics, err := eventTopics(event, 3, EventTransfer)
+	topics, err := eventTopics(event, EventTransfer, 3)
 	if err != nil {
 		return nil, err
 	}
@@ -90,13 +90,18 @@ func ParseTransferEvent(event xdr.ContractEvent) (*TransferEvent, error) {
 	return &TransferEvent{From: from, To: to, Amount: amt, ToMuxedID: muxedID}, nil
 }
 
-// ParseMintEvent decodes a SEP-41 mint event: [sym("mint"), to: Address] with i128 or map data.
+// ParseMintEvent decodes a SEP-41 mint ContractEvent. Two topic shapes are accepted:
+//   - normalized (soroban-sdk 25.x+): [sym("mint"), to: Address]
+//   - legacy (soroban-sdk <=24.x, Stellar Asset Contract, Blend, DeFindex): [sym("mint"), admin: Address, to: Address]
+//
+// `to` is always the last address topic; the optional admin topic is ignored
+// because the data layer only needs the recipient/amount pair.
 func ParseMintEvent(event xdr.ContractEvent) (*MintEvent, error) {
-	topics, err := eventTopics(event, 2, EventMint)
+	topics, err := eventTopics(event, EventMint, 2, 3)
 	if err != nil {
 		return nil, err
 	}
-	to, err := extractAddressFromScVal(topics[1])
+	to, err := extractAddressFromScVal(topics[len(topics)-1])
 	if err != nil {
 		return nil, fmt.Errorf("decoding mint.to: %w", err)
 	}
@@ -109,7 +114,7 @@ func ParseMintEvent(event xdr.ContractEvent) (*MintEvent, error) {
 
 // ParseBurnEvent decodes a SEP-41 burn event: [sym("burn"), from: Address], data = i128.
 func ParseBurnEvent(event xdr.ContractEvent) (*BurnEvent, error) {
-	topics, err := eventTopics(event, 2, EventBurn)
+	topics, err := eventTopics(event, EventBurn, 2)
 	if err != nil {
 		return nil, err
 	}
@@ -124,13 +129,18 @@ func ParseBurnEvent(event xdr.ContractEvent) (*BurnEvent, error) {
 	return &BurnEvent{From: from, Amount: amt}, nil
 }
 
-// ParseClawbackEvent decodes a SEP-41 clawback event: [sym("clawback"), from: Address], data = i128.
+// ParseClawbackEvent decodes a SEP-41 clawback ContractEvent. Two topic shapes are accepted:
+//   - 2-topic [sym("clawback"), from: Address]
+//   - legacy 3-topic [sym("clawback"), admin: Address, from: Address] — emitted by the
+//     Stellar Asset Contract reference and by tokens built against soroban-sdk <=24.x.
+//
+// `from` is always the last address topic.
 func ParseClawbackEvent(event xdr.ContractEvent) (*ClawbackEvent, error) {
-	topics, err := eventTopics(event, 2, EventClawback)
+	topics, err := eventTopics(event, EventClawback, 2, 3)
 	if err != nil {
 		return nil, err
 	}
-	from, err := extractAddressFromScVal(topics[1])
+	from, err := extractAddressFromScVal(topics[len(topics)-1])
 	if err != nil {
 		return nil, fmt.Errorf("decoding clawback.from: %w", err)
 	}
@@ -145,7 +155,7 @@ func ParseClawbackEvent(event xdr.ContractEvent) (*ClawbackEvent, error) {
 // topics: [sym("approve"), from: Address, spender: Address]
 // data:   [ i128 amount, u32 live_until_ledger ]  (ScVec of 2 elements)
 func ParseApproveEvent(event xdr.ContractEvent) (*ApproveEvent, error) {
-	topics, err := eventTopics(event, 3, EventApprove)
+	topics, err := eventTopics(event, EventApprove, 3)
 	if err != nil {
 		return nil, err
 	}
@@ -184,8 +194,11 @@ func ParseApproveEvent(event xdr.ContractEvent) (*ApproveEvent, error) {
 	}, nil
 }
 
-// eventTopics validates a contract event's shape and returns its topics slice when it starts with symName.
-func eventTopics(event xdr.ContractEvent, wantTopics int, symName string) ([]xdr.ScVal, error) {
+// eventTopics validates a contract event's shape and returns its topics slice when it
+// starts with symName. wantTopics lists every acceptable topic count — mint and clawback
+// pass both 2 and 3 because the legacy Soroban Token Interface emits the longer form
+// ([sym, admin, addr]) while the normalized SEP-41 form ([sym, addr]) emits the shorter.
+func eventTopics(event xdr.ContractEvent, symName string, wantTopics ...int) ([]xdr.ScVal, error) {
 	if event.Type != xdr.ContractEventTypeContract {
 		return nil, fmt.Errorf("event type must be Contract, got %v", event.Type)
 	}
@@ -193,8 +206,15 @@ func eventTopics(event xdr.ContractEvent, wantTopics int, symName string) ([]xdr
 		return nil, fmt.Errorf("unsupported event body version %d", event.Body.V)
 	}
 	topics := event.Body.V0.Topics
-	if len(topics) != wantTopics {
-		return nil, fmt.Errorf("expected %d topics for %s, got %d", wantTopics, symName, len(topics))
+	matched := false
+	for _, want := range wantTopics {
+		if len(topics) == want {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return nil, fmt.Errorf("expected one of %v topics for %s, got %d", wantTopics, symName, len(topics))
 	}
 	sym, ok := topics[0].GetSym()
 	if !ok || string(sym) != symName {

--- a/internal/services/sep41/events.go
+++ b/internal/services/sep41/events.go
@@ -92,14 +92,22 @@ func ParseTransferEvent(event xdr.ContractEvent) (*TransferEvent, error) {
 
 // ParseMintEvent decodes a SEP-41 mint ContractEvent. Two topic shapes are accepted:
 //   - normalized (soroban-sdk 25.x+): [sym("mint"), to: Address]
-//   - legacy (soroban-sdk <=24.x, Stellar Asset Contract, Blend, DeFindex): [sym("mint"), admin: Address, to: Address]
+//   - legacy (soroban-sdk <=24.x, Stellar Asset Contract, Aqua AMM, DeFindex): [sym("mint"), admin: Address, to: Address]
 //
-// `to` is always the last address topic; the optional admin topic is ignored
-// because the data layer only needs the recipient/amount pair.
+// `to` is always the last address topic. The admin topic in the legacy shape is
+// not used downstream, but its type is still validated so we don't accept
+// arbitrary 3-topic events that just happen to start with `mint` and end with
+// an Address.
 func ParseMintEvent(event xdr.ContractEvent) (*MintEvent, error) {
 	topics, err := eventTopics(event, EventMint, 2, 3)
 	if err != nil {
 		return nil, err
+	}
+	if len(topics) == 3 {
+		// Validate the legacy admin slot is an Address; discard the value.
+		if _, err := extractAddressFromScVal(topics[1]); err != nil {
+			return nil, fmt.Errorf("decoding mint.admin: %w", err)
+		}
 	}
 	to, err := extractAddressFromScVal(topics[len(topics)-1])
 	if err != nil {
@@ -134,11 +142,18 @@ func ParseBurnEvent(event xdr.ContractEvent) (*BurnEvent, error) {
 //   - legacy 3-topic [sym("clawback"), admin: Address, from: Address] — emitted by the
 //     Stellar Asset Contract reference and by tokens built against soroban-sdk <=24.x.
 //
-// `from` is always the last address topic.
+// `from` is always the last address topic. As with ParseMintEvent, the admin
+// topic in the legacy shape is unused but still type-checked so a 3-topic
+// `clawback` event with a non-Address middle topic is rejected.
 func ParseClawbackEvent(event xdr.ContractEvent) (*ClawbackEvent, error) {
 	topics, err := eventTopics(event, EventClawback, 2, 3)
 	if err != nil {
 		return nil, err
+	}
+	if len(topics) == 3 {
+		if _, err := extractAddressFromScVal(topics[1]); err != nil {
+			return nil, fmt.Errorf("decoding clawback.admin: %w", err)
+		}
 	}
 	from, err := extractAddressFromScVal(topics[len(topics)-1])
 	if err != nil {

--- a/internal/services/sep41/events_test.go
+++ b/internal/services/sep41/events_test.go
@@ -123,7 +123,8 @@ func TestParseTransferEvent_CAP67Map(t *testing.T) {
 	assert.Equal(t, uint64(7), *got.ToMuxedID)
 }
 
-func TestParseMintEvent(t *testing.T) {
+// TestParseMintEvent_Normalized covers the soroban-sdk 25.x topic shape: [sym, to].
+func TestParseMintEvent_Normalized(t *testing.T) {
 	event := contractEvent(
 		[]xdr.ScVal{symScVal(EventMint), mustAddressScVal(t, testAccountB)},
 		i128ScVal(999),
@@ -132,6 +133,34 @@ func TestParseMintEvent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, testAccountB, got.To)
 	assert.Equal(t, big.NewInt(999), got.Amount)
+}
+
+// TestParseMintEvent_LegacyAdminTopic covers the legacy SAC / soroban-sdk <=24.x shape
+// `[sym("mint"), admin: Address, to: Address]`. `to` must be read from the last topic.
+func TestParseMintEvent_LegacyAdminTopic(t *testing.T) {
+	event := contractEvent(
+		[]xdr.ScVal{
+			symScVal(EventMint),
+			mustAddressScVal(t, testAccountA), // admin (ignored)
+			mustAddressScVal(t, testAccountB), // to
+		},
+		i128ScVal(1_234_567),
+	)
+	got, err := ParseMintEvent(event)
+	require.NoError(t, err)
+	assert.Equal(t, testAccountB, got.To)
+	assert.Equal(t, big.NewInt(1_234_567), got.Amount)
+}
+
+// TestParseMintEvent_RejectsUnsupportedTopicCount guards the parser from accepting
+// shapes it doesn't actually understand (e.g., a single-topic emit).
+func TestParseMintEvent_RejectsUnsupportedTopicCount(t *testing.T) {
+	event := contractEvent(
+		[]xdr.ScVal{symScVal(EventMint)},
+		i128ScVal(1),
+	)
+	_, err := ParseMintEvent(event)
+	assert.Error(t, err)
 }
 
 func TestParseBurnEvent(t *testing.T) {
@@ -145,7 +174,7 @@ func TestParseBurnEvent(t *testing.T) {
 	assert.Equal(t, big.NewInt(50), got.Amount)
 }
 
-func TestParseClawbackEvent(t *testing.T) {
+func TestParseClawbackEvent_Normalized(t *testing.T) {
 	event := contractEvent(
 		[]xdr.ScVal{symScVal(EventClawback), mustAddressScVal(t, testAccountA)},
 		i128ScVal(25),
@@ -154,6 +183,23 @@ func TestParseClawbackEvent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, testAccountA, got.From)
 	assert.Equal(t, big.NewInt(25), got.Amount)
+}
+
+// TestParseClawbackEvent_LegacyAdminTopic covers the legacy 3-topic shape
+// `[sym("clawback"), admin: Address, from: Address]`. `from` must be the last topic.
+func TestParseClawbackEvent_LegacyAdminTopic(t *testing.T) {
+	event := contractEvent(
+		[]xdr.ScVal{
+			symScVal(EventClawback),
+			mustAddressScVal(t, testAccountB), // admin (ignored)
+			mustAddressScVal(t, testAccountA), // from
+		},
+		i128ScVal(77),
+	)
+	got, err := ParseClawbackEvent(event)
+	require.NoError(t, err)
+	assert.Equal(t, testAccountA, got.From)
+	assert.Equal(t, big.NewInt(77), got.Amount)
 }
 
 func TestParseApproveEvent(t *testing.T) {

--- a/internal/services/sep41/events_test.go
+++ b/internal/services/sep41/events_test.go
@@ -163,6 +163,23 @@ func TestParseMintEvent_RejectsUnsupportedTopicCount(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestParseMintEvent_Rejects3TopicWithNonAddressAdmin rejects a 3-topic shape where
+// the middle (admin) topic isn't an Address — this isn't the legacy SEP-41 mint
+// shape, so we shouldn't silently accept it just because the last topic happens
+// to be an address.
+func TestParseMintEvent_Rejects3TopicWithNonAddressAdmin(t *testing.T) {
+	event := contractEvent(
+		[]xdr.ScVal{
+			symScVal(EventMint),
+			symScVal("not_an_address"),        // wrong type in admin slot
+			mustAddressScVal(t, testAccountB), // valid recipient
+		},
+		i128ScVal(42),
+	)
+	_, err := ParseMintEvent(event)
+	assert.Error(t, err)
+}
+
 func TestParseBurnEvent(t *testing.T) {
 	event := contractEvent(
 		[]xdr.ScVal{symScVal(EventBurn), mustAddressScVal(t, testAccountA)},
@@ -200,6 +217,21 @@ func TestParseClawbackEvent_LegacyAdminTopic(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, testAccountA, got.From)
 	assert.Equal(t, big.NewInt(77), got.Amount)
+}
+
+// TestParseClawbackEvent_Rejects3TopicWithNonAddressAdmin mirrors the mint guard:
+// 3-topic clawback events whose admin slot isn't an Address are rejected.
+func TestParseClawbackEvent_Rejects3TopicWithNonAddressAdmin(t *testing.T) {
+	event := contractEvent(
+		[]xdr.ScVal{
+			symScVal(EventClawback),
+			symScVal("not_an_address"),
+			mustAddressScVal(t, testAccountA),
+		},
+		i128ScVal(11),
+	)
+	_, err := ParseClawbackEvent(event)
+	assert.Error(t, err)
 }
 
 func TestParseApproveEvent(t *testing.T) {


### PR DESCRIPTION
### What
Changes the SEP-41 event parser to accept the legacy 3-topic shape `[sym, admin, addr]` for `mint` and `clawback` events, in addition to the normalized 2-topic form `[sym, addr]`. The recipient/source address is always the last address topic; the optional admin topic is ignored because the data layer only needs the recipient/amount pair.

Two files changed:
- `internal/services/sep41/events.go` — `eventTopics` now takes a variadic list of acceptable topic counts; `ParseMintEvent` and `ParseClawbackEvent` accept both 2- and 3-topic shapes.
- `internal/services/sep41/events_test.go` — adds `TestParseMintEvent_LegacyAdminTopic`, `TestParseMintEvent_RejectsUnsupportedTopicCount`, and `TestParseClawbackEvent_LegacyAdminTopic`. Existing 2-topic tests are renamed to `_Normalized` for clarity.

### Why

The SEP-41 processor required exactly 2 topics for `mint` and `clawback`. The canonical Soroban Token Interface — the Stellar Asset Contract reference and every contract built against `soroban-sdk` ≤24.x, which includes Aqua AMM pool share tokens and DeFindex vaults — emits the longer 3-topic shape `[sym, admin, addr]`. Every legacy `mint` / `clawback` event was silently rejected as a "malformed event" in `processor.processTransaction`, so the running-delta balance accumulator saw burns and transfers but never the offsetting mints.

#### Legacy event-topic references

**1. `soroban-sdk` doc strings** (the canonical source — it's the trait that token implementations are written against). Two relevant versions on disk:

`~/.cargo/registry/src/index.crates.io-*/soroban-sdk-21.6.0/src/token.rs:288`:
```
/// Emits an event with topics `["mint", admin: Address, to: Address], data = amount: i128`
fn mint(env: Env, to: Address, amount: i128);
```

`soroban-sdk-21.6.0/src/token.rs:303`:
```
/// Emits an event with topics `["clawback", admin: Address, to: Address], ...`
```

`soroban-sdk-25.1.0/src/token.rs:454`:
```
/// Emits an event with topics `["mint", to: Address], data = amount: i128`
fn mint(env: Env, to: Address, amount: i128);
```

`soroban-sdk-25.1.0/src/token.rs:469` — clawback **still** documented as 3-topic in 25.1.0. So `mint` shrank from 3 → 2 across the major version bump; `clawback` never normalized. The patch accepts both shapes for `clawback` defensively, in case it normalizes later.

**2. Reference SAC implementation** at `stellar-core/contracts/token/src/contract.rs:55`:
```rust
TokenUtils::new(&e).events().mint(admin, to, amount);
```
Three positional args (admin + to + amount). `TokenUtils::events().mint(...)` is the helper that publishes the event with topics `[symbol_short!("mint"), admin, to]`.

**3. On-chain confirmation via Soroban RPC `getEvents`**, against pubnet (`https://soroban-rpc.mainnet.stellar.gateway.fm`) for `CBNKCU3HGFKHFOF7JTGXQCNKE3G3DXS5RDBQUKQMIIECYKXPIOUGB2S3` (BNSUSDC / DeFindex BeansUsdcVault). Sample event:

```json
{
  "topicJson": [
    {"symbol": "mint"},
    {"address": "CBNKCU3HGFKHFOF7JTGXQCNKE3G3DXS5RDBQUKQMIIECYKXPIOUGB2S3"},
    {"address": "GB4MBRCG6BHAIYPJN7YP6HSDTXPEOK5XWBYYJN45YLJIZONDH6TVRT2I"}
  ],
  "valueJson": {"i128": "227739911"}
}
```

Three topics, contract acting as its own admin in topic[1], recipient in topic[2]. Reproducible with:

```bash
curl -sS -X POST -H "Content-Type: application/json" --data '{
  "jsonrpc":"2.0","id":1,"method":"getEvents",
  "params":{
    "startLedger": <recent>,
    "endLedger":   <recent+100>,
    "filters":[{"type":"contract","contractIds":["CBNKCU3HGFKHFOF7JTGXQCNKE3G3DXS5RDBQUKQMIIECYKXPIOUGB2S3"]}],
    "pagination":{"limit":300},
    "xdrFormat":"json"
  }
}' https://soroban-rpc.mainnet.stellar.gateway.fm
```

A broader sweep across the 12 worst-affected contracts confirmed the same pattern: 79 mint events all 3-topic, 24 burn events all 2-topic, 13 transfer / 10 approve all 3-topic (matching the existing parser, no change needed). Aqua AMM pool share tokens (`CAVKLYY4RWFQBRA2YI5GTGGXKUKJQI3JLAHDGXMS7L5RDH6X6A47NMOZ`, source: [AquaToken/soroban-amm](https://github.com/AquaToken/soroban-amm/tree/5ca19bb14ec421340ff4ca9e138ec877550940d7/token)) were checked separately and also emit standard 3-topic mints. Blend's lending pool, by contrast, does not implement SEP-41 at all — it tracks bToken/dToken positions in a `Positions` struct in pool storage, so it is never classified as SEP-41 and produces no `sep41_balances` rows.

### Known limitations
N/A

### Issue that this PR addresses
Discovered during dev validation of `feature/sep41-data-migration`.

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested — N/A, no SQL changes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production — N/A, bugfix.
