### PR TITLE
fix(docker-compose): make testnet quickstart work from a clean volume

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -87,7 +87,7 @@ services:
         ./wallet-backend serve
     environment:
       RPC_URL: ${RPC_URL:-http://stellar-rpc-testnet:8000}
-      DATABASE_URL: postgres://postgres@db:5432/wallet-backend?sslmode=disable&search_path=wallet_backend_testnet
+      DATABASE_URL: postgres://postgres@db:5432/wallet-backend?sslmode=disable&search_path=wallet_backend_testnet,public
       PORT: 8002
       SERVER_BASE_URL: ${SERVER_BASE_URL:-http://api-testnet:8002}
       LOG_LEVEL: TRACE
@@ -122,7 +122,7 @@ services:
         ./wallet-backend serve
     environment:
       RPC_URL: ${RPC_URL:-http://stellar-rpc-mainnet:8000}
-      DATABASE_URL: postgres://postgres@db:5432/wallet-backend?sslmode=disable&search_path=wallet_backend_mainnet
+      DATABASE_URL: postgres://postgres@db:5432/wallet-backend?sslmode=disable&search_path=wallet_backend_mainnet,public
       PORT: 8003
       SERVER_BASE_URL: ${SERVER_BASE_URL:-http://api-mainnet:8003}
       LOG_LEVEL: TRACE
@@ -165,7 +165,8 @@ services:
         fi
     environment:
       RPC_URL: ${RPC_URL:-http://stellar-rpc-testnet:8000}
-      DATABASE_URL: postgres://postgres@db:5432/wallet-backend?sslmode=disable&search_path=wallet_backend_testnet
+      LEDGER_BACKEND_TYPE: ${LEDGER_BACKEND_TYPE:-rpc}
+      DATABASE_URL: postgres://postgres@db:5432/wallet-backend?sslmode=disable&search_path=wallet_backend_testnet,public
       INGEST_SERVER_PORT: 8004
       NETWORK: testnet
       NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
@@ -207,7 +208,7 @@ services:
         fi
     environment:
       RPC_URL: ${RPC_URL:-http://stellar-rpc-mainnet:8000}
-      DATABASE_URL: postgres://postgres@db:5432/wallet-backend?sslmode=disable&search_path=wallet_backend_mainnet
+      DATABASE_URL: postgres://postgres@db:5432/wallet-backend?sslmode=disable&search_path=wallet_backend_mainnet,public
       INGEST_SERVER_PORT: 8005
       NETWORK: mainnet
       NETWORK_PASSPHRASE: "Public Global Stellar Network ; September 2015"
@@ -224,3 +225,5 @@ configs:
   postgres_init:
     content: |
       CREATE EXTENSION IF NOT EXISTS timescaledb;
+      CREATE SCHEMA IF NOT EXISTS wallet_backend_testnet;
+      CREATE SCHEMA IF NOT EXISTS wallet_backend_mainnet;


### PR DESCRIPTION
### What

Fix the local `docker-compose` quickstart so the testnet stack (`docker compose up db ingest-testnet api-testnet`) starts successfully from a clean volume. 
1. **Create the per-network Postgres schemas** in the DB init config (`wallet_backend_testnet`, `wallet_backend_mainnet`), previously only the `timescaledb` extension was created.
2. **Add `public` to `search_path`** on all four service `DATABASE_URL`s so TimescaleDB's functions (installed in public) resolve.
3. **Default `ingest-testnet` to the RPC ledger backend** via `LEDGER_BACKEND_TYPE: ${LEDGER_BACKEND_TYPE:-rpc}`.


### Why

1. The services connect with `search_path=wallet_backend_<network>`, but nothing creates those schemas, so `migrate up` panics with `ERROR: no schema has been selected to create in (SQLSTATE 3F000)`.
2. Specifying `search_path=wallet_backend_testnet` replaces the default path (which includes `public`), so the migration/hypertable setup can't find TimescaleDB functions: `function set_chunk_time_interval(regclass, interval) does not exist / function enable_chunk_skipping(...) does not exist`.
3. The `ingest` command defaults to the `datastore` backend pointed at the pubnet dataset, so the testnet ingest container fails on a passphrase mismatch before it can start. Defaulting testnet ingest to `rpc` (which honors RPC_URL) fixes this; it stays overridable via the `LEDGER_BACKEND_TYPE` env var.

### Known limitations

- The `stellar/stellar-rpc:stable` image (built 2026-04-07) rejects the committed RPC config (`could not parse network: "testnet", network option conflicts with values provided for passphrase and/or history archive URLs`). This PR does **not** fix that; for local dev you can point `RPC_URL` at the public testnet RPC and run services without the local stellar-rpc container. 

### Issue that this PR addresses

No dedicated issue 

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.
- [ ] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
