### PR TITLE
feat(graphql): expose deployer address on contract-deploy AccountChange state changes

### DIFF
--- a/internal/integrationtests/data_validation_test.go
+++ b/internal/integrationtests/data_validation_test.go
@@ -151,6 +151,17 @@ func validateAccountChange(suite *DataValidationTestSuite, ac *types.AccountChan
 	suite.Require().Equal(expectedFunderAddress, *ac.FunderAddress, "funder address mismatch")
 }
 
+// validateDeployAccountChange validates a contract-deploy account state change (ACCOUNT/CREATE),
+// which carries a deployer address and no funder address.
+func validateDeployAccountChange(suite *DataValidationTestSuite, ac *types.AccountChange, expectedDeployerAddress string) {
+	suite.Require().NotNil(ac, "account change should not be nil")
+	suite.Require().Equal(types.StateChangeCategoryAccount, ac.GetType(), "should be ACCOUNT type")
+	suite.Require().Equal(types.StateChangeReasonCreate, ac.GetReason(), "reason mismatch")
+	suite.Require().NotNil(ac.DeployerAddress, "deployer address should not be nil")
+	suite.Require().Equal(expectedDeployerAddress, *ac.DeployerAddress, "deployer address mismatch")
+	suite.Require().Nil(ac.FunderAddress, "funder address should be nil for a contract deploy")
+}
+
 // validateSignerChange validates a signer state change
 func validateSignerChange(suite *DataValidationTestSuite, sc *types.SignerChange, expectedSignerAddress string, expectedSignerWeights int32, expectedReason types.StateChangeReason) {
 	suite.Require().NotNil(sc, "signer change should not be nil")
@@ -1108,6 +1119,35 @@ func (suite *DataValidationTestSuite) validateInvokeContractStateChanges(ctx con
 	suite.Require().Len(balanceDebitChanges.Edges, 1, "should have exactly 1 BALANCE/DEBIT change")
 	balanceDebitChange := balanceDebitChanges.Edges[0].Node.(*types.StandardBalanceChange)
 	validateBalanceChange(suite, balanceDebitChange, xlmContractAddress, "100000000", types.StateChangeReasonDebit)
+}
+
+func (suite *DataValidationTestSuite) TestDeployContractOpsDataValidation() {
+	ctx := context.Background()
+	log.Ctx(ctx).Info("🔍 Validating contract-deploy operation data...")
+
+	useCase := infrastructure.FindUseCase(suite.testEnv.UseCases, "Soroban/deployContractOp")
+	suite.Require().NotNil(useCase, "deployContractOp use case not found")
+	suite.Require().NotEmpty(useCase.GetTransactionResult.Hash, "transaction hash should not be empty")
+
+	txHash := useCase.GetTransactionResult.Hash
+	tx := validateTransactionBase(suite, ctx, txHash)
+
+	// The deploy change's account is the contract ID, not the deployer, so fetch by tx hash.
+	first := int32(15)
+	stateChanges, err := suite.testEnv.WBClient.GetTransactionStateChanges(ctx, txHash, &first, nil, nil, nil)
+	suite.Require().NoError(err, "failed to get transaction state changes")
+	suite.Require().NotNil(stateChanges, "state changes should not be nil")
+
+	// Validate base fields on every change and locate the ACCOUNT/CREATE deploy change in one pass.
+	var deployChange *types.AccountChange
+	for _, edge := range stateChanges.Edges {
+		validateStateChangeBase(suite, edge.Node, int64(tx.LedgerNumber))
+		if ac, ok := edge.Node.(*types.AccountChange); ok && ac.GetReason() == types.StateChangeReasonCreate {
+			deployChange = ac
+		}
+	}
+	suite.Require().NotNil(deployChange, "expected an ACCOUNT/CREATE contract-deploy state change")
+	validateDeployAccountChange(suite, deployChange, suite.testEnv.PrimaryAccountKP.Address())
 }
 
 func (suite *DataValidationTestSuite) TestCreateClaimableBalanceOpsDataValidation() {

--- a/internal/integrationtests/infrastructure/fixtures.go
+++ b/internal/integrationtests/infrastructure/fixtures.go
@@ -67,6 +67,7 @@ type Fixtures struct {
 	SEP41ContractAddress  string
 	USDCContractAddress   string
 	MasterAccountKP       *keypair.Full
+	HolderWasmHash        xdr.Hash
 }
 
 func NewFixtures(
@@ -83,6 +84,7 @@ func NewFixtures(
 	eurcContractAddress string,
 	sep41ContractAddress string,
 	usdcContractAddress string,
+	holderWasmHash xdr.Hash,
 ) (*Fixtures, error) {
 	return &Fixtures{
 		NetworkPassphrase:     networkPassphrase,
@@ -97,6 +99,7 @@ func NewFixtures(
 		EURCContractAddress:   eurcContractAddress,
 		SEP41ContractAddress:  sep41ContractAddress,
 		USDCContractAddress:   usdcContractAddress,
+		HolderWasmHash:        holderWasmHash,
 	}, nil
 }
 
@@ -834,6 +837,53 @@ func (f *Fixtures) createInvokeContractOp(sourceAccountKP *keypair.Full) (txnbui
 	return invokeXLMTransferSAC, nil
 }
 
+// prepareDeployContractOp creates a from-address CreateContractV2 deploy of the holder WASM with the
+// PrimaryAccount as deployer, producing an ACCOUNT/CREATE state change that carries deployerAddress.
+func (f *Fixtures) prepareDeployContractOp(ctx context.Context) (opXDR string, txSigners *Set[*keypair.Full], simulationResponse entities.RPCSimulateTransactionResult, err error) {
+	deployerSCAddress, err := SCAccountID(f.PrimaryAccountKP.Address())
+	if err != nil {
+		return "", nil, entities.RPCSimulateTransactionResult{}, fmt.Errorf("building deployer address: %w", err)
+	}
+
+	// Random salt so each deployment yields a unique contract address.
+	salt := make([]byte, 32)
+	if _, err = rand.Read(salt); err != nil {
+		return "", nil, entities.RPCSimulateTransactionResult{}, fmt.Errorf("generating salt: %w", err)
+	}
+	var saltHash xdr.Uint256
+	copy(saltHash[:], salt)
+
+	wasmHash := f.HolderWasmHash
+	deployOp := txnbuild.InvokeHostFunction{
+		HostFunction: xdr.HostFunction{
+			Type: xdr.HostFunctionTypeHostFunctionTypeCreateContractV2,
+			CreateContractV2: &xdr.CreateContractArgsV2{
+				ContractIdPreimage: xdr.ContractIdPreimage{
+					Type: xdr.ContractIdPreimageTypeContractIdPreimageFromAddress,
+					FromAddress: &xdr.ContractIdPreimageFromAddress{
+						Address: deployerSCAddress,
+						Salt:    saltHash,
+					},
+				},
+				Executable: xdr.ContractExecutable{
+					Type:     xdr.ContractExecutableTypeContractExecutableWasm,
+					WasmHash: &wasmHash,
+				},
+				ConstructorArgs: []xdr.ScVal{},
+			},
+		},
+	}
+
+	opXDR, simulationResponse, err = f.prepareSimulateAndSignContractOp(ctx, deployOp, f.PrimaryAccountKP)
+	if err != nil {
+		return "", nil, entities.RPCSimulateTransactionResult{}, fmt.Errorf("preparing simulate and sign deploy operation: %w", err)
+	}
+
+	// Deployer auth is carried in the signed Soroban auth entries; only the tx source account
+	// (added at submission time) needs to sign the envelope.
+	return opXDR, NewSet[*keypair.Full](), simulationResponse, nil
+}
+
 // prepareSimulateAndSignContractOp processes a raw contractInvokeOp and returns a signed version along with its simulation result.
 // The function performs two simulations:
 // 1. The first simulation retrieves the authorization entries and the initial simulation result.
@@ -1382,6 +1432,18 @@ func (f *Fixtures) appendSorobanUseCases(ctx context.Context, useCases []*UseCas
 		return nil, fmt.Errorf("preparing SEP-41 transfer operation: %w", err)
 	}
 	useCase, err = f.buildSorobanUseCase(sep41TransferOpXDR, sep41TransferSigners, simulationResponse, "sep41TransferOp", timeoutSeconds)
+	if err != nil {
+		return nil, err
+	}
+	useCases = append(useCases, useCase)
+
+	// Contract deployment (from-address) — produces an ACCOUNT/CREATE deploy state change whose
+	// deployerAddress is the PrimaryAccount.
+	deployOpXDR, deploySigners, simulationResponse, err := f.prepareDeployContractOp(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("preparing deploy contract operation: %w", err)
+	}
+	useCase, err = f.buildSorobanUseCase(deployOpXDR, deploySigners, simulationResponse, "deployContractOp", timeoutSeconds)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/integrationtests/infrastructure/main_setup.go
+++ b/internal/integrationtests/infrastructure/main_setup.go
@@ -64,6 +64,10 @@ type SharedContainers struct {
 	// but can receive and hold balances from both SAC and SEP-41 tokens.
 	// Used for testing C-address token balances.
 	holderContractAddress string
+	// holderWasmHash is the WASM hash of the uploaded holder contract. It is reused to deploy a
+	// fresh contract instance as a submitted use case so the contract-deploy state change
+	// (ACCOUNT/CREATE with a deployer) gets ingested and can be validated.
+	holderWasmHash xdr.Hash
 }
 
 // initializeContainerInfrastructure sets up Docker network and core infrastructure containers.
@@ -237,6 +241,7 @@ func (s *SharedContainers) setupContracts(ctx context.Context, t *testing.T, dir
 		return fmt.Errorf("reading holder contract WASM file: %w", err)
 	}
 	holderWasmHash := s.uploadContractWasm(ctx, t, holderWasmBytes)
+	s.holderWasmHash = holderWasmHash
 	log.Ctx(ctx).Infof("✅ Uploaded holder contract WASM with hash: %x", holderWasmHash)
 
 	s.holderContractAddress = s.deployContractWithConstructor(ctx, t, holderWasmHash, []xdr.ScVal{})
@@ -595,6 +600,7 @@ func NewTestEnvironment(ctx context.Context, containers *SharedContainers) (*Tes
 		containers.eurcContractAddress,
 		containers.sep41ContractAddress,
 		containers.usdcContractAddress,
+		containers.holderWasmHash,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/serve/graphql/generated/generated.go
+++ b/internal/serve/graphql/generated/generated.go
@@ -61,6 +61,7 @@ type ComplexityRoot struct {
 
 	AccountChange struct {
 		Account         func(childComplexity int) int
+		DeployerAddress func(childComplexity int) int
 		FunderAddress   func(childComplexity int) int
 		IngestedAt      func(childComplexity int) int
 		LedgerCreatedAt func(childComplexity int) int
@@ -356,6 +357,7 @@ type AccountChangeResolver interface {
 	Operation(ctx context.Context, obj *types.AccountStateChangeModel) (*types.Operation, error)
 	Transaction(ctx context.Context, obj *types.AccountStateChangeModel) (*types.Transaction, error)
 	FunderAddress(ctx context.Context, obj *types.AccountStateChangeModel) (*string, error)
+	DeployerAddress(ctx context.Context, obj *types.AccountStateChangeModel) (*string, error)
 }
 type AccountTransactionEdgeResolver interface {
 	Operations(ctx context.Context, obj *types.AccountTransactionEdge) ([]*types.Operation, error)
@@ -550,6 +552,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.AccountChange.Account(childComplexity), true
+	case "AccountChange.deployerAddress":
+		if e.ComplexityRoot.AccountChange.DeployerAddress == nil {
+			break
+		}
+
+		return e.ComplexityRoot.AccountChange.DeployerAddress(childComplexity), true
 	case "AccountChange.funderAddress":
 		if e.ComplexityRoot.AccountChange.FunderAddress == nil {
 			break
@@ -2231,6 +2239,7 @@ type AccountChange implements BaseStateChange {
   transaction:                Transaction! @goField(forceResolver: true)
 
   funderAddress:              String @goField(forceResolver: true)
+  deployerAddress:            String @goField(forceResolver: true)
 }
 
 type SignerChange implements BaseStateChange {
@@ -3354,6 +3363,35 @@ func (ec *executionContext) _AccountChange_funderAddress(ctx context.Context, fi
 }
 
 func (ec *executionContext) fieldContext_AccountChange_funderAddress(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AccountChange",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AccountChange_deployerAddress(ctx context.Context, field graphql.CollectedField, obj *types.AccountStateChangeModel) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_AccountChange_deployerAddress,
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.AccountChange().DeployerAddress(ctx, obj)
+		},
+		nil,
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_AccountChange_deployerAddress(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "AccountChange",
 		Field:      field,
@@ -11739,6 +11777,39 @@ func (ec *executionContext) _AccountChange(ctx context.Context, sel ast.Selectio
 					}
 				}()
 				res = ec._AccountChange_funderAddress(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "deployerAddress":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._AccountChange_deployerAddress(ctx, field, obj)
 				return res
 			}
 

--- a/internal/serve/graphql/resolvers/statechange.resolvers.go
+++ b/internal/serve/graphql/resolvers/statechange.resolvers.go
@@ -43,6 +43,11 @@ func (r *accountChangeResolver) FunderAddress(ctx context.Context, obj *types.Ac
 	return r.resolveNullableAddress(obj.FunderAccountID), nil
 }
 
+// DeployerAddress is the resolver for the deployerAddress field.
+func (r *accountChangeResolver) DeployerAddress(ctx context.Context, obj *types.AccountStateChangeModel) (*string, error) {
+	return r.resolveNullableAddress(obj.DeployerAccountID), nil
+}
+
 // Type is the resolver for the type field.
 func (r *balanceAuthorizationChangeResolver) Type(ctx context.Context, obj *types.BalanceAuthorizationStateChangeModel) (types.StateChangeCategory, error) {
 	return obj.StateChangeCategory, nil

--- a/internal/serve/graphql/resolvers/statechange_resolvers_test.go
+++ b/internal/serve/graphql/resolvers/statechange_resolvers_test.go
@@ -224,6 +224,38 @@ func TestStateChangeResolver_TypedFields(t *testing.T) {
 	})
 }
 
+func TestStateChangeResolver_AccountAddressFields(t *testing.T) {
+	ctx := context.Background()
+	resolver := &accountChangeResolver{&Resolver{}}
+
+	t.Run("funder and deployer populated", func(t *testing.T) {
+		obj := &types.AccountStateChangeModel{
+			StateChange: types.StateChange{
+				FunderAccountID:   types.NullAddressBytea{AddressBytea: types.AddressBytea(sharedTestAccountAddress), Valid: true},
+				DeployerAccountID: types.NullAddressBytea{AddressBytea: types.AddressBytea(sharedTestAccountAddress), Valid: true},
+			},
+		}
+
+		funder, err := resolver.FunderAddress(ctx, obj)
+		require.NoError(t, err)
+		require.NotNil(t, funder)
+		assert.Equal(t, sharedTestAccountAddress, *funder)
+
+		deployer, err := resolver.DeployerAddress(ctx, obj)
+		require.NoError(t, err)
+		require.NotNil(t, deployer)
+		assert.Equal(t, sharedTestAccountAddress, *deployer)
+	})
+
+	t.Run("classic account change and deployerAddress is null", func(t *testing.T) {
+		obj := &types.AccountStateChangeModel{}
+
+		deployer, err := resolver.DeployerAddress(ctx, obj)
+		require.NoError(t, err)
+		assert.Nil(t, deployer)
+	})
+}
+
 func TestStateChangeResolver_Account(t *testing.T) {
 	resolver := &standardBalanceChangeResolver{&Resolver{}}
 

--- a/internal/serve/graphql/resolvers/utils.go
+++ b/internal/serve/graphql/resolvers/utils.go
@@ -248,6 +248,8 @@ func getDBColumns(model any, fields []graphql.CollectedField) []string {
 			fieldName = "signerAccountId"
 		case "funderAddress":
 			fieldName = "funderAccountId"
+		case "deployerAddress":
+			fieldName = "deployerAccountId"
 		case "limit":
 			// GraphQL "limit" field requires both old and new trustline limit columns
 			dbColumns = append(dbColumns, "trustline_limit_old", "trustline_limit_new")

--- a/internal/serve/graphql/schema/statechange.graphqls
+++ b/internal/serve/graphql/schema/statechange.graphqls
@@ -45,6 +45,7 @@ type AccountChange implements BaseStateChange {
   transaction:                Transaction! @goField(forceResolver: true)
 
   funderAddress:              String @goField(forceResolver: true)
+  deployerAddress:            String @goField(forceResolver: true)
 }
 
 type SignerChange implements BaseStateChange {

--- a/pkg/wbclient/queries.go
+++ b/pkg/wbclient/queries.go
@@ -50,6 +50,7 @@ const (
 		}
 		... on AccountChange {
 			funderAddress
+			deployerAddress
 		}
 		... on SignerChange {
 			signerAddress

--- a/pkg/wbclient/types/statechange.go
+++ b/pkg/wbclient/types/statechange.go
@@ -61,7 +61,8 @@ type StandardBalanceChange struct {
 // AccountChange represents an account state change
 type AccountChange struct {
 	BaseStateChangeFields
-	FunderAddress *string `json:"funderAddress,omitempty"`
+	FunderAddress   *string `json:"funderAddress,omitempty"`
+	DeployerAddress *string `json:"deployerAddress,omitempty"`
 }
 
 // SignerChange represents a signer state change


### PR DESCRIPTION
Closes #632 

### What

Add a deployerAddress field to AccountChange:
- schema: deployerAddress on AccountChange
- resolver: resolves from DeployerAccountID
- getDBColumns: map deployerAddress -> deployer_account_id so the column is selected
- regenerate gqlgen
- wbclient: add deployerAddress to the AccountChange fragment + struct

### Why

For contract deployments, the deployer is stored but invisible through the API

### Known limitations

N/A

### Issue that this PR addresses

https://github.com/stellar/wallet-backend/issues/626

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
