### PR TITLE
fix(cmd): run protocol migrations during full migrate up

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -68,6 +68,21 @@ func (c *migrateCmd) RunMigrateUp(ctx context.Context, databaseURL string, args 
 	if err := executeMigrations(ctx, databaseURL, migrate.Up, count); err != nil {
 		return fmt.Errorf("executing migrate up: %w", err)
 	}
+
+	// A full `migrate up` also registers protocols so live ingestion can classify
+	// new-protocol WASMs immediately on restart, without waiting for protocol-setup.
+	// Skipped on partial (`migrate up N`) runs, which may not have created the
+	// protocols table yet. The protocol SQL is idempotent (ON CONFLICT DO NOTHING).
+	if count == 0 {
+		pool, err := db.OpenDBConnectionPool(ctx, databaseURL)
+		if err != nil {
+			return fmt.Errorf("opening database connection pool for protocol migrations: %w", err)
+		}
+		defer pool.Close()
+		if _, err := db.RunProtocolMigrations(ctx, pool); err != nil {
+			return fmt.Errorf("running protocol migrations: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/docs/data-migrations/adding-a-protocol.md
+++ b/docs/data-migrations/adding-a-protocol.md
@@ -32,7 +32,7 @@ Code changes:
   6. Models struct                (wire data model for dependency injection)
 
 Operational:
-  7. Run the 4-step migration workflow (setup -> live ingest + history + current-state)
+  7. Run the migration workflow (migrate up -> restart ingest -> protocol-setup -> history + current-state)
 ```
 
 > The framework treats each protocol's validator as a black box during classification. Inside `Validate` you are free to do anything you need (signature checks, RPC fetches, writes to your own protocol-specific tables). The only thing the framework cares about is the `MatchedWasms` slice your validator returns — that drives the generic `protocol_wasms.protocol_id` stamp.
@@ -49,7 +49,7 @@ Create a protocol migration SQL file that inserts a row into the `protocols` tab
 
 **File:** `internal/db/migrations/protocols/NNN_<protocol-name>.sql`
 
-Use the next available sequence number. The file is executed by the `protocol-setup` command.
+Use the next available sequence number. A full `migrate up` runs this file so the protocol is registered before live ingestion restarts; `protocol-setup` also re-runs it as an idempotent safeguard.
 
 ```sql
 INSERT INTO protocols (id) VALUES ('<PROTOCOL_ID>') ON CONFLICT (id) DO NOTHING;
@@ -534,37 +534,26 @@ func NewModels(db db.ConnectionPool, metricsService metrics.MetricsService) (*Mo
 
 For full command reference with all flags and options, see [Running a Data Migration](./running-a-data-migration.md).
 
-Once the code is deployed, run the 4-step protocol onboarding workflow. Steps 2, 3a, and 3b run concurrently.
+Once the code is deployed, run the workflow below. Restart ingestion **before** `protocol-setup` so live ingestion classifies new-protocol WASMs immediately; `protocol-setup` then drains the pre-existing backlog. Steps 7.4a and 7.4b run concurrently with each other and with live ingestion.
 
 ```
-  Step 1: Setup             Steps 2, 3a, 3b: Run Concurrently
-+--------------------+     +----------------------------------------------+
-| protocol-setup     |---->| Live ingestion (restart with new processor)  |
-| --protocol-id X    |     | protocol-migrate history --protocol-id X    |
-| Classifies         |     | protocol-migrate current-state --protocol-  |
-| existing contracts |     |   id X --start-ledger N                     |
-+--------------------+     +----------------------------------------------+
+  Step 7.1         Step 7.2              Step 7.3              Step 7.4 (concurrent)
+  migrate up  ──>  restart ingestion ──> protocol-setup  ──>  protocol-migrate history
+  (schema +        (classifies new       (classifies           protocol-migrate current-state
+   registration)    WASMs inline)         existing backlog)    (converge w/ live ingestion via CAS)
 ```
 
-### Step 7.1: Protocol Setup
+### Step 7.1: Schema Migration
 
-Classifies existing contracts on the network by handing each protocol's validator the batch of unclassified WASMs:
+Apply pending schema migrations. A full `migrate up` also registers your protocol in the `protocols` table, so live ingestion can classify its WASMs as soon as it restarts:
 
 ```bash
-./wallet-backend protocol-setup --protocol-id <PROTOCOL_ID>
+./wallet-backend migrate up
 ```
-
-This:
-- Runs your protocol migration SQL (registers the protocol in the `protocols` table)
-- Fetches all unclassified WASM bytecodes via RPC
-- Calls each registered validator's `Validate` (your code) inside one DB tx
-- Stamps `protocol_wasms.protocol_id` from the returned matches and lets your validator write to its own tables in the same tx
-- Sets `classification_status = success`
-- Initializes both CAS cursors
 
 ### Step 7.2: Restart Live Ingestion
 
-Restart the ingestion service. It picks up the new processor automatically via the registry:
+Restart the ingestion service. It picks up the new processor automatically via the registry and, because the protocol is now registered, classifies new-protocol WASMs inline from the moment it restarts:
 
 ```bash
 ./wallet-backend ingest
@@ -572,7 +561,23 @@ Restart the ingestion service. It picks up the new processor automatically via t
 
 Live ingestion uses CAS cursors to coordinate with the migration subcommands. It only produces state for ledgers where the migration hasn't already written data.
 
-### Step 7.3a: History Migration
+### Step 7.3: Protocol Setup
+
+Classifies the existing unclassified WASMs already recorded in `protocol_wasms` by handing each protocol's validator the batch of unclassified bytecodes:
+
+```bash
+./wallet-backend protocol-setup --protocol-id <PROTOCOL_ID>
+```
+
+This:
+- Fetches all unclassified WASM bytecodes via RPC
+- Calls each registered validator's `Validate` (your code) inside one DB tx
+- Stamps `protocol_wasms.protocol_id` from the returned matches and lets your validator write to its own tables in the same tx
+- Sets `classification_status = success`
+- Initializes both CAS cursors
+- Re-runs your protocol registration SQL as an idempotent safeguard
+
+### Step 7.4a: History Migration
 
 Backfills historical state changes within the retention window:
 
@@ -582,7 +587,7 @@ Backfills historical state changes within the retention window:
 
 Walks forward from the oldest ingestion cursor to the latest, calling `PersistHistory` at each ledger. Converges with live ingestion via the history CAS cursor. When the migration's CAS fails (cursor already advanced by live ingestion), it sets `history_migration_status = success` and exits.
 
-### Step 7.3b: Current-State Migration(if your protocol tracks current-state data)
+### Step 7.4b: Current-State Migration (if your protocol tracks current-state data)
 
 Builds current state from a specified start ledger forward to the tip:
 

--- a/docs/data-migrations/running-a-data-migration.md
+++ b/docs/data-migrations/running-a-data-migration.md
@@ -4,7 +4,7 @@ This guide covers the commands for running the data migration workflow after a n
 
 ## Prerequisites
 
-- A running PostgreSQL database with schema migrations applied
+- A running PostgreSQL database
 - A running Stellar RPC instance
 - The protocol code (validator, processor, registration) is compiled into the binary
 
@@ -19,31 +19,45 @@ Infrastructure config (`--database-url`, `--rpc-url`, `--network-passphrase`, et
 
 ## Migration Workflow
 
-The migration runs in two phases: a setup step, then three concurrent processes.
+The workflow runs in order: apply schema migrations, restart ingestion, then classify the backlog and backfill state. Restarting ingestion **before** `protocol-setup` is deliberate — live ingestion starts classifying new-protocol WASMs the moment it restarts, so no deployment can slip through the window between `protocol-setup`'s backlog snapshot and ingestion picking up the new validator.
 
 ```
-Phase 1 (sequential)          Phase 2 (concurrent)
-┌─────────────────────┐       ┌──────────────────────────────────────────────┐
-│ 1. protocol-setup   │──────>│ 2.  Restart live ingestion                  │
-│                     │       │ 3a. protocol-migrate history                │
-│                     │       │ 3b. protocol-migrate current-state          │
-└─────────────────────┘       └──────────────────────────────────────────────┘
+Step 1             Step 2                Step 3                Step 4 (concurrent)
+migrate up   ───>  restart ingestion ──> protocol-setup  ───>  protocol-migrate history
+(schema +          (classifies new       (classifies            protocol-migrate current-state
+ registration)      WASMs inline)         existing backlog)     (converge with live ingestion via CAS)
 ```
 
-### Step 1: Protocol Setup
+### Step 1: Schema Migration
 
-Classifies existing contracts on the network against your protocol's validator. This must complete before starting the other steps.
+Apply pending schema migrations. A full `migrate up` also registers the new protocol in the `protocols` table, so live ingestion can classify the protocol's WASMs as soon as it restarts.
+
+```bash
+go run main.go migrate up
+```
+
+This applies pending schema migrations from `internal/db/migrations/` and runs the idempotent protocol registration SQL from `internal/db/migrations/protocols/`. Partial runs (`migrate up N`) skip protocol registration, since the `protocols` table may not exist yet.
+
+### Step 2: Restart Live Ingestion
+
+Restart the ingestion service so it picks up the new protocol processor from the registry. No special flags are needed -- just restart the existing `ingest` process with its current configuration. Because Step 1 registered the protocol, ingestion classifies new-protocol WASMs inline from the moment it restarts.
+
+Live ingestion uses CAS cursors to coordinate with the migration subcommands. It only produces state for ledgers where the migration hasn't already written data. Once the history and current-state migrations converge with live ingestion (their CAS operations start failing because live ingestion has already advanced the cursor), they exit automatically.
+
+### Step 3: Protocol Setup
+
+Classifies the existing unclassified WASMs already recorded in `protocol_wasms` -- the backlog ingestion captured before the new validator existed. Running it after the ingestion restart makes the two classification windows overlap: live ingestion covers everything from the restart forward, `protocol-setup` covers the backlog up to its snapshot, and there is no gap between them.
 
 ```bash
 go run main.go protocol-setup --protocol-id <PROTOCOL_ID>
 ```
 
 What it does:
-- Runs protocol migration SQL (registers the protocol in the `protocols` table)
 - Fetches all unclassified WASM bytecodes from the network via RPC
 - Validates each WASM against registered protocol validators
 - Populates `protocol_wasms` and `protocol_contracts` tables
 - Initializes CAS cursors for both history and current-state migrations
+- Re-runs the protocol registration SQL as an idempotent safeguard, so the command remains self-sufficient if run standalone
 
 You can set up multiple protocols at once:
 
@@ -51,13 +65,7 @@ You can set up multiple protocols at once:
 go run main.go protocol-setup --protocol-id SEP41 --protocol-id BLEND
 ```
 
-### Step 2: Restart Live Ingestion
-
-Restart the ingestion service so it picks up the new protocol processor from the registry. No special flags are needed -- just restart the existing `ingest` process with its current configuration.
-
-Live ingestion uses CAS cursors to coordinate with the migration subcommands. It only produces state for ledgers where the migration hasn't already written data. Once the history and current-state migrations converge with live ingestion (their CAS operations start failing because live ingestion has already advanced the cursor), they exit automatically.
-
-### Step 3a: History Migration
+### Step 4a: History Migration
 
 Backfills historical state changes within the retention window:
 
@@ -78,7 +86,7 @@ Optional flags:
 | `--latest-ledger-cursor-name` | `latest_ingest_ledger` | Name of the latest ledger cursor in the ingest store. Must match the value used by the ingest service. |
 | `--oldest-ledger-cursor-name` | `oldest_ingest_ledger` | Name of the oldest ledger cursor in the ingest store. Must match the value used by the ingest service. |
 
-### Step 3b: Current-State Migration
+### Step 4b: Current-State Migration
 
 Builds current state from a specified start ledger forward to the tip. Only needed if your protocol tracks current-state data.
 
@@ -103,13 +111,3 @@ All three concurrent processes (live ingestion, history migration, current-state
 - **CAS convergence**: When a migration process logs that its CAS operation failed, it means live ingestion has caught up to that point. The migration will exit with a success status.
 - **Protocol status transitions**: Each protocol tracks `history_migration_status` and `current_state_migration_status` in the `protocols` table. These transition from `not_started` -> `in_progress` -> `success`.
 - **Error recovery**: If a migration process crashes, it can be safely restarted. It will resume from the last CAS cursor position.
-
-## Database Schema Migration
-
-Before running the data migration workflow, ensure the database schema is up to date:
-
-```bash
-go run main.go migrate up
-```
-
-This applies any pending schema migrations from `internal/db/migrations/`. The `protocol-setup` command handles protocol-specific migrations (from `internal/db/migrations/protocols/`) automatically.

--- a/docs/feature-design/data-migrations.md
+++ b/docs/feature-design/data-migrations.md
@@ -118,29 +118,29 @@ CREATE TABLE protocol_wasms (
 
 ## Overview
 
-Adding a new protocol requires four coordinated processes:
+Adding a new protocol runs a schema migration, then coordinates live ingestion with classification and two backfill migrations:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────────┐
 │                      PROTOCOL ONBOARDING WORKFLOW                               │
 └─────────────────────────────────────────────────────────────────────────────────┘
 
-   STEP 1: SETUP             STEP 2: LIVE INGESTION
-┌──────────────────────┐    ┌──────────────────────┐
-│ ./wallet-backend     │    │ Restart ingestion    │
-│ protocol-setup       │───▶│ with new processor   │
-│                      │    │                      │
-│ Classifies existing  │    │ Produces state from  │
-│ contracts            │    │ restart ledger onward│
-└──────────────────────┘    └──────────┬───────────┘
+  STEP 1: MIGRATE UP        STEP 2: RESTART INGEST    STEP 3: PROTOCOL-SETUP
+┌──────────────────────┐  ┌──────────────────────┐  ┌──────────────────────┐
+│ ./wallet-backend     │  │ Restart ingestion    │  │ ./wallet-backend     │
+│ migrate up           │─▶│ with new processor   │─▶│ protocol-setup       │
+│                      │  │                      │  │                      │
+│ Applies schema +     │  │ Classifies new WASMs │  │ Classifies existing  │
+│ registers protocol   │  │ inline; makes state  │  │ unclassified backlog │
+└──────────────────────┘  └────────────┬─────────┘  └──────────────────────┘
                                        │
-                 Steps 2, 3a, and 3b run concurrently
+          Step 4 (history + current-state) runs concurrently with live ingestion
                                        │
                     ┌──────────────────┼──────────────────┐
                     │                  │                  │
                     ▼                  ▼                  ▼
           ┌──────────────────┐  ┌──────────────┐  ┌──────────────────┐
-          │ Live ingestion:  │  │ STEP 3a:     │  │ STEP 3b:         │
+          │ Live ingestion:  │  │ STEP 4a:     │  │ STEP 4b:         │
           │ state changes    │  │ HISTORY      │  │ CURRENT-STATE    │
           │ after history    │  │ MIGRATION    │  │ MIGRATION        │
           │ convergence,     │  │              │  │                  │
@@ -173,18 +173,19 @@ Adding a new protocol requires four coordinated processes:
 
 | Step | Requires | Produces |
 |------|----------|----------|
-| **1. protocol-setup** | Protocol migration SQL file, protocol implementation in code | Protocol in DB, `protocol_wasms`, `protocol_contracts`, `classification_status = success`, both cursors initialized |
-| **2. ingest (live)** | `classification_status = success`, processor registered | State changes after history convergence (history cursor). Current state after current-state convergence (current-state cursor). |
-| **3a. protocol-migrate history** | `classification_status = success` | Protocol state changes within retention window, through convergence with live ingestion |
-| **3b. protocol-migrate current-state** | `classification_status = success` | Current state from `start_ledger` through convergence with live ingestion |
+| **1. migrate up** | Protocol migration SQL file, protocol implementation in code | Schema applied; protocol registered in the `protocols` table |
+| **2. ingest (live)** | Protocol registered, processor registered | Records and classifies new WASMs inline; produces protocol state, converging with the backfill migrations via CAS cursors |
+| **3. protocol-setup** | Protocol registered (from `migrate up`) | `protocol_wasms` / `protocol_contracts` classified, `classification_status = success`, both cursors initialized |
+| **4a. protocol-migrate history** | `protocol_contracts` populated (from `protocol-setup`) | Protocol state changes within retention window, through convergence with live ingestion |
+| **4b. protocol-migrate current-state** | `protocol_contracts` populated (from `protocol-setup`) | Current state from `start_ledger` through convergence with live ingestion |
 
-Steps 2, 3a, and 3b run **concurrently**. Each migration subcommand converges independently with live ingestion via its own CAS cursor:
+Steps 4a and 4b run **concurrently** with live ingestion, after `protocol-setup`. Each migration subcommand converges independently with live ingestion via its own CAS cursor:
 - History migration converges via `protocol_{ID}_history_cursor` — when its CAS fails, live ingestion owns state change production
 - Current-state migration converges via `protocol_{ID}_current_state_cursor` — when its CAS fails, live ingestion owns current state production
 
 The two subcommands are fully independent. They write to different tables, use different CAS cursors, and track different status columns. They can run in any order, concurrently, or only one can be run.
 
-Both live ingestion and backfill migration need the `protocol_contracts` table populated to know which contracts to process. The `protocol-setup` command ensures this data exists before either process runs.
+The backfill migrations (`protocol-migrate history` / `current-state`) need the `protocol_contracts` table populated to know which contracts to process, so they run after `protocol-setup`. Live ingestion does not wait for `protocol-setup`: it classifies new WASMs and populates `protocol_contracts` inline as deployments arrive, which is why it restarts first.
 
 ## Classification
 Classification is the act of identifying new and existing contracts on the network and assigning a relationship to a known protocol.
@@ -581,7 +582,7 @@ Backfill migrations rely on checkpoint population being complete before they can
 
 ### What It Does
 
-1. **Runs protocol migrations** - Executes SQL migrations from `internal/data/migrations/protocols/` to register new protocols in the `protocols` table with status `not_started`
+1. **Runs protocol migrations** - Executes SQL migrations from `internal/db/migrations/protocols/` to register new protocols in the `protocols` table with status `not_started`
 2. **Sets status** to `classification_in_progress` for specified protocols
 3. **Queries existing unclassified entries** from `protocol_wasms WHERE protocol_id IS NULL`
 4. **Gets bytecode** from all unknown contracts using RPC
@@ -593,16 +594,16 @@ Backfill migrations rely on checkpoint population being complete before they can
 
 ### Protocol Migration Files
 
-Protocol registrations are defined as SQL migration files in `internal/data/migrations/protocols/`:
+Protocol registrations are defined as SQL migration files in `internal/db/migrations/protocols/`:
 
 ```
-internal/data/migrations/protocols/
+internal/db/migrations/protocols/
 ├── 001_sep50.sql
 ├── 002_blend.sql
 └── 003_aqua.sql
 ```
 
-These migrations are tracked separately from the main schema migrations, allowing `protocol-setup` to run them independently.
+These files are idempotent (`INSERT ... ON CONFLICT DO NOTHING`) and live outside the tracked schema-migration table. A full `migrate up` runs them after the schema migrations, so protocols are registered before live ingestion restarts; `protocol-setup` also re-runs them as a safeguard.
 
 ### Explicit Protocol Selection
 


### PR DESCRIPTION
A full `migrate up` now registers protocols (idempotent), so a `migrate up && ingest` deploy can restart ingestion **before** `protocol-setup`. Live ingestion then classifies new-protocol WASMs inline from the restart, closing the gap where deploys landing between `protocol-setup`'s backlog snapshot and the ingestion restart were never classified.

- `cmd/migrate.go`: run `RunProtocolMigrations` after a full `migrate up` (skipped on partial `migrate up N`; never on `down`)
- Docs: reorder the workflow to `migrate up → restart ingest → protocol-setup → history/current-state`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
