### PR TITLE
Mirror Balance nil-handling pattern in account-scoped transaction/operation/state-change queries

### DIFF
--- a/pkg/wbclient/client.go
+++ b/pkg/wbclient/client.go
@@ -63,19 +63,19 @@ type StateChangesData struct {
 }
 
 type AccountTransactionsData struct {
-	AccountByAddress struct {
+	AccountByAddress *struct {
 		Transactions *types.TransactionConnection `json:"transactions"`
 	} `json:"accountByAddress"`
 }
 
 type AccountOperationsData struct {
-	AccountByAddress struct {
+	AccountByAddress *struct {
 		Operations *types.OperationConnection `json:"operations"`
 	} `json:"accountByAddress"`
 }
 
 type AccountStateChangesData struct {
-	AccountByAddress struct {
+	AccountByAddress *struct {
 		StateChanges *types.StateChangeConnection `json:"stateChanges"`
 	} `json:"accountByAddress"`
 }
@@ -376,6 +376,10 @@ func (c *Client) GetAccountTransactions(ctx context.Context, address string, sin
 		return nil, err
 	}
 
+	if data.AccountByAddress == nil {
+		return nil, fmt.Errorf("%w: %s", ErrAccountNotFound, address)
+	}
+
 	return data.AccountByAddress.Transactions, nil
 }
 
@@ -404,6 +408,10 @@ func (c *Client) GetAccountOperations(ctx context.Context, address string, since
 	data, err := executeGraphQL[AccountOperationsData](c, ctx, buildAccountOperationsQuery(fields), variables)
 	if err != nil {
 		return nil, err
+	}
+
+	if data.AccountByAddress == nil {
+		return nil, fmt.Errorf("%w: %s", ErrAccountNotFound, address)
 	}
 
 	return data.AccountByAddress.Operations, nil
@@ -449,6 +457,10 @@ func (c *Client) GetAccountStateChanges(ctx context.Context, address string, tra
 	data, err := executeGraphQL[AccountStateChangesData](c, ctx, buildAccountStateChangesQuery(), variables)
 	if err != nil {
 		return nil, err
+	}
+
+	if data.AccountByAddress == nil {
+		return nil, fmt.Errorf("%w: %s", ErrAccountNotFound, address)
 	}
 
 	return data.AccountByAddress.StateChanges, nil

--- a/pkg/wbclient/client_test.go
+++ b/pkg/wbclient/client_test.go
@@ -26,128 +26,137 @@ func graphqlServer(t *testing.T, dataJSON string) *httptest.Server {
 	}))
 }
 
-func TestGetAccountTransactions_AccountNotFound(t *testing.T) {
-	srv := graphqlServer(t, `{"accountByAddress": null}`)
-	defer srv.Close()
+func TestGetAccountTransactions(t *testing.T) {
+	ctx := context.Background()
 
-	c := NewClient(srv.URL, nil)
-	conn, err := c.GetAccountTransactions(context.Background(), "GABC", nil, nil, nil, nil, nil, nil)
-	assert.Nil(t, conn)
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrAccountNotFound), "expected ErrAccountNotFound, got %v", err)
-}
+	t.Run("returns ErrAccountNotFound when accountByAddress is null", func(t *testing.T) {
+		srv := graphqlServer(t, `{"accountByAddress": null}`)
+		defer srv.Close()
 
-func TestGetAccountTransactions_NullConnectionPassesThrough(t *testing.T) {
-	srv := graphqlServer(t, `{"accountByAddress": {"transactions": null}}`)
-	defer srv.Close()
+		c := NewClient(srv.URL, nil)
+		conn, err := c.GetAccountTransactions(ctx, "GABC", nil, nil, nil, nil, nil, nil)
+		assert.Nil(t, conn)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrAccountNotFound), "expected ErrAccountNotFound, got %v", err)
+	})
 
-	c := NewClient(srv.URL, nil)
-	conn, err := c.GetAccountTransactions(context.Background(), "GABC", nil, nil, nil, nil, nil, nil)
-	require.NoError(t, err)
-	assert.Nil(t, conn, "schema permits null transactions on existing account")
-}
+	t.Run("passes through null transactions connection on existing account", func(t *testing.T) {
+		srv := graphqlServer(t, `{"accountByAddress": {"transactions": null}}`)
+		defer srv.Close()
 
-func TestGetAccountTransactions_EmptyEdgesReturnsConnection(t *testing.T) {
-	srv := graphqlServer(t, `{"accountByAddress": {"transactions": {"edges": [], "pageInfo": {"hasNextPage": false, "hasPreviousPage": false}}}}`)
-	defer srv.Close()
-
-	c := NewClient(srv.URL, nil)
-	conn, err := c.GetAccountTransactions(context.Background(), "GABC", nil, nil, nil, nil, nil, nil)
-	require.NoError(t, err)
-	require.NotNil(t, conn)
-	assert.Empty(t, conn.Edges)
-	require.NotNil(t, conn.PageInfo)
-}
-
-func TestGetAccountOperations_AccountNotFound(t *testing.T) {
-	srv := graphqlServer(t, `{"accountByAddress": null}`)
-	defer srv.Close()
-
-	c := NewClient(srv.URL, nil)
-	conn, err := c.GetAccountOperations(context.Background(), "GABC", nil, nil, nil, nil, nil, nil)
-	assert.Nil(t, conn)
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrAccountNotFound), "expected ErrAccountNotFound, got %v", err)
-}
-
-func TestGetAccountOperations_NullConnectionPassesThrough(t *testing.T) {
-	srv := graphqlServer(t, `{"accountByAddress": {"operations": null}}`)
-	defer srv.Close()
-
-	c := NewClient(srv.URL, nil)
-	conn, err := c.GetAccountOperations(context.Background(), "GABC", nil, nil, nil, nil, nil, nil)
-	require.NoError(t, err)
-	assert.Nil(t, conn, "schema permits null operations on existing account")
-}
-
-func TestGetAccountOperations_EmptyEdgesReturnsConnection(t *testing.T) {
-	srv := graphqlServer(t, `{"accountByAddress": {"operations": {"edges": [], "pageInfo": {"hasNextPage": false, "hasPreviousPage": false}}}}`)
-	defer srv.Close()
-
-	c := NewClient(srv.URL, nil)
-	conn, err := c.GetAccountOperations(context.Background(), "GABC", nil, nil, nil, nil, nil, nil)
-	require.NoError(t, err)
-	require.NotNil(t, conn)
-	assert.Empty(t, conn.Edges)
-	require.NotNil(t, conn.PageInfo)
-}
-
-func TestGetAccountStateChanges_AccountNotFound(t *testing.T) {
-	srv := graphqlServer(t, `{"accountByAddress": null}`)
-	defer srv.Close()
-
-	c := NewClient(srv.URL, nil)
-	conn, err := c.GetAccountStateChanges(context.Background(), "GABC", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
-	assert.Nil(t, conn)
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrAccountNotFound), "expected ErrAccountNotFound, got %v", err)
-}
-
-func TestGetAccountStateChanges_NullConnectionPassesThrough(t *testing.T) {
-	srv := graphqlServer(t, `{"accountByAddress": {"stateChanges": null}}`)
-	defer srv.Close()
-
-	c := NewClient(srv.URL, nil)
-	conn, err := c.GetAccountStateChanges(context.Background(), "GABC", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
-	require.NoError(t, err)
-	assert.Nil(t, conn, "schema permits null stateChanges on existing account")
-}
-
-func TestGetAccountStateChanges_EmptyEdgesReturnsConnection(t *testing.T) {
-	srv := graphqlServer(t, `{"accountByAddress": {"stateChanges": {"edges": [], "pageInfo": {"hasNextPage": false, "hasPreviousPage": false}}}}`)
-	defer srv.Close()
-
-	c := NewClient(srv.URL, nil)
-	conn, err := c.GetAccountStateChanges(context.Background(), "GABC", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
-	require.NoError(t, err)
-	require.NotNil(t, conn)
-	assert.Empty(t, conn.Edges)
-	require.NotNil(t, conn.PageInfo)
-}
-
-// Sanity check that the request body is well-formed GraphQL JSON. The
-// account-not-found path is the same regardless of arguments, so we only
-// verify the body shape on one method.
-func TestGetAccountTransactions_SendsGraphQLRequest(t *testing.T) {
-	type gqlReq struct {
-		Query     string         `json:"query"`
-		Variables map[string]any `json:"variables"`
-	}
-
-	var received gqlReq
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := json.NewDecoder(r.Body).Decode(&received)
+		c := NewClient(srv.URL, nil)
+		conn, err := c.GetAccountTransactions(ctx, "GABC", nil, nil, nil, nil, nil, nil)
 		require.NoError(t, err)
-		w.Header().Set("Content-Type", "application/json")
-		_, err = w.Write([]byte(`{"data":{"accountByAddress": null}}`))
+		assert.Nil(t, conn, "schema permits null transactions on existing account")
+	})
+
+	t.Run("returns connection with empty edges when account has no transactions", func(t *testing.T) {
+		srv := graphqlServer(t, `{"accountByAddress": {"transactions": {"edges": [], "pageInfo": {"hasNextPage": false, "hasPreviousPage": false}}}}`)
+		defer srv.Close()
+
+		c := NewClient(srv.URL, nil)
+		conn, err := c.GetAccountTransactions(ctx, "GABC", nil, nil, nil, nil, nil, nil)
 		require.NoError(t, err)
-	}))
-	defer srv.Close()
+		require.NotNil(t, conn)
+		assert.Empty(t, conn.Edges)
+		require.NotNil(t, conn.PageInfo)
+	})
 
