### PR TITLE
fix: correct swapped JSON tags on PaginationLinks Prev/Next fields

### DIFF
--- a/internal/entities/pagination.go
+++ b/internal/entities/pagination.go
@@ -2,8 +2,8 @@ package entities
 
 type PaginationLinks struct {
 	Self string `json:"self"`
-	Prev string `json:"next"`
-	Next string `json:"prev"`
+	Prev string `json:"prev"`
+	Next string `json:"next"`
 }
 
 type Pagination struct {

--- a/internal/entities/pagination_test.go
+++ b/internal/entities/pagination_test.go
@@ -1,0 +1,34 @@
+package entities
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPaginationLinks_JSONTagsMatchFieldNames(t *testing.T) {
+	links := PaginationLinks{
+		Self: "self-url",
+		Prev: "prev-url",
+		Next: "next-url",
+	}
+
+	raw, err := json.Marshal(links)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded map[string]string
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got := decoded["prev"]; got != "prev-url" {
+		t.Errorf(`json key "prev" = %q, want "prev-url"`, got)
+	}
+	if got := decoded["next"]; got != "next-url" {
+		t.Errorf(`json key "next" = %q, want "next-url"`, got)
+	}
+	if got := decoded["self"]; got != "self-url" {
+		t.Errorf(`json key "self" = %q, want "self-url"`, got)
+	}
+}


### PR DESCRIPTION
Fixes #593.

`internal/entities/pagination.go` had the `Prev` and `Next` field tags
swapped, so any code that populated `PaginationLinks` by Go field name
emitted cursors under the wrong JSON key. The struct is currently unused
in this repository, so swapping the tags to match the field names has no
wire-format impact today.

Added a round-trip JSON test in `internal/entities/pagination_test.go`
that fails on the previous (swapped) tags and passes on the fix.