-	c := NewClient(srv.URL, nil)
-	_, err := c.GetAccountTransactions(context.Background(), "GABC", nil, nil, nil, nil, nil, nil)
-	require.ErrorIs(t, err, ErrAccountNotFound)
+	t.Run("sends well-formed GraphQL request body", func(t *testing.T) {
+		type gqlReq struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
 
-	assert.Contains(t, received.Query, "accountByAddress")
-	assert.Equal(t, "GABC", received.Variables["address"])
+		var received gqlReq
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			err := json.NewDecoder(r.Body).Decode(&received)
+			require.NoError(t, err)
+			w.Header().Set("Content-Type", "application/json")
+			_, err = w.Write([]byte(`{"data":{"accountByAddress": null}}`))
+			require.NoError(t, err)
+		}))
+		defer srv.Close()
+
+		c := NewClient(srv.URL, nil)
+		_, err := c.GetAccountTransactions(ctx, "GABC", nil, nil, nil, nil, nil, nil)
+		require.ErrorIs(t, err, ErrAccountNotFound)
+
+		assert.Contains(t, received.Query, "accountByAddress")
+		assert.Equal(t, "GABC", received.Variables["address"])
+	})
+}
+
+func TestGetAccountOperations(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns ErrAccountNotFound when accountByAddress is null", func(t *testing.T) {
+		srv := graphqlServer(t, `{"accountByAddress": null}`)
+		defer srv.Close()
+
+		c := NewClient(srv.URL, nil)
+		conn, err := c.GetAccountOperations(ctx, "GABC", nil, nil, nil, nil, nil, nil)
+		assert.Nil(t, conn)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrAccountNotFound), "expected ErrAccountNotFound, got %v", err)
+	})
+
+	t.Run("passes through null operations connection on existing account", func(t *testing.T) {
+		srv := graphqlServer(t, `{"accountByAddress": {"operations": null}}`)
+		defer srv.Close()
+
+		c := NewClient(srv.URL, nil)
+		conn, err := c.GetAccountOperations(ctx, "GABC", nil, nil, nil, nil, nil, nil)
+		require.NoError(t, err)
+		assert.Nil(t, conn, "schema permits null operations on existing account")
+	})
+
+	t.Run("returns connection with empty edges when account has no operations", func(t *testing.T) {
+		srv := graphqlServer(t, `{"accountByAddress": {"operations": {"edges": [], "pageInfo": {"hasNextPage": false, "hasPreviousPage": false}}}}`)
+		defer srv.Close()
+
+		c := NewClient(srv.URL, nil)
+		conn, err := c.GetAccountOperations(ctx, "GABC", nil, nil, nil, nil, nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, conn)
+		assert.Empty(t, conn.Edges)
+		require.NotNil(t, conn.PageInfo)
+	})
+}
+
+func TestGetAccountStateChanges(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns ErrAccountNotFound when accountByAddress is null", func(t *testing.T) {
+		srv := graphqlServer(t, `{"accountByAddress": null}`)
+		defer srv.Close()
+
+		c := NewClient(srv.URL, nil)
+		conn, err := c.GetAccountStateChanges(ctx, "GABC", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		assert.Nil(t, conn)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrAccountNotFound), "expected ErrAccountNotFound, got %v", err)
+	})
+
+	t.Run("passes through null stateChanges connection on existing account", func(t *testing.T) {
+		srv := graphqlServer(t, `{"accountByAddress": {"stateChanges": null}}`)
+		defer srv.Close()
+
+		c := NewClient(srv.URL, nil)
+		conn, err := c.GetAccountStateChanges(ctx, "GABC", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		require.NoError(t, err)
+		assert.Nil(t, conn, "schema permits null stateChanges on existing account")
+	})
+
+	t.Run("returns connection with empty edges when account has no state changes", func(t *testing.T) {
+		srv := graphqlServer(t, `{"accountByAddress": {"stateChanges": {"edges": [], "pageInfo": {"hasNextPage": false, "hasPreviousPage": false}}}}`)
+		defer srv.Close()
+
+		c := NewClient(srv.URL, nil)
+		conn, err := c.GetAccountStateChanges(ctx, "GABC", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, conn)
+		assert.Empty(t, conn.Edges)
+		require.NotNil(t, conn.PageInfo)
+	})
 }

--- a/pkg/wbclient/client_test.go
+++ b/pkg/wbclient/client_test.go
@@ -122,6 +122,30 @@ func TestGetAccountOperations(t *testing.T) {
 		assert.Empty(t, conn.Edges)
 		require.NotNil(t, conn.PageInfo)
 	})
+
+	t.Run("sends well-formed GraphQL request body", func(t *testing.T) {
+		type gqlReq struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+
+		var received gqlReq
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			err := json.NewDecoder(r.Body).Decode(&received)
+			require.NoError(t, err)
+			w.Header().Set("Content-Type", "application/json")
+			_, err = w.Write([]byte(`{"data":{"accountByAddress": null}}`))
+			require.NoError(t, err)
+		}))
+		defer srv.Close()
+
+		c := NewClient(srv.URL, nil)
+		_, err := c.GetAccountOperations(ctx, "GABC", nil, nil, nil, nil, nil, nil)
+		require.ErrorIs(t, err, ErrAccountNotFound)
+
+		assert.Contains(t, received.Query, "accountByAddress")
+		assert.Equal(t, "GABC", received.Variables["address"])
+	})
 }
 
 func TestGetAccountStateChanges(t *testing.T) {
@@ -158,5 +182,36 @@ func TestGetAccountStateChanges(t *testing.T) {
 		require.NotNil(t, conn)
 		assert.Empty(t, conn.Edges)
 		require.NotNil(t, conn.PageInfo)
+	})
+
+	t.Run("sends well-formed GraphQL request body with filter variables", func(t *testing.T) {
+		type gqlReq struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+
+		var received gqlReq
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			err := json.NewDecoder(r.Body).Decode(&received)
+			require.NoError(t, err)
+			w.Header().Set("Content-Type", "application/json")
+			_, err = w.Write([]byte(`{"data":{"accountByAddress": null}}`))
+			require.NoError(t, err)
+		}))
+		defer srv.Close()
+
+		c := NewClient(srv.URL, nil)
+		txHash := "deadbeef"
+		category := "CREDIT"
+		_, err := c.GetAccountStateChanges(ctx, "GABC", &txHash, nil, &category, nil, nil, nil, nil, nil, nil, nil)
+		require.ErrorIs(t, err, ErrAccountNotFound)
+
+		assert.Contains(t, received.Query, "accountByAddress")
+		assert.Equal(t, "GABC", received.Variables["address"])
+
+		filter, ok := received.Variables["filter"].(map[string]any)
+		require.True(t, ok, "expected filter to be encoded as a JSON object, got %T", received.Variables["filter"])
+		assert.Equal(t, "deadbeef", filter["transactionHash"])
+		assert.Equal(t, "CREDIT", filter["category"])
 	})
 }

--- a/pkg/wbclient/client_test.go
+++ b/pkg/wbclient/client_test.go
@@ -1,0 +1,153 @@
+package wbclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// graphqlServer returns an httptest.Server that always responds with the given
+// `data` JSON object wrapped in a GraphQL response envelope and no errors.
+func graphqlServer(t *testing.T, dataJSON string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.Copy(io.Discard, r.Body)
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+		_, err = w.Write([]byte(`{"data":` + dataJSON + `}`))
+		require.NoError(t, err)
+	}))
+}
+
+func TestGetAccountTransactions_AccountNotFound(t *testing.T) {
+	srv := graphqlServer(t, `{"accountByAddress": null}`)
+	defer srv.Close()
+
+	c := NewClient(srv.URL, nil)
+	conn, err := c.GetAccountTransactions(context.Background(), "GABC", nil, nil, nil, nil, nil, nil)
+	assert.Nil(t, conn)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAccountNotFound), "expected ErrAccountNotFound, got %v", err)
+}
+
+func TestGetAccountTransactions_NullConnectionPassesThrough(t *testing.T) {
+	srv := graphqlServer(t, `{"accountByAddress": {"transactions": null}}`)
+	defer srv.Close()
+
+	c := NewClient(srv.URL, nil)
+	conn, err := c.GetAccountTransactions(context.Background(), "GABC", nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, conn, "schema permits null transactions on existing account")
+}
+
+func TestGetAccountTransactions_EmptyEdgesReturnsConnection(t *testing.T) {
+	srv := graphqlServer(t, `{"accountByAddress": {"transactions": {"edges": [], "pageInfo": {"hasNextPage": false, "hasPreviousPage": false}}}}`)
+	defer srv.Close()
+
+	c := NewClient(srv.URL, nil)
+	conn, err := c.GetAccountTransactions(context.Background(), "GABC", nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	assert.Empty(t, conn.Edges)
+	require.NotNil(t, conn.PageInfo)
+}
+
+func TestGetAccountOperations_AccountNotFound(t *testing.T) {
+	srv := graphqlServer(t, `{"accountByAddress": null}`)
+	defer srv.Close()
+
+	c := NewClient(srv.URL, nil)
+	conn, err := c.GetAccountOperations(context.Background(), "GABC", nil, nil, nil, nil, nil, nil)
+	assert.Nil(t, conn)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAccountNotFound), "expected ErrAccountNotFound, got %v", err)
+}
+
+func TestGetAccountOperations_NullConnectionPassesThrough(t *testing.T) {
+	srv := graphqlServer(t, `{"accountByAddress": {"operations": null}}`)
+	defer srv.Close()
+
+	c := NewClient(srv.URL, nil)
+	conn, err := c.GetAccountOperations(context.Background(), "GABC", nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, conn, "schema permits null operations on existing account")
+}
+
+func TestGetAccountOperations_EmptyEdgesReturnsConnection(t *testing.T) {
+	srv := graphqlServer(t, `{"accountByAddress": {"operations": {"edges": [], "pageInfo": {"hasNextPage": false, "hasPreviousPage": false}}}}`)
+	defer srv.Close()
+
+	c := NewClient(srv.URL, nil)
+	conn, err := c.GetAccountOperations(context.Background(), "GABC", nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	assert.Empty(t, conn.Edges)
+	require.NotNil(t, conn.PageInfo)
+}
+
+func TestGetAccountStateChanges_AccountNotFound(t *testing.T) {
+	srv := graphqlServer(t, `{"accountByAddress": null}`)
+	defer srv.Close()
+
+	c := NewClient(srv.URL, nil)
+	conn, err := c.GetAccountStateChanges(context.Background(), "GABC", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	assert.Nil(t, conn)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAccountNotFound), "expected ErrAccountNotFound, got %v", err)
+}
+
+func TestGetAccountStateChanges_NullConnectionPassesThrough(t *testing.T) {
+	srv := graphqlServer(t, `{"accountByAddress": {"stateChanges": null}}`)
+	defer srv.Close()
+
+	c := NewClient(srv.URL, nil)
+	conn, err := c.GetAccountStateChanges(context.Background(), "GABC", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, conn, "schema permits null stateChanges on existing account")
+}
+
+func TestGetAccountStateChanges_EmptyEdgesReturnsConnection(t *testing.T) {
+	srv := graphqlServer(t, `{"accountByAddress": {"stateChanges": {"edges": [], "pageInfo": {"hasNextPage": false, "hasPreviousPage": false}}}}`)
+	defer srv.Close()
+
+	c := NewClient(srv.URL, nil)
+	conn, err := c.GetAccountStateChanges(context.Background(), "GABC", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	assert.Empty(t, conn.Edges)
+	require.NotNil(t, conn.PageInfo)
+}
+
+// Sanity check that the request body is well-formed GraphQL JSON. The
+// account-not-found path is the same regardless of arguments, so we only
+// verify the body shape on one method.
+func TestGetAccountTransactions_SendsGraphQLRequest(t *testing.T) {
+	type gqlReq struct {
+		Query     string         `json:"query"`
+		Variables map[string]any `json:"variables"`
+	}
+
+	var received gqlReq
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewDecoder(r.Body).Decode(&received)
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+		_, err = w.Write([]byte(`{"data":{"accountByAddress": null}}`))
+		require.NoError(t, err)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, nil)
+	_, err := c.GetAccountTransactions(context.Background(), "GABC", nil, nil, nil, nil, nil, nil)
+	require.ErrorIs(t, err, ErrAccountNotFound)
+
+	assert.Contains(t, received.Query, "accountByAddress")
+	assert.Equal(t, "GABC", received.Variables["address"])
+}

--- a/pkg/wbclient/types/types.go
+++ b/pkg/wbclient/types/types.go
@@ -234,10 +234,75 @@ type TransactionEdge struct {
 	Cursor string              `json:"cursor"`
 }
 
+// UnmarshalJSON implements custom JSON unmarshaling for TransactionEdge.
+// The GraphQL schema declares the edge as `node: Transaction` (nullable),
+// so a null or missing node is a schema-valid response and leaves
+// e.Node == nil rather than returning an error. Callers iterating
+// connection.Edges must nil-check edge.Node.
+func (e *TransactionEdge) UnmarshalJSON(data []byte) error {
+	type tempEdge struct {
+		Node   json.RawMessage `json:"node,omitempty"`
+		Cursor string          `json:"cursor"`
+	}
+
+	var temp tempEdge
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return fmt.Errorf("unmarshaling transaction edge: %w", err)
+	}
+
+	e.Cursor = temp.Cursor
+
+	if len(temp.Node) == 0 || string(temp.Node) == "null" {
+		e.Node = nil
+		return nil
+	}
+
+	var node GraphQLTransaction
+	if err := json.Unmarshal(temp.Node, &node); err != nil {
+		return fmt.Errorf("decoding transaction edge node: %w", err)
+	}
+	e.Node = &node
+	return nil
+}
+
 // TransactionConnection represents a paginated list of transactions
 type TransactionConnection struct {
 	Edges    []*TransactionEdge `json:"edges,omitempty"`
 	PageInfo *PageInfo          `json:"pageInfo"`
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling for TransactionConnection
+// and enforces the schema's non-null guarantees. The schema declares
+// edges as [TransactionEdge!] and pageInfo as PageInfo!, so:
+//   - a null entry within the edges array is a server bug and is rejected
+//   - a missing or null pageInfo field is a server bug and is rejected
+//
+// In contrast to BalanceConnection, the edges field itself is nullable in
+// the schema, so a missing or null edges field is accepted (Edges stays nil).
+func (c *TransactionConnection) UnmarshalJSON(data []byte) error {
+	type tempConnection struct {
+		Edges    []*TransactionEdge `json:"edges"`
+		PageInfo *PageInfo          `json:"pageInfo"`
+	}
+
+	var temp tempConnection
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return fmt.Errorf("unmarshaling transaction connection: %w", err)
+	}
+
+	for i, edge := range temp.Edges {
+		if edge == nil {
+			return fmt.Errorf("transaction connection edge at index %d is null: the GraphQL schema declares TransactionEdge as non-null", i)
+		}
+	}
+
+	if temp.PageInfo == nil {
+		return fmt.Errorf("transaction connection missing required pageInfo field: the GraphQL schema declares pageInfo as non-null")
+	}
+
+	c.Edges = temp.Edges
+	c.PageInfo = temp.PageInfo
+	return nil
 }
 
 // OperationEdge represents an edge in the operation connection
@@ -246,10 +311,75 @@ type OperationEdge struct {
 	Cursor string     `json:"cursor"`
 }
 
+// UnmarshalJSON implements custom JSON unmarshaling for OperationEdge.
+// The GraphQL schema declares the edge as `node: Operation` (nullable),
+// so a null or missing node is a schema-valid response and leaves
+// e.Node == nil rather than returning an error. Callers iterating
+// connection.Edges must nil-check edge.Node.
+func (e *OperationEdge) UnmarshalJSON(data []byte) error {
+	type tempEdge struct {
+		Node   json.RawMessage `json:"node,omitempty"`
+		Cursor string          `json:"cursor"`
+	}
+
+	var temp tempEdge
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return fmt.Errorf("unmarshaling operation edge: %w", err)
+	}
+
+	e.Cursor = temp.Cursor
+
+	if len(temp.Node) == 0 || string(temp.Node) == "null" {
+		e.Node = nil
+		return nil
+	}
+
+	var node Operation
+	if err := json.Unmarshal(temp.Node, &node); err != nil {
+		return fmt.Errorf("decoding operation edge node: %w", err)
+	}
+	e.Node = &node
+	return nil
+}
+
 // OperationConnection represents a paginated list of operations
 type OperationConnection struct {
 	Edges    []*OperationEdge `json:"edges,omitempty"`
 	PageInfo *PageInfo        `json:"pageInfo"`
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling for OperationConnection
+// and enforces the schema's non-null guarantees. The schema declares
+// edges as [OperationEdge!] and pageInfo as PageInfo!, so:
+//   - a null entry within the edges array is a server bug and is rejected
+//   - a missing or null pageInfo field is a server bug and is rejected
+//
+// In contrast to BalanceConnection, the edges field itself is nullable in
+// the schema, so a missing or null edges field is accepted (Edges stays nil).
+func (c *OperationConnection) UnmarshalJSON(data []byte) error {
+	type tempConnection struct {
+		Edges    []*OperationEdge `json:"edges"`
+		PageInfo *PageInfo        `json:"pageInfo"`
+	}
+
+	var temp tempConnection
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return fmt.Errorf("unmarshaling operation connection: %w", err)
+	}
+
+	for i, edge := range temp.Edges {
+		if edge == nil {
+			return fmt.Errorf("operation connection edge at index %d is null: the GraphQL schema declares OperationEdge as non-null", i)
+		}
+	}
+
+	if temp.PageInfo == nil {
+		return fmt.Errorf("operation connection missing required pageInfo field: the GraphQL schema declares pageInfo as non-null")
+	}
+
+	c.Edges = temp.Edges
+	c.PageInfo = temp.PageInfo
+	return nil
 }
 
 // StateChangeEdge represents an edge in the state change connection
@@ -258,8 +388,12 @@ type StateChangeEdge struct {
 	Cursor string          `json:"cursor"`
 }
 
-// UnmarshalJSON implements custom JSON unmarshaling for StateChangeEdge
-// to properly handle polymorphic state change types
+// UnmarshalJSON implements custom JSON unmarshaling for StateChangeEdge.
+// The GraphQL schema declares the edge as `node: BaseStateChange`
+// (nullable), so a null or missing node is a schema-valid response and
+// leaves e.Node == nil. When a node is present, it is dispatched to the
+// correct concrete type via UnmarshalStateChangeNode (which reads the
+// __typename discriminator).
 func (e *StateChangeEdge) UnmarshalJSON(data []byte) error {
 	// Create a temporary struct to unmarshal the edge structure
 	type tempEdge struct {
@@ -294,6 +428,40 @@ func (e *StateChangeEdge) UnmarshalJSON(data []byte) error {
 type StateChangeConnection struct {
 	Edges    []*StateChangeEdge `json:"edges,omitempty"`
 	PageInfo *PageInfo          `json:"pageInfo"`
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling for StateChangeConnection
+// and enforces the schema's non-null guarantees. The schema declares
+// edges as [StateChangeEdge!] and pageInfo as PageInfo!, so:
+//   - a null entry within the edges array is a server bug and is rejected
+//   - a missing or null pageInfo field is a server bug and is rejected
+//
+// In contrast to BalanceConnection, the edges field itself is nullable in
+// the schema, so a missing or null edges field is accepted (Edges stays nil).
+func (c *StateChangeConnection) UnmarshalJSON(data []byte) error {
+	type tempConnection struct {
+		Edges    []*StateChangeEdge `json:"edges"`
+		PageInfo *PageInfo          `json:"pageInfo"`
+	}
+
+	var temp tempConnection
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return fmt.Errorf("unmarshaling state change connection: %w", err)
+	}
+
+	for i, edge := range temp.Edges {
+		if edge == nil {
+			return fmt.Errorf("state change connection edge at index %d is null: the GraphQL schema declares StateChangeEdge as non-null", i)
+		}
+	}
+
+	if temp.PageInfo == nil {
+		return fmt.Errorf("state change connection missing required pageInfo field: the GraphQL schema declares pageInfo as non-null")
+	}
+
+	c.Edges = temp.Edges
+	c.PageInfo = temp.PageInfo
+	return nil
 }
 
 // BalanceEdge represents an edge in the balance connection

--- a/pkg/wbclient/types/types.go
+++ b/pkg/wbclient/types/types.go
@@ -241,7 +241,7 @@ type TransactionEdge struct {
 // connection.Edges must nil-check edge.Node.
 func (e *TransactionEdge) UnmarshalJSON(data []byte) error {
 	type tempEdge struct {
-		Node   json.RawMessage `json:"node,omitempty"`
+		Node   json.RawMessage `json:"node"`
 		Cursor string          `json:"cursor"`
 	}
 
@@ -318,7 +318,7 @@ type OperationEdge struct {
 // connection.Edges must nil-check edge.Node.
 func (e *OperationEdge) UnmarshalJSON(data []byte) error {
 	type tempEdge struct {
-		Node   json.RawMessage `json:"node,omitempty"`
+		Node   json.RawMessage `json:"node"`
 		Cursor string          `json:"cursor"`
 	}
 
@@ -397,7 +397,7 @@ type StateChangeEdge struct {
 func (e *StateChangeEdge) UnmarshalJSON(data []byte) error {
 	// Create a temporary struct to unmarshal the edge structure
 	type tempEdge struct {
-		Node   json.RawMessage `json:"node,omitempty"`
+		Node   json.RawMessage `json:"node"`
 		Cursor string          `json:"cursor"`
 	}
 
@@ -475,7 +475,7 @@ type BalanceEdge struct {
 // TrustlineBalance, SACBalance) discriminated by __typename.
 func (e *BalanceEdge) UnmarshalJSON(data []byte) error {
 	type tempEdge struct {
-		Node   json.RawMessage `json:"node,omitempty"`
+		Node   json.RawMessage `json:"node"`
 		Cursor string          `json:"cursor"`
 	}
 

--- a/pkg/wbclient/types/types_test.go
+++ b/pkg/wbclient/types/types_test.go
@@ -211,3 +211,397 @@ func Test_BalanceConnection_UnmarshalJSON_DecodesValidConnection(t *testing.T) {
 	require.NotNil(t, conn.PageInfo.EndCursor)
 	assert.Equal(t, "c1", *conn.PageInfo.EndCursor)
 }
+
+// ---- TransactionEdge ----
+
+func Test_TransactionEdge_UnmarshalJSON_AcceptsNullNode(t *testing.T) {
+	var edge TransactionEdge
+	err := json.Unmarshal([]byte(`{"node": null, "cursor": "abc"}`), &edge)
+	require.NoError(t, err)
+	assert.Nil(t, edge.Node)
+	assert.Equal(t, "abc", edge.Cursor)
+}
+
+func Test_TransactionEdge_UnmarshalJSON_AcceptsMissingNode(t *testing.T) {
+	var edge TransactionEdge
+	err := json.Unmarshal([]byte(`{"cursor": "abc"}`), &edge)
+	require.NoError(t, err)
+	assert.Nil(t, edge.Node)
+	assert.Equal(t, "abc", edge.Cursor)
+}
+
+func Test_TransactionEdge_UnmarshalJSON_DecodesPopulatedNode(t *testing.T) {
+	payload := []byte(`{
+		"cursor": "tx-1",
+		"node": {
+			"hash": "abc123",
+			"feeCharged": 100,
+			"resultCode": "tx_success",
+			"ledgerNumber": 42,
+			"ledgerCreatedAt": "2024-01-01T00:00:00Z",
+			"isFeeBump": false,
+			"ingestedAt": "2024-01-02T00:00:00Z"
+		}
+	}`)
+
+	var edge TransactionEdge
+	err := json.Unmarshal(payload, &edge)
+	require.NoError(t, err)
+	require.NotNil(t, edge.Node)
+	assert.Equal(t, "tx-1", edge.Cursor)
+	assert.Equal(t, "abc123", edge.Node.Hash)
+	assert.Equal(t, int64(100), edge.Node.FeeCharged)
+	assert.Equal(t, uint32(42), edge.Node.LedgerNumber)
+}
+
+// ---- OperationEdge ----
+
+func Test_OperationEdge_UnmarshalJSON_AcceptsNullNode(t *testing.T) {
+	var edge OperationEdge
+	err := json.Unmarshal([]byte(`{"node": null, "cursor": "abc"}`), &edge)
+	require.NoError(t, err)
+	assert.Nil(t, edge.Node)
+	assert.Equal(t, "abc", edge.Cursor)
+}
+
+func Test_OperationEdge_UnmarshalJSON_AcceptsMissingNode(t *testing.T) {
+	var edge OperationEdge
+	err := json.Unmarshal([]byte(`{"cursor": "abc"}`), &edge)
+	require.NoError(t, err)
+	assert.Nil(t, edge.Node)
+	assert.Equal(t, "abc", edge.Cursor)
+}
+
+func Test_OperationEdge_UnmarshalJSON_DecodesPopulatedNode(t *testing.T) {
+	payload := []byte(`{
+		"cursor": "op-1",
+		"node": {
+			"id": 1234567,
+			"operationType": "PAYMENT",
+			"operationXdr": "AAAA",
+			"resultCode": "op_success",
+			"successful": true,
+			"ledgerNumber": 99,
+			"ledgerCreatedAt": "2024-01-01T00:00:00Z",
+			"ingestedAt": "2024-01-02T00:00:00Z"
+		}
+	}`)
+
+	var edge OperationEdge
+	err := json.Unmarshal(payload, &edge)
+	require.NoError(t, err)
+	require.NotNil(t, edge.Node)
+	assert.Equal(t, "op-1", edge.Cursor)
+	assert.Equal(t, int64(1234567), edge.Node.ID)
+	assert.Equal(t, OperationTypePayment, edge.Node.OperationType)
+	assert.True(t, edge.Node.Successful)
+}
+
+// ---- TransactionConnection ----
+
+func Test_TransactionConnection_UnmarshalJSON_AcceptsMissingEdgesField(t *testing.T) {
+	payload := []byte(`{
+		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+	}`)
+
+	var conn TransactionConnection
+	err := json.Unmarshal(payload, &conn)
+	require.NoError(t, err)
+	assert.Nil(t, conn.Edges)
+	require.NotNil(t, conn.PageInfo)
+}
+
+func Test_TransactionConnection_UnmarshalJSON_AcceptsNullEdgesField(t *testing.T) {
+	payload := []byte(`{
+		"edges": null,
+		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+	}`)
+
+	var conn TransactionConnection
+	err := json.Unmarshal(payload, &conn)
+	require.NoError(t, err)
+	assert.Nil(t, conn.Edges)
+	require.NotNil(t, conn.PageInfo)
+}
+
+func Test_TransactionConnection_UnmarshalJSON_AcceptsEmptyEdgesArray(t *testing.T) {
+	payload := []byte(`{
+		"edges": [],
+		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+	}`)
+
+	var conn TransactionConnection
+	err := json.Unmarshal(payload, &conn)
+	require.NoError(t, err)
+	require.NotNil(t, conn.Edges)
+	assert.Empty(t, conn.Edges)
+}
+
+func Test_TransactionConnection_UnmarshalJSON_RejectsNullEdge(t *testing.T) {
+	payload := []byte(`{
+		"edges": [
+			{"cursor": "c1", "node": null},
+			null
+		],
+		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+	}`)
+
+	var conn TransactionConnection
+	err := json.Unmarshal(payload, &conn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "edge at index 1 is null")
+	assert.Contains(t, err.Error(), "TransactionEdge as non-null")
+}
+
+func Test_TransactionConnection_UnmarshalJSON_RejectsMissingPageInfo(t *testing.T) {
+	payload := []byte(`{"edges": []}`)
+
+	var conn TransactionConnection
+	err := json.Unmarshal(payload, &conn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required pageInfo field")
+}
+
+func Test_TransactionConnection_UnmarshalJSON_RejectsNullPageInfo(t *testing.T) {
+	payload := []byte(`{"edges": [], "pageInfo": null}`)
+
+	var conn TransactionConnection
+	err := json.Unmarshal(payload, &conn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required pageInfo field")
+}
+
+func Test_TransactionConnection_UnmarshalJSON_DecodesValidConnection(t *testing.T) {
+	payload := []byte(`{
+		"edges": [
+			{
+				"cursor": "tx-1",
+				"node": {
+					"hash": "abc",
+					"feeCharged": 100,
+					"resultCode": "tx_success",
+					"ledgerNumber": 1,
+					"ledgerCreatedAt": "2024-01-01T00:00:00Z",
+					"isFeeBump": false,
+					"ingestedAt": "2024-01-02T00:00:00Z"
+				}
+			}
+		],
+		"pageInfo": {"hasNextPage": true, "hasPreviousPage": false, "endCursor": "tx-1"}
+	}`)
+
+	var conn TransactionConnection
+	err := json.Unmarshal(payload, &conn)
+	require.NoError(t, err)
+	require.Len(t, conn.Edges, 1)
+	require.NotNil(t, conn.Edges[0].Node)
+	assert.Equal(t, "abc", conn.Edges[0].Node.Hash)
+	require.NotNil(t, conn.PageInfo)
+	assert.True(t, conn.PageInfo.HasNextPage)
+}
+
+// ---- OperationConnection ----
+
+func Test_OperationConnection_UnmarshalJSON_AcceptsMissingEdgesField(t *testing.T) {
+	payload := []byte(`{
+		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+	}`)
+
+	var conn OperationConnection
+	err := json.Unmarshal(payload, &conn)
+	require.NoError(t, err)
+	assert.Nil(t, conn.Edges)
+	require.NotNil(t, conn.PageInfo)
+}
+
+func Test_OperationConnection_UnmarshalJSON_AcceptsNullEdgesField(t *testing.T) {
+	payload := []byte(`{
+		"edges": null,
+		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+	}`)
+
+	var conn OperationConnection
+	err := json.Unmarshal(payload, &conn)
+	require.NoError(t, err)
+	assert.Nil(t, conn.Edges)
+}
+
+func Test_OperationConnection_UnmarshalJSON_AcceptsEmptyEdgesArray(t *testing.T) {
+	payload := []byte(`{
+		"edges": [],
+		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+	}`)
+
+	var conn OperationConnection
+	err := json.Unmarshal(payload, &conn)
+	require.NoError(t, err)
+	require.NotNil(t, conn.Edges)
+	assert.Empty(t, conn.Edges)
+}
+
+func Test_OperationConnection_UnmarshalJSON_RejectsNullEdge(t *testing.T) {
+	payload := []byte(`{
+		"edges": [null],
+		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+	}`)
+
+	var conn OperationConnection
+	err := json.Unmarshal(payload, &conn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "edge at index 0 is null")
+	assert.Contains(t, err.Error(), "OperationEdge as non-null")
+}
+
+func Test_OperationConnection_UnmarshalJSON_RejectsMissingPageInfo(t *testing.T) {
+	payload := []byte(`{"edges": []}`)
+
+	var conn OperationConnection
+	err := json.Unmarshal(payload, &conn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required pageInfo field")
+}
+
+func Test_OperationConnection_UnmarshalJSON_RejectsNullPageInfo(t *testing.T) {
+	payload := []byte(`{"edges": [], "pageInfo": null}`)
+
+	var conn OperationConnection
+	err := json.Unmarshal(payload, &conn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required pageInfo field")
+}
+
+func Test_OperationConnection_UnmarshalJSON_DecodesValidConnection(t *testing.T) {
+	payload := []byte(`{
+		"edges": [
+			{
+				"cursor": "op-1",
+				"node": {
+					"id": 42,
+					"operationType": "PAYMENT",
+					"operationXdr": "AAAA",
+					"resultCode": "op_success",
+					"successful": true,
+					"ledgerNumber": 1,
+					"ledgerCreatedAt": "2024-01-01T00:00:00Z",
+					"ingestedAt": "2024-01-02T00:00:00Z"
+				}
+			}
+		],
+		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false, "endCursor": "op-1"}
+	}`)
+
+	var conn OperationConnection
+	err := json.Unmarshal(payload, &conn)
+	require.NoError(t, err)
+	require.Len(t, conn.Edges, 1)
+	require.NotNil(t, conn.Edges[0].Node)
+	assert.Equal(t, int64(42), conn.Edges[0].Node.ID)
+}
+
+// ---- StateChangeConnection ----
+
+func Test_StateChangeConnection_UnmarshalJSON_AcceptsMissingEdgesField(t *testing.T) {
+	payload := []byte(`{
+		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+	}`)
+
+	var conn StateChangeConnection
+	err := json.Unmarshal(payload, &conn)
+	require.NoError(t, err)
+	assert.Nil(t, conn.Edges)
+}
+
+func Test_StateChangeConnection_UnmarshalJSON_AcceptsNullEdgesField(t *testing.T) {
+	payload := []byte(`{
+		"edges": null,
+		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+	}`)
+
+	var conn StateChangeConnection
+	err := json.Unmarshal(payload, &conn)
+	require.NoError(t, err)
+	assert.Nil(t, conn.Edges)
+}
+
+func Test_StateChangeConnection_UnmarshalJSON_AcceptsEmptyEdgesArray(t *testing.T) {
+	payload := []byte(`{
+		"edges": [],
+		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+	}`)
+
+	var conn StateChangeConnection
+	err := json.Unmarshal(payload, &conn)
+	require.NoError(t, err)
+	require.NotNil(t, conn.Edges)
+	assert.Empty(t, conn.Edges)
+}
+
+func Test_StateChangeConnection_UnmarshalJSON_RejectsNullEdge(t *testing.T) {
+	payload := []byte(`{
+		"edges": [null],
+		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+	}`)
+
+	var conn StateChangeConnection
+	err := json.Unmarshal(payload, &conn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "edge at index 0 is null")
+	assert.Contains(t, err.Error(), "StateChangeEdge as non-null")
+}
+
+func Test_StateChangeConnection_UnmarshalJSON_RejectsMissingPageInfo(t *testing.T) {
+	payload := []byte(`{"edges": []}`)
+
+	var conn StateChangeConnection
+	err := json.Unmarshal(payload, &conn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required pageInfo field")
+}
+
+func Test_StateChangeConnection_UnmarshalJSON_RejectsNullPageInfo(t *testing.T) {
+	payload := []byte(`{"edges": [], "pageInfo": null}`)
+
+	var conn StateChangeConnection
+	err := json.Unmarshal(payload, &conn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required pageInfo field")
+}
+
+func Test_StateChangeConnection_UnmarshalJSON_DecodesValidConnection(t *testing.T) {
+	payload := []byte(`{
+		"edges": [
+			{
+				"cursor": "sc-1",
+				"node": {
+					"__typename": "StandardBalanceChange",
+					"type": "CREDIT",
+					"reason": "PAYMENT",
+					"ingestedAt": "2024-01-02T00:00:00Z",
+					"ledgerCreatedAt": "2024-01-01T00:00:00Z",
+					"ledgerNumber": 1,
+					"standardBalanceTokenId": "native",
+					"amount": "100"
+				}
+			},
+			{
+				"cursor": "sc-2",
+				"node": null
+			}
+		],
+		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false, "endCursor": "sc-2"}
+	}`)
+
+	var conn StateChangeConnection
+	err := json.Unmarshal(payload, &conn)
+	require.NoError(t, err)
+	require.Len(t, conn.Edges, 2)
+
+	require.NotNil(t, conn.Edges[0].Node)
+	standard, ok := conn.Edges[0].Node.(*StandardBalanceChange)
+	require.True(t, ok, "expected first node to decode into *StandardBalanceChange, got %T", conn.Edges[0].Node)
+	assert.Equal(t, "100", standard.Amount)
+	assert.Equal(t, "native", standard.TokenID)
+
+	assert.Nil(t, conn.Edges[1].Node, "schema permits null node and StateChangeEdge must preserve that")
+	assert.Equal(t, "sc-2", conn.Edges[1].Cursor)
+}

--- a/pkg/wbclient/types/types_test.go
+++ b/pkg/wbclient/types/types_test.go
@@ -212,396 +212,396 @@ func Test_BalanceConnection_UnmarshalJSON_DecodesValidConnection(t *testing.T) {
 	assert.Equal(t, "c1", *conn.PageInfo.EndCursor)
 }
 
-// ---- TransactionEdge ----
+func Test_TransactionEdge_UnmarshalJSON(t *testing.T) {
+	t.Run("accepts null node", func(t *testing.T) {
+		var edge TransactionEdge
+		err := json.Unmarshal([]byte(`{"node": null, "cursor": "abc"}`), &edge)
+		require.NoError(t, err)
+		assert.Nil(t, edge.Node)
+		assert.Equal(t, "abc", edge.Cursor)
+	})
 
-func Test_TransactionEdge_UnmarshalJSON_AcceptsNullNode(t *testing.T) {
-	var edge TransactionEdge
-	err := json.Unmarshal([]byte(`{"node": null, "cursor": "abc"}`), &edge)
-	require.NoError(t, err)
-	assert.Nil(t, edge.Node)
-	assert.Equal(t, "abc", edge.Cursor)
-}
+	t.Run("accepts missing node", func(t *testing.T) {
+		var edge TransactionEdge
+		err := json.Unmarshal([]byte(`{"cursor": "abc"}`), &edge)
+		require.NoError(t, err)
+		assert.Nil(t, edge.Node)
+		assert.Equal(t, "abc", edge.Cursor)
+	})
 
-func Test_TransactionEdge_UnmarshalJSON_AcceptsMissingNode(t *testing.T) {
-	var edge TransactionEdge
-	err := json.Unmarshal([]byte(`{"cursor": "abc"}`), &edge)
-	require.NoError(t, err)
-	assert.Nil(t, edge.Node)
-	assert.Equal(t, "abc", edge.Cursor)
-}
-
-func Test_TransactionEdge_UnmarshalJSON_DecodesPopulatedNode(t *testing.T) {
-	payload := []byte(`{
-		"cursor": "tx-1",
-		"node": {
-			"hash": "abc123",
-			"feeCharged": 100,
-			"resultCode": "tx_success",
-			"ledgerNumber": 42,
-			"ledgerCreatedAt": "2024-01-01T00:00:00Z",
-			"isFeeBump": false,
-			"ingestedAt": "2024-01-02T00:00:00Z"
-		}
-	}`)
-
-	var edge TransactionEdge
-	err := json.Unmarshal(payload, &edge)
-	require.NoError(t, err)
-	require.NotNil(t, edge.Node)
-	assert.Equal(t, "tx-1", edge.Cursor)
-	assert.Equal(t, "abc123", edge.Node.Hash)
-	assert.Equal(t, int64(100), edge.Node.FeeCharged)
-	assert.Equal(t, uint32(42), edge.Node.LedgerNumber)
-}
-
-// ---- OperationEdge ----
-
-func Test_OperationEdge_UnmarshalJSON_AcceptsNullNode(t *testing.T) {
-	var edge OperationEdge
-	err := json.Unmarshal([]byte(`{"node": null, "cursor": "abc"}`), &edge)
-	require.NoError(t, err)
-	assert.Nil(t, edge.Node)
-	assert.Equal(t, "abc", edge.Cursor)
-}
-
-func Test_OperationEdge_UnmarshalJSON_AcceptsMissingNode(t *testing.T) {
-	var edge OperationEdge
-	err := json.Unmarshal([]byte(`{"cursor": "abc"}`), &edge)
-	require.NoError(t, err)
-	assert.Nil(t, edge.Node)
-	assert.Equal(t, "abc", edge.Cursor)
-}
-
-func Test_OperationEdge_UnmarshalJSON_DecodesPopulatedNode(t *testing.T) {
-	payload := []byte(`{
-		"cursor": "op-1",
-		"node": {
-			"id": 1234567,
-			"operationType": "PAYMENT",
-			"operationXdr": "AAAA",
-			"resultCode": "op_success",
-			"successful": true,
-			"ledgerNumber": 99,
-			"ledgerCreatedAt": "2024-01-01T00:00:00Z",
-			"ingestedAt": "2024-01-02T00:00:00Z"
-		}
-	}`)
-
-	var edge OperationEdge
-	err := json.Unmarshal(payload, &edge)
-	require.NoError(t, err)
-	require.NotNil(t, edge.Node)
-	assert.Equal(t, "op-1", edge.Cursor)
-	assert.Equal(t, int64(1234567), edge.Node.ID)
-	assert.Equal(t, OperationTypePayment, edge.Node.OperationType)
-	assert.True(t, edge.Node.Successful)
-}
-
-// ---- TransactionConnection ----
-
-func Test_TransactionConnection_UnmarshalJSON_AcceptsMissingEdgesField(t *testing.T) {
-	payload := []byte(`{
-		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
-	}`)
-
-	var conn TransactionConnection
-	err := json.Unmarshal(payload, &conn)
-	require.NoError(t, err)
-	assert.Nil(t, conn.Edges)
-	require.NotNil(t, conn.PageInfo)
-}
-
-func Test_TransactionConnection_UnmarshalJSON_AcceptsNullEdgesField(t *testing.T) {
-	payload := []byte(`{
-		"edges": null,
-		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
-	}`)
-
-	var conn TransactionConnection
-	err := json.Unmarshal(payload, &conn)
-	require.NoError(t, err)
-	assert.Nil(t, conn.Edges)
-	require.NotNil(t, conn.PageInfo)
-}
-
-func Test_TransactionConnection_UnmarshalJSON_AcceptsEmptyEdgesArray(t *testing.T) {
-	payload := []byte(`{
-		"edges": [],
-		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
-	}`)
-
-	var conn TransactionConnection
-	err := json.Unmarshal(payload, &conn)
-	require.NoError(t, err)
-	require.NotNil(t, conn.Edges)
-	assert.Empty(t, conn.Edges)
-}
-
-func Test_TransactionConnection_UnmarshalJSON_RejectsNullEdge(t *testing.T) {
-	payload := []byte(`{
-		"edges": [
-			{"cursor": "c1", "node": null},
-			null
-		],
-		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
-	}`)
-
-	var conn TransactionConnection
-	err := json.Unmarshal(payload, &conn)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "edge at index 1 is null")
-	assert.Contains(t, err.Error(), "TransactionEdge as non-null")
-}
-
-func Test_TransactionConnection_UnmarshalJSON_RejectsMissingPageInfo(t *testing.T) {
-	payload := []byte(`{"edges": []}`)
-
-	var conn TransactionConnection
-	err := json.Unmarshal(payload, &conn)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "missing required pageInfo field")
-}
-
-func Test_TransactionConnection_UnmarshalJSON_RejectsNullPageInfo(t *testing.T) {
-	payload := []byte(`{"edges": [], "pageInfo": null}`)
-
-	var conn TransactionConnection
-	err := json.Unmarshal(payload, &conn)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "missing required pageInfo field")
-}
-
-func Test_TransactionConnection_UnmarshalJSON_DecodesValidConnection(t *testing.T) {
-	payload := []byte(`{
-		"edges": [
-			{
-				"cursor": "tx-1",
-				"node": {
-					"hash": "abc",
-					"feeCharged": 100,
-					"resultCode": "tx_success",
-					"ledgerNumber": 1,
-					"ledgerCreatedAt": "2024-01-01T00:00:00Z",
-					"isFeeBump": false,
-					"ingestedAt": "2024-01-02T00:00:00Z"
-				}
+	t.Run("decodes populated node", func(t *testing.T) {
+		payload := []byte(`{
+			"cursor": "tx-1",
+			"node": {
+				"hash": "abc123",
+				"feeCharged": 100,
+				"resultCode": "tx_success",
+				"ledgerNumber": 42,
+				"ledgerCreatedAt": "2024-01-01T00:00:00Z",
+				"isFeeBump": false,
+				"ingestedAt": "2024-01-02T00:00:00Z"
 			}
-		],
-		"pageInfo": {"hasNextPage": true, "hasPreviousPage": false, "endCursor": "tx-1"}
-	}`)
+		}`)
 
-	var conn TransactionConnection
-	err := json.Unmarshal(payload, &conn)
-	require.NoError(t, err)
-	require.Len(t, conn.Edges, 1)
-	require.NotNil(t, conn.Edges[0].Node)
-	assert.Equal(t, "abc", conn.Edges[0].Node.Hash)
-	require.NotNil(t, conn.PageInfo)
-	assert.True(t, conn.PageInfo.HasNextPage)
+		var edge TransactionEdge
+		err := json.Unmarshal(payload, &edge)
+		require.NoError(t, err)
+		require.NotNil(t, edge.Node)
+		assert.Equal(t, "tx-1", edge.Cursor)
+		assert.Equal(t, "abc123", edge.Node.Hash)
+		assert.Equal(t, int64(100), edge.Node.FeeCharged)
+		assert.Equal(t, uint32(42), edge.Node.LedgerNumber)
+	})
 }
 
-// ---- OperationConnection ----
+func Test_OperationEdge_UnmarshalJSON(t *testing.T) {
+	t.Run("accepts null node", func(t *testing.T) {
+		var edge OperationEdge
+		err := json.Unmarshal([]byte(`{"node": null, "cursor": "abc"}`), &edge)
+		require.NoError(t, err)
+		assert.Nil(t, edge.Node)
+		assert.Equal(t, "abc", edge.Cursor)
+	})
 
-func Test_OperationConnection_UnmarshalJSON_AcceptsMissingEdgesField(t *testing.T) {
-	payload := []byte(`{
-		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
-	}`)
+	t.Run("accepts missing node", func(t *testing.T) {
+		var edge OperationEdge
+		err := json.Unmarshal([]byte(`{"cursor": "abc"}`), &edge)
+		require.NoError(t, err)
+		assert.Nil(t, edge.Node)
+		assert.Equal(t, "abc", edge.Cursor)
+	})
 
-	var conn OperationConnection
-	err := json.Unmarshal(payload, &conn)
-	require.NoError(t, err)
-	assert.Nil(t, conn.Edges)
-	require.NotNil(t, conn.PageInfo)
-}
-
-func Test_OperationConnection_UnmarshalJSON_AcceptsNullEdgesField(t *testing.T) {
-	payload := []byte(`{
-		"edges": null,
-		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
-	}`)
-
-	var conn OperationConnection
-	err := json.Unmarshal(payload, &conn)
-	require.NoError(t, err)
-	assert.Nil(t, conn.Edges)
-}
-
-func Test_OperationConnection_UnmarshalJSON_AcceptsEmptyEdgesArray(t *testing.T) {
-	payload := []byte(`{
-		"edges": [],
-		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
-	}`)
-
-	var conn OperationConnection
-	err := json.Unmarshal(payload, &conn)
-	require.NoError(t, err)
-	require.NotNil(t, conn.Edges)
-	assert.Empty(t, conn.Edges)
-}
-
-func Test_OperationConnection_UnmarshalJSON_RejectsNullEdge(t *testing.T) {
-	payload := []byte(`{
-		"edges": [null],
-		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
-	}`)
-
-	var conn OperationConnection
-	err := json.Unmarshal(payload, &conn)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "edge at index 0 is null")
-	assert.Contains(t, err.Error(), "OperationEdge as non-null")
-}
-
-func Test_OperationConnection_UnmarshalJSON_RejectsMissingPageInfo(t *testing.T) {
-	payload := []byte(`{"edges": []}`)
-
-	var conn OperationConnection
-	err := json.Unmarshal(payload, &conn)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "missing required pageInfo field")
-}
-
-func Test_OperationConnection_UnmarshalJSON_RejectsNullPageInfo(t *testing.T) {
-	payload := []byte(`{"edges": [], "pageInfo": null}`)
-
-	var conn OperationConnection
-	err := json.Unmarshal(payload, &conn)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "missing required pageInfo field")
-}
-
-func Test_OperationConnection_UnmarshalJSON_DecodesValidConnection(t *testing.T) {
-	payload := []byte(`{
-		"edges": [
-			{
-				"cursor": "op-1",
-				"node": {
-					"id": 42,
-					"operationType": "PAYMENT",
-					"operationXdr": "AAAA",
-					"resultCode": "op_success",
-					"successful": true,
-					"ledgerNumber": 1,
-					"ledgerCreatedAt": "2024-01-01T00:00:00Z",
-					"ingestedAt": "2024-01-02T00:00:00Z"
-				}
+	t.Run("decodes populated node", func(t *testing.T) {
+		payload := []byte(`{
+			"cursor": "op-1",
+			"node": {
+				"id": 1234567,
+				"operationType": "PAYMENT",
+				"operationXdr": "AAAA",
+				"resultCode": "op_success",
+				"successful": true,
+				"ledgerNumber": 99,
+				"ledgerCreatedAt": "2024-01-01T00:00:00Z",
+				"ingestedAt": "2024-01-02T00:00:00Z"
 			}
-		],
-		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false, "endCursor": "op-1"}
-	}`)
+		}`)
 
-	var conn OperationConnection
-	err := json.Unmarshal(payload, &conn)
-	require.NoError(t, err)
-	require.Len(t, conn.Edges, 1)
-	require.NotNil(t, conn.Edges[0].Node)
-	assert.Equal(t, int64(42), conn.Edges[0].Node.ID)
+		var edge OperationEdge
+		err := json.Unmarshal(payload, &edge)
+		require.NoError(t, err)
+		require.NotNil(t, edge.Node)
+		assert.Equal(t, "op-1", edge.Cursor)
+		assert.Equal(t, int64(1234567), edge.Node.ID)
+		assert.Equal(t, OperationTypePayment, edge.Node.OperationType)
+		assert.True(t, edge.Node.Successful)
+	})
 }
 
-// ---- StateChangeConnection ----
+func Test_TransactionConnection_UnmarshalJSON(t *testing.T) {
+	t.Run("accepts missing edges field", func(t *testing.T) {
+		payload := []byte(`{
+			"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+		}`)
 
-func Test_StateChangeConnection_UnmarshalJSON_AcceptsMissingEdgesField(t *testing.T) {
-	payload := []byte(`{
-		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
-	}`)
+		var conn TransactionConnection
+		err := json.Unmarshal(payload, &conn)
+		require.NoError(t, err)
+		assert.Nil(t, conn.Edges)
+		require.NotNil(t, conn.PageInfo)
+	})
 
-	var conn StateChangeConnection
-	err := json.Unmarshal(payload, &conn)
-	require.NoError(t, err)
-	assert.Nil(t, conn.Edges)
-}
+	t.Run("accepts null edges field", func(t *testing.T) {
+		payload := []byte(`{
+			"edges": null,
+			"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+		}`)
 
-func Test_StateChangeConnection_UnmarshalJSON_AcceptsNullEdgesField(t *testing.T) {
-	payload := []byte(`{
-		"edges": null,
-		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
-	}`)
+		var conn TransactionConnection
+		err := json.Unmarshal(payload, &conn)
+		require.NoError(t, err)
+		assert.Nil(t, conn.Edges)
+		require.NotNil(t, conn.PageInfo)
+	})
 
-	var conn StateChangeConnection
-	err := json.Unmarshal(payload, &conn)
-	require.NoError(t, err)
-	assert.Nil(t, conn.Edges)
-}
+	t.Run("accepts empty edges array", func(t *testing.T) {
+		payload := []byte(`{
+			"edges": [],
+			"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+		}`)
 
-func Test_StateChangeConnection_UnmarshalJSON_AcceptsEmptyEdgesArray(t *testing.T) {
-	payload := []byte(`{
-		"edges": [],
-		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
-	}`)
+		var conn TransactionConnection
+		err := json.Unmarshal(payload, &conn)
+		require.NoError(t, err)
+		require.NotNil(t, conn.Edges)
+		assert.Empty(t, conn.Edges)
+	})
 
-	var conn StateChangeConnection
-	err := json.Unmarshal(payload, &conn)
-	require.NoError(t, err)
-	require.NotNil(t, conn.Edges)
-	assert.Empty(t, conn.Edges)
-}
+	t.Run("rejects null edge entry", func(t *testing.T) {
+		payload := []byte(`{
+			"edges": [
+				{"cursor": "c1", "node": null},
+				null
+			],
+			"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+		}`)
 
-func Test_StateChangeConnection_UnmarshalJSON_RejectsNullEdge(t *testing.T) {
-	payload := []byte(`{
-		"edges": [null],
-		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
-	}`)
+		var conn TransactionConnection
+		err := json.Unmarshal(payload, &conn)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "edge at index 1 is null")
+		assert.Contains(t, err.Error(), "TransactionEdge as non-null")
+	})
 
-	var conn StateChangeConnection
-	err := json.Unmarshal(payload, &conn)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "edge at index 0 is null")
-	assert.Contains(t, err.Error(), "StateChangeEdge as non-null")
-}
+	t.Run("rejects missing pageInfo", func(t *testing.T) {
+		payload := []byte(`{"edges": []}`)
 
-func Test_StateChangeConnection_UnmarshalJSON_RejectsMissingPageInfo(t *testing.T) {
-	payload := []byte(`{"edges": []}`)
+		var conn TransactionConnection
+		err := json.Unmarshal(payload, &conn)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing required pageInfo field")
+	})
 
-	var conn StateChangeConnection
-	err := json.Unmarshal(payload, &conn)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "missing required pageInfo field")
-}
+	t.Run("rejects null pageInfo", func(t *testing.T) {
+		payload := []byte(`{"edges": [], "pageInfo": null}`)
 
-func Test_StateChangeConnection_UnmarshalJSON_RejectsNullPageInfo(t *testing.T) {
-	payload := []byte(`{"edges": [], "pageInfo": null}`)
+		var conn TransactionConnection
+		err := json.Unmarshal(payload, &conn)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing required pageInfo field")
+	})
 
-	var conn StateChangeConnection
-	err := json.Unmarshal(payload, &conn)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "missing required pageInfo field")
-}
-
-func Test_StateChangeConnection_UnmarshalJSON_DecodesValidConnection(t *testing.T) {
-	payload := []byte(`{
-		"edges": [
-			{
-				"cursor": "sc-1",
-				"node": {
-					"__typename": "StandardBalanceChange",
-					"type": "CREDIT",
-					"reason": "PAYMENT",
-					"ingestedAt": "2024-01-02T00:00:00Z",
-					"ledgerCreatedAt": "2024-01-01T00:00:00Z",
-					"ledgerNumber": 1,
-					"standardBalanceTokenId": "native",
-					"amount": "100"
+	t.Run("decodes valid connection", func(t *testing.T) {
+		payload := []byte(`{
+			"edges": [
+				{
+					"cursor": "tx-1",
+					"node": {
+						"hash": "abc",
+						"feeCharged": 100,
+						"resultCode": "tx_success",
+						"ledgerNumber": 1,
+						"ledgerCreatedAt": "2024-01-01T00:00:00Z",
+						"isFeeBump": false,
+						"ingestedAt": "2024-01-02T00:00:00Z"
+					}
 				}
-			},
-			{
-				"cursor": "sc-2",
-				"node": null
-			}
-		],
-		"pageInfo": {"hasNextPage": false, "hasPreviousPage": false, "endCursor": "sc-2"}
-	}`)
+			],
+			"pageInfo": {"hasNextPage": true, "hasPreviousPage": false, "endCursor": "tx-1"}
+		}`)
 
-	var conn StateChangeConnection
-	err := json.Unmarshal(payload, &conn)
-	require.NoError(t, err)
-	require.Len(t, conn.Edges, 2)
+		var conn TransactionConnection
+		err := json.Unmarshal(payload, &conn)
+		require.NoError(t, err)
+		require.Len(t, conn.Edges, 1)
+		require.NotNil(t, conn.Edges[0].Node)
+		assert.Equal(t, "abc", conn.Edges[0].Node.Hash)
+		require.NotNil(t, conn.PageInfo)
+		assert.True(t, conn.PageInfo.HasNextPage)
+	})
+}
 
-	require.NotNil(t, conn.Edges[0].Node)
-	standard, ok := conn.Edges[0].Node.(*StandardBalanceChange)
-	require.True(t, ok, "expected first node to decode into *StandardBalanceChange, got %T", conn.Edges[0].Node)
-	assert.Equal(t, "100", standard.Amount)
-	assert.Equal(t, "native", standard.TokenID)
+func Test_OperationConnection_UnmarshalJSON(t *testing.T) {
+	t.Run("accepts missing edges field", func(t *testing.T) {
+		payload := []byte(`{
+			"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+		}`)
 
-	assert.Nil(t, conn.Edges[1].Node, "schema permits null node and StateChangeEdge must preserve that")
-	assert.Equal(t, "sc-2", conn.Edges[1].Cursor)
+		var conn OperationConnection
+		err := json.Unmarshal(payload, &conn)
+		require.NoError(t, err)
+		assert.Nil(t, conn.Edges)
+		require.NotNil(t, conn.PageInfo)
+	})
+
+	t.Run("accepts null edges field", func(t *testing.T) {
+		payload := []byte(`{
+			"edges": null,
+			"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+		}`)
+
+		var conn OperationConnection
+		err := json.Unmarshal(payload, &conn)
+		require.NoError(t, err)
+		assert.Nil(t, conn.Edges)
+	})
+
+	t.Run("accepts empty edges array", func(t *testing.T) {
+		payload := []byte(`{
+			"edges": [],
+			"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+		}`)
+
+		var conn OperationConnection
+		err := json.Unmarshal(payload, &conn)
+		require.NoError(t, err)
+		require.NotNil(t, conn.Edges)
+		assert.Empty(t, conn.Edges)
+	})
+
+	t.Run("rejects null edge entry", func(t *testing.T) {
+		payload := []byte(`{
+			"edges": [null],
+			"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+		}`)
+
+		var conn OperationConnection
+		err := json.Unmarshal(payload, &conn)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "edge at index 0 is null")
+		assert.Contains(t, err.Error(), "OperationEdge as non-null")
+	})
+
+	t.Run("rejects missing pageInfo", func(t *testing.T) {
+		payload := []byte(`{"edges": []}`)
+
+		var conn OperationConnection
+		err := json.Unmarshal(payload, &conn)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing required pageInfo field")
+	})
+
+	t.Run("rejects null pageInfo", func(t *testing.T) {
+		payload := []byte(`{"edges": [], "pageInfo": null}`)
+
+		var conn OperationConnection
+		err := json.Unmarshal(payload, &conn)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing required pageInfo field")
+	})
+
+	t.Run("decodes valid connection", func(t *testing.T) {
+		payload := []byte(`{
+			"edges": [
+				{
+					"cursor": "op-1",
+					"node": {
+						"id": 42,
+						"operationType": "PAYMENT",
+						"operationXdr": "AAAA",
+						"resultCode": "op_success",
+						"successful": true,
+						"ledgerNumber": 1,
+						"ledgerCreatedAt": "2024-01-01T00:00:00Z",
+						"ingestedAt": "2024-01-02T00:00:00Z"
+					}
+				}
+			],
+			"pageInfo": {"hasNextPage": false, "hasPreviousPage": false, "endCursor": "op-1"}
+		}`)
+
+		var conn OperationConnection
+		err := json.Unmarshal(payload, &conn)
+		require.NoError(t, err)
+		require.Len(t, conn.Edges, 1)
+		require.NotNil(t, conn.Edges[0].Node)
+		assert.Equal(t, int64(42), conn.Edges[0].Node.ID)
+	})
+}
+
+func Test_StateChangeConnection_UnmarshalJSON(t *testing.T) {
+	t.Run("accepts missing edges field", func(t *testing.T) {
+		payload := []byte(`{
+			"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+		}`)
+
+		var conn StateChangeConnection
+		err := json.Unmarshal(payload, &conn)
+		require.NoError(t, err)
+		assert.Nil(t, conn.Edges)
+	})
+
+	t.Run("accepts null edges field", func(t *testing.T) {
+		payload := []byte(`{
+			"edges": null,
+			"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+		}`)
+
+		var conn StateChangeConnection
+		err := json.Unmarshal(payload, &conn)
+		require.NoError(t, err)
+		assert.Nil(t, conn.Edges)
+	})
+
+	t.Run("accepts empty edges array", func(t *testing.T) {
+		payload := []byte(`{
+			"edges": [],
+			"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+		}`)
+
+		var conn StateChangeConnection
+		err := json.Unmarshal(payload, &conn)
+		require.NoError(t, err)
+		require.NotNil(t, conn.Edges)
+		assert.Empty(t, conn.Edges)
+	})
+
+	t.Run("rejects null edge entry", func(t *testing.T) {
+		payload := []byte(`{
+			"edges": [null],
+			"pageInfo": {"hasNextPage": false, "hasPreviousPage": false}
+		}`)
+
+		var conn StateChangeConnection
+		err := json.Unmarshal(payload, &conn)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "edge at index 0 is null")
+		assert.Contains(t, err.Error(), "StateChangeEdge as non-null")
+	})
+
+	t.Run("rejects missing pageInfo", func(t *testing.T) {
+		payload := []byte(`{"edges": []}`)
+
+		var conn StateChangeConnection
+		err := json.Unmarshal(payload, &conn)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing required pageInfo field")
+	})
+
+	t.Run("rejects null pageInfo", func(t *testing.T) {
+		payload := []byte(`{"edges": [], "pageInfo": null}`)
+
+		var conn StateChangeConnection
+		err := json.Unmarshal(payload, &conn)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing required pageInfo field")
+	})
+
+	t.Run("decodes valid connection with mixed null and populated nodes", func(t *testing.T) {
+		payload := []byte(`{
+			"edges": [
+				{
+					"cursor": "sc-1",
+					"node": {
+						"__typename": "StandardBalanceChange",
+						"type": "CREDIT",
+						"reason": "PAYMENT",
+						"ingestedAt": "2024-01-02T00:00:00Z",
+						"ledgerCreatedAt": "2024-01-01T00:00:00Z",
+						"ledgerNumber": 1,
+						"standardBalanceTokenId": "native",
+						"amount": "100"
+					}
+				},
+				{
+					"cursor": "sc-2",
+					"node": null
+				}
+			],
+			"pageInfo": {"hasNextPage": false, "hasPreviousPage": false, "endCursor": "sc-2"}
+		}`)
+
+		var conn StateChangeConnection
+		err := json.Unmarshal(payload, &conn)
+		require.NoError(t, err)
+		require.Len(t, conn.Edges, 2)
+
+		require.NotNil(t, conn.Edges[0].Node)
+		standard, ok := conn.Edges[0].Node.(*StandardBalanceChange)
+		require.True(t, ok, "expected first node to decode into *StandardBalanceChange, got %T", conn.Edges[0].Node)
+		assert.Equal(t, "100", standard.Amount)
+		assert.Equal(t, "native", standard.TokenID)
+
+		assert.Nil(t, conn.Edges[1].Node, "schema permits null node and StateChangeEdge must preserve that")
+		assert.Equal(t, "sc-2", conn.Edges[1].Cursor)
+	})
 }


### PR DESCRIPTION
## Summary

Brings `GetAccountTransactions`, `GetAccountOperations`, and `GetAccountStateChanges` in `pkg/wbclient` in line with the existing `GetAccountBalances` behavior so that SDK consumers can distinguish *"account does not exist"* from *"account exists but has no items"*.

Today, a `(nil, nil)` return from any of these three methods is ambiguous. After this change, an absent account produces a wrapped `ErrAccountNotFound` that callers can match with `errors.Is`.

The change is split across two commits:

1. **Type-layer validators** — adds custom `UnmarshalJSON` to `TransactionEdge`, `OperationEdge`, `TransactionConnection`, `OperationConnection`, and `StateChangeConnection` (plus a clarifying comment on the pre-existing `StateChangeEdge.UnmarshalJSON`). These reject schema-violating server responses — null entries inside the edges array, and missing or null `pageInfo` — and accept everything the schema permits.
2. **Client-layer ErrAccountNotFound** — reshapes the three response data structs so `AccountByAddress` is a pointer, and returns `ErrAccountNotFound` (wrapped with the queried address) when the field comes back null.

## Schema asymmetry — why this isn't a copy of `BalanceConnection.UnmarshalJSON`

The GraphQL schema's non-null declarations differ across the four connection types, so the new validators are looser than `BalanceConnection.UnmarshalJSON`:

| Type | `edges` field | edge entries | `node` | parent `Account.X` field |
|------|---------------|--------------|--------|--------------------------|
| Balance | `[BalanceEdge!]!` — non-null | non-null | `Balance!` — non-null | non-null |
| Transaction | `[TransactionEdge!]` — **nullable** | non-null | `Transaction` — **nullable** | **nullable** |
| Operation | `[OperationEdge!]` — **nullable** | non-null | `Operation` — **nullable** | **nullable** |
| StateChange | `[StateChangeEdge!]` — **nullable** | non-null | `BaseStateChange` — **nullable** | **nullable** |

This means:
- For these three types, a null `edges` field, null `node`, or null parent connection field is **schema-valid** and passes through silently.
- Only null entries inside the edges array and null `pageInfo` are rejected (the schema's only non-null declarations).
- Callers iterating `connection.Edges` must nil-check `edge.Node` for these three types — unlike `BalanceConnection` where `edge.Node` is guaranteed non-nil after unmarshal.

## What is intentionally *not* changed

- No new `GetAllAccount{Transactions,Operations,StateChanges}` paginating helpers.
- No new flat-slice helpers like `BalanceConnection.Balances()` for these three types.
- No schema tightening — the `.graphqls` files are untouched.
- `BalanceConnection` / `BalanceEdge` / `GetAccountBalances` / `GetAllAccountBalances` are unchanged.

## Test plan

- [x] Type-layer: 27 new unit tests in `pkg/wbclient/types/types_test.go` covering edge null-node accept paths, connection null-edge reject path, connection null/missing pageInfo reject path, end-to-end decode.
- [x] Client-layer: 10 new tests in `pkg/wbclient/client_test.go` using `httptest.Server` to cover `ErrAccountNotFound`, null-connection passthrough, and empty-edges connection for each of the three methods.
- [x] Full `go test -race ./pkg/wbclient/...` passes (105 tests across 3 packages).
- [x] `go vet ./pkg/wbclient/...` passes.
- [x] `go build ./pkg/wbclient/...` passes.