### PR TITLE
feat(balances): add liquidity-pool share balances

### DIFF
--- a/internal/data/liquidity_pool_balances.go
+++ b/internal/data/liquidity_pool_balances.go
@@ -1,0 +1,238 @@
+// Package data provides data access layer for liquidity pool balance operations.
+// This file handles PostgreSQL storage of account liquidity-pool share balances.
+package data
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+	"github.com/stellar/wallet-backend/internal/utils"
+)
+
+// LiquidityPoolBalance holds an account's pool-share balance together with the pool's reserves
+// (constituent assets + amounts) from the JOIN with liquidity_pools.
+type LiquidityPoolBalance struct {
+	AccountID    types.AddressBytea `db:"account_id"`
+	PoolID       string             `db:"pool_id"`
+	Shares       int64              `db:"shares"`
+	LedgerNumber uint32             `db:"last_modified_ledger"`
+	// Pool reserves from JOIN with liquidity_pools:
+	AssetA  string `db:"asset_a"`  // Canonical asset A ("native" or "CODE:ISSUER")
+	AmountA int64  `db:"amount_a"` // Reserve of asset A
+	AssetB  string `db:"asset_b"`  // Canonical asset B ("native" or "CODE:ISSUER")
+	AmountB int64  `db:"amount_b"` // Reserve of asset B
+}
+
+// LiquidityPoolBalanceModelInterface defines the interface for liquidity pool balance operations.
+type LiquidityPoolBalanceModelInterface interface {
+	// GetByAccount returns an account's pool-share balances ordered by pool_id, JOINed with
+	// liquidity_pools for reserves. Pass nil limit/cursor to fetch all rows, or provide them
+	// for keyset pagination (the cursor is the last seen pool_id from the previous page).
+	GetByAccount(ctx context.Context, accountAddress string, limit *int32, cursor *string, sortOrder SortOrder) ([]LiquidityPoolBalance, error)
+
+	// Write operations (for live ingestion)
+	BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts []LiquidityPoolBalance, deletes []LiquidityPoolBalance) error
+
+	// Batch operations (for initial population)
+	BatchCopy(ctx context.Context, dbTx pgx.Tx, balances []LiquidityPoolBalance) error
+}
+
+// LiquidityPoolBalanceModel implements LiquidityPoolBalanceModelInterface.
+type LiquidityPoolBalanceModel struct {
+	DB      *pgxpool.Pool
+	Metrics *metrics.DBMetrics
+}
+
+var _ LiquidityPoolBalanceModelInterface = (*LiquidityPoolBalanceModel)(nil)
+
+// GetByAccount retrieves an account's pool-share balances ordered by pool_id, JOINed with
+// liquidity_pools for reserves. Pass nil limit/cursor to fetch all rows; provide them for
+// keyset pagination (the cursor is the last seen pool_id from the previous page).
+func (m *LiquidityPoolBalanceModel) GetByAccount(ctx context.Context, accountAddress string, limit *int32, cursor *string, sortOrder SortOrder) ([]LiquidityPoolBalance, error) {
+	if accountAddress == "" {
+		return nil, fmt.Errorf("empty account address")
+	}
+
+	query := `
+		SELECT lpb.account_id, lpb.pool_id, lpb.shares, lpb.last_modified_ledger,
+		       lp.asset_a, lp.amount_a, lp.asset_b, lp.amount_b
+		FROM liquidity_pool_balances lpb
+		INNER JOIN liquidity_pools lp ON lp.pool_id = lpb.pool_id
+		WHERE lpb.account_id = $1`
+	args := []interface{}{types.AddressBytea(accountAddress)}
+	argIndex := 2
+
+	if cursor != nil {
+		// Cursor comparisons implement keyset pagination over the primary key.
+		op := ">"
+		if sortOrder == DESC {
+			op = "<"
+		}
+		query += fmt.Sprintf(" AND lpb.pool_id %s $%d", op, argIndex)
+		args = append(args, *cursor)
+		argIndex++
+	}
+
+	if sortOrder == DESC {
+		query += " ORDER BY lpb.pool_id DESC"
+	} else {
+		query += " ORDER BY lpb.pool_id ASC"
+	}
+
+	if limit != nil {
+		query += fmt.Sprintf(" LIMIT $%d", argIndex)
+		args = append(args, *limit)
+	}
+
+	start := time.Now()
+	balances, err := db.QueryMany[LiquidityPoolBalance](ctx, m.DB, query, args...)
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("GetByAccount", "liquidity_pool_balances").Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("GetByAccount", "liquidity_pool_balances").Inc()
+	if err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("GetByAccount", "liquidity_pool_balances", utils.GetDBErrorType(err)).Inc()
+		return nil, fmt.Errorf("querying paginated liquidity pool balances for %s: %w", accountAddress, err)
+	}
+	return balances, nil
+}
+
+// BatchUpsert performs upserts and deletes using UNNEST for efficiency.
+// For upserts (ADD/UPDATE): inserts or updates the share balance.
+// For deletes (REMOVE): removes the balance row.
+func (m *LiquidityPoolBalanceModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts []LiquidityPoolBalance, deletes []LiquidityPoolBalance) error {
+	if len(upserts) == 0 && len(deletes) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	if len(upserts) > 0 {
+		accountIDs := make([][]byte, len(upserts))
+		poolIDs := make([]string, len(upserts))
+		shares := make([]int64, len(upserts))
+		ledgerNumbers := make([]int64, len(upserts))
+
+		for i, lpb := range upserts {
+			raw, err := lpb.AccountID.Value()
+			if err != nil {
+				return fmt.Errorf("converting account address to bytes for upsert: %w", err)
+			}
+			rawBytes, ok := raw.([]byte)
+			if !ok {
+				return fmt.Errorf("converting account address to bytes for upsert: expected []byte, got %T", raw)
+			}
+			accountIDs[i] = rawBytes
+			poolIDs[i] = lpb.PoolID
+			shares[i] = lpb.Shares
+			ledgerNumbers[i] = int64(lpb.LedgerNumber)
+		}
+
+		const upsertQuery = `
+			INSERT INTO liquidity_pool_balances (
+				account_id, pool_id, shares, last_modified_ledger
+			)
+			SELECT * FROM UNNEST($1::bytea[], $2::text[], $3::bigint[], $4::bigint[])
+			ON CONFLICT (account_id, pool_id) DO UPDATE SET
+				shares = EXCLUDED.shares,
+				last_modified_ledger = EXCLUDED.last_modified_ledger`
+
+		if _, err := dbTx.Exec(ctx, upsertQuery, accountIDs, poolIDs, shares, ledgerNumbers); err != nil {
+			m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", "liquidity_pool_balances").Observe(time.Since(start).Seconds())
+			m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", "liquidity_pool_balances").Inc()
+			m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", "liquidity_pool_balances", utils.GetDBErrorType(err)).Inc()
+			return fmt.Errorf("upserting liquidity pool balances: %w", err)
+		}
+	}
+
+	if len(deletes) > 0 {
+		deleteAccountIDs := make([][]byte, len(deletes))
+		deletePoolIDs := make([]string, len(deletes))
+
+		for i, lpb := range deletes {
+			raw, err := lpb.AccountID.Value()
+			if err != nil {
+				return fmt.Errorf("converting account address to bytes for delete: %w", err)
+			}
+			rawBytes, ok := raw.([]byte)
+			if !ok {
+				return fmt.Errorf("converting account address to bytes for delete: expected []byte, got %T", raw)
+			}
+			deleteAccountIDs[i] = rawBytes
+			deletePoolIDs[i] = lpb.PoolID
+		}
+
+		const deleteQuery = `
+			DELETE FROM liquidity_pool_balances
+			WHERE (account_id, pool_id) IN (
+				SELECT * FROM UNNEST($1::bytea[], $2::text[])
+			)`
+
+		if _, err := dbTx.Exec(ctx, deleteQuery, deleteAccountIDs, deletePoolIDs); err != nil {
+			m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", "liquidity_pool_balances").Observe(time.Since(start).Seconds())
+			m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", "liquidity_pool_balances").Inc()
+			m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", "liquidity_pool_balances", utils.GetDBErrorType(err)).Inc()
+			return fmt.Errorf("deleting liquidity pool balances: %w", err)
+		}
+	}
+
+	m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", "liquidity_pool_balances").Observe(time.Since(start).Seconds())
+	m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", "liquidity_pool_balances").Inc()
+	return nil
+}
+
+// BatchCopy performs bulk insert using COPY protocol for speed during checkpoint population.
+func (m *LiquidityPoolBalanceModel) BatchCopy(ctx context.Context, dbTx pgx.Tx, balances []LiquidityPoolBalance) error {
+	if len(balances) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	copyCount, err := dbTx.CopyFrom(
+		ctx,
+		pgx.Identifier{"liquidity_pool_balances"},
+		[]string{
+			"account_id",
+			"pool_id",
+			"shares",
+			"last_modified_ledger",
+		},
+		pgx.CopyFromSlice(len(balances), func(i int) ([]any, error) {
+			lpb := balances[i]
+			accountIDBytes, err := lpb.AccountID.Value()
+			if err != nil {
+				return nil, fmt.Errorf("converting account address to bytes: %w", err)
+			}
+			return []any{
+				accountIDBytes,
+				lpb.PoolID,
+				lpb.Shares,
+				lpb.LedgerNumber,
+			}, nil
+		}),
+	)
+	if err != nil {
+		m.Metrics.QueryDuration.WithLabelValues("BatchCopy", "liquidity_pool_balances").Observe(time.Since(start).Seconds())
+		m.Metrics.QueriesTotal.WithLabelValues("BatchCopy", "liquidity_pool_balances").Inc()
+		m.Metrics.QueryErrors.WithLabelValues("BatchCopy", "liquidity_pool_balances", utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("batch inserting liquidity pool balances via COPY: %w", err)
+	}
+
+	if int(copyCount) != len(balances) {
+		m.Metrics.QueryDuration.WithLabelValues("BatchCopy", "liquidity_pool_balances").Observe(time.Since(start).Seconds())
+		m.Metrics.QueriesTotal.WithLabelValues("BatchCopy", "liquidity_pool_balances").Inc()
+		m.Metrics.QueryErrors.WithLabelValues("BatchCopy", "liquidity_pool_balances", "row_count_mismatch").Inc()
+		return fmt.Errorf("expected %d rows copied, got %d", len(balances), copyCount)
+	}
+
+	m.Metrics.QueryDuration.WithLabelValues("BatchCopy", "liquidity_pool_balances").Observe(time.Since(start).Seconds())
+	m.Metrics.QueriesTotal.WithLabelValues("BatchCopy", "liquidity_pool_balances").Inc()
+	return nil
+}

--- a/internal/data/liquidity_pool_balances_test.go
+++ b/internal/data/liquidity_pool_balances_test.go
@@ -1,0 +1,293 @@
+// Unit tests for LiquidityPoolBalanceModel and LiquidityPoolModel.
+package data
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+)
+
+// poolIDHex builds a deterministic 64-character hex pool id from a single byte, so
+// ordering in tests is predictable (0x01 < 0x02 < 0x03).
+func poolIDHex(b byte) string {
+	return strings.Repeat(fmt.Sprintf("%02x", b), 32)
+}
+
+func TestLiquidityPoolBalanceModel_GetByAccount(t *testing.T) {
+	ctx := context.Background()
+
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	pool1, pool2, pool3 := poolIDHex(1), poolIDHex(2), poolIDHex(3)
+	_, err = dbConnectionPool.Exec(ctx, `
+		INSERT INTO liquidity_pools (pool_id, asset_a, amount_a, asset_b, amount_b, last_modified_ledger) VALUES
+		($1, 'native', 100, 'USDC:ISSUER1', 200, 10),
+		($2, 'BTC:ISSUER2', 300, 'ETH:ISSUER3', 400, 11),
+		($3, 'native', 500, 'EURC:ISSUER4', 600, 12)
+	`, pool1, pool2, pool3)
+	require.NoError(t, err)
+
+	cleanUpDB := func() {
+		_, err = dbConnectionPool.Exec(ctx, `DELETE FROM liquidity_pool_balances`)
+		require.NoError(t, err)
+	}
+
+	dbMetrics := metrics.NewMetrics(prometheus.NewRegistry()).DB
+	m := &LiquidityPoolBalanceModel{DB: dbConnectionPool, Metrics: dbMetrics}
+
+	t.Run("returns error for empty account address", func(t *testing.T) {
+		balances, err := m.GetByAccount(ctx, "", nil, nil, ASC)
+		require.Error(t, err)
+		require.Nil(t, balances)
+		require.Contains(t, err.Error(), "empty account address")
+	})
+
+	t.Run("returns empty slice for account with no pool shares", func(t *testing.T) {
+		cleanUpDB()
+		balances, err := m.GetByAccount(ctx, keypair.MustRandom().Address(), nil, nil, ASC)
+		require.NoError(t, err)
+		require.Empty(t, balances)
+	})
+
+	t.Run("returns single pool share with reserves from JOIN", func(t *testing.T) {
+		cleanUpDB()
+		accountAddr := keypair.MustRandom().Address()
+		_, err := dbConnectionPool.Exec(ctx, `
+			INSERT INTO liquidity_pool_balances (account_id, pool_id, shares, last_modified_ledger)
+			VALUES ($1, $2, 1000, 12345)
+		`, types.AddressBytea(accountAddr), pool1)
+		require.NoError(t, err)
+
+		balances, err := m.GetByAccount(ctx, accountAddr, nil, nil, ASC)
+		require.NoError(t, err)
+		require.Len(t, balances, 1)
+
+		require.Equal(t, types.AddressBytea(accountAddr), balances[0].AccountID)
+		require.Equal(t, pool1, balances[0].PoolID)
+		require.Equal(t, int64(1000), balances[0].Shares)
+		require.Equal(t, uint32(12345), balances[0].LedgerNumber)
+		// JOINed reserves:
+		require.Equal(t, "native", balances[0].AssetA)
+		require.Equal(t, int64(100), balances[0].AmountA)
+		require.Equal(t, "USDC:ISSUER1", balances[0].AssetB)
+		require.Equal(t, int64(200), balances[0].AmountB)
+	})
+
+	t.Run("omits pool shares with no matching pool row (INNER JOIN)", func(t *testing.T) {
+		cleanUpDB()
+		accountAddr := keypair.MustRandom().Address()
+		_, err := dbConnectionPool.Exec(ctx, `
+			INSERT INTO liquidity_pool_balances (account_id, pool_id, shares, last_modified_ledger)
+			VALUES ($1, $2, 1000, 1)
+		`, types.AddressBytea(accountAddr), poolIDHex(9))
+		require.NoError(t, err)
+
+		balances, err := m.GetByAccount(ctx, accountAddr, nil, nil, ASC)
+		require.NoError(t, err)
+		require.Empty(t, balances)
+	})
+
+	t.Run("paginates with limit and cursor in ASC and DESC order", func(t *testing.T) {
+		cleanUpDB()
+		accountAddr := keypair.MustRandom().Address()
+		_, err := dbConnectionPool.Exec(ctx, `
+			INSERT INTO liquidity_pool_balances (account_id, pool_id, shares, last_modified_ledger) VALUES
+			($1, $2, 1000, 100),
+			($1, $3, 2000, 101),
+			($1, $4, 3000, 102)
+		`, types.AddressBytea(accountAddr), pool1, pool2, pool3)
+		require.NoError(t, err)
+
+		limit := int32(2)
+		page, err := m.GetByAccount(ctx, accountAddr, &limit, nil, ASC)
+		require.NoError(t, err)
+		require.Len(t, page, 2)
+		require.Equal(t, pool1, page[0].PoolID)
+		require.Equal(t, pool2, page[1].PoolID)
+
+		cursor := page[1].PoolID
+		nextPage, err := m.GetByAccount(ctx, accountAddr, &limit, &cursor, ASC)
+		require.NoError(t, err)
+		require.Len(t, nextPage, 1)
+		require.Equal(t, pool3, nextPage[0].PoolID)
+
+		descPage, err := m.GetByAccount(ctx, accountAddr, &limit, nil, DESC)
+		require.NoError(t, err)
+		require.Len(t, descPage, 2)
+		require.Equal(t, pool3, descPage[0].PoolID)
+		require.Equal(t, pool2, descPage[1].PoolID)
+	})
+}
+
+func TestLiquidityPoolBalanceModel_BatchUpsertAndCopy(t *testing.T) {
+	ctx := context.Background()
+
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	dbMetrics := metrics.NewMetrics(prometheus.NewRegistry()).DB
+	m := &LiquidityPoolBalanceModel{DB: dbConnectionPool, Metrics: dbMetrics}
+
+	cleanUpDB := func() {
+		_, err = dbConnectionPool.Exec(ctx, `DELETE FROM liquidity_pool_balances`)
+		require.NoError(t, err)
+	}
+
+	sharesFor := func(account, poolID string) (int64, bool) {
+		var shares int64
+		row := dbConnectionPool.QueryRow(ctx, `SELECT shares FROM liquidity_pool_balances WHERE account_id = $1 AND pool_id = $2`, types.AddressBytea(account), poolID)
+		if scanErr := row.Scan(&shares); scanErr != nil {
+			return 0, false
+		}
+		return shares, true
+	}
+
+	t.Run("insert, update, and delete via BatchUpsert", func(t *testing.T) {
+		cleanUpDB()
+		account := keypair.MustRandom().Address()
+		pool := poolIDHex(1)
+
+		// Insert
+		tx, err := dbConnectionPool.Begin(ctx)
+		require.NoError(t, err)
+		require.NoError(t, m.BatchUpsert(ctx, tx, []LiquidityPoolBalance{
+			{AccountID: types.AddressBytea(account), PoolID: pool, Shares: 1000, LedgerNumber: 10},
+		}, nil))
+		require.NoError(t, tx.Commit(ctx))
+		got, ok := sharesFor(account, pool)
+		require.True(t, ok)
+		require.Equal(t, int64(1000), got)
+
+		// Update on conflict
+		tx, err = dbConnectionPool.Begin(ctx)
+		require.NoError(t, err)
+		require.NoError(t, m.BatchUpsert(ctx, tx, []LiquidityPoolBalance{
+			{AccountID: types.AddressBytea(account), PoolID: pool, Shares: 7777, LedgerNumber: 11},
+		}, nil))
+		require.NoError(t, tx.Commit(ctx))
+		got, ok = sharesFor(account, pool)
+		require.True(t, ok)
+		require.Equal(t, int64(7777), got)
+
+		// Delete
+		tx, err = dbConnectionPool.Begin(ctx)
+		require.NoError(t, err)
+		require.NoError(t, m.BatchUpsert(ctx, tx, nil, []LiquidityPoolBalance{
+			{AccountID: types.AddressBytea(account), PoolID: pool},
+		}))
+		require.NoError(t, tx.Commit(ctx))
+		_, ok = sharesFor(account, pool)
+		require.False(t, ok)
+	})
+
+	t.Run("BatchCopy bulk inserts", func(t *testing.T) {
+		cleanUpDB()
+		account := keypair.MustRandom().Address()
+		tx, err := dbConnectionPool.Begin(ctx)
+		require.NoError(t, err)
+		require.NoError(t, m.BatchCopy(ctx, tx, []LiquidityPoolBalance{
+			{AccountID: types.AddressBytea(account), PoolID: poolIDHex(1), Shares: 100, LedgerNumber: 1},
+			{AccountID: types.AddressBytea(account), PoolID: poolIDHex(2), Shares: 200, LedgerNumber: 2},
+		}))
+		require.NoError(t, tx.Commit(ctx))
+
+		var count int
+		require.NoError(t, dbConnectionPool.QueryRow(ctx, `SELECT COUNT(*) FROM liquidity_pool_balances WHERE account_id = $1`, types.AddressBytea(account)).Scan(&count))
+		require.Equal(t, 2, count)
+	})
+}
+
+func TestLiquidityPoolModel_BatchUpsertAndCopy(t *testing.T) {
+	ctx := context.Background()
+
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbConnectionPool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	dbMetrics := metrics.NewMetrics(prometheus.NewRegistry()).DB
+	m := &LiquidityPoolModel{DB: dbConnectionPool, Metrics: dbMetrics}
+
+	cleanUpDB := func() {
+		_, err = dbConnectionPool.Exec(ctx, `DELETE FROM liquidity_pools`)
+		require.NoError(t, err)
+	}
+
+	readPool := func(poolID string) (LiquidityPool, bool) {
+		var lp LiquidityPool
+		row := dbConnectionPool.QueryRow(ctx, `SELECT pool_id, asset_a, amount_a, asset_b, amount_b, last_modified_ledger FROM liquidity_pools WHERE pool_id = $1`, poolID)
+		if scanErr := row.Scan(&lp.PoolID, &lp.AssetA, &lp.AmountA, &lp.AssetB, &lp.AmountB, &lp.LedgerNumber); scanErr != nil {
+			return LiquidityPool{}, false
+		}
+		return lp, true
+	}
+
+	t.Run("insert, update reserves, and delete via BatchUpsert", func(t *testing.T) {
+		cleanUpDB()
+		pool := poolIDHex(1)
+
+		tx, err := dbConnectionPool.Begin(ctx)
+		require.NoError(t, err)
+		require.NoError(t, m.BatchUpsert(ctx, tx, []LiquidityPool{
+			{PoolID: pool, AssetA: "native", AmountA: 100, AssetB: "USDC:ISSUER1", AmountB: 200, LedgerNumber: 10},
+		}, nil))
+		require.NoError(t, tx.Commit(ctx))
+		lp, ok := readPool(pool)
+		require.True(t, ok)
+		require.Equal(t, int64(100), lp.AmountA)
+		require.Equal(t, int64(200), lp.AmountB)
+
+		// Update reserves on conflict
+		tx, err = dbConnectionPool.Begin(ctx)
+		require.NoError(t, err)
+		require.NoError(t, m.BatchUpsert(ctx, tx, []LiquidityPool{
+			{PoolID: pool, AssetA: "native", AmountA: 999, AssetB: "USDC:ISSUER1", AmountB: 888, LedgerNumber: 11},
+		}, nil))
+		require.NoError(t, tx.Commit(ctx))
+		lp, ok = readPool(pool)
+		require.True(t, ok)
+		require.Equal(t, int64(999), lp.AmountA)
+		require.Equal(t, int64(888), lp.AmountB)
+
+		// Delete
+		tx, err = dbConnectionPool.Begin(ctx)
+		require.NoError(t, err)
+		require.NoError(t, m.BatchUpsert(ctx, tx, nil, []LiquidityPool{{PoolID: pool}}))
+		require.NoError(t, tx.Commit(ctx))
+		_, ok = readPool(pool)
+		require.False(t, ok)
+	})
+
+	t.Run("BatchCopy bulk inserts", func(t *testing.T) {
+		cleanUpDB()
+		tx, err := dbConnectionPool.Begin(ctx)
+		require.NoError(t, err)
+		require.NoError(t, m.BatchCopy(ctx, tx, []LiquidityPool{
+			{PoolID: poolIDHex(1), AssetA: "native", AmountA: 1, AssetB: "USDC:ISSUER1", AmountB: 2, LedgerNumber: 1},
+			{PoolID: poolIDHex(2), AssetA: "BTC:ISSUER2", AmountA: 3, AssetB: "ETH:ISSUER3", AmountB: 4, LedgerNumber: 2},
+		}))
+		require.NoError(t, tx.Commit(ctx))
+
+		var count int
+		require.NoError(t, dbConnectionPool.QueryRow(ctx, `SELECT COUNT(*) FROM liquidity_pools`).Scan(&count))
+		require.Equal(t, 2, count)
+	})
+}

--- a/internal/data/liquidity_pools.go
+++ b/internal/data/liquidity_pools.go
@@ -1,0 +1,164 @@
+// Package data provides data access layer for liquidity pool operations.
+// This file handles PostgreSQL storage of constant-product liquidity pool reserves.
+package data
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/stellar/wallet-backend/internal/metrics"
+	"github.com/stellar/wallet-backend/internal/utils"
+)
+
+// LiquidityPool holds a constant-product pool's constituent assets and reserve amounts.
+// Assets are stored canonically ("native" or "CODE:ISSUER"). Joined with liquidity_pool_balances
+// at query time to expose a holder's shares alongside the pool's reserves.
+type LiquidityPool struct {
+	PoolID       string `db:"pool_id"`
+	AssetA       string `db:"asset_a"`
+	AmountA      int64  `db:"amount_a"`
+	AssetB       string `db:"asset_b"`
+	AmountB      int64  `db:"amount_b"`
+	LedgerNumber uint32 `db:"last_modified_ledger"`
+}
+
+// LiquidityPoolModelInterface defines the interface for liquidity pool operations.
+type LiquidityPoolModelInterface interface {
+	// Write operations (for live ingestion)
+	BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts []LiquidityPool, deletes []LiquidityPool) error
+
+	// Batch operations (for initial population)
+	BatchCopy(ctx context.Context, dbTx pgx.Tx, pools []LiquidityPool) error
+}
+
+// LiquidityPoolModel implements LiquidityPoolModelInterface.
+type LiquidityPoolModel struct {
+	DB      *pgxpool.Pool
+	Metrics *metrics.DBMetrics
+}
+
+var _ LiquidityPoolModelInterface = (*LiquidityPoolModel)(nil)
+
+// BatchUpsert performs upserts and deletes using UNNEST for efficiency.
+// For upserts (ADD/UPDATE): inserts or updates the pool reserves.
+// For deletes (REMOVE): removes the pool row.
+func (m *LiquidityPoolModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts []LiquidityPool, deletes []LiquidityPool) error {
+	if len(upserts) == 0 && len(deletes) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	if len(upserts) > 0 {
+		poolIDs := make([]string, len(upserts))
+		assetsA := make([]string, len(upserts))
+		amountsA := make([]int64, len(upserts))
+		assetsB := make([]string, len(upserts))
+		amountsB := make([]int64, len(upserts))
+		ledgerNumbers := make([]int64, len(upserts))
+
+		for i, lp := range upserts {
+			poolIDs[i] = lp.PoolID
+			assetsA[i] = lp.AssetA
+			amountsA[i] = lp.AmountA
+			assetsB[i] = lp.AssetB
+			amountsB[i] = lp.AmountB
+			ledgerNumbers[i] = int64(lp.LedgerNumber)
+		}
+
+		const upsertQuery = `
+			INSERT INTO liquidity_pools (
+				pool_id, asset_a, amount_a, asset_b, amount_b, last_modified_ledger
+			)
+			SELECT * FROM UNNEST($1::text[], $2::text[], $3::bigint[], $4::text[], $5::bigint[], $6::bigint[])
+			ON CONFLICT (pool_id) DO UPDATE SET
+				asset_a = EXCLUDED.asset_a,
+				amount_a = EXCLUDED.amount_a,
+				asset_b = EXCLUDED.asset_b,
+				amount_b = EXCLUDED.amount_b,
+				last_modified_ledger = EXCLUDED.last_modified_ledger`
+
+		if _, err := dbTx.Exec(ctx, upsertQuery, poolIDs, assetsA, amountsA, assetsB, amountsB, ledgerNumbers); err != nil {
+			m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", "liquidity_pools").Observe(time.Since(start).Seconds())
+			m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", "liquidity_pools").Inc()
+			m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", "liquidity_pools", utils.GetDBErrorType(err)).Inc()
+			return fmt.Errorf("upserting liquidity pools: %w", err)
+		}
+	}
+
+	if len(deletes) > 0 {
+		deletePoolIDs := make([]string, len(deletes))
+		for i, lp := range deletes {
+			deletePoolIDs[i] = lp.PoolID
+		}
+
+		const deleteQuery = `
+			DELETE FROM liquidity_pools
+			WHERE pool_id = ANY($1::text[])`
+
+		if _, err := dbTx.Exec(ctx, deleteQuery, deletePoolIDs); err != nil {
+			m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", "liquidity_pools").Observe(time.Since(start).Seconds())
+			m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", "liquidity_pools").Inc()
+			m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", "liquidity_pools", utils.GetDBErrorType(err)).Inc()
+			return fmt.Errorf("deleting liquidity pools: %w", err)
+		}
+	}
+
+	m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", "liquidity_pools").Observe(time.Since(start).Seconds())
+	m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", "liquidity_pools").Inc()
+	return nil
+}
+
+// BatchCopy performs bulk insert using COPY protocol for speed during checkpoint population.
+func (m *LiquidityPoolModel) BatchCopy(ctx context.Context, dbTx pgx.Tx, pools []LiquidityPool) error {
+	if len(pools) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	copyCount, err := dbTx.CopyFrom(
+		ctx,
+		pgx.Identifier{"liquidity_pools"},
+		[]string{
+			"pool_id",
+			"asset_a",
+			"amount_a",
+			"asset_b",
+			"amount_b",
+			"last_modified_ledger",
+		},
+		pgx.CopyFromSlice(len(pools), func(i int) ([]any, error) {
+			lp := pools[i]
+			return []any{
+				lp.PoolID,
+				lp.AssetA,
+				lp.AmountA,
+				lp.AssetB,
+				lp.AmountB,
+				lp.LedgerNumber,
+			}, nil
+		}),
+	)
+	if err != nil {
+		m.Metrics.QueryDuration.WithLabelValues("BatchCopy", "liquidity_pools").Observe(time.Since(start).Seconds())
+		m.Metrics.QueriesTotal.WithLabelValues("BatchCopy", "liquidity_pools").Inc()
+		m.Metrics.QueryErrors.WithLabelValues("BatchCopy", "liquidity_pools", utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("batch inserting liquidity pools via COPY: %w", err)
+	}
+
+	if int(copyCount) != len(pools) {
+		m.Metrics.QueryDuration.WithLabelValues("BatchCopy", "liquidity_pools").Observe(time.Since(start).Seconds())
+		m.Metrics.QueriesTotal.WithLabelValues("BatchCopy", "liquidity_pools").Inc()
+		m.Metrics.QueryErrors.WithLabelValues("BatchCopy", "liquidity_pools", "row_count_mismatch").Inc()
+		return fmt.Errorf("expected %d rows copied, got %d", len(pools), copyCount)
+	}
+
+	m.Metrics.QueryDuration.WithLabelValues("BatchCopy", "liquidity_pools").Observe(time.Since(start).Seconds())
+	m.Metrics.QueriesTotal.WithLabelValues("BatchCopy", "liquidity_pools").Inc()
+	return nil
+}

--- a/internal/data/mocks.go
+++ b/internal/data/mocks.go
@@ -371,3 +371,73 @@ func (m *ProtocolContractsModelMock) GetByWasmHashes(ctx context.Context, wasmHa
 	}
 	return args.Get(0).([]ProtocolContracts), args.Error(1)
 }
+
+// LiquidityPoolModelMock is a mock implementation of LiquidityPoolModelInterface.
+type LiquidityPoolModelMock struct {
+	mock.Mock
+}
+
+var _ LiquidityPoolModelInterface = (*LiquidityPoolModelMock)(nil)
+
+// NewLiquidityPoolModelMock creates a new instance of LiquidityPoolModelMock.
+func NewLiquidityPoolModelMock(t interface {
+	mock.TestingT
+	Cleanup(func())
+},
+) *LiquidityPoolModelMock {
+	mockModel := &LiquidityPoolModelMock{}
+	mockModel.Mock.Test(t)
+
+	t.Cleanup(func() { mockModel.AssertExpectations(t) })
+
+	return mockModel
+}
+
+func (m *LiquidityPoolModelMock) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts []LiquidityPool, deletes []LiquidityPool) error {
+	args := m.Called(ctx, dbTx, upserts, deletes)
+	return args.Error(0)
+}
+
+func (m *LiquidityPoolModelMock) BatchCopy(ctx context.Context, dbTx pgx.Tx, pools []LiquidityPool) error {
+	args := m.Called(ctx, dbTx, pools)
+	return args.Error(0)
+}
+
+// LiquidityPoolBalanceModelMock is a mock implementation of LiquidityPoolBalanceModelInterface.
+type LiquidityPoolBalanceModelMock struct {
+	mock.Mock
+}
+
+var _ LiquidityPoolBalanceModelInterface = (*LiquidityPoolBalanceModelMock)(nil)
+
+// NewLiquidityPoolBalanceModelMock creates a new instance of LiquidityPoolBalanceModelMock.
+func NewLiquidityPoolBalanceModelMock(t interface {
+	mock.TestingT
+	Cleanup(func())
+},
+) *LiquidityPoolBalanceModelMock {
+	mockModel := &LiquidityPoolBalanceModelMock{}
+	mockModel.Mock.Test(t)
+
+	t.Cleanup(func() { mockModel.AssertExpectations(t) })
+
+	return mockModel
+}
+
+func (m *LiquidityPoolBalanceModelMock) GetByAccount(ctx context.Context, accountAddress string, limit *int32, cursor *string, sortOrder SortOrder) ([]LiquidityPoolBalance, error) {
+	args := m.Called(ctx, accountAddress, limit, cursor, sortOrder)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]LiquidityPoolBalance), args.Error(1)
+}
+
+func (m *LiquidityPoolBalanceModelMock) BatchUpsert(ctx context.Context, dbTx pgx.Tx, upserts []LiquidityPoolBalance, deletes []LiquidityPoolBalance) error {
+	args := m.Called(ctx, dbTx, upserts, deletes)
+	return args.Error(0)
+}
+
+func (m *LiquidityPoolBalanceModelMock) BatchCopy(ctx context.Context, dbTx pgx.Tx, balances []LiquidityPoolBalance) error {
+	args := m.Called(ctx, dbTx, balances)
+	return args.Error(0)
+}

--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -10,21 +10,23 @@ import (
 )
 
 type Models struct {
-	DB                *pgxpool.Pool
-	Account           *AccountModel
-	Contract          ContractModelInterface
-	TrustlineAsset    TrustlineAssetModelInterface
-	TrustlineBalance  TrustlineBalanceModelInterface
-	NativeBalance     NativeBalanceModelInterface
-	SACBalance        SACBalanceModelInterface
-	ProtocolWasms     ProtocolWasmsModelInterface
-	Protocols         ProtocolsModelInterface
-	ProtocolContracts ProtocolContractsModelInterface
-	IngestStore       *IngestStoreModel
-	Operations        *OperationModel
-	Transactions      *TransactionModel
-	StateChanges      *StateChangeModel
-	SEP41             sep41.Models
+	DB                   *pgxpool.Pool
+	Account              *AccountModel
+	Contract             ContractModelInterface
+	TrustlineAsset       TrustlineAssetModelInterface
+	TrustlineBalance     TrustlineBalanceModelInterface
+	NativeBalance        NativeBalanceModelInterface
+	SACBalance           SACBalanceModelInterface
+	LiquidityPool        LiquidityPoolModelInterface
+	LiquidityPoolBalance LiquidityPoolBalanceModelInterface
+	ProtocolWasms        ProtocolWasmsModelInterface
+	Protocols            ProtocolsModelInterface
+	ProtocolContracts    ProtocolContractsModelInterface
+	IngestStore          *IngestStoreModel
+	Operations           *OperationModel
+	Transactions         *TransactionModel
+	StateChanges         *StateChangeModel
+	SEP41                sep41.Models
 }
 
 func NewModels(pool *pgxpool.Pool, dbMetrics *metrics.DBMetrics) (*Models, error) {
@@ -33,20 +35,22 @@ func NewModels(pool *pgxpool.Pool, dbMetrics *metrics.DBMetrics) (*Models, error
 	}
 
 	return &Models{
-		DB:                pool,
-		Account:           &AccountModel{DB: pool, Metrics: dbMetrics},
-		Contract:          &ContractModel{DB: pool, Metrics: dbMetrics},
-		TrustlineAsset:    &TrustlineAssetModel{DB: pool, Metrics: dbMetrics},
-		TrustlineBalance:  &TrustlineBalanceModel{DB: pool, Metrics: dbMetrics},
-		NativeBalance:     &NativeBalanceModel{DB: pool, Metrics: dbMetrics},
-		SACBalance:        &SACBalanceModel{DB: pool, Metrics: dbMetrics},
-		ProtocolWasms:     &ProtocolWasmsModel{DB: pool, Metrics: dbMetrics},
-		Protocols:         &ProtocolsModel{DB: pool, Metrics: dbMetrics},
-		ProtocolContracts: &ProtocolContractsModel{DB: pool, Metrics: dbMetrics},
-		IngestStore:       &IngestStoreModel{DB: pool, Metrics: dbMetrics},
-		Operations:        &OperationModel{DB: pool, Metrics: dbMetrics},
-		Transactions:      &TransactionModel{DB: pool, Metrics: dbMetrics},
-		StateChanges:      &StateChangeModel{DB: pool, Metrics: dbMetrics},
-		SEP41:             sep41.NewModels(pool, dbMetrics),
+		DB:                   pool,
+		Account:              &AccountModel{DB: pool, Metrics: dbMetrics},
+		Contract:             &ContractModel{DB: pool, Metrics: dbMetrics},
+		TrustlineAsset:       &TrustlineAssetModel{DB: pool, Metrics: dbMetrics},
+		TrustlineBalance:     &TrustlineBalanceModel{DB: pool, Metrics: dbMetrics},
+		NativeBalance:        &NativeBalanceModel{DB: pool, Metrics: dbMetrics},
+		SACBalance:           &SACBalanceModel{DB: pool, Metrics: dbMetrics},
+		LiquidityPool:        &LiquidityPoolModel{DB: pool, Metrics: dbMetrics},
+		LiquidityPoolBalance: &LiquidityPoolBalanceModel{DB: pool, Metrics: dbMetrics},
+		ProtocolWasms:        &ProtocolWasmsModel{DB: pool, Metrics: dbMetrics},
+		Protocols:            &ProtocolsModel{DB: pool, Metrics: dbMetrics},
+		ProtocolContracts:    &ProtocolContractsModel{DB: pool, Metrics: dbMetrics},
+		IngestStore:          &IngestStoreModel{DB: pool, Metrics: dbMetrics},
+		Operations:           &OperationModel{DB: pool, Metrics: dbMetrics},
+		Transactions:         &TransactionModel{DB: pool, Metrics: dbMetrics},
+		StateChanges:         &StateChangeModel{DB: pool, Metrics: dbMetrics},
+		SEP41:                sep41.NewModels(pool, dbMetrics),
 	}, nil
 }

--- a/internal/data/native_balances.go
+++ b/internal/data/native_balances.go
@@ -19,13 +19,15 @@ import (
 
 // NativeBalance contains native XLM balance data for an account.
 type NativeBalance struct {
-	AccountID          types.AddressBytea `db:"account_id"`
-	Balance            int64              `db:"balance"`
-	MinimumBalance     int64              `db:"minimum_balance"`
-	BuyingLiabilities  int64              `db:"buying_liabilities"`
-	SellingLiabilities int64              `db:"selling_liabilities"`
-	NumSubEntries      uint32             `db:"num_subentries"`
-	LedgerNumber       uint32             `db:"last_modified_ledger"`
+	AccountID types.AddressBytea `db:"account_id"`
+	Balance   int64              `db:"balance"`
+	// MinimumBalance is the base reserve requirement in stroops (excludes liabilities):
+	// (2 + NumSubEntries + numSponsoring - numSponsored) * baseReserve; matches stellar-core getMinBalance.
+	MinimumBalance     int64  `db:"minimum_balance"`
+	BuyingLiabilities  int64  `db:"buying_liabilities"`
+	SellingLiabilities int64  `db:"selling_liabilities"`
+	NumSubEntries      uint32 `db:"num_subentries"`
+	LedgerNumber       uint32 `db:"last_modified_ledger"`
 }
 
 // NativeBalanceModelInterface defines the interface for native balance operations.

--- a/internal/db/migrations/2026-07-02.0-liquidity_pools.sql
+++ b/internal/db/migrations/2026-07-02.0-liquidity_pools.sql
@@ -1,0 +1,40 @@
+-- +migrate Up
+
+-- Table: liquidity_pools
+-- Stores constant-product liquidity pool reserves (constituent assets + amounts) during ingestion.
+-- Populated from LiquidityPoolEntry ledger entries and joined at query time with liquidity_pool_balances
+-- to expose an account's pool-share balance alongside the pool's reserves.
+-- Assets are stored canonically ("native" or "CODE:ISSUER").
+-- Storage parameters tuned for heavy UPSERT during ledger ingestion (reserves shift on every
+-- deposit/withdraw). UPSERTs only modify non-indexed columns (asset_a, amount_a, asset_b, amount_b,
+-- last_modified_ledger) while the PK column (pool_id) is never changed.
+CREATE TABLE liquidity_pools (
+    pool_id TEXT PRIMARY KEY,
+    asset_a TEXT NOT NULL,
+    amount_a BIGINT NOT NULL DEFAULT 0,
+    asset_b TEXT NOT NULL,
+    amount_b BIGINT NOT NULL DEFAULT 0,
+    last_modified_ledger BIGINT NOT NULL DEFAULT 0
+) WITH (
+    -- Reserve 20% free space per page so PostgreSQL can do HOT (Heap-Only Tuple) updates.
+    -- HOT updates rewrite the row in-place on the same page without creating dead tuples
+    -- or new index entries, since no indexed column is modified during UPSERTs.
+    fillfactor = 80,
+    -- Trigger vacuum when 2% of rows are dead (default 20%).
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 50,
+    -- Refresh planner statistics at 1% change (default 10%). Reserves shift every ledger,
+    -- so stale stats can cause bad query plans.
+    autovacuum_analyze_scale_factor = 0.01,
+    autovacuum_analyze_threshold = 50,
+    -- No sleep between vacuum page-processing cycles (default 2ms). Per-table setting,
+    -- so only workers on this table run full-speed; other tables are unaffected.
+    autovacuum_vacuum_cost_delay = 0,
+    -- 5x the default page-processing budget per cycle (default 200). Combined with
+    -- cost_delay=0, vacuum finishes quickly.
+    autovacuum_vacuum_cost_limit = 1000
+);
+
+-- +migrate Down
+
+DROP TABLE IF EXISTS liquidity_pools;

--- a/internal/db/migrations/2026-07-02.1-liquidity_pool_balances.sql
+++ b/internal/db/migrations/2026-07-02.1-liquidity_pool_balances.sql
@@ -1,0 +1,37 @@
+-- +migrate Up
+
+-- Table: liquidity_pool_balances
+-- Stores an account's liquidity-pool share balance (from pool_share trustlines) during ingestion.
+-- Joined at query time with liquidity_pools to expose the pool's reserves alongside the shares.
+-- Storage parameters tuned for heavy UPSERT/DELETE during ledger ingestion.
+-- UPSERTs only modify non-indexed columns (shares, last_modified_ledger) while the PK columns
+-- (account_id, pool_id) are never changed.
+CREATE TABLE liquidity_pool_balances (
+    account_id BYTEA NOT NULL,
+    pool_id TEXT NOT NULL,
+    shares BIGINT NOT NULL DEFAULT 0,
+    last_modified_ledger BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (account_id, pool_id)
+) WITH (
+    -- Reserve 20% free space per page so PostgreSQL can do HOT (Heap-Only Tuple) updates.
+    -- HOT updates rewrite the row in-place on the same page without creating dead tuples
+    -- or new index entries, since no indexed column is modified during UPSERTs.
+    fillfactor = 80,
+    -- Trigger vacuum when 2% of rows are dead (default 20%).
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 50,
+    -- Refresh planner statistics at 1% change (default 10%). Balances shift every ledger,
+    -- so stale stats can cause bad query plans (e.g. on the GetByAccount JOIN).
+    autovacuum_analyze_scale_factor = 0.01,
+    autovacuum_analyze_threshold = 50,
+    -- No sleep between vacuum page-processing cycles (default 2ms). Per-table setting,
+    -- so only workers on this table run full-speed; other tables are unaffected.
+    autovacuum_vacuum_cost_delay = 0,
+    -- 5x the default page-processing budget per cycle (default 200). Combined with
+    -- cost_delay=0, vacuum finishes quickly.
+    autovacuum_vacuum_cost_limit = 1000
+);
+
+-- +migrate Down
+
+DROP TABLE IF EXISTS liquidity_pool_balances;

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -35,9 +35,13 @@ type IndexerBufferInterface interface {
 	GetTrustlineChanges() map[TrustlineChangeKey]types.TrustlineChange
 	GetAccountChanges() map[string]types.AccountChange
 	GetSACBalanceChanges() map[SACBalanceChangeKey]types.SACBalanceChange
+	GetLiquidityPoolShareChanges() map[LiquidityPoolShareChangeKey]types.LiquidityPoolShareChange
+	GetLiquidityPoolChanges() map[string]types.LiquidityPoolChange
 	PushTrustlineChange(trustlineChange types.TrustlineChange)
 	PushAccountChange(accountChange types.AccountChange)
 	PushSACBalanceChange(sacBalanceChange types.SACBalanceChange)
+	PushLiquidityPoolShareChange(change types.LiquidityPoolShareChange)
+	PushLiquidityPoolChange(change types.LiquidityPoolChange)
 	PushSACContract(c *data.Contract)
 	PushProtocolWasm(wasm data.ProtocolWasms)
 	PushProtocolWasmBytecode(wasmHash string, bytecode []byte)
@@ -91,6 +95,8 @@ type Indexer struct {
 	trustlinesProcessor        LedgerChangeProcessor[types.TrustlineChange]
 	accountsProcessor          AccountsProcessorInterface
 	sacBalancesProcessor       LedgerChangeProcessor[types.SACBalanceChange]
+	lpSharesProcessor          LedgerChangeProcessor[types.LiquidityPoolShareChange]
+	lpProcessor                LedgerChangeProcessor[types.LiquidityPoolChange]
 	sacInstancesProcessor      LedgerChangeProcessor[*data.Contract]
 	protocolWasmsProcessor     LedgerChangeProcessor[processors.ProtocolWasmObservation]
 	protocolContractsProcessor LedgerChangeProcessor[data.ProtocolContracts]
@@ -114,6 +120,8 @@ func NewIndexer(networkPassphrase string, pool pond.Pool, ingestionMetrics *metr
 		protocolContractsProcessor: processors.NewProtocolContractsProcessor(ingestionMetrics),
 		accountsProcessor:          processors.NewAccountsProcessor(ingestionMetrics),
 		trustlinesProcessor:        processors.NewTrustlinesProcessor(ingestionMetrics),
+		lpSharesProcessor:          processors.NewLiquidityPoolSharesProcessor(ingestionMetrics),
+		lpProcessor:                processors.NewLiquidityPoolsProcessor(ingestionMetrics),
 		processors: []OperationProcessorInterface{
 			processors.NewEffectsProcessor(networkPassphrase, ingestionMetrics),
 			processors.NewContractDeployProcessor(networkPassphrase, ingestionMetrics),
@@ -252,6 +260,22 @@ func (i *Indexer) processTransaction(ctx context.Context, tx ingest.LedgerTransa
 		}
 		for _, sacChange := range sacBalanceChanges {
 			buffer.PushSACBalanceChange(sacChange)
+		}
+
+		lpShareChanges, lpShareErr := i.lpSharesProcessor.ProcessOperation(ctx, opParticipants.OpWrapper)
+		if lpShareErr != nil {
+			return 0, fmt.Errorf("processing liquidity pool share changes: %w", lpShareErr)
+		}
+		for _, lpShareChange := range lpShareChanges {
+			buffer.PushLiquidityPoolShareChange(lpShareChange)
+		}
+
+		lpChanges, lpErr := i.lpProcessor.ProcessOperation(ctx, opParticipants.OpWrapper)
+		if lpErr != nil {
+			return 0, fmt.Errorf("processing liquidity pool changes: %w", lpErr)
+		}
+		for _, lpChange := range lpChanges {
+			buffer.PushLiquidityPoolChange(lpChange)
 		}
 
 		sacContracts, sacInstanceErr := i.sacInstancesProcessor.ProcessOperation(ctx, opParticipants.OpWrapper)

--- a/internal/indexer/indexer_buffer.go
+++ b/internal/indexer/indexer_buffer.go
@@ -57,6 +57,12 @@ type SACBalanceChangeKey struct {
 	ContractID string
 }
 
+// LiquidityPoolShareChangeKey is a composite key for deduplicating pool-share balance changes.
+type LiquidityPoolShareChangeKey struct {
+	AccountID string
+	PoolID    string
+}
+
 // ContractEventKey identifies a contract-event group by transaction and
 // operation index within a single ledger. The indexer extracts contract
 // events once per InvokeHostFunction op (successful txs only) and stashes
@@ -77,12 +83,16 @@ type IndexerBuffer struct {
 	trustlineChangesByTrustlineKey map[TrustlineChangeKey]types.TrustlineChange
 	accountChangesByAccountID      map[string]types.AccountChange
 	sacBalanceChangesByKey         map[SACBalanceChangeKey]types.SACBalanceChange
+	lpShareChangesByKey            map[LiquidityPoolShareChangeKey]types.LiquidityPoolShareChange
+	lpChangesByPoolID              map[string]types.LiquidityPoolChange
 	// Tombstones record the order value at which a create/add was cancelled by a same-ledger
 	// remove. They keep the highest-order-wins invariant intact across the delete, so a later
 	// lower-order change cannot resurrect a removed key. See pushWithTombstone.
 	accountTombstones     map[string]int64
 	trustlineTombstones   map[TrustlineChangeKey]int64
 	sacTombstones         map[SACBalanceChangeKey]int64
+	lpShareTombstones     map[LiquidityPoolShareChangeKey]int64
+	lpTombstones          map[string]int64
 	uniqueTrustlineAssets map[uuid.UUID]data.TrustlineAsset
 	sacContractsByID      map[string]*data.Contract         // SAC contract metadata extracted from instance entries
 	protocolWasmsByHash   map[string]data.ProtocolWasms     // wasmHash → ProtocolWasms (protocol_id stamped post-classification)
@@ -103,9 +113,13 @@ func NewIndexerBuffer() *IndexerBuffer {
 		trustlineChangesByTrustlineKey: make(map[TrustlineChangeKey]types.TrustlineChange),
 		accountChangesByAccountID:      make(map[string]types.AccountChange),
 		sacBalanceChangesByKey:         make(map[SACBalanceChangeKey]types.SACBalanceChange),
+		lpShareChangesByKey:            make(map[LiquidityPoolShareChangeKey]types.LiquidityPoolShareChange),
+		lpChangesByPoolID:              make(map[string]types.LiquidityPoolChange),
 		accountTombstones:              make(map[string]int64),
 		trustlineTombstones:            make(map[TrustlineChangeKey]int64),
 		sacTombstones:                  make(map[SACBalanceChangeKey]int64),
+		lpShareTombstones:              make(map[LiquidityPoolShareChangeKey]int64),
+		lpTombstones:                   make(map[string]int64),
 		uniqueTrustlineAssets:          make(map[uuid.UUID]data.TrustlineAsset),
 		sacContractsByID:               make(map[string]*data.Contract),
 		protocolWasmsByHash:            make(map[string]data.ProtocolWasms),
@@ -272,6 +286,18 @@ func sacBalanceIsNoopRemove(existing, incoming types.SACBalanceChange) bool {
 	return existing.Operation == types.SACBalanceOpAdd && incoming.Operation == types.SACBalanceOpRemove
 }
 
+func lpShareOrder(c types.LiquidityPoolShareChange) int64 { return c.OperationID }
+
+func lpShareIsNoopRemove(existing, incoming types.LiquidityPoolShareChange) bool {
+	return existing.Operation == types.LiquidityPoolShareOpAdd && incoming.Operation == types.LiquidityPoolShareOpRemove
+}
+
+func lpOrder(c types.LiquidityPoolChange) int64 { return c.OperationID }
+
+func lpIsNoopRemove(existing, incoming types.LiquidityPoolChange) bool {
+	return existing.Operation == types.LiquidityPoolOpAdd && incoming.Operation == types.LiquidityPoolOpRemove
+}
+
 // PushTrustlineChange adds a trustline change to the buffer and tracks unique assets.
 // Thread-safe: acquires write lock.
 func (b *IndexerBuffer) PushTrustlineChange(trustlineChange types.TrustlineChange) {
@@ -351,6 +377,50 @@ func (b *IndexerBuffer) GetSACBalanceChanges() map[SACBalanceChangeKey]types.SAC
 	defer b.mu.RUnlock()
 
 	return b.sacBalanceChangesByKey
+}
+
+// PushLiquidityPoolShareChange adds a pool-share balance change to the buffer with deduplication.
+// Keeps the change with highest OperationID per (AccountID, PoolID). An ADD→REMOVE within the same
+// ledger nets to nothing and is tombstoned so a later lower-key change cannot resurrect it (see
+// pushWithTombstone). Thread-safe: acquires write lock.
+func (b *IndexerBuffer) PushLiquidityPoolShareChange(change types.LiquidityPoolShareChange) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	key := LiquidityPoolShareChangeKey{
+		AccountID: change.AccountID,
+		PoolID:    change.PoolID,
+	}
+	pushWithTombstone(b.lpShareChangesByKey, b.lpShareTombstones, key, change, lpShareOrder, lpShareIsNoopRemove)
+}
+
+// GetLiquidityPoolShareChanges returns all pool-share balance changes stored in the buffer.
+// Thread-safe: uses read lock.
+func (b *IndexerBuffer) GetLiquidityPoolShareChanges() map[LiquidityPoolShareChangeKey]types.LiquidityPoolShareChange {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	return b.lpShareChangesByKey
+}
+
+// PushLiquidityPoolChange adds a pool reserve change to the buffer with deduplication.
+// Keeps the change with highest OperationID per PoolID. An ADD→REMOVE within the same ledger nets
+// to nothing and is tombstoned so a later lower-key change cannot resurrect it (see
+// pushWithTombstone). Thread-safe: acquires write lock.
+func (b *IndexerBuffer) PushLiquidityPoolChange(change types.LiquidityPoolChange) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	pushWithTombstone(b.lpChangesByPoolID, b.lpTombstones, change.PoolID, change, lpOrder, lpIsNoopRemove)
+}
+
+// GetLiquidityPoolChanges returns all pool reserve changes stored in the buffer.
+// Thread-safe: uses read lock.
+func (b *IndexerBuffer) GetLiquidityPoolChanges() map[string]types.LiquidityPoolChange {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	return b.lpChangesByPoolID
 }
 
 // PushOperation adds an operation and its parent transaction, associating both with a participant.
@@ -494,6 +564,8 @@ func (b *IndexerBuffer) Merge(other IndexerBufferInterface) {
 	mergeWithTombstone(b.trustlineChangesByTrustlineKey, otherBuffer.trustlineChangesByTrustlineKey, b.trustlineTombstones, otherBuffer.trustlineTombstones, trustlineOrder, trustlineIsNoopRemove)
 	mergeWithTombstone(b.accountChangesByAccountID, otherBuffer.accountChangesByAccountID, b.accountTombstones, otherBuffer.accountTombstones, accountOrder, accountIsNoopRemove)
 	mergeWithTombstone(b.sacBalanceChangesByKey, otherBuffer.sacBalanceChangesByKey, b.sacTombstones, otherBuffer.sacTombstones, sacBalanceOrder, sacBalanceIsNoopRemove)
+	mergeWithTombstone(b.lpShareChangesByKey, otherBuffer.lpShareChangesByKey, b.lpShareTombstones, otherBuffer.lpShareTombstones, lpShareOrder, lpShareIsNoopRemove)
+	mergeWithTombstone(b.lpChangesByPoolID, otherBuffer.lpChangesByPoolID, b.lpTombstones, otherBuffer.lpTombstones, lpOrder, lpIsNoopRemove)
 
 	// Merge unique trustline assets
 	maps.Copy(b.uniqueTrustlineAssets, otherBuffer.uniqueTrustlineAssets)
@@ -556,14 +628,18 @@ func (b *IndexerBuffer) Clear() {
 	// Reset slices (reuse underlying arrays by slicing to zero)
 	b.stateChanges = b.stateChanges[:0]
 
-	// Clear account and SAC balance changes maps
+	// Clear account, SAC, and liquidity-pool balance changes maps
 	clear(b.accountChangesByAccountID)
 	clear(b.sacBalanceChangesByKey)
+	clear(b.lpShareChangesByKey)
+	clear(b.lpChangesByPoolID)
 
 	// Clear tombstones
 	clear(b.accountTombstones)
 	clear(b.trustlineTombstones)
 	clear(b.sacTombstones)
+	clear(b.lpShareTombstones)
+	clear(b.lpTombstones)
 }
 
 // GetUniqueTrustlineAssets returns all unique trustline assets with pre-computed IDs.

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -166,6 +166,8 @@ func TestIndexer_ProcessLedgerTransactions(t *testing.T) {
 		mockTrustlines := &MockTrustlinesProcessor{}
 		mockAccounts := &MockAccountsProcessor{}
 		mockSACBalances := &MockSACBalancesProcessor{}
+		mockLPShares := &MockLiquidityPoolSharesProcessor{}
+		mockLPPools := &MockLiquidityPoolsProcessor{}
 		mockSACInstances := &MockSACInstancesProcessor{}
 		mockProtocolWasms := &MockProtocolWasmsProcessor{}
 		mockProtocolContracts := &MockProtocolContractsProcessor{}
@@ -203,6 +205,8 @@ func TestIndexer_ProcessLedgerTransactions(t *testing.T) {
 		mockAccounts.On("ProcessOperation", mock.Anything, mock.Anything).Return([]types.AccountChange{}, nil)
 		mockAccounts.On("ProcessTransactionFees", mock.Anything, mock.Anything).Return([]types.AccountChange{}, nil)
 		mockSACBalances.On("ProcessOperation", mock.Anything, mock.Anything).Return([]types.SACBalanceChange{}, nil)
+		mockLPShares.On("ProcessOperation", mock.Anything, mock.Anything).Return([]types.LiquidityPoolShareChange{}, nil)
+		mockLPPools.On("ProcessOperation", mock.Anything, mock.Anything).Return([]types.LiquidityPoolChange{}, nil)
 		mockSACInstances.On("ProcessOperation", mock.Anything, mock.Anything).Return([]*data.Contract{}, nil)
 		mockProtocolWasms.On("ProcessOperation", mock.Anything, mock.Anything).Return([]processors.ProtocolWasmObservation{}, nil)
 		mockProtocolContracts.On("ProcessOperation", mock.Anything, mock.Anything).Return([]data.ProtocolContracts{}, nil)
@@ -214,6 +218,8 @@ func TestIndexer_ProcessLedgerTransactions(t *testing.T) {
 			trustlinesProcessor:        mockTrustlines,
 			accountsProcessor:          mockAccounts,
 			sacBalancesProcessor:       mockSACBalances,
+			lpSharesProcessor:          mockLPShares,
+			lpProcessor:                mockLPPools,
 			sacInstancesProcessor:      mockSACInstances,
 			protocolWasmsProcessor:     mockProtocolWasms,
 			protocolContractsProcessor: mockProtocolContracts,
@@ -268,6 +274,8 @@ func TestIndexer_ProcessLedgerTransactions(t *testing.T) {
 		mockTrustlines := &MockTrustlinesProcessor{}
 		mockAccounts := &MockAccountsProcessor{}
 		mockSACBalances := &MockSACBalancesProcessor{}
+		mockLPShares := &MockLiquidityPoolSharesProcessor{}
+		mockLPPools := &MockLiquidityPoolsProcessor{}
 		mockSACInstances := &MockSACInstancesProcessor{}
 		mockProtocolWasms := &MockProtocolWasmsProcessor{}
 		mockProtocolContracts := &MockProtocolContractsProcessor{}
@@ -315,6 +323,8 @@ func TestIndexer_ProcessLedgerTransactions(t *testing.T) {
 		mockAccounts.On("ProcessOperation", mock.Anything, mock.Anything).Return([]types.AccountChange{}, nil)
 		mockAccounts.On("ProcessTransactionFees", mock.Anything, mock.Anything).Return([]types.AccountChange{}, nil)
 		mockSACBalances.On("ProcessOperation", mock.Anything, mock.Anything).Return([]types.SACBalanceChange{}, nil)
+		mockLPShares.On("ProcessOperation", mock.Anything, mock.Anything).Return([]types.LiquidityPoolShareChange{}, nil)
+		mockLPPools.On("ProcessOperation", mock.Anything, mock.Anything).Return([]types.LiquidityPoolChange{}, nil)
 		mockSACInstances.On("ProcessOperation", mock.Anything, mock.Anything).Return([]*data.Contract{}, nil)
 		mockProtocolWasms.On("ProcessOperation", mock.Anything, mock.Anything).Return([]processors.ProtocolWasmObservation{}, nil)
 		mockProtocolContracts.On("ProcessOperation", mock.Anything, mock.Anything).Return([]data.ProtocolContracts{}, nil)
@@ -326,6 +336,8 @@ func TestIndexer_ProcessLedgerTransactions(t *testing.T) {
 			trustlinesProcessor:        mockTrustlines,
 			accountsProcessor:          mockAccounts,
 			sacBalancesProcessor:       mockSACBalances,
+			lpSharesProcessor:          mockLPShares,
+			lpProcessor:                mockLPPools,
 			sacInstancesProcessor:      mockSACInstances,
 			protocolWasmsProcessor:     mockProtocolWasms,
 			protocolContractsProcessor: mockProtocolContracts,
@@ -608,6 +620,8 @@ func TestIndexer_ProcessLedgerTransactions(t *testing.T) {
 		mockTrustlines := &MockTrustlinesProcessor{}
 		mockAccounts := &MockAccountsProcessor{}
 		mockSACBalances := &MockSACBalancesProcessor{}
+		mockLPShares := &MockLiquidityPoolSharesProcessor{}
+		mockLPPools := &MockLiquidityPoolsProcessor{}
 		mockSACInstances := &MockSACInstancesProcessor{}
 		mockProtocolWasms := &MockProtocolWasmsProcessor{}
 		mockProtocolContracts := &MockProtocolContractsProcessor{}
@@ -643,6 +657,8 @@ func TestIndexer_ProcessLedgerTransactions(t *testing.T) {
 		mockAccounts.On("ProcessOperation", mock.Anything, mock.Anything).Return([]types.AccountChange{}, nil)
 		mockAccounts.On("ProcessTransactionFees", mock.Anything, mock.Anything).Return([]types.AccountChange{}, nil)
 		mockSACBalances.On("ProcessOperation", mock.Anything, mock.Anything).Return([]types.SACBalanceChange{}, nil)
+		mockLPShares.On("ProcessOperation", mock.Anything, mock.Anything).Return([]types.LiquidityPoolShareChange{}, nil)
+		mockLPPools.On("ProcessOperation", mock.Anything, mock.Anything).Return([]types.LiquidityPoolChange{}, nil)
 		mockSACInstances.On("ProcessOperation", mock.Anything, mock.Anything).Return([]*data.Contract{}, nil)
 		mockProtocolWasms.On("ProcessOperation", mock.Anything, mock.Anything).Return([]processors.ProtocolWasmObservation{}, nil)
 		mockProtocolContracts.On("ProcessOperation", mock.Anything, mock.Anything).Return([]data.ProtocolContracts{}, nil)
@@ -654,6 +670,8 @@ func TestIndexer_ProcessLedgerTransactions(t *testing.T) {
 			trustlinesProcessor:        mockTrustlines,
 			accountsProcessor:          mockAccounts,
 			sacBalancesProcessor:       mockSACBalances,
+			lpSharesProcessor:          mockLPShares,
+			lpProcessor:                mockLPPools,
 			sacInstancesProcessor:      mockSACInstances,
 			protocolWasmsProcessor:     mockProtocolWasms,
 			protocolContractsProcessor: mockProtocolContracts,

--- a/internal/indexer/mocks.go
+++ b/internal/indexer/mocks.go
@@ -150,3 +150,31 @@ var (
 	_ LedgerChangeProcessor[processors.ProtocolWasmObservation] = &MockProtocolWasmsProcessor{}
 	_ LedgerChangeProcessor[data.ProtocolContracts]             = &MockProtocolContractsProcessor{}
 )
+
+type MockLiquidityPoolSharesProcessor struct {
+	mock.Mock
+}
+
+func (m *MockLiquidityPoolSharesProcessor) ProcessOperation(ctx context.Context, opWrapper *processors.TransactionOperationWrapper) ([]types.LiquidityPoolShareChange, error) {
+	args := m.Called(ctx, opWrapper)
+	return args.Get(0).([]types.LiquidityPoolShareChange), args.Error(1)
+}
+
+func (m *MockLiquidityPoolSharesProcessor) Name() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+type MockLiquidityPoolsProcessor struct {
+	mock.Mock
+}
+
+func (m *MockLiquidityPoolsProcessor) ProcessOperation(ctx context.Context, opWrapper *processors.TransactionOperationWrapper) ([]types.LiquidityPoolChange, error) {
+	args := m.Called(ctx, opWrapper)
+	return args.Get(0).([]types.LiquidityPoolChange), args.Error(1)
+}
+
+func (m *MockLiquidityPoolsProcessor) Name() string {
+	args := m.Called()
+	return args.String(0)
+}

--- a/internal/indexer/processors/accounts.go
+++ b/internal/indexer/processors/accounts.go
@@ -190,12 +190,15 @@ func (p *AccountsProcessor) buildAccountChange(change ingest.Change, ledgerSeq u
 	accChange.BuyingLiabilities = int64(liabilities.Buying)
 	accChange.SellingLiabilities = int64(liabilities.Selling)
 
-	// Calculate the minimum balance for base reserves: https://developers.stellar.org/docs/build/guides/transactions/sponsored-reserves#effect-on-minimum-balance
+	// MinimumBalance is the base reserve requirement in stroops, matching stellar-core's getMinBalance:
+	// (2 + numSubEntries + numSponsoring - numSponsored) * baseReserve. It excludes liabilities;
+	// consumers that need spendable balance subtract selling liabilities themselves.
+	// https://developers.stellar.org/docs/build/guides/transactions/sponsored-reserves#effect-on-minimum-balance
 	numSubEntries := account.NumSubEntries
 	accChange.NumSubEntries = uint32(numSubEntries)
 	numSponsoring := account.NumSponsoring()
 	numSponsored := account.NumSponsored()
-	accChange.MinimumBalance = int64(MinimumBaseReserveCount+numSubEntries+numSponsoring-numSponsored)*BaseReserveStroops + accChange.SellingLiabilities
+	accChange.MinimumBalance = int64(MinimumBaseReserveCount+numSubEntries+numSponsoring-numSponsored) * BaseReserveStroops
 
 	return accChange, false, nil
 }

--- a/internal/indexer/processors/accounts.go
+++ b/internal/indexer/processors/accounts.go
@@ -19,6 +19,14 @@ const (
 	BaseReserveStroops      = 5_000_000
 )
 
+// MinimumBalance returns the base reserve requirement in stroops for an account,
+// matching stellar-core's getMinBalance: (2 + numSubEntries + numSponsoring - numSponsored) * baseReserve.
+// It excludes liabilities; consumers needing spendable balance subtract selling liabilities themselves.
+// https://developers.stellar.org/docs/build/guides/transactions/sponsored-reserves#effect-on-minimum-balance
+func MinimumBalance(account xdr.AccountEntry) int64 {
+	return int64(MinimumBaseReserveCount+account.NumSubEntries+account.NumSponsoring()-account.NumSponsored()) * BaseReserveStroops
+}
+
 // Balance-change phases within a single ledger, in Stellar's canonical close order: every
 // transaction's fee is charged, then all operations apply, then post-apply (Soroban) fee refunds
 // are credited. Refunds come from GetPostApplyFeeChanges, which surfaces the protocol-23+
@@ -190,15 +198,8 @@ func (p *AccountsProcessor) buildAccountChange(change ingest.Change, ledgerSeq u
 	accChange.BuyingLiabilities = int64(liabilities.Buying)
 	accChange.SellingLiabilities = int64(liabilities.Selling)
 
-	// MinimumBalance is the base reserve requirement in stroops, matching stellar-core's getMinBalance:
-	// (2 + numSubEntries + numSponsoring - numSponsored) * baseReserve. It excludes liabilities;
-	// consumers that need spendable balance subtract selling liabilities themselves.
-	// https://developers.stellar.org/docs/build/guides/transactions/sponsored-reserves#effect-on-minimum-balance
-	numSubEntries := account.NumSubEntries
-	accChange.NumSubEntries = uint32(numSubEntries)
-	numSponsoring := account.NumSponsoring()
-	numSponsored := account.NumSponsored()
-	accChange.MinimumBalance = int64(MinimumBaseReserveCount+numSubEntries+numSponsoring-numSponsored) * BaseReserveStroops
+	accChange.NumSubEntries = uint32(account.NumSubEntries)
+	accChange.MinimumBalance = MinimumBalance(account)
 
 	return accChange, false, nil
 }

--- a/internal/indexer/processors/accounts_test.go
+++ b/internal/indexer/processors/accounts_test.go
@@ -194,8 +194,8 @@ func TestAccountsProcessor_ProcessOperation(t *testing.T) {
 					assert.Equal(t, int64(10000000), change.Balance)
 					assert.Equal(t, int64(100), change.BuyingLiabilities)
 					assert.Equal(t, int64(200), change.SellingLiabilities)
-					// MinimumBalance = (2 + 0 + 0 - 0) * 5_000_000 + 200 = 10_000_200
-					assert.Equal(t, int64(10000200), change.MinimumBalance)
+					// MinimumBalance is the pure base reserve, excluding the 200 selling liabilities: (2 + 0 + 0 - 0) * 5_000_000.
+					assert.Equal(t, int64(10000000), change.MinimumBalance)
 				}
 			}
 		})
@@ -233,8 +233,8 @@ func TestAccountsProcessor_ProcessOperation_PersistsNumSubEntries(t *testing.T) 
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	assert.Equal(t, uint32(3), got[0].NumSubEntries)
-	// MinimumBalance folds the 3 subentries into the base reserve: (2 + 3) * 5_000_000 + 200.
-	assert.Equal(t, int64(25000200), got[0].MinimumBalance)
+	// MinimumBalance folds the 3 subentries into the base reserve (excludes liabilities): (2 + 3) * 5_000_000.
+	assert.Equal(t, int64(25000000), got[0].MinimumBalance)
 }
 
 func TestAccountsProcessor_ProcessTransactionFees(t *testing.T) {
@@ -331,8 +331,8 @@ func TestAccountsProcessor_ProcessTransactionFees(t *testing.T) {
 				assert.Equal(t, ledgerSeq, got.LedgerNumber)
 				assert.Equal(t, want.sortKey, got.SortKey)
 				assert.Equal(t, want.balance, got.Balance)
-				// Reserve calc still runs on fee-phase entries: (2 + 0 + 0 - 0) * 5_000_000 + 200.
-				assert.Equal(t, int64(10000200), got.MinimumBalance)
+				// Reserve calc still runs on fee-phase entries, excluding liabilities: (2 + 0 + 0 - 0) * 5_000_000.
+				assert.Equal(t, int64(10000000), got.MinimumBalance)
 			}
 		})
 	}

--- a/internal/indexer/processors/liquidity_pools.go
+++ b/internal/indexer/processors/liquidity_pools.go
@@ -1,0 +1,188 @@
+// Liquidity pool processors extract pool-share balances and pool reserves from ledger changes.
+//
+// Pool-share balances live on pool_share trustlines (per-account shares); pool reserves live on
+// LiquidityPoolEntry ledger entries (constituent assets + amounts). The two are ingested separately
+// and joined at query time. Both processors read ledger changes directly (like the trustline and
+// account processors) to capture ALL modifications, including those from deposits and withdrawals.
+package processors
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/stellar/go-stellar-sdk/ingest"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+)
+
+// LiquidityPoolSharesProcessor extracts an account's pool-share balances from pool_share
+// trustline changes.
+type LiquidityPoolSharesProcessor struct {
+	metricsService *metrics.IngestionMetrics
+}
+
+// NewLiquidityPoolSharesProcessor creates a new liquidity-pool-shares processor.
+func NewLiquidityPoolSharesProcessor(metricsService *metrics.IngestionMetrics) *LiquidityPoolSharesProcessor {
+	return &LiquidityPoolSharesProcessor{
+		metricsService: metricsService,
+	}
+}
+
+// Name returns the processor name for logging and metrics.
+func (p *LiquidityPoolSharesProcessor) Name() string {
+	return "liquidity_pool_shares"
+}
+
+// ProcessOperation extracts pool-share balance changes from an operation's ledger changes.
+func (p *LiquidityPoolSharesProcessor) ProcessOperation(ctx context.Context, opWrapper *TransactionOperationWrapper) ([]types.LiquidityPoolShareChange, error) {
+	startTime := time.Now()
+	defer func() {
+		if p.metricsService != nil {
+			duration := time.Since(startTime).Seconds()
+			p.metricsService.StateChangeProcessingDuration.WithLabelValues("LiquidityPoolSharesProcessor").Observe(duration)
+		}
+	}()
+
+	changes, err := opWrapper.Transaction.GetOperationChanges(opWrapper.Index)
+	if err != nil {
+		return nil, fmt.Errorf("getting operation changes: %w", err)
+	}
+
+	var shareChanges []types.LiquidityPoolShareChange
+	for _, change := range changes {
+		if change.Type != xdr.LedgerEntryTypeTrustline {
+			continue
+		}
+
+		shareChange, skip := p.processShareChange(change, opWrapper)
+		if skip {
+			continue
+		}
+		shareChanges = append(shareChanges, shareChange)
+	}
+
+	return shareChanges, nil
+}
+
+// processShareChange converts a pool_share trustline change to a LiquidityPoolShareChange.
+// Returns skip=true for non-pool-share trustlines (regular asset trustlines are handled by
+// TrustlinesProcessor) and for invalid changes.
+func (p *LiquidityPoolSharesProcessor) processShareChange(change ingest.Change, opWrapper *TransactionOperationWrapper) (types.LiquidityPoolShareChange, bool) {
+	var shareChange types.LiquidityPoolShareChange
+
+	var entry *xdr.LedgerEntry
+	switch {
+	case change.Pre == nil && change.Post != nil:
+		shareChange.Operation = types.LiquidityPoolShareOpAdd
+		entry = change.Post
+	case change.Pre != nil && change.Post != nil:
+		shareChange.Operation = types.LiquidityPoolShareOpUpdate
+		entry = change.Post
+	case change.Pre != nil && change.Post == nil:
+		shareChange.Operation = types.LiquidityPoolShareOpRemove
+		entry = change.Pre
+	default:
+		return shareChange, true // Invalid change, skip
+	}
+
+	trustLine := entry.Data.MustTrustLine()
+	if trustLine.Asset.Type != xdr.AssetTypeAssetTypePoolShare {
+		return shareChange, true // Regular asset trustline, not a pool share
+	}
+
+	shareChange.AccountID = trustLine.AccountId.Address()
+	shareChange.PoolID = PoolIDToString(*trustLine.Asset.LiquidityPoolId)
+	shareChange.OperationID = opWrapper.ID()
+	shareChange.LedgerNumber = opWrapper.Transaction.Ledger.LedgerSequence()
+	shareChange.Shares = int64(trustLine.Balance)
+
+	return shareChange, false
+}
+
+// LiquidityPoolsProcessor extracts constant-product pool reserves from LiquidityPoolEntry changes.
+type LiquidityPoolsProcessor struct {
+	metricsService *metrics.IngestionMetrics
+}
+
+// NewLiquidityPoolsProcessor creates a new liquidity-pools processor.
+func NewLiquidityPoolsProcessor(metricsService *metrics.IngestionMetrics) *LiquidityPoolsProcessor {
+	return &LiquidityPoolsProcessor{
+		metricsService: metricsService,
+	}
+}
+
+// Name returns the processor name for logging and metrics.
+func (p *LiquidityPoolsProcessor) Name() string {
+	return "liquidity_pools"
+}
+
+// ProcessOperation extracts pool reserve changes from an operation's ledger changes.
+func (p *LiquidityPoolsProcessor) ProcessOperation(ctx context.Context, opWrapper *TransactionOperationWrapper) ([]types.LiquidityPoolChange, error) {
+	startTime := time.Now()
+	defer func() {
+		if p.metricsService != nil {
+			duration := time.Since(startTime).Seconds()
+			p.metricsService.StateChangeProcessingDuration.WithLabelValues("LiquidityPoolsProcessor").Observe(duration)
+		}
+	}()
+
+	changes, err := opWrapper.Transaction.GetOperationChanges(opWrapper.Index)
+	if err != nil {
+		return nil, fmt.Errorf("getting operation changes: %w", err)
+	}
+
+	var poolChanges []types.LiquidityPoolChange
+	for _, change := range changes {
+		if change.Type != xdr.LedgerEntryTypeLiquidityPool {
+			continue
+		}
+
+		poolChange, skip := p.processPoolChange(change, opWrapper)
+		if skip {
+			continue
+		}
+		poolChanges = append(poolChanges, poolChange)
+	}
+
+	return poolChanges, nil
+}
+
+// processPoolChange converts a LiquidityPoolEntry change to a LiquidityPoolChange.
+// Returns skip=true for invalid changes and non-constant-product pools (the only pool type today).
+func (p *LiquidityPoolsProcessor) processPoolChange(change ingest.Change, opWrapper *TransactionOperationWrapper) (types.LiquidityPoolChange, bool) {
+	var poolChange types.LiquidityPoolChange
+
+	var entry *xdr.LedgerEntry
+	switch {
+	case change.Pre == nil && change.Post != nil:
+		poolChange.Operation = types.LiquidityPoolOpAdd
+		entry = change.Post
+	case change.Pre != nil && change.Post != nil:
+		poolChange.Operation = types.LiquidityPoolOpUpdate
+		entry = change.Post
+	case change.Pre != nil && change.Post == nil:
+		poolChange.Operation = types.LiquidityPoolOpRemove
+		entry = change.Pre
+	default:
+		return poolChange, true // Invalid change, skip
+	}
+
+	pool := entry.Data.MustLiquidityPool()
+	cp, ok := pool.Body.GetConstantProduct()
+	if !ok {
+		return poolChange, true // Only constant-product pools exist today
+	}
+
+	poolChange.PoolID = PoolIDToString(pool.LiquidityPoolId)
+	poolChange.OperationID = opWrapper.ID()
+	poolChange.LedgerNumber = opWrapper.Transaction.Ledger.LedgerSequence()
+	poolChange.AssetA = cp.Params.AssetA.StringCanonical()
+	poolChange.ReserveA = int64(cp.ReserveA)
+	poolChange.AssetB = cp.Params.AssetB.StringCanonical()
+	poolChange.ReserveB = int64(cp.ReserveB)
+
+	return poolChange, false
+}

--- a/internal/indexer/processors/liquidity_pools_test.go
+++ b/internal/indexer/processors/liquidity_pools_test.go
@@ -1,0 +1,243 @@
+// Unit tests for the liquidity pool processors.
+// Tests pool-share balance extraction from pool_share trustlines and pool reserve extraction
+// from LiquidityPoolEntry ledger entries.
+package processors
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stellar/go-stellar-sdk/xdr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+)
+
+// poolShareEntry creates a pool_share trustline entry with the given shares.
+func poolShareEntry(accountID xdr.AccountId, poolID xdr.PoolId, shares int64) *xdr.LedgerEntry {
+	return &xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 12345,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeTrustline,
+			TrustLine: &xdr.TrustLineEntry{
+				AccountId: accountID,
+				Asset: xdr.TrustLineAsset{
+					Type:            xdr.AssetTypeAssetTypePoolShare,
+					LiquidityPoolId: &poolID,
+				},
+				Balance: xdr.Int64(shares),
+				Limit:   xdr.Int64(10000000),
+			},
+		},
+	}
+}
+
+func TestLiquidityPoolSharesProcessor_Name(t *testing.T) {
+	assert.Equal(t, "liquidity_pool_shares", NewLiquidityPoolSharesProcessor(nil).Name())
+}
+
+func TestLiquidityPoolSharesProcessor_ProcessOperation(t *testing.T) {
+	processor := NewLiquidityPoolSharesProcessor(nil)
+	testAccount := accountA.ToAccountId()
+	poolID := lpBtcEthID
+
+	tests := []struct {
+		name           string
+		changes        xdr.LedgerEntryChanges
+		expectedCount  int
+		expectedOp     types.LiquidityPoolShareOp
+		expectedShares int64
+	}{
+		{
+			name: "pool share created",
+			changes: xdr.LedgerEntryChanges{
+				{Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated, Created: poolShareEntry(testAccount, poolID, 5000)},
+			},
+			expectedCount:  1,
+			expectedOp:     types.LiquidityPoolShareOpAdd,
+			expectedShares: 5000,
+		},
+		{
+			name: "pool share updated",
+			changes: xdr.LedgerEntryChanges{
+				{Type: xdr.LedgerEntryChangeTypeLedgerEntryState, State: poolShareEntry(testAccount, poolID, 5000)},
+				{Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated, Updated: poolShareEntry(testAccount, poolID, 8000)},
+			},
+			expectedCount:  1,
+			expectedOp:     types.LiquidityPoolShareOpUpdate,
+			expectedShares: 8000,
+		},
+		{
+			name: "pool share removed",
+			changes: xdr.LedgerEntryChanges{
+				{Type: xdr.LedgerEntryChangeTypeLedgerEntryState, State: poolShareEntry(testAccount, poolID, 5000)},
+				{
+					Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved,
+					Removed: &xdr.LedgerKey{
+						Type: xdr.LedgerEntryTypeTrustline,
+						TrustLine: &xdr.LedgerKeyTrustLine{
+							AccountId: testAccount,
+							Asset:     xdr.TrustLineAsset{Type: xdr.AssetTypeAssetTypePoolShare, LiquidityPoolId: &poolID},
+						},
+					},
+				},
+			},
+			expectedCount:  1,
+			expectedOp:     types.LiquidityPoolShareOpRemove,
+			expectedShares: 5000, // removal reports the pre-state shares
+		},
+		{
+			name: "regular asset trustline skipped",
+			changes: xdr.LedgerEntryChanges{
+				{Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated, Created: trustlineLedgerEntry(testAccount, usdcAsset, 5000000)},
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "non-trustline change skipped",
+			changes: xdr.LedgerEntryChanges{
+				{
+					Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+					Created: &xdr.LedgerEntry{Data: xdr.LedgerEntryData{
+						Type:    xdr.LedgerEntryTypeAccount,
+						Account: accountEntry(accountA, 10000000),
+					}},
+				},
+			},
+			expectedCount: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			op := xdr.Operation{
+				SourceAccount: &accountA,
+				Body:          xdr.OperationBody{Type: xdr.OperationTypeChangeTrust, ChangeTrustOp: &xdr.ChangeTrustOp{}},
+			}
+			tx := createTx(op, tc.changes, nil, false)
+			wrapper := &TransactionOperationWrapper{
+				Index:          0,
+				Transaction:    tx,
+				Operation:      op,
+				LedgerSequence: 12345,
+				Network:        networkPassphrase,
+			}
+
+			changes, err := processor.ProcessOperation(context.Background(), wrapper)
+			require.NoError(t, err)
+			require.Len(t, changes, tc.expectedCount)
+
+			if tc.expectedCount > 0 {
+				change := changes[0]
+				assert.Equal(t, tc.expectedOp, change.Operation)
+				assert.Equal(t, testAccount.Address(), change.AccountID)
+				assert.Equal(t, PoolIDToString(poolID), change.PoolID)
+				assert.Equal(t, tc.expectedShares, change.Shares)
+				assert.Equal(t, uint32(12345), change.LedgerNumber)
+				assert.NotZero(t, change.OperationID)
+			}
+		})
+	}
+}
+
+func TestLiquidityPoolsProcessor_Name(t *testing.T) {
+	assert.Equal(t, "liquidity_pools", NewLiquidityPoolsProcessor(nil).Name())
+}
+
+func TestLiquidityPoolsProcessor_ProcessOperation(t *testing.T) {
+	processor := NewLiquidityPoolsProcessor(nil)
+	poolID := lpBtcEthID
+
+	tests := []struct {
+		name             string
+		changes          xdr.LedgerEntryChanges
+		expectedCount    int
+		expectedOp       types.LiquidityPoolOp
+		expectedAssetA   string
+		expectedReserveA int64
+		expectedAssetB   string
+		expectedReserveB int64
+	}{
+		{
+			name: "pool created",
+			changes: xdr.LedgerEntryChanges{
+				generateLpEntryCreatedChange(lpLedgerEntry(poolID, btcAsset, ethAsset, 100, 200)),
+			},
+			expectedCount:    1,
+			expectedOp:       types.LiquidityPoolOpAdd,
+			expectedAssetA:   btcAsset.StringCanonical(),
+			expectedReserveA: 100,
+			expectedAssetB:   ethAsset.StringCanonical(),
+			expectedReserveB: 200,
+		},
+		{
+			name: "pool updated with native reserve",
+			changes: xdr.LedgerEntryChanges{
+				generateLpEntryChangeState(lpLedgerEntry(poolID, xlmAsset, ethAsset, 100, 200)),
+				{Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated, Updated: ptrLpEntry(lpLedgerEntry(poolID, xlmAsset, ethAsset, 500, 900))},
+			},
+			expectedCount:    1,
+			expectedOp:       types.LiquidityPoolOpUpdate,
+			expectedAssetA:   "native",
+			expectedReserveA: 500,
+			expectedAssetB:   ethAsset.StringCanonical(),
+			expectedReserveB: 900,
+		},
+		{
+			name: "pool removed",
+			changes: xdr.LedgerEntryChanges{
+				generateLpEntryChangeState(lpLedgerEntry(poolID, btcAsset, ethAsset, 100, 200)),
+				generateLpEntryRemovedChange(poolID),
+			},
+			expectedCount:    1,
+			expectedOp:       types.LiquidityPoolOpRemove,
+			expectedAssetA:   btcAsset.StringCanonical(),
+			expectedReserveA: 100,
+			expectedAssetB:   ethAsset.StringCanonical(),
+			expectedReserveB: 200,
+		},
+		{
+			name: "non-pool change skipped",
+			changes: xdr.LedgerEntryChanges{
+				{Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated, Created: trustlineLedgerEntry(accountA.ToAccountId(), usdcAsset, 5000000)},
+			},
+			expectedCount: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			op := lpDepositOp(poolID, 100, 200, 1, 2, &accountA)
+			tx := createTx(op, tc.changes, nil, false)
+			wrapper := &TransactionOperationWrapper{
+				Index:          0,
+				Transaction:    tx,
+				Operation:      op,
+				LedgerSequence: 12345,
+				Network:        networkPassphrase,
+			}
+
+			changes, err := processor.ProcessOperation(context.Background(), wrapper)
+			require.NoError(t, err)
+			require.Len(t, changes, tc.expectedCount)
+
+			if tc.expectedCount > 0 {
+				change := changes[0]
+				assert.Equal(t, tc.expectedOp, change.Operation)
+				assert.Equal(t, PoolIDToString(poolID), change.PoolID)
+				assert.Equal(t, tc.expectedAssetA, change.AssetA)
+				assert.Equal(t, tc.expectedReserveA, change.ReserveA)
+				assert.Equal(t, tc.expectedAssetB, change.AssetB)
+				assert.Equal(t, tc.expectedReserveB, change.ReserveB)
+				assert.Equal(t, uint32(12345), change.LedgerNumber)
+				assert.NotZero(t, change.OperationID)
+			}
+		})
+	}
+}
+
+// ptrLpEntry returns a pointer to a liquidity pool ledger entry (for building Updated changes).
+func ptrLpEntry(entry xdr.LedgerEntry) *xdr.LedgerEntry {
+	return &entry
+}

--- a/internal/indexer/types/types.go
+++ b/internal/indexer/types/types.go
@@ -280,6 +280,47 @@ const (
 	SACBalanceOpRemove SACBalanceOp = "REMOVE"
 )
 
+// LiquidityPoolShareChange is an account's pool-share balance change extracted from a
+// pool_share trustline. PoolID is the hex-encoded pool id; Shares is the trustline balance.
+type LiquidityPoolShareChange struct {
+	AccountID    string
+	PoolID       string
+	OperationID  int64
+	LedgerNumber uint32
+	Operation    LiquidityPoolShareOp
+	Shares       int64
+}
+
+type LiquidityPoolShareOp string
+
+const (
+	LiquidityPoolShareOpAdd    LiquidityPoolShareOp = "ADD"
+	LiquidityPoolShareOpUpdate LiquidityPoolShareOp = "UPDATE"
+	LiquidityPoolShareOpRemove LiquidityPoolShareOp = "REMOVE"
+)
+
+// LiquidityPoolChange is a constant-product pool's reserve change extracted from a
+// LiquidityPoolEntry ledger entry. PoolID is the hex-encoded pool id; AssetA/AssetB are
+// canonical asset strings ("native" or "CODE:ISSUER").
+type LiquidityPoolChange struct {
+	PoolID       string
+	OperationID  int64
+	LedgerNumber uint32
+	Operation    LiquidityPoolOp
+	AssetA       string
+	ReserveA     int64
+	AssetB       string
+	ReserveB     int64
+}
+
+type LiquidityPoolOp string
+
+const (
+	LiquidityPoolOpAdd    LiquidityPoolOp = "ADD"
+	LiquidityPoolOpUpdate LiquidityPoolOp = "UPDATE"
+	LiquidityPoolOpRemove LiquidityPoolOp = "REMOVE"
+)
+
 type Account struct {
 	StellarAddress AddressBytea `json:"address,omitempty" db:"stellar_address"`
 	CreatedAt      time.Time    `json:"createdAt,omitempty" db:"created_at"`

--- a/internal/indexer/types/types.go
+++ b/internal/indexer/types/types.go
@@ -244,10 +244,12 @@ type AccountChange struct {
 	// SortKey is a within-ledger dedup rank (phase|tx|op via accountSortKey), not a TOID.
 	// The buffer keeps the highest per account to pick the chronologically-last balance;
 	// it is never persisted.
-	SortKey            int64
-	LedgerNumber       uint32
-	Operation          AccountOpType
-	Balance            int64
+	SortKey      int64
+	LedgerNumber uint32
+	Operation    AccountOpType
+	Balance      int64
+	// MinimumBalance is the base reserve requirement in stroops (excludes liabilities):
+	// (2 + NumSubEntries + numSponsoring - numSponsored) * baseReserve; matches stellar-core getMinBalance.
 	MinimumBalance     int64
 	BuyingLiabilities  int64
 	SellingLiabilities int64

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -193,24 +193,28 @@ func setupDeps(cfg Configs) (services.IngestService, error) {
 	}
 
 	tokenIngestionService := services.NewTokenIngestionService(services.TokenIngestionServiceConfig{
-		TrustlineBalanceModel: models.TrustlineBalance,
-		NativeBalanceModel:    models.NativeBalance,
-		SACBalanceModel:       models.SACBalance,
-		NetworkPassphrase:     cfg.NetworkPassphrase,
+		TrustlineBalanceModel:     models.TrustlineBalance,
+		NativeBalanceModel:        models.NativeBalance,
+		SACBalanceModel:           models.SACBalance,
+		LiquidityPoolModel:        models.LiquidityPool,
+		LiquidityPoolBalanceModel: models.LiquidityPoolBalance,
+		NetworkPassphrase:         cfg.NetworkPassphrase,
 	})
 
 	checkpointService := services.NewCheckpointService(services.CheckpointServiceConfig{
-		DB:                      models.DB,
-		Archive:                 archive,
-		ContractMetadataService: contractMetadataService,
-		TrustlineAssetModel:     models.TrustlineAsset,
-		TrustlineBalanceModel:   models.TrustlineBalance,
-		NativeBalanceModel:      models.NativeBalance,
-		SACBalanceModel:         models.SACBalance,
-		ContractModel:           models.Contract,
-		ProtocolWasmsModel:      models.ProtocolWasms,
-		ProtocolContractsModel:  models.ProtocolContracts,
-		NetworkPassphrase:       cfg.NetworkPassphrase,
+		DB:                        models.DB,
+		Archive:                   archive,
+		ContractMetadataService:   contractMetadataService,
+		TrustlineAssetModel:       models.TrustlineAsset,
+		TrustlineBalanceModel:     models.TrustlineBalance,
+		NativeBalanceModel:        models.NativeBalance,
+		SACBalanceModel:           models.SACBalance,
+		LiquidityPoolModel:        models.LiquidityPool,
+		LiquidityPoolBalanceModel: models.LiquidityPoolBalance,
+		ContractModel:             models.Contract,
+		ProtocolWasmsModel:        models.ProtocolWasms,
+		ProtocolContractsModel:    models.ProtocolContracts,
+		NetworkPassphrase:         cfg.NetworkPassphrase,
 	})
 
 	// Create a factory function for parallel backfill (each batch needs its own backend)

--- a/internal/integrationtests/account_balances_test.go
+++ b/internal/integrationtests/account_balances_test.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 
 	"github.com/stellar/go-stellar-sdk/amount"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/stellar/wallet-backend/internal/integrationtests/infrastructure"
@@ -160,6 +161,42 @@ func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_HolderContr
 			suite.Fail("Unexpected balance type: %T", balance)
 		}
 	}
+}
+
+// TestCheckpoint_LiquidityPoolAccount_HasPoolShareBalance verifies that the dedicated liquidity-pool
+// account — which established a constant-product pool and deposited before the checkpoint snapshot —
+// has its pool-share balance hydrated through the checkpoint BatchCopy path. This proves the
+// liquidity_pool_balances ⋈ liquidity_pools JOIN is populated from the snapshot:
+//   - Native XLM (reduced by the deposited leg + fees)
+//   - Liquidity-pool share balance (TestLPShareStroops shares; native + LPTEST reserves)
+func (suite *AccountBalancesAfterCheckpointTestSuite) TestCheckpoint_LiquidityPoolAccount_HasPoolShareBalance() {
+	balances, err := suite.testEnv.WBClient.GetAllAccountBalances(
+		context.Background(),
+		suite.testEnv.CheckpointLPAccountKP.Address(),
+	)
+	suite.Require().NoError(err)
+	suite.Require().Equal(2, len(balances), "Expected 2 balances: native XLM and the liquidity-pool share")
+
+	var lp *types.LiquidityPoolBalance
+	for _, balance := range balances {
+		switch b := balance.(type) {
+		case *types.NativeBalance:
+			suite.Require().Equal(types.TokenTypeNative, b.GetTokenType())
+			suite.Require().Greater(b.LastModifiedLedger, uint32(0), "LastModifiedLedger should be set")
+		case *types.LiquidityPoolBalance:
+			lp = b
+		default:
+			suite.Fail("Unexpected balance type: %T", balance)
+		}
+	}
+
+	suite.Require().NotNil(lp, "expected a liquidity-pool share balance hydrated from the checkpoint")
+	assetB := infrastructure.TestCheckpointLPAssetCode + ":" + suite.testEnv.CheckpointLPAccountKP.Address()
+	assertLiquidityPoolBalance(suite.Require(), lp,
+		suite.testEnv.CheckpointLiquidityPoolID,
+		amount.StringFromInt64(infrastructure.TestLPShareStroops),
+		"native", amount.StringFromInt64(infrastructure.TestLPReserveStroops),
+		assetB, amount.StringFromInt64(infrastructure.TestLPReserveStroops))
 }
 
 // TestCheckpoint_Account1_ForwardPagination verifies that GetAccountBalances
@@ -450,6 +487,43 @@ func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_Sorob
 	suite.Require().Less(onChainStroops, fundingStroops, "source should have paid a net fee and transferred XLM out")
 }
 
+// TestLiveIngestion_LiquidityPoolAccount_HasPoolShareBalance verifies that the dedicated live
+// liquidity-pool account — which deposited into a constant-product pool via a submitted use case
+// (prepareLiveLiquidityPoolDepositOps) without withdrawing — has its pool-share balance produced by
+// the live delta-ingestion path (liquidity_pools + liquidity_pool_balances upserts). This is the
+// live counterpart to the checkpoint hydration test:
+//   - Native XLM (reduced by the deposited leg + fees)
+//   - Liquidity-pool share balance (TestLPShareStroops shares; native + LPLIVE reserves)
+func (suite *AccountBalancesAfterLiveIngestionTestSuite) TestLiveIngestion_LiquidityPoolAccount_HasPoolShareBalance() {
+	balances, err := suite.testEnv.WBClient.GetAllAccountBalances(
+		context.Background(),
+		suite.testEnv.LiveLPAccountKP.Address(),
+	)
+	suite.Require().NoError(err)
+	suite.Require().Equal(2, len(balances), "Expected 2 balances: native XLM and the liquidity-pool share")
+
+	var lp *types.LiquidityPoolBalance
+	for _, balance := range balances {
+		switch b := balance.(type) {
+		case *types.NativeBalance:
+			suite.Require().Equal(types.TokenTypeNative, b.GetTokenType())
+			suite.Require().Greater(b.LastModifiedLedger, uint32(0), "LastModifiedLedger should be set")
+		case *types.LiquidityPoolBalance:
+			lp = b
+		default:
+			suite.Fail("Unexpected balance type: %T", balance)
+		}
+	}
+
+	suite.Require().NotNil(lp, "expected a liquidity-pool share balance produced by live ingestion")
+	assetB := infrastructure.TestLiveLPAssetCode + ":" + suite.testEnv.LiveLPAccountKP.Address()
+	assertLiquidityPoolBalance(suite.Require(), lp,
+		suite.testEnv.LiveLiquidityPoolID,
+		amount.StringFromInt64(infrastructure.TestLPShareStroops),
+		"native", amount.StringFromInt64(infrastructure.TestLPReserveStroops),
+		assetB, amount.StringFromInt64(infrastructure.TestLPReserveStroops))
+}
+
 // assertSEP41TokenBalance verifies a SEP-41 balance node matches the custom token
 // deployed in setup and migrated by DataMigrationTestSuite. The API returns the
 // raw i128 amount (unscaled by decimals), so expectedAmount is the stroop count
@@ -459,4 +533,21 @@ func (suite *AccountBalancesAfterLiveIngestionTestSuite) assertSEP41TokenBalance
 	suite.Require().Equal(suite.testEnv.SEP41ContractAddress, b.GetTokenID())
 	suite.Require().Equal(expectedAmount, b.GetBalance(), "SEP-41 balance should equal the migrated amount")
 	suite.Require().Equal(int32(7), b.Decimals, "SEP-41 token was deployed with 7 decimals")
+}
+
+// assertLiquidityPoolBalance verifies a liquidity-pool balance node exposes the expected pool id,
+// share balance, and both reserve legs (canonical asset + amount, in AssetA/AssetB order). It is a
+// free function rather than a suite method because both the checkpoint and live-ingestion suites
+// assert pool-share balances; expectedShares/amountA/amountB are decimal strings (e.g. "100.0000000").
+func assertLiquidityPoolBalance(r *require.Assertions, b *types.LiquidityPoolBalance, expectedPoolID, expectedShares, assetA, amountA, assetB, amountB string) {
+	r.Equal(types.TokenTypeLiquidityPool, b.GetTokenType())
+	r.Equal(expectedPoolID, b.GetTokenID(), "LP tokenId should be the pool id")
+	r.Equal(expectedPoolID, b.LiquidityPoolID, "LP liquidityPoolId should be the pool id")
+	r.Equal(expectedShares, b.GetBalance(), "LP share balance mismatch")
+	r.Greater(b.LastModifiedLedger, uint32(0), "LastModifiedLedger should be set")
+	r.Len(b.Reserves, 2, "LP should expose both reserve legs")
+	r.Equal(assetA, b.Reserves[0].Asset, "reserve[0] asset mismatch")
+	r.Equal(amountA, b.Reserves[0].Amount, "reserve[0] amount mismatch")
+	r.Equal(assetB, b.Reserves[1].Asset, "reserve[1] asset mismatch")
+	r.Equal(amountB, b.Reserves[1].Amount, "reserve[1] amount mismatch")
 }

--- a/internal/integrationtests/infrastructure/account_setup.go
+++ b/internal/integrationtests/infrastructure/account_setup.go
@@ -8,7 +8,10 @@ import (
 	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/txnbuild"
+	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/indexer/processors"
 )
 
 // CreateAndFundAccounts creates and funds multiple accounts in a single transaction using the master account
@@ -123,6 +126,60 @@ func (s *SharedContainers) createEURCTrustlines(ctx context.Context, t *testing.
 	require.NoError(t, err, "failed to create EURC trustline")
 
 	log.Ctx(ctx).Infof("🔗 Created EURC trustline for balance test account 1 %s: %s:%s", s.balanceTestAccount1KeyPair.Address(), eurcAsset.Code, eurcAsset.Issuer)
+}
+
+// createLiquidityPool establishes a constant-product liquidity pool for the checkpoint LP test
+// account BEFORE the checkpoint snapshot is taken, so the resulting pool reserves and pool-share
+// balance are hydrated through the checkpoint BatchCopy path (liquidity_pool_balances JOINed with
+// liquidity_pools) rather than live delta ingestion.
+//
+// The account issues its own credit asset, pairs it with native XLM, and deposits equal legs of
+// TestLiquidityPoolAmount. The initial deposit into an empty pool mints TestLPShareStroops shares
+// and leaves TestLPReserveStroops in each reserve. It deliberately does not withdraw, so the shares
+// persist into the snapshot. The computed pool id is recorded on SharedContainers for the assertion.
+func (s *SharedContainers) createLiquidityPool(ctx context.Context, t *testing.T) {
+	xlmAsset := txnbuild.NativeAsset{}
+	customAsset := txnbuild.CreditAsset{
+		Code:   TestCheckpointLPAssetCode,
+		Issuer: s.checkpointLPAccountKeyPair.Address(),
+	}
+
+	poolID, err := txnbuild.NewLiquidityPoolId(xlmAsset, customAsset)
+	require.NoError(t, err, "creating checkpoint liquidity pool ID")
+	poolIDXDR, err := poolID.ToXDR()
+	require.NoError(t, err, "converting checkpoint liquidity pool ID to XDR")
+	s.checkpointLiquidityPoolID = processors.PoolIDToString(poolIDXDR)
+
+	poolAsset := txnbuild.LiquidityPoolShareChangeTrustAsset{
+		LiquidityPoolParameters: txnbuild.LiquidityPoolParameters{
+			AssetA: xlmAsset,
+			AssetB: customAsset,
+			Fee:    txnbuild.LiquidityPoolFeeV18,
+		},
+	}
+
+	ops := []txnbuild.Operation{
+		// The account establishes a trustline to the liquidity pool (creates the pool + share trustline).
+		&txnbuild.ChangeTrust{
+			Line:          poolAsset,
+			SourceAccount: s.checkpointLPAccountKeyPair.Address(),
+		},
+		// The account deposits equal legs and keeps the resulting shares.
+		&txnbuild.LiquidityPoolDeposit{
+			LiquidityPoolID: poolID,
+			MaxAmountA:      TestLiquidityPoolAmount, // 100 XLM
+			MaxAmountB:      TestLiquidityPoolAmount, // 100 LPTEST
+			MinPrice:        xdr.Price{N: xdr.Int32(1), D: xdr.Int32(1)},
+			MaxPrice:        xdr.Price{N: xdr.Int32(1), D: xdr.Int32(1)},
+			SourceAccount:   s.checkpointLPAccountKeyPair.Address(),
+		},
+	}
+
+	_, err = executeClassicOperation(ctx, t, s, ops, []*keypair.Full{s.masterKeyPair, s.checkpointLPAccountKeyPair})
+	require.NoError(t, err, "failed to create checkpoint liquidity pool")
+
+	log.Ctx(ctx).Infof("💧 Created checkpoint liquidity pool %s for account %s (asset %s:%s)",
+		s.checkpointLiquidityPoolID, s.checkpointLPAccountKeyPair.Address(), customAsset.Code, customAsset.Issuer)
 }
 
 // SubmitPaymentOp executes a native XLM payment from the master account to a destination

--- a/internal/integrationtests/infrastructure/fixtures.go
+++ b/internal/integrationtests/infrastructure/fixtures.go
@@ -61,6 +61,11 @@ type Fixtures struct {
 	BalanceTestAccount1KP *keypair.Full
 	BalanceTestAccount2KP *keypair.Full
 	LiquidityPoolID       string
+	// LiveLPAccountKP issues its own credit asset and, as a submitted use case, establishes a
+	// pool-share trustline and deposits into a constant-product pool WITHOUT withdrawing — leaving
+	// a live-ingested pool-share balance to assert. LiveLiquidityPoolID is that pool's id.
+	LiveLPAccountKP       *keypair.Full
+	LiveLiquidityPoolID   string
 	RPCService            services.RPCService
 	HolderContractAddress string
 	EURCContractAddress   string
@@ -78,6 +83,7 @@ func NewFixtures(
 	sponsoredNewAccountKP *keypair.Full,
 	balanceTestAccount1KP *keypair.Full,
 	balanceTestAccount2KP *keypair.Full,
+	liveLPAccountKP *keypair.Full,
 	masterAccountKP *keypair.Full,
 	rpcService services.RPCService,
 	holderContractAddress string,
@@ -93,6 +99,7 @@ func NewFixtures(
 		SponsoredNewAccountKP: sponsoredNewAccountKP,
 		BalanceTestAccount1KP: balanceTestAccount1KP,
 		BalanceTestAccount2KP: balanceTestAccount2KP,
+		LiveLPAccountKP:       liveLPAccountKP,
 		MasterAccountKP:       masterAccountKP,
 		RPCService:            rpcService,
 		HolderContractAddress: holderContractAddress,
@@ -675,6 +682,68 @@ func (f *Fixtures) prepareLiquidityPoolOps() ([]string, *Set[*keypair.Full], err
 	}
 
 	return b64OpsXDRs, NewSet(f.PrimaryAccountKP), nil
+}
+
+// prepareLiveLiquidityPoolDepositOps establishes a pool-share trustline and deposits into a
+// constant-product pool for LiveLPAccountKP, which issues its own credit asset. Unlike
+// prepareLiquidityPoolOps it deliberately does NOT withdraw or remove the trustline, so a
+// pool-share balance survives live ingestion for AccountBalancesAfterLiveIngestionTestSuite to
+// assert. The initial deposit of equal legs mints TestLPShareStroops shares and leaves
+// TestLPReserveStroops in each reserve.
+func (f *Fixtures) prepareLiveLiquidityPoolDepositOps() ([]string, *Set[*keypair.Full], error) {
+	xlmAsset := txnbuild.NativeAsset{}
+	customAsset := txnbuild.CreditAsset{
+		Issuer: f.LiveLPAccountKP.Address(),
+		Code:   TestLiveLPAssetCode,
+	}
+
+	poolID, err := txnbuild.NewLiquidityPoolId(xlmAsset, customAsset)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating live liquidity pool ID: %w", err)
+	}
+	poolIDXDR, err := poolID.ToXDR()
+	if err != nil {
+		return nil, nil, fmt.Errorf("converting live liquidity pool ID to XDR: %w", err)
+	}
+	f.LiveLiquidityPoolID = processors.PoolIDToString(poolIDXDR)
+
+	poolAsset := txnbuild.LiquidityPoolShareChangeTrustAsset{
+		LiquidityPoolParameters: txnbuild.LiquidityPoolParameters{
+			AssetA: xlmAsset,
+			AssetB: customAsset,
+			Fee:    txnbuild.LiquidityPoolFeeV18,
+		},
+	}
+
+	operations := []txnbuild.Operation{
+		// LiveLPAccountKP establishes a trustline to the liquidity pool.
+		&txnbuild.ChangeTrust{
+			Line:          poolAsset,
+			SourceAccount: f.LiveLPAccountKP.Address(),
+		},
+		// LiveLPAccountKP deposits equal legs and keeps the resulting shares.
+		&txnbuild.LiquidityPoolDeposit{
+			LiquidityPoolID: poolID,
+			MaxAmountA:      TestLiquidityPoolAmount, // 100 XLM
+			MaxAmountB:      TestLiquidityPoolAmount, // 100 LPLIVE
+			MinPrice: xdr.Price{
+				N: xdr.Int32(1),
+				D: xdr.Int32(1),
+			},
+			MaxPrice: xdr.Price{
+				N: xdr.Int32(1),
+				D: xdr.Int32(1),
+			},
+			SourceAccount: f.LiveLPAccountKP.Address(),
+		},
+	}
+
+	b64OpsXDRs, err := ConvertOperationsToBase64XDR(operations)
+	if err != nil {
+		return nil, nil, fmt.Errorf("encoding operations to base64 XDR: %w", err)
+	}
+
+	return b64OpsXDRs, NewSet(f.LiveLPAccountKP), nil
 }
 
 // prepareRevokeSponsorshipOps creates revoke sponsorship operations.
@@ -1355,6 +1424,18 @@ func (f *Fixtures) appendClassicUseCases(ctx context.Context, useCases []*UseCas
 		return nil, fmt.Errorf("preparing liquidity pool operations: %w", err)
 	}
 	useCase, err = f.buildMultiOperationUseCase(liquidityPoolOps, txSigners, "liquidityPoolOps", categoryStellarClassic, timeoutSeconds)
+	if err != nil {
+		return nil, err
+	}
+	useCases = append(useCases, useCase)
+
+	// LiveLiquidityPoolDepositOps — deposit without withdrawing so a live-ingested pool-share
+	// balance survives for AccountBalancesAfterLiveIngestionTestSuite to assert.
+	liveLPDepositOps, txSigners, err := f.prepareLiveLiquidityPoolDepositOps()
+	if err != nil {
+		return nil, fmt.Errorf("preparing live liquidity pool deposit operations: %w", err)
+	}
+	useCase, err = f.buildMultiOperationUseCase(liveLPDepositOps, txSigners, "liveLiquidityPoolDepositOps", categoryStellarClassic, timeoutSeconds)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/integrationtests/infrastructure/main_setup.go
+++ b/internal/integrationtests/infrastructure/main_setup.go
@@ -52,8 +52,17 @@ type SharedContainers struct {
 	balanceTestAccount2KeyPair    *keypair.Full
 	feeBumpSourceKeyPair          *keypair.Full // Fee-bump fee source for the fee-phase balance test (#637); moves only in the fee phase
 	sorobanRefundSourceKeyPair    *keypair.Full // Soroban tx source: pays a refunded resource fee and is touched by its own transfer op
-	masterKeyPair                 *keypair.Full
-	masterAccount                 *txnbuild.SimpleAccount
+	// checkpointLPAccountKeyPair issues its own credit asset and establishes a liquidity pool BEFORE
+	// the checkpoint snapshot, so its pool-share balance is hydrated via checkpoint BatchCopy.
+	checkpointLPAccountKeyPair *keypair.Full
+	// liveLPAccountKeyPair issues its own credit asset and deposits into a pool AFTER the snapshot,
+	// as a submitted use case, so its pool-share balance is produced by live delta ingestion.
+	liveLPAccountKeyPair *keypair.Full
+	masterKeyPair        *keypair.Full
+	masterAccount        *txnbuild.SimpleAccount
+
+	// checkpointLiquidityPoolID is the pool id (hex) of the pool created before the checkpoint snapshot.
+	checkpointLiquidityPoolID string
 
 	// Deployed contracts
 	usdcContractAddress string
@@ -137,6 +146,8 @@ func (s *SharedContainers) setupTestAccounts(ctx context.Context, t *testing.T) 
 	s.balanceTestAccount2KeyPair = keypair.MustRandom()
 	s.feeBumpSourceKeyPair = keypair.MustRandom()
 	s.sorobanRefundSourceKeyPair = keypair.MustRandom()
+	s.checkpointLPAccountKeyPair = keypair.MustRandom()
+	s.liveLPAccountKeyPair = keypair.MustRandom()
 
 	// We are not funding this account, as it will be funded by the primary account through a sponsored account creation operation
 	s.sponsoredNewAccountKeyPair = keypair.MustRandom()
@@ -151,6 +162,8 @@ func (s *SharedContainers) setupTestAccounts(ctx context.Context, t *testing.T) 
 		s.balanceTestAccount2KeyPair,
 		s.feeBumpSourceKeyPair,
 		s.sorobanRefundSourceKeyPair,
+		s.checkpointLPAccountKeyPair,
+		s.liveLPAccountKeyPair,
 	})
 
 	// Create trustlines - these will be used for the account balances test
@@ -161,6 +174,11 @@ func (s *SharedContainers) setupTestAccounts(ctx context.Context, t *testing.T) 
 
 	// Create EURC trustlines for balance test account 1 only
 	s.createEURCTrustlines(ctx, t)
+
+	// Create a liquidity pool for the checkpoint LP account BEFORE the checkpoint snapshot so its
+	// pool-share balance is hydrated via the checkpoint BatchCopy path. The live LP account only
+	// deposits later, as a submitted use case, exercising the live delta-ingestion path instead.
+	s.createLiquidityPool(ctx, t)
 
 	return nil
 }
@@ -520,6 +538,12 @@ type TestEnvironment struct {
 	SponsoredNewAccountKP *keypair.Full
 	BalanceTestAccount1KP *keypair.Full
 	BalanceTestAccount2KP *keypair.Full
+	// CheckpointLPAccountKP holds pool shares from a pool established before the checkpoint snapshot,
+	// exercising checkpoint BatchCopy hydration of liquidity_pool_balances JOINed with liquidity_pools.
+	CheckpointLPAccountKP *keypair.Full
+	// LiveLPAccountKP holds pool shares deposited via a submitted use case after the snapshot,
+	// exercising the live delta-ingestion path.
+	LiveLPAccountKP *keypair.Full
 	// FeeBumpSourceKP pays only a fee-bump fee in the fixtures — touched by no operation —
 	// so its native balance moves only in the fee phase (#637 regression coverage).
 	FeeBumpSourceKP *keypair.Full
@@ -538,10 +562,14 @@ type TestEnvironment struct {
 	HolderContractAddress string
 	// MasterAccountAddress is the address of the master/root account that issues classic assets.
 	// Used for asserting issuer addresses in trustline and SAC balance tests.
-	MasterAccountAddress     string
-	ClaimBalanceID           string
-	ClawbackBalanceID        string
-	LiquidityPoolID          string
+	MasterAccountAddress string
+	ClaimBalanceID       string
+	ClawbackBalanceID    string
+	LiquidityPoolID      string
+	// CheckpointLiquidityPoolID is the pool id (hex) of the pool created before the checkpoint snapshot.
+	CheckpointLiquidityPoolID string
+	// LiveLiquidityPoolID is the pool id (hex) of the pool created by the live LP deposit use case.
+	LiveLiquidityPoolID      string
 	NetworkPassphrase        string
 	UseCases                 []*UseCase
 	ClaimAndClawbackUseCases []*UseCase
@@ -618,6 +646,7 @@ func NewTestEnvironment(ctx context.Context, containers *SharedContainers) (*Tes
 		sponsoredNewAccountKP,
 		balanceTestAccount1KP,
 		balanceTestAccount2KP,
+		containers.liveLPAccountKeyPair,
 		masterAccountKP,
 		rpcService,
 		containers.holderContractAddress,
@@ -646,16 +675,20 @@ func NewTestEnvironment(ctx context.Context, containers *SharedContainers) (*Tes
 		SponsoredNewAccountKP: sponsoredNewAccountKP,
 		BalanceTestAccount1KP: balanceTestAccount1KP,
 		BalanceTestAccount2KP: balanceTestAccount2KP,
+		CheckpointLPAccountKP: containers.checkpointLPAccountKeyPair,
+		LiveLPAccountKP:       containers.liveLPAccountKeyPair,
 		FeeBumpSourceKP:       containers.feeBumpSourceKeyPair,
 		SorobanRefundSourceKP: containers.sorobanRefundSourceKeyPair,
 		USDCContractAddress:   containers.usdcContractAddress,
 		EURCContractAddress:   containers.eurcContractAddress,
 		// Pass through contract addresses for test assertions
-		SEP41ContractAddress:  containers.sep41ContractAddress,
-		HolderContractAddress: containers.holderContractAddress,
-		MasterAccountAddress:  masterAccountKP.Address(),
-		UseCases:              useCases,
-		NetworkPassphrase:     networkPassphrase,
-		LiquidityPoolID:       fixtures.LiquidityPoolID,
+		SEP41ContractAddress:      containers.sep41ContractAddress,
+		HolderContractAddress:     containers.holderContractAddress,
+		MasterAccountAddress:      masterAccountKP.Address(),
+		UseCases:                  useCases,
+		NetworkPassphrase:         networkPassphrase,
+		LiquidityPoolID:           fixtures.LiquidityPoolID,
+		CheckpointLiquidityPoolID: containers.checkpointLiquidityPoolID,
+		LiveLiquidityPoolID:       fixtures.LiveLiquidityPoolID,
 	}, nil
 }

--- a/internal/integrationtests/infrastructure/testconstants.go
+++ b/internal/integrationtests/infrastructure/testconstants.go
@@ -16,6 +16,20 @@ const (
 	TestEURCPaymentAmount         = "75"
 	TestUSDCPaymentAmount         = "100"
 
+	// Liquidity-pool balance test fixtures.
+	//
+	// Two dedicated accounts each issue their own credit asset, pair it with native XLM in a
+	// constant-product pool, and deposit equal legs of TestLiquidityPoolAmount. The initial
+	// deposit into an empty constant-product pool mints sqrt(amountA*amountB) shares, so equal
+	// 100-unit legs mint exactly 100 shares and leave 100 of each asset in reserve. One account
+	// establishes its pool BEFORE the checkpoint snapshot (exercising checkpoint BatchCopy
+	// hydration of liquidity_pool_balances JOINed with liquidity_pools); the other deposits live
+	// AFTER the snapshot (exercising the live delta-ingestion upsert path).
+	TestCheckpointLPAssetCode = "LPTEST"      // credit asset issued by the checkpoint LP account
+	TestLiveLPAssetCode       = "LPLIVE"      // credit asset issued by the live LP account
+	TestLPReserveStroops      = 1_000_000_000 // 100.0000000 per reserve leg after the deposit
+	TestLPShareStroops        = 1_000_000_000 // 100.0000000 pool shares minted by the initial deposit
+
 	// Soroban contract amounts (in stroops with 7 decimals)
 	TestEURCTransferStroops  = 500000000  // 50 EURC
 	TestSEP41TransferStroops = 2000000000 // 200 SEP41 (partial: account1 keeps 300 of its 500 mint)

--- a/internal/loadtest/runner.go
+++ b/internal/loadtest/runner.go
@@ -92,10 +92,12 @@ func Run(ctx context.Context, cfg RunConfig) error {
 
 	// Create TokenIngestionService for token change processing
 	tokenIngestionService := services.NewTokenIngestionService(services.TokenIngestionServiceConfig{
-		NetworkPassphrase:     cfg.NetworkPassphrase,
-		TrustlineBalanceModel: models.TrustlineBalance,
-		NativeBalanceModel:    models.NativeBalance,
-		SACBalanceModel:       models.SACBalance,
+		NetworkPassphrase:         cfg.NetworkPassphrase,
+		TrustlineBalanceModel:     models.TrustlineBalance,
+		NativeBalanceModel:        models.NativeBalance,
+		SACBalanceModel:           models.SACBalance,
+		LiquidityPoolModel:        models.LiquidityPool,
+		LiquidityPoolBalanceModel: models.LiquidityPoolBalance,
 	})
 
 	// Create ingest service for shared persistence logic

--- a/internal/serve/graphql/generated/generated.go
+++ b/internal/serve/graphql/generated/generated.go
@@ -1970,6 +1970,8 @@ type NativeBalance implements Balance {
     tokenId: String!
     tokenType: TokenType!
 
+    # base reserve requirement (excludes liabilities): (2 + numSubentries + numSponsoring - numSponsored) * baseReserve.
+    # Spendable balance = balance - minimumBalance - sellingLiabilities.
     minimumBalance: String!
     buyingLiabilities: String!
     sellingLiabilities: String!

--- a/internal/serve/graphql/generated/generated.go
+++ b/internal/serve/graphql/generated/generated.go
@@ -121,6 +121,20 @@ type ComplexityRoot struct {
 		Type            func(childComplexity int) int
 	}
 
+	LiquidityPoolBalance struct {
+		Balance            func(childComplexity int) int
+		LastModifiedLedger func(childComplexity int) int
+		LiquidityPoolID    func(childComplexity int) int
+		Reserves           func(childComplexity int) int
+		TokenID            func(childComplexity int) int
+		TokenType          func(childComplexity int) int
+	}
+
+	LiquidityPoolReserve struct {
+		Amount func(childComplexity int) int
+		Asset  func(childComplexity int) int
+	}
+
 	MetadataChange struct {
 		Account         func(childComplexity int) int
 		IngestedAt      func(childComplexity int) int
@@ -800,6 +814,56 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.FlagsChange.Type(childComplexity), true
+
+	case "LiquidityPoolBalance.balance":
+		if e.ComplexityRoot.LiquidityPoolBalance.Balance == nil {
+			break
+		}
+
+		return e.ComplexityRoot.LiquidityPoolBalance.Balance(childComplexity), true
+	case "LiquidityPoolBalance.lastModifiedLedger":
+		if e.ComplexityRoot.LiquidityPoolBalance.LastModifiedLedger == nil {
+			break
+		}
+
+		return e.ComplexityRoot.LiquidityPoolBalance.LastModifiedLedger(childComplexity), true
+	case "LiquidityPoolBalance.liquidityPoolId":
+		if e.ComplexityRoot.LiquidityPoolBalance.LiquidityPoolID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.LiquidityPoolBalance.LiquidityPoolID(childComplexity), true
+	case "LiquidityPoolBalance.reserves":
+		if e.ComplexityRoot.LiquidityPoolBalance.Reserves == nil {
+			break
+		}
+
+		return e.ComplexityRoot.LiquidityPoolBalance.Reserves(childComplexity), true
+	case "LiquidityPoolBalance.tokenId":
+		if e.ComplexityRoot.LiquidityPoolBalance.TokenID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.LiquidityPoolBalance.TokenID(childComplexity), true
+	case "LiquidityPoolBalance.tokenType":
+		if e.ComplexityRoot.LiquidityPoolBalance.TokenType == nil {
+			break
+		}
+
+		return e.ComplexityRoot.LiquidityPoolBalance.TokenType(childComplexity), true
+
+	case "LiquidityPoolReserve.amount":
+		if e.ComplexityRoot.LiquidityPoolReserve.Amount == nil {
+			break
+		}
+
+		return e.ComplexityRoot.LiquidityPoolReserve.Amount(childComplexity), true
+	case "LiquidityPoolReserve.asset":
+		if e.ComplexityRoot.LiquidityPoolReserve.Asset == nil {
+			break
+		}
+
+		return e.ComplexityRoot.LiquidityPoolReserve.Asset(childComplexity), true
 
 	case "MetadataChange.account":
 		if e.ComplexityRoot.MetadataChange.Account == nil {
@@ -1933,6 +1997,27 @@ type SACBalance implements Balance {
     isClawbackEnabled: Boolean!
 }
 
+"""LiquidityPoolReserve is one constituent asset of a liquidity pool and its reserve amount."""
+type LiquidityPoolReserve {
+    asset: String!
+    amount: String!
+}
+
+"""
+LiquidityPoolBalance represents an account's liquidity-pool share holding. ` + "`" + `balance` + "`" + ` is the
+account's pool shares and ` + "`" + `tokenId` + "`" + ` is the pool id; ` + "`" + `reserves` + "`" + ` carries the pool's constituent
+assets and amounts.
+"""
+type LiquidityPoolBalance implements Balance {
+    balance: String!
+    tokenId: String!
+    tokenType: TokenType!
+
+    liquidityPoolId: String!
+    reserves: [LiquidityPoolReserve!]!
+    lastModifiedLedger: UInt32!
+}
+
 """SEP41Balance represents a pure SEP-41 (non-SAC) token balance for a holder."""
 type SEP41Balance implements Balance {
     balance: String!
@@ -2056,6 +2141,7 @@ enum TokenType {
   CLASSIC
   SAC
   SEP41
+  LIQUIDITY_POOL
 }
 `, BuiltIn: false},
 	{Name: "../schema/filters.graphqls", Input: `# GraphQL Filter Input Types - used for filtering queries
@@ -4507,6 +4593,244 @@ func (ec *executionContext) fieldContext_FlagsChange_flags(_ context.Context, fi
 		Field:      field,
 		IsMethod:   true,
 		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LiquidityPoolBalance_balance(ctx context.Context, field graphql.CollectedField, obj *LiquidityPoolBalance) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_LiquidityPoolBalance_balance,
+		func(ctx context.Context) (any, error) {
+			return obj.Balance, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_LiquidityPoolBalance_balance(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LiquidityPoolBalance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LiquidityPoolBalance_tokenId(ctx context.Context, field graphql.CollectedField, obj *LiquidityPoolBalance) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_LiquidityPoolBalance_tokenId,
+		func(ctx context.Context) (any, error) {
+			return obj.TokenID, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_LiquidityPoolBalance_tokenId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LiquidityPoolBalance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LiquidityPoolBalance_tokenType(ctx context.Context, field graphql.CollectedField, obj *LiquidityPoolBalance) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_LiquidityPoolBalance_tokenType,
+		func(ctx context.Context) (any, error) {
+			return obj.TokenType, nil
+		},
+		nil,
+		ec.marshalNTokenType2githubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐTokenType,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_LiquidityPoolBalance_tokenType(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LiquidityPoolBalance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type TokenType does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LiquidityPoolBalance_liquidityPoolId(ctx context.Context, field graphql.CollectedField, obj *LiquidityPoolBalance) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_LiquidityPoolBalance_liquidityPoolId,
+		func(ctx context.Context) (any, error) {
+			return obj.LiquidityPoolID, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_LiquidityPoolBalance_liquidityPoolId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LiquidityPoolBalance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LiquidityPoolBalance_reserves(ctx context.Context, field graphql.CollectedField, obj *LiquidityPoolBalance) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_LiquidityPoolBalance_reserves,
+		func(ctx context.Context) (any, error) {
+			return obj.Reserves, nil
+		},
+		nil,
+		ec.marshalNLiquidityPoolReserve2ᚕᚖgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐLiquidityPoolReserveᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_LiquidityPoolBalance_reserves(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LiquidityPoolBalance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "asset":
+				return ec.fieldContext_LiquidityPoolReserve_asset(ctx, field)
+			case "amount":
+				return ec.fieldContext_LiquidityPoolReserve_amount(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type LiquidityPoolReserve", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LiquidityPoolBalance_lastModifiedLedger(ctx context.Context, field graphql.CollectedField, obj *LiquidityPoolBalance) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_LiquidityPoolBalance_lastModifiedLedger,
+		func(ctx context.Context) (any, error) {
+			return obj.LastModifiedLedger, nil
+		},
+		nil,
+		ec.marshalNUInt322uint32,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_LiquidityPoolBalance_lastModifiedLedger(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LiquidityPoolBalance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type UInt32 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LiquidityPoolReserve_asset(ctx context.Context, field graphql.CollectedField, obj *LiquidityPoolReserve) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_LiquidityPoolReserve_asset,
+		func(ctx context.Context) (any, error) {
+			return obj.Asset, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_LiquidityPoolReserve_asset(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LiquidityPoolReserve",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LiquidityPoolReserve_amount(ctx context.Context, field graphql.CollectedField, obj *LiquidityPoolReserve) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_LiquidityPoolReserve_amount,
+		func(ctx context.Context) (any, error) {
+			return obj.Amount, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_LiquidityPoolReserve_amount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LiquidityPoolReserve",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
 		},
@@ -11272,6 +11596,13 @@ func (ec *executionContext) _Balance(ctx context.Context, sel ast.SelectionSet, 
 			return graphql.Null
 		}
 		return ec._NativeBalance(ctx, sel, obj)
+	case LiquidityPoolBalance:
+		return ec._LiquidityPoolBalance(ctx, sel, &obj)
+	case *LiquidityPoolBalance:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._LiquidityPoolBalance(ctx, sel, obj)
 	default:
 		if typedObj, ok := obj.(graphql.Marshaler); ok {
 			return typedObj
@@ -12742,6 +13073,114 @@ func (ec *executionContext) _FlagsChange(ctx context.Context, sel ast.SelectionS
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var liquidityPoolBalanceImplementors = []string{"LiquidityPoolBalance", "Balance"}
+
+func (ec *executionContext) _LiquidityPoolBalance(ctx context.Context, sel ast.SelectionSet, obj *LiquidityPoolBalance) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, liquidityPoolBalanceImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("LiquidityPoolBalance")
+		case "balance":
+			out.Values[i] = ec._LiquidityPoolBalance_balance(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "tokenId":
+			out.Values[i] = ec._LiquidityPoolBalance_tokenId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "tokenType":
+			out.Values[i] = ec._LiquidityPoolBalance_tokenType(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "liquidityPoolId":
+			out.Values[i] = ec._LiquidityPoolBalance_liquidityPoolId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "reserves":
+			out.Values[i] = ec._LiquidityPoolBalance_reserves(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "lastModifiedLedger":
+			out.Values[i] = ec._LiquidityPoolBalance_lastModifiedLedger(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var liquidityPoolReserveImplementors = []string{"LiquidityPoolReserve"}
+
+func (ec *executionContext) _LiquidityPoolReserve(ctx context.Context, sel ast.SelectionSet, obj *LiquidityPoolReserve) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, liquidityPoolReserveImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("LiquidityPoolReserve")
+		case "asset":
+			out.Values[i] = ec._LiquidityPoolReserve_asset(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "amount":
+			out.Values[i] = ec._LiquidityPoolReserve_amount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -16496,6 +16935,32 @@ func (ec *executionContext) marshalNInt642int64(ctx context.Context, sel ast.Sel
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) marshalNLiquidityPoolReserve2ᚕᚖgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐLiquidityPoolReserveᚄ(ctx context.Context, sel ast.SelectionSet, v []*LiquidityPoolReserve) graphql.Marshaler {
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNLiquidityPoolReserve2ᚖgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐLiquidityPoolReserve(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNLiquidityPoolReserve2ᚖgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋserveᚋgraphqlᚋgeneratedᚐLiquidityPoolReserve(ctx context.Context, sel ast.SelectionSet, v *LiquidityPoolReserve) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._LiquidityPoolReserve(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNOperation2ᚕᚖgithubᚗcomᚋstellarᚋwalletᚑbackendᚋinternalᚋindexerᚋtypesᚐOperationᚄ(ctx context.Context, sel ast.SelectionSet, v []*types.Operation) graphql.Marshaler {

--- a/internal/serve/graphql/generated/models_gen.go
+++ b/internal/serve/graphql/generated/models_gen.go
@@ -58,6 +58,29 @@ type BalanceEdge struct {
 	Cursor string  `json:"cursor"`
 }
 
+// LiquidityPoolBalance represents an account's liquidity-pool share holding. `balance` is the
+// account's pool shares and `tokenId` is the pool id; `reserves` carries the pool's constituent
+// assets and amounts.
+type LiquidityPoolBalance struct {
+	Balance            string                  `json:"balance"`
+	TokenID            string                  `json:"tokenId"`
+	TokenType          TokenType               `json:"tokenType"`
+	LiquidityPoolID    string                  `json:"liquidityPoolId"`
+	Reserves           []*LiquidityPoolReserve `json:"reserves"`
+	LastModifiedLedger uint32                  `json:"lastModifiedLedger"`
+}
+
+func (LiquidityPoolBalance) IsBalance()                   {}
+func (this LiquidityPoolBalance) GetBalance() string      { return this.Balance }
+func (this LiquidityPoolBalance) GetTokenID() string      { return this.TokenID }
+func (this LiquidityPoolBalance) GetTokenType() TokenType { return this.TokenType }
+
+// LiquidityPoolReserve is one constituent asset of a liquidity pool and its reserve amount.
+type LiquidityPoolReserve struct {
+	Asset  string `json:"asset"`
+	Amount string `json:"amount"`
+}
+
 type NativeBalance struct {
 	Balance            string    `json:"balance"`
 	TokenID            string    `json:"tokenId"`
@@ -188,10 +211,11 @@ func (this TrustlineBalance) GetTokenType() TokenType { return this.TokenType }
 type TokenType string
 
 const (
-	TokenTypeNative  TokenType = "NATIVE"
-	TokenTypeClassic TokenType = "CLASSIC"
-	TokenTypeSac     TokenType = "SAC"
-	TokenTypeSep41   TokenType = "SEP41"
+	TokenTypeNative        TokenType = "NATIVE"
+	TokenTypeClassic       TokenType = "CLASSIC"
+	TokenTypeSac           TokenType = "SAC"
+	TokenTypeSep41         TokenType = "SEP41"
+	TokenTypeLiquidityPool TokenType = "LIQUIDITY_POOL"
 )
 
 var AllTokenType = []TokenType{
@@ -199,11 +223,12 @@ var AllTokenType = []TokenType{
 	TokenTypeClassic,
 	TokenTypeSac,
 	TokenTypeSep41,
+	TokenTypeLiquidityPool,
 }
 
 func (e TokenType) IsValid() bool {
 	switch e {
-	case TokenTypeNative, TokenTypeClassic, TokenTypeSac, TokenTypeSep41:
+	case TokenTypeNative, TokenTypeClassic, TokenTypeSac, TokenTypeSep41, TokenTypeLiquidityPool:
 		return true
 	}
 	return false

--- a/internal/serve/graphql/resolvers/account_allowances_test.go
+++ b/internal/serve/graphql/resolvers/account_allowances_test.go
@@ -57,6 +57,7 @@ func TestAccountResolver_SEP41AllowancesFiltersExpired(t *testing.T) {
 		&data.TrustlineBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
 		&data.NativeBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
 		&data.SACBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
+		&data.LiquidityPoolBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
 		&sep41data.BalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
 		&sep41data.AllowanceModel{DB: testDBConnectionPool, Metrics: m.DB},
 	)
@@ -122,6 +123,7 @@ func TestAccountResolver_SEP41AllowancesPaginates(t *testing.T) {
 		&data.TrustlineBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
 		&data.NativeBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
 		&data.SACBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
+		&data.LiquidityPoolBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
 		&sep41data.BalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
 		&sep41data.AllowanceModel{DB: testDBConnectionPool, Metrics: m.DB},
 	)

--- a/internal/serve/graphql/resolvers/account_balances.go
+++ b/internal/serve/graphql/resolvers/account_balances.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"slices"
 	"strings"
@@ -30,10 +31,11 @@ const (
 	// The source order is the canonical connection order exposed by Account.balances.
 	// Cursors are opaque to clients, but the resolver must keep this ordering stable
 	// so forward/backward pagination works consistently across mixed balance types.
-	balanceSourceNative  balanceSource = "native"
-	balanceSourceClassic balanceSource = "classic"
-	balanceSourceSAC     balanceSource = "sac"
-	balanceSourceSEP41   balanceSource = "sep41"
+	balanceSourceNative        balanceSource = "native"
+	balanceSourceClassic       balanceSource = "classic"
+	balanceSourceSAC           balanceSource = "sac"
+	balanceSourceSEP41         balanceSource = "sep41"
+	balanceSourceLiquidityPool balanceSource = "lp"
 )
 
 // balanceCursor is the decoded form of our opaque cursor payload:
@@ -49,6 +51,7 @@ const (
 // - native -> literal "native"
 // - classic -> trustline asset UUID
 // - sac/sep41 -> contract UUID
+// - lp -> liquidity pool id (hex string)
 //
 // Example:
 //   - canonical order: native, classic(A), classic(B), sep41(X)
@@ -97,14 +100,14 @@ func balanceInternalError() error {
 // balanceSourcesForAddress returns the ordered set of balance sources that can
 // apply to the requested address type.
 //
-// G-addresses can have native XLM, classic trustlines, and SEP-41 token balances.
-// C-addresses can hold SAC balances and SEP-41 token balances, but never
-// native/classic rows.
+// G-addresses can have native XLM, classic trustlines, SEP-41 token balances, and
+// liquidity-pool share balances. C-addresses can hold SAC balances and SEP-41 token
+// balances, but never native/classic/liquidity-pool rows.
 func balanceSourcesForAddress(address string) []balanceSource {
 	if utils.IsContractAddress(address) {
 		return []balanceSource{balanceSourceSAC, balanceSourceSEP41}
 	}
-	return []balanceSource{balanceSourceNative, balanceSourceClassic, balanceSourceSEP41}
+	return []balanceSource{balanceSourceNative, balanceSourceClassic, balanceSourceSEP41, balanceSourceLiquidityPool}
 }
 
 // balanceSourceIndex maps a source to its canonical order position. The walkers
@@ -166,6 +169,12 @@ func parseBalanceCursor(cursor *string, sources []balanceSource) (*balanceCursor
 		if parts[2] != string(balanceSourceNative) {
 			return nil, balanceBadUserInputError("invalid balance cursor id")
 		}
+	case balanceSourceLiquidityPool:
+		// Liquidity pools are keyed by their pool id (a 32-byte hash rendered as hex),
+		// not a UUID like the other contract/asset-backed sources.
+		if !isValidPoolID(parts[2]) {
+			return nil, balanceBadUserInputError("invalid balance cursor id")
+		}
 	default:
 		if _, err := uuid.Parse(parts[2]); err != nil {
 			return nil, balanceBadUserInputError("invalid balance cursor id")
@@ -176,6 +185,14 @@ func parseBalanceCursor(cursor *string, sources []balanceSource) (*balanceCursor
 		Source: source,
 		ID:     parts[2],
 	}, nil
+}
+
+// isValidPoolID reports whether s is a liquidity pool id: a 32-byte hash rendered as
+// a 64-character hex string. Used to validate the liquidity-pool cursor payload, which
+// (unlike the other contract/asset-backed sources) is keyed by pool id rather than a UUID.
+func isValidPoolID(s string) bool {
+	decoded, err := hex.DecodeString(s)
+	return err == nil && len(decoded) == 32
 }
 
 // uuid converts cursor IDs for the UUID-backed sources. Native uses a sentinel
@@ -412,6 +429,8 @@ func (r *Resolver) getBalanceNodesForSource(
 		return r.getSACBalanceNodes(ctx, address, cursor, sortOrder, limit)
 	case balanceSourceSEP41:
 		return r.getSEP41BalanceNodes(ctx, address, cursor, sortOrder, limit)
+	case balanceSourceLiquidityPool:
+		return r.getLiquidityPoolBalanceNodes(ctx, address, cursor, sortOrder, limit)
 	default:
 		return nil, balanceBadUserInputError("invalid balance source")
 	}
@@ -538,6 +557,39 @@ func (r *Resolver) getSEP41BalanceNodes(
 			Balance: buildSEP41BalanceFromDB(bal),
 			Source:  balanceSourceSEP41,
 			ID:      bal.ContractID.String(),
+		})
+	}
+
+	return nodes, nil
+}
+
+// getLiquidityPoolBalanceNodes pages an account's pool-share balances by their pool id, joining
+// each row with the pool's reserves. Unlike the other contract/asset-backed sources, the keyset
+// cursor is the pool id (a hex string) rather than a UUID.
+func (r *Resolver) getLiquidityPoolBalanceNodes(
+	ctx context.Context,
+	address string,
+	cursor *balanceCursor,
+	sortOrder data.SortOrder,
+	limit int32,
+) ([]*balanceNode, error) {
+	var cursorID *string
+	if cursor != nil {
+		cursorID = &cursor.ID
+	}
+
+	balances, err := r.balanceReader.GetLiquidityPoolBalances(ctx, address, &limit, cursorID, sortOrder)
+	if err != nil {
+		log.Ctx(ctx).Errorf("failed to get paginated liquidity pool balances for %s: %v", address, err)
+		return nil, balanceInternalError()
+	}
+
+	nodes := make([]*balanceNode, 0, len(balances))
+	for _, lp := range balances {
+		nodes = append(nodes, &balanceNode{
+			Balance: buildLiquidityPoolBalanceFromDB(lp),
+			Source:  balanceSourceLiquidityPool,
+			ID:      lp.PoolID,
 		})
 	}
 

--- a/internal/serve/graphql/resolvers/account_balances_test.go
+++ b/internal/serve/graphql/resolvers/account_balances_test.go
@@ -100,6 +100,7 @@ func TestAccountResolver_SEP41BalancesReturnedByBalancesConnection(t *testing.T)
 		&data.TrustlineBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
 		&data.NativeBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
 		&data.SACBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
+		&data.LiquidityPoolBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
 		&sep41data.BalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
 		&sep41data.AllowanceModel{DB: testDBConnectionPool, Metrics: m.DB},
 	)

--- a/internal/serve/graphql/resolvers/account_balances_test.go
+++ b/internal/serve/graphql/resolvers/account_balances_test.go
@@ -24,7 +24,8 @@ func TestBalanceSourcesForAddress(t *testing.T) {
 		g := keypair.MustRandom().Address()
 		gSources := balanceSourcesForAddress(g)
 		assert.Contains(t, gSources, balanceSourceSEP41, "G-addresses must advertise SEP-41 as a balance source")
-		assert.Equal(t, []balanceSource{balanceSourceNative, balanceSourceClassic, balanceSourceSEP41}, gSources)
+		assert.Contains(t, gSources, balanceSourceLiquidityPool, "G-addresses must advertise liquidity-pool shares as a balance source")
+		assert.Equal(t, []balanceSource{balanceSourceNative, balanceSourceClassic, balanceSourceSEP41, balanceSourceLiquidityPool}, gSources)
 	})
 
 	t.Run("includes SEP-41 for C-addresses alongside SAC", func(t *testing.T) {

--- a/internal/serve/graphql/resolvers/account_balances_utils.go
+++ b/internal/serve/graphql/resolvers/account_balances_utils.go
@@ -69,6 +69,23 @@ func buildSACBalanceFromDB(sacBalance data.SACBalance) *graphql1.SACBalance {
 	}
 }
 
+// buildLiquidityPoolBalanceFromDB constructs a LiquidityPoolBalance from a liquidity_pool_balances
+// row JOINed with its pool reserves. `balance` is the account's pool shares and `tokenId`/
+// `liquidityPoolId` are the pool id; `reserves` carries the pool's constituent assets and amounts.
+func buildLiquidityPoolBalanceFromDB(lp data.LiquidityPoolBalance) *graphql1.LiquidityPoolBalance {
+	return &graphql1.LiquidityPoolBalance{
+		TokenID:         lp.PoolID,
+		Balance:         amount.StringFromInt64(lp.Shares),
+		TokenType:       graphql1.TokenTypeLiquidityPool,
+		LiquidityPoolID: lp.PoolID,
+		Reserves: []*graphql1.LiquidityPoolReserve{
+			{Asset: lp.AssetA, Amount: amount.StringFromInt64(lp.AmountA)},
+			{Asset: lp.AssetB, Amount: amount.StringFromInt64(lp.AmountB)},
+		},
+		LastModifiedLedger: lp.LedgerNumber,
+	}
+}
+
 // buildTrustlineBalanceFromDB constructs a TrustlineBalance from database trustline balance data.
 func buildTrustlineBalanceFromDB(trustline data.TrustlineBalance, networkPassphrase string) (*graphql1.TrustlineBalance, error) {
 	// Build xdr.Asset to compute contract ID

--- a/internal/serve/graphql/resolvers/account_balances_utils_test.go
+++ b/internal/serve/graphql/resolvers/account_balances_utils_test.go
@@ -13,7 +13,7 @@ import (
 func TestBuildNativeBalanceFromDB(t *testing.T) {
 	nb := &data.NativeBalance{
 		Balance:            1000000000,
-		MinimumBalance:     10000200,
+		MinimumBalance:     30000000, // pure base reserve for 4 subentries: (2 + 4) * 5_000_000
 		BuyingLiabilities:  100,
 		SellingLiabilities: 200,
 		NumSubEntries:      4,

--- a/internal/serve/graphql/resolvers/account_liquidity_pool_balances_test.go
+++ b/internal/serve/graphql/resolvers/account_liquidity_pool_balances_test.go
@@ -1,0 +1,147 @@
+package resolvers
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/data"
+	sep41data "github.com/stellar/wallet-backend/internal/data/sep41"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+	graphql1 "github.com/stellar/wallet-backend/internal/serve/graphql/generated"
+	"github.com/stellar/wallet-backend/internal/services"
+)
+
+func TestBuildLiquidityPoolBalanceFromDB(t *testing.T) {
+	lp := data.LiquidityPoolBalance{
+		PoolID:       "abc123",
+		Shares:       15000000, // 1.5 shares in stroops
+		LedgerNumber: 999,
+		AssetA:       "native",
+		AmountA:      100000000, // 10.0
+		AssetB:       "USDC:GISSUER",
+		AmountB:      250000000, // 25.0
+	}
+
+	got := buildLiquidityPoolBalanceFromDB(lp)
+
+	assert.Equal(t, "abc123", got.TokenID)
+	assert.Equal(t, "abc123", got.LiquidityPoolID)
+	assert.Equal(t, graphql1.TokenTypeLiquidityPool, got.TokenType)
+	assert.Equal(t, "1.5000000", got.Balance)
+	assert.Equal(t, uint32(999), got.LastModifiedLedger)
+	require.Len(t, got.Reserves, 2)
+	assert.Equal(t, "native", got.Reserves[0].Asset)
+	assert.Equal(t, "10.0000000", got.Reserves[0].Amount)
+	assert.Equal(t, "USDC:GISSUER", got.Reserves[1].Asset)
+	assert.Equal(t, "25.0000000", got.Reserves[1].Amount)
+}
+
+// TestAccountResolver_LiquidityPoolBalancesCrossSourcePagination verifies the Account.balances
+// connection pages across the SEP-41 → liquidity-pool source boundary and that the opaque cursor
+// round-trips both across that boundary and within the LP source's own keyset.
+func TestAccountResolver_LiquidityPoolBalancesCrossSourcePagination(t *testing.T) {
+	acct := keypair.MustRandom().Address()
+	parentAccount := &types.Account{StellarAddress: types.AddressBytea(acct)}
+
+	// Two SEP-41 tokens for the account.
+	sep41Contract1 := "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA"
+	sep41Contract2 := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
+	cid1 := data.DeterministicContractID(sep41Contract1)
+	cid2 := data.DeterministicContractID(sep41Contract2)
+
+	// Two liquidity pools the account holds shares in. Hex pool ids order aaaa... < bbbb...
+	pool1 := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	pool2 := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	execTestDB(t, `
+		INSERT INTO contract_tokens (id, contract_id, type, name, symbol, decimals) VALUES ($1, $2, 'sep41', 'AAA', 'AAA', 7), ($3, $4, 'sep41', 'BBB', 'BBB', 7)
+		ON CONFLICT (id) DO NOTHING
+	`, cid1, sep41Contract1, cid2, sep41Contract2)
+	execTestDB(t, `
+		INSERT INTO sep41_balances (account_id, contract_id, balance, last_modified_ledger) VALUES ($1, $2, '111', 10), ($1, $3, '222', 11)
+	`, types.AddressBytea(acct), cid1, cid2)
+	execTestDB(t, `
+		INSERT INTO liquidity_pools (pool_id, asset_a, amount_a, asset_b, amount_b, last_modified_ledger) VALUES
+		($1, 'native', 100, 'USDC:GISSUER', 200, 20),
+		($2, 'BTC:GISSUER', 300, 'ETH:GISSUER', 400, 21)
+	`, pool1, pool2)
+	execTestDB(t, `
+		INSERT INTO liquidity_pool_balances (account_id, pool_id, shares, last_modified_ledger) VALUES ($1, $2, 5000, 20), ($1, $3, 9000, 21)
+	`, types.AddressBytea(acct), pool1, pool2)
+
+	t.Cleanup(func() {
+		execTestDB(t, `DELETE FROM liquidity_pool_balances WHERE account_id = $1`, types.AddressBytea(acct))
+		execTestDB(t, `DELETE FROM sep41_balances WHERE account_id = $1`, types.AddressBytea(acct))
+		execTestDB(t, `DELETE FROM liquidity_pools WHERE pool_id IN ($1, $2)`, pool1, pool2)
+	})
+
+	m := metrics.NewMetrics(prometheus.NewRegistry())
+	rpcMock := services.NewRPCServiceMock(t)
+	rpcMock.On("NetworkPassphrase").Return("Test SDF Network ; September 2015").Maybe()
+
+	reader := NewBalanceReader(
+		&data.TrustlineBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
+		&data.NativeBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
+		&data.SACBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
+		&data.LiquidityPoolBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
+		&sep41data.BalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
+		&sep41data.AllowanceModel{DB: testDBConnectionPool, Metrics: m.DB},
+	)
+
+	resolver := &accountResolver{&Resolver{
+		rpcService:    rpcMock,
+		balanceReader: reader,
+		metrics:       m,
+	}}
+
+	ctx := getTestCtx("balances", []string{"balance", "tokenId", "liquidityPoolId"})
+
+	// Full connection: canonical order is SEP-41 first, then liquidity pools.
+	first := int32(10)
+	conn, err := resolver.Balances(ctx, parentAccount, &first, nil, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, conn.Edges, 4)
+
+	_, ok0 := conn.Edges[0].Node.(*graphql1.SEP41Balance)
+	require.True(t, ok0, "edge[0] should be SEP41Balance, got %T", conn.Edges[0].Node)
+	_, ok1 := conn.Edges[1].Node.(*graphql1.SEP41Balance)
+	require.True(t, ok1, "edge[1] should be SEP41Balance, got %T", conn.Edges[1].Node)
+
+	lp1, ok2 := conn.Edges[2].Node.(*graphql1.LiquidityPoolBalance)
+	require.True(t, ok2, "edge[2] should be LiquidityPoolBalance, got %T", conn.Edges[2].Node)
+	lp2, ok3 := conn.Edges[3].Node.(*graphql1.LiquidityPoolBalance)
+	require.True(t, ok3, "edge[3] should be LiquidityPoolBalance, got %T", conn.Edges[3].Node)
+
+	assert.Equal(t, pool1, lp1.LiquidityPoolID)
+	assert.Equal(t, "0.0005000", lp1.Balance)
+	require.Len(t, lp1.Reserves, 2)
+	assert.Equal(t, "native", lp1.Reserves[0].Asset)
+	assert.Equal(t, pool2, lp2.LiquidityPoolID)
+
+	// Cursor round-trip ACROSS the SEP-41 → LP boundary: resume after the last SEP-41 edge and
+	// expect exactly the two LP balances (SEP-41 fully consumed, LP scanned from its start).
+	afterLastSEP41 := conn.Edges[1].Cursor
+	lpPage, err := resolver.Balances(ctx, parentAccount, &first, &afterLastSEP41, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, lpPage.Edges, 2)
+	got1, okA := lpPage.Edges[0].Node.(*graphql1.LiquidityPoolBalance)
+	require.True(t, okA, "expected LiquidityPoolBalance after SEP-41 boundary, got %T", lpPage.Edges[0].Node)
+	assert.Equal(t, pool1, got1.LiquidityPoolID)
+	got2, okB := lpPage.Edges[1].Node.(*graphql1.LiquidityPoolBalance)
+	require.True(t, okB)
+	assert.Equal(t, pool2, got2.LiquidityPoolID)
+
+	// Cursor round-trip WITHIN the LP source's own keyset: resume after the first LP edge.
+	afterFirstLP := lpPage.Edges[0].Cursor
+	tailPage, err := resolver.Balances(ctx, parentAccount, &first, &afterFirstLP, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, tailPage.Edges, 1)
+	tail, okC := tailPage.Edges[0].Node.(*graphql1.LiquidityPoolBalance)
+	require.True(t, okC)
+	assert.Equal(t, pool2, tail.LiquidityPoolID)
+}

--- a/internal/serve/graphql/resolvers/balance_reader.go
+++ b/internal/serve/graphql/resolvers/balance_reader.go
@@ -15,11 +15,12 @@ import (
 // balanceReaderAdapter wraps balance model interfaces to implement BalanceReader.
 // This adapter allows the GraphQL resolver to use a consistent interface for balance reads.
 type balanceReaderAdapter struct {
-	trustlineBalanceModel data.TrustlineBalanceModelInterface
-	nativeBalanceModel    data.NativeBalanceModelInterface
-	sacBalanceModel       data.SACBalanceModelInterface
-	sep41BalanceModel     sep41data.BalanceModelInterface
-	sep41AllowanceModel   sep41data.AllowanceModelInterface
+	trustlineBalanceModel     data.TrustlineBalanceModelInterface
+	nativeBalanceModel        data.NativeBalanceModelInterface
+	sacBalanceModel           data.SACBalanceModelInterface
+	liquidityPoolBalanceModel data.LiquidityPoolBalanceModelInterface
+	sep41BalanceModel         sep41data.BalanceModelInterface
+	sep41AllowanceModel       sep41data.AllowanceModelInterface
 }
 
 // NewBalanceReader creates a BalanceReader from the underlying model interfaces.
@@ -27,15 +28,17 @@ func NewBalanceReader(
 	trustlineBalanceModel data.TrustlineBalanceModelInterface,
 	nativeBalanceModel data.NativeBalanceModelInterface,
 	sacBalanceModel data.SACBalanceModelInterface,
+	liquidityPoolBalanceModel data.LiquidityPoolBalanceModelInterface,
 	sep41BalanceModel sep41data.BalanceModelInterface,
 	sep41AllowanceModel sep41data.AllowanceModelInterface,
 ) BalanceReader {
 	return &balanceReaderAdapter{
-		trustlineBalanceModel: trustlineBalanceModel,
-		nativeBalanceModel:    nativeBalanceModel,
-		sacBalanceModel:       sacBalanceModel,
-		sep41BalanceModel:     sep41BalanceModel,
-		sep41AllowanceModel:   sep41AllowanceModel,
+		trustlineBalanceModel:     trustlineBalanceModel,
+		nativeBalanceModel:        nativeBalanceModel,
+		sacBalanceModel:           sacBalanceModel,
+		liquidityPoolBalanceModel: liquidityPoolBalanceModel,
+		sep41BalanceModel:         sep41BalanceModel,
+		sep41AllowanceModel:       sep41AllowanceModel,
 	}
 }
 
@@ -82,6 +85,17 @@ func (r *balanceReaderAdapter) GetSEP41Balances(ctx context.Context, accountAddr
 	balances, err := r.sep41BalanceModel.GetByAccount(ctx, accountAddress, limit, cursor, sep41Sort)
 	if err != nil {
 		return nil, fmt.Errorf("getting SEP-41 balances: %w", err)
+	}
+	return balances, nil
+}
+
+// GetLiquidityPoolBalances retrieves an account's pool-share balances (with reserves). Pass nil
+// limit/cursor to fetch all rows, or provide them for keyset pagination (the cursor is the last
+// seen pool_id from the previous page).
+func (r *balanceReaderAdapter) GetLiquidityPoolBalances(ctx context.Context, accountAddress string, limit *int32, cursor *string, sortOrder data.SortOrder) ([]data.LiquidityPoolBalance, error) {
+	balances, err := r.liquidityPoolBalanceModel.GetByAccount(ctx, accountAddress, limit, cursor, sortOrder)
+	if err != nil {
+		return nil, fmt.Errorf("getting liquidity pool balances: %w", err)
 	}
 	return balances, nil
 }

--- a/internal/serve/graphql/resolvers/resolver.go
+++ b/internal/serve/graphql/resolvers/resolver.go
@@ -34,6 +34,7 @@ type BalanceReader interface {
 	GetNativeBalance(ctx context.Context, accountAddress string) (*data.NativeBalance, error)
 	GetSACBalances(ctx context.Context, accountAddress string, limit *int32, cursor *uuid.UUID, sortOrder data.SortOrder) ([]data.SACBalance, error)
 	GetSEP41Balances(ctx context.Context, accountAddress string, limit *int32, cursor *uuid.UUID, sortOrder data.SortOrder) ([]sep41data.Balance, error)
+	GetLiquidityPoolBalances(ctx context.Context, accountAddress string, limit *int32, cursor *string, sortOrder data.SortOrder) ([]data.LiquidityPoolBalance, error)
 	GetSEP41Allowances(ctx context.Context, ownerAddress string, limit int32, cursor *sep41data.AllowanceCursor, sortOrder sep41data.SortOrder) ([]sep41data.Allowance, error)
 }
 

--- a/internal/serve/graphql/resolvers/statechange.resolvers.go
+++ b/internal/serve/graphql/resolvers/statechange.resolvers.go
@@ -451,12 +451,14 @@ func (r *Resolver) TrustlineChange() graphql1.TrustlineChangeResolver {
 	return &trustlineChangeResolver{r}
 }
 
-type accountChangeResolver struct{ *Resolver }
-type balanceAuthorizationChangeResolver struct{ *Resolver }
-type flagsChangeResolver struct{ *Resolver }
-type metadataChangeResolver struct{ *Resolver }
-type reservesChangeResolver struct{ *Resolver }
-type signerChangeResolver struct{ *Resolver }
-type signerThresholdsChangeResolver struct{ *Resolver }
-type standardBalanceChangeResolver struct{ *Resolver }
-type trustlineChangeResolver struct{ *Resolver }
+type (
+	accountChangeResolver              struct{ *Resolver }
+	balanceAuthorizationChangeResolver struct{ *Resolver }
+	flagsChangeResolver                struct{ *Resolver }
+	metadataChangeResolver             struct{ *Resolver }
+	reservesChangeResolver             struct{ *Resolver }
+	signerChangeResolver               struct{ *Resolver }
+	signerThresholdsChangeResolver     struct{ *Resolver }
+	standardBalanceChangeResolver      struct{ *Resolver }
+	trustlineChangeResolver            struct{ *Resolver }
+)

--- a/internal/serve/graphql/resolvers/statechange.resolvers.go
+++ b/internal/serve/graphql/resolvers/statechange.resolvers.go
@@ -451,14 +451,12 @@ func (r *Resolver) TrustlineChange() graphql1.TrustlineChangeResolver {
 	return &trustlineChangeResolver{r}
 }
 
-type (
-	accountChangeResolver              struct{ *Resolver }
-	balanceAuthorizationChangeResolver struct{ *Resolver }
-	flagsChangeResolver                struct{ *Resolver }
-	metadataChangeResolver             struct{ *Resolver }
-	reservesChangeResolver             struct{ *Resolver }
-	signerChangeResolver               struct{ *Resolver }
-	signerThresholdsChangeResolver     struct{ *Resolver }
-	standardBalanceChangeResolver      struct{ *Resolver }
-	trustlineChangeResolver            struct{ *Resolver }
-)
+type accountChangeResolver struct{ *Resolver }
+type balanceAuthorizationChangeResolver struct{ *Resolver }
+type flagsChangeResolver struct{ *Resolver }
+type metadataChangeResolver struct{ *Resolver }
+type reservesChangeResolver struct{ *Resolver }
+type signerChangeResolver struct{ *Resolver }
+type signerThresholdsChangeResolver struct{ *Resolver }
+type standardBalanceChangeResolver struct{ *Resolver }
+type trustlineChangeResolver struct{ *Resolver }

--- a/internal/serve/graphql/schema/balances.graphqls
+++ b/internal/serve/graphql/schema/balances.graphqls
@@ -43,6 +43,27 @@ type SACBalance implements Balance {
     isClawbackEnabled: Boolean!
 }
 
+"""LiquidityPoolReserve is one constituent asset of a liquidity pool and its reserve amount."""
+type LiquidityPoolReserve {
+    asset: String!
+    amount: String!
+}
+
+"""
+LiquidityPoolBalance represents an account's liquidity-pool share holding. `balance` is the
+account's pool shares and `tokenId` is the pool id; `reserves` carries the pool's constituent
+assets and amounts.
+"""
+type LiquidityPoolBalance implements Balance {
+    balance: String!
+    tokenId: String!
+    tokenType: TokenType!
+
+    liquidityPoolId: String!
+    reserves: [LiquidityPoolReserve!]!
+    lastModifiedLedger: UInt32!
+}
+
 """SEP41Balance represents a pure SEP-41 (non-SAC) token balance for a holder."""
 type SEP41Balance implements Balance {
     balance: String!

--- a/internal/serve/graphql/schema/balances.graphqls
+++ b/internal/serve/graphql/schema/balances.graphqls
@@ -9,6 +9,8 @@ type NativeBalance implements Balance {
     tokenId: String!
     tokenType: TokenType!
 
+    # base reserve requirement (excludes liabilities): (2 + numSubentries + numSponsoring - numSponsored) * baseReserve.
+    # Spendable balance = balance - minimumBalance - sellingLiabilities.
     minimumBalance: String!
     buyingLiabilities: String!
     sellingLiabilities: String!

--- a/internal/serve/graphql/schema/enums.graphqls
+++ b/internal/serve/graphql/schema/enums.graphqls
@@ -75,4 +75,5 @@ enum TokenType {
   CLASSIC
   SAC
   SEP41
+  LIQUIDITY_POOL
 }

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -97,13 +97,14 @@ type handlerDeps struct {
 	NetworkPassphrase   string
 
 	// Services
-	Metrics               *metrics.Metrics
-	RPCService            services.RPCService
-	TrustlineBalanceModel data.TrustlineBalanceModelInterface
-	NativeBalanceModel    data.NativeBalanceModelInterface
-	SACBalanceModel       data.SACBalanceModelInterface
-	SEP41BalanceModel     sep41data.BalanceModelInterface
-	SEP41AllowanceModel   sep41data.AllowanceModelInterface
+	Metrics                   *metrics.Metrics
+	RPCService                services.RPCService
+	TrustlineBalanceModel     data.TrustlineBalanceModelInterface
+	NativeBalanceModel        data.NativeBalanceModelInterface
+	SACBalanceModel           data.SACBalanceModelInterface
+	LiquidityPoolBalanceModel data.LiquidityPoolBalanceModelInterface
+	SEP41BalanceModel         sep41data.BalanceModelInterface
+	SEP41AllowanceModel       sep41data.AllowanceModelInterface
 
 	// GraphQL
 	GraphQLComplexityLimit int
@@ -188,19 +189,20 @@ func initHandlerDeps(ctx context.Context, cfg Configs) (handlerDeps, error) {
 	}
 
 	return handlerDeps{
-		Models:                 models,
-		RequestAuthVerifier:    requestAuthVerifier,
-		SupportedAssets:        cfg.SupportedAssets,
-		Metrics:                m,
-		RPCService:             rpcService,
-		TrustlineBalanceModel:  models.TrustlineBalance,
-		NativeBalanceModel:     models.NativeBalance,
-		SACBalanceModel:        models.SACBalance,
-		SEP41BalanceModel:      models.SEP41.Balances,
-		SEP41AllowanceModel:    models.SEP41.Allowances,
-		AppTracker:             cfg.AppTracker,
-		NetworkPassphrase:      cfg.NetworkPassphrase,
-		GraphQLComplexityLimit: cfg.GraphQLComplexityLimit,
+		Models:                    models,
+		RequestAuthVerifier:       requestAuthVerifier,
+		SupportedAssets:           cfg.SupportedAssets,
+		Metrics:                   m,
+		RPCService:                rpcService,
+		TrustlineBalanceModel:     models.TrustlineBalance,
+		NativeBalanceModel:        models.NativeBalance,
+		SACBalanceModel:           models.SACBalance,
+		LiquidityPoolBalanceModel: models.LiquidityPoolBalance,
+		SEP41BalanceModel:         models.SEP41.Balances,
+		SEP41AllowanceModel:       models.SEP41.Allowances,
+		AppTracker:                cfg.AppTracker,
+		NetworkPassphrase:         cfg.NetworkPassphrase,
+		GraphQLComplexityLimit:    cfg.GraphQLComplexityLimit,
 	}, nil
 }
 
@@ -233,7 +235,7 @@ func handler(deps handlerDeps) http.Handler {
 			resolver := resolvers.NewResolver(
 				deps.Models,
 				deps.RPCService,
-				resolvers.NewBalanceReader(deps.TrustlineBalanceModel, deps.NativeBalanceModel, deps.SACBalanceModel, deps.SEP41BalanceModel, deps.SEP41AllowanceModel),
+				resolvers.NewBalanceReader(deps.TrustlineBalanceModel, deps.NativeBalanceModel, deps.SACBalanceModel, deps.LiquidityPoolBalanceModel, deps.SEP41BalanceModel, deps.SEP41AllowanceModel),
 				deps.Metrics,
 				resolvers.ResolverConfig{},
 			)

--- a/internal/services/checkpoint.go
+++ b/internal/services/checkpoint.go
@@ -335,7 +335,8 @@ func (p *checkpointProcessor) processEntry(change ingest.Change) {
 		numSubEntries := accountEntry.NumSubEntries
 		numSponsoring := accountEntry.NumSponsoring()
 		numSponsored := accountEntry.NumSponsored()
-		minimumBalance := int64(processors.MinimumBaseReserveCount+numSubEntries+numSponsoring-numSponsored)*processors.BaseReserveStroops + int64(liabilities.Selling)
+		// Base reserve requirement only (excludes liabilities); mirrors accounts.go and stellar-core getMinBalance.
+		minimumBalance := int64(processors.MinimumBaseReserveCount+numSubEntries+numSponsoring-numSponsored) * processors.BaseReserveStroops
 		p.batch.addNativeBalance(accountEntry.AccountId.Address(), int64(accountEntry.Balance), minimumBalance, int64(liabilities.Buying), int64(liabilities.Selling), uint32(numSubEntries), p.checkpointLedger)
 		p.entries++
 		p.accountCount++

--- a/internal/services/checkpoint.go
+++ b/internal/services/checkpoint.go
@@ -52,49 +52,55 @@ func defaultReaderFactory(ctx context.Context, archive historyarchive.ArchiveInt
 
 // CheckpointServiceConfig holds configuration for creating a CheckpointService.
 type CheckpointServiceConfig struct {
-	DB                      *pgxpool.Pool
-	Archive                 historyarchive.ArchiveInterface
-	ContractMetadataService ContractMetadataService
-	TrustlineAssetModel     wbdata.TrustlineAssetModelInterface
-	TrustlineBalanceModel   wbdata.TrustlineBalanceModelInterface
-	NativeBalanceModel      wbdata.NativeBalanceModelInterface
-	SACBalanceModel         wbdata.SACBalanceModelInterface
-	ContractModel           wbdata.ContractModelInterface
-	ProtocolWasmsModel      wbdata.ProtocolWasmsModelInterface
-	ProtocolContractsModel  wbdata.ProtocolContractsModelInterface
-	NetworkPassphrase       string
+	DB                        *pgxpool.Pool
+	Archive                   historyarchive.ArchiveInterface
+	ContractMetadataService   ContractMetadataService
+	TrustlineAssetModel       wbdata.TrustlineAssetModelInterface
+	TrustlineBalanceModel     wbdata.TrustlineBalanceModelInterface
+	NativeBalanceModel        wbdata.NativeBalanceModelInterface
+	SACBalanceModel           wbdata.SACBalanceModelInterface
+	LiquidityPoolModel        wbdata.LiquidityPoolModelInterface
+	LiquidityPoolBalanceModel wbdata.LiquidityPoolBalanceModelInterface
+	ContractModel             wbdata.ContractModelInterface
+	ProtocolWasmsModel        wbdata.ProtocolWasmsModelInterface
+	ProtocolContractsModel    wbdata.ProtocolContractsModelInterface
+	NetworkPassphrase         string
 }
 
 type checkpointService struct {
-	db                      *pgxpool.Pool
-	archive                 historyarchive.ArchiveInterface
-	contractMetadataService ContractMetadataService
-	trustlineAssetModel     wbdata.TrustlineAssetModelInterface
-	trustlineBalanceModel   wbdata.TrustlineBalanceModelInterface
-	nativeBalanceModel      wbdata.NativeBalanceModelInterface
-	sacBalanceModel         wbdata.SACBalanceModelInterface
-	contractModel           wbdata.ContractModelInterface
-	protocolWasmModel       wbdata.ProtocolWasmsModelInterface
-	protocolContractsModel  wbdata.ProtocolContractsModelInterface
-	networkPassphrase       string
-	readerFactory           readerFactory
+	db                        *pgxpool.Pool
+	archive                   historyarchive.ArchiveInterface
+	contractMetadataService   ContractMetadataService
+	trustlineAssetModel       wbdata.TrustlineAssetModelInterface
+	trustlineBalanceModel     wbdata.TrustlineBalanceModelInterface
+	nativeBalanceModel        wbdata.NativeBalanceModelInterface
+	sacBalanceModel           wbdata.SACBalanceModelInterface
+	liquidityPoolModel        wbdata.LiquidityPoolModelInterface
+	liquidityPoolBalanceModel wbdata.LiquidityPoolBalanceModelInterface
+	contractModel             wbdata.ContractModelInterface
+	protocolWasmModel         wbdata.ProtocolWasmsModelInterface
+	protocolContractsModel    wbdata.ProtocolContractsModelInterface
+	networkPassphrase         string
+	readerFactory             readerFactory
 }
 
 // NewCheckpointService creates a CheckpointService.
 func NewCheckpointService(cfg CheckpointServiceConfig) *checkpointService {
 	return &checkpointService{
-		db:                      cfg.DB,
-		archive:                 cfg.Archive,
-		contractMetadataService: cfg.ContractMetadataService,
-		trustlineAssetModel:     cfg.TrustlineAssetModel,
-		trustlineBalanceModel:   cfg.TrustlineBalanceModel,
-		nativeBalanceModel:      cfg.NativeBalanceModel,
-		sacBalanceModel:         cfg.SACBalanceModel,
-		contractModel:           cfg.ContractModel,
-		protocolWasmModel:       cfg.ProtocolWasmsModel,
-		protocolContractsModel:  cfg.ProtocolContractsModel,
-		networkPassphrase:       cfg.NetworkPassphrase,
-		readerFactory:           defaultReaderFactory,
+		db:                        cfg.DB,
+		archive:                   cfg.Archive,
+		contractMetadataService:   cfg.ContractMetadataService,
+		trustlineAssetModel:       cfg.TrustlineAssetModel,
+		trustlineBalanceModel:     cfg.TrustlineBalanceModel,
+		nativeBalanceModel:        cfg.NativeBalanceModel,
+		sacBalanceModel:           cfg.SACBalanceModel,
+		liquidityPoolModel:        cfg.LiquidityPoolModel,
+		liquidityPoolBalanceModel: cfg.LiquidityPoolBalanceModel,
+		contractModel:             cfg.ContractModel,
+		protocolWasmModel:         cfg.ProtocolWasmsModel,
+		protocolContractsModel:    cfg.ProtocolContractsModel,
+		networkPassphrase:         cfg.NetworkPassphrase,
+		readerFactory:             defaultReaderFactory,
 	}
 }
 
@@ -114,28 +120,38 @@ func newCheckpointData() checkpointData {
 	}
 }
 
-// batch holds a batch of trustline balances, native balances, and SAC balances for streaming insertion.
+// batch holds a batch of trustline, native, SAC, and liquidity-pool balances for streaming insertion.
 type batch struct {
-	trustlineBalances     []wbdata.TrustlineBalance
-	nativeBalances        []wbdata.NativeBalance
-	sacBalances           []wbdata.SACBalance
-	trustlineBalanceModel wbdata.TrustlineBalanceModelInterface
-	nativeBalanceModel    wbdata.NativeBalanceModelInterface
-	sacBalanceModel       wbdata.SACBalanceModelInterface
+	trustlineBalances         []wbdata.TrustlineBalance
+	nativeBalances            []wbdata.NativeBalance
+	sacBalances               []wbdata.SACBalance
+	liquidityPools            []wbdata.LiquidityPool
+	liquidityPoolBalances     []wbdata.LiquidityPoolBalance
+	trustlineBalanceModel     wbdata.TrustlineBalanceModelInterface
+	nativeBalanceModel        wbdata.NativeBalanceModelInterface
+	sacBalanceModel           wbdata.SACBalanceModelInterface
+	liquidityPoolModel        wbdata.LiquidityPoolModelInterface
+	liquidityPoolBalanceModel wbdata.LiquidityPoolBalanceModelInterface
 }
 
 func newBatch(
 	trustlineBalanceModel wbdata.TrustlineBalanceModelInterface,
 	nativeBalanceModel wbdata.NativeBalanceModelInterface,
 	sacBalanceModel wbdata.SACBalanceModelInterface,
+	liquidityPoolModel wbdata.LiquidityPoolModelInterface,
+	liquidityPoolBalanceModel wbdata.LiquidityPoolBalanceModelInterface,
 ) *batch {
 	return &batch{
-		trustlineBalances:     make([]wbdata.TrustlineBalance, 0, flushBatchSize),
-		nativeBalances:        make([]wbdata.NativeBalance, 0, flushBatchSize),
-		sacBalances:           make([]wbdata.SACBalance, 0, flushBatchSize),
-		trustlineBalanceModel: trustlineBalanceModel,
-		nativeBalanceModel:    nativeBalanceModel,
-		sacBalanceModel:       sacBalanceModel,
+		trustlineBalances:         make([]wbdata.TrustlineBalance, 0, flushBatchSize),
+		nativeBalances:            make([]wbdata.NativeBalance, 0, flushBatchSize),
+		sacBalances:               make([]wbdata.SACBalance, 0, flushBatchSize),
+		liquidityPools:            make([]wbdata.LiquidityPool, 0, flushBatchSize),
+		liquidityPoolBalances:     make([]wbdata.LiquidityPoolBalance, 0, flushBatchSize),
+		trustlineBalanceModel:     trustlineBalanceModel,
+		nativeBalanceModel:        nativeBalanceModel,
+		sacBalanceModel:           sacBalanceModel,
+		liquidityPoolModel:        liquidityPoolModel,
+		liquidityPoolBalanceModel: liquidityPoolBalanceModel,
 	}
 }
 
@@ -167,6 +183,19 @@ func (b *batch) addSACBalance(sacBalance wbdata.SACBalance) {
 	b.sacBalances = append(b.sacBalances, sacBalance)
 }
 
+func (b *batch) addLiquidityPool(pool wbdata.LiquidityPool) {
+	b.liquidityPools = append(b.liquidityPools, pool)
+}
+
+func (b *batch) addLiquidityPoolShare(accountAddress string, poolID string, shares int64, ledger uint32) {
+	b.liquidityPoolBalances = append(b.liquidityPoolBalances, wbdata.LiquidityPoolBalance{
+		AccountID:    types.AddressBytea(accountAddress),
+		PoolID:       poolID,
+		Shares:       shares,
+		LedgerNumber: ledger,
+	})
+}
+
 // flush inserts the batch's data into DB.
 func (b *batch) flush(ctx context.Context, dbTx pgx.Tx) error {
 	if err := b.trustlineBalanceModel.BatchCopy(ctx, dbTx, b.trustlineBalances); err != nil {
@@ -178,17 +207,26 @@ func (b *batch) flush(ctx context.Context, dbTx pgx.Tx) error {
 	if err := b.sacBalanceModel.BatchCopy(ctx, dbTx, b.sacBalances); err != nil {
 		return fmt.Errorf("batch inserting SAC balances: %w", err)
 	}
+	if err := b.liquidityPoolModel.BatchCopy(ctx, dbTx, b.liquidityPools); err != nil {
+		return fmt.Errorf("batch inserting liquidity pools: %w", err)
+	}
+	if err := b.liquidityPoolBalanceModel.BatchCopy(ctx, dbTx, b.liquidityPoolBalances); err != nil {
+		return fmt.Errorf("batch inserting liquidity pool balances: %w", err)
+	}
 	return nil
 }
 
 func (b *batch) count() int {
-	return len(b.trustlineBalances) + len(b.nativeBalances) + len(b.sacBalances)
+	return len(b.trustlineBalances) + len(b.nativeBalances) + len(b.sacBalances) +
+		len(b.liquidityPools) + len(b.liquidityPoolBalances)
 }
 
 func (b *batch) reset() {
 	b.trustlineBalances = b.trustlineBalances[:0]
 	b.nativeBalances = b.nativeBalances[:0]
 	b.sacBalances = b.sacBalances[:0]
+	b.liquidityPools = b.liquidityPools[:0]
+	b.liquidityPoolBalances = b.liquidityPoolBalances[:0]
 }
 
 // checkpointProcessor holds per-invocation state for processing a checkpoint.
@@ -234,7 +272,7 @@ func (s *checkpointService) PopulateFromCheckpoint(ctx context.Context, checkpoi
 			dbTx:                        dbTx,
 			checkpointLedger:            checkpointLedger,
 			data:                        newCheckpointData(),
-			batch:                       newBatch(s.trustlineBalanceModel, s.nativeBalanceModel, s.sacBalanceModel),
+			batch:                       newBatch(s.trustlineBalanceModel, s.nativeBalanceModel, s.sacBalanceModel, s.liquidityPoolModel, s.liquidityPoolBalanceModel),
 			wasmClassifications:         make(map[xdr.Hash]types.ContractType),
 			contractAddressesByWasmHash: make(map[xdr.Hash][]xdr.Hash),
 			startTime:                   time.Now(),
@@ -302,6 +340,16 @@ func (p *checkpointProcessor) processEntry(change ingest.Change) {
 		p.accountCount++
 
 	case xdr.LedgerEntryTypeTrustline:
+		// Pool-share trustlines carry an account's liquidity-pool shares rather than an asset
+		// balance; route them to liquidity_pool_balances instead of trustline_balances.
+		trustlineEntry := change.Post.Data.MustTrustLine()
+		if trustlineEntry.Asset.Type == xdr.AssetTypeAssetTypePoolShare {
+			poolID := processors.PoolIDToString(*trustlineEntry.Asset.LiquidityPoolId)
+			p.batch.addLiquidityPoolShare(trustlineEntry.AccountId.Address(), poolID, int64(trustlineEntry.Balance), p.checkpointLedger)
+			p.entries++
+			return
+		}
+
 		accountAddress, asset, xdrFields, skip := p.service.processTrustlineChange(change)
 		if skip {
 			return
@@ -312,6 +360,22 @@ func (p *checkpointProcessor) processEntry(change ingest.Change) {
 		if _, exists := p.data.uniqueAssets[asset.ID]; !exists {
 			p.data.uniqueAssets[asset.ID] = &asset
 		}
+
+	case xdr.LedgerEntryTypeLiquidityPool:
+		pool := change.Post.Data.MustLiquidityPool()
+		cp, ok := pool.Body.GetConstantProduct()
+		if !ok {
+			return
+		}
+		p.batch.addLiquidityPool(wbdata.LiquidityPool{
+			PoolID:       processors.PoolIDToString(pool.LiquidityPoolId),
+			AssetA:       cp.Params.AssetA.StringCanonical(),
+			AmountA:      int64(cp.ReserveA),
+			AssetB:       cp.Params.AssetB.StringCanonical(),
+			AmountB:      int64(cp.ReserveB),
+			LedgerNumber: p.checkpointLedger,
+		})
+		p.entries++
 
 	case xdr.LedgerEntryTypeContractData:
 		contractDataEntry := change.Post.Data.MustContractData()

--- a/internal/services/checkpoint.go
+++ b/internal/services/checkpoint.go
@@ -332,12 +332,8 @@ func (p *checkpointProcessor) processEntry(change ingest.Change) {
 	case xdr.LedgerEntryTypeAccount:
 		accountEntry := change.Post.Data.MustAccount()
 		liabilities := accountEntry.Liabilities()
-		numSubEntries := accountEntry.NumSubEntries
-		numSponsoring := accountEntry.NumSponsoring()
-		numSponsored := accountEntry.NumSponsored()
-		// Base reserve requirement only (excludes liabilities); mirrors accounts.go and stellar-core getMinBalance.
-		minimumBalance := int64(processors.MinimumBaseReserveCount+numSubEntries+numSponsoring-numSponsored) * processors.BaseReserveStroops
-		p.batch.addNativeBalance(accountEntry.AccountId.Address(), int64(accountEntry.Balance), minimumBalance, int64(liabilities.Buying), int64(liabilities.Selling), uint32(numSubEntries), p.checkpointLedger)
+		minimumBalance := processors.MinimumBalance(accountEntry)
+		p.batch.addNativeBalance(accountEntry.AccountId.Address(), int64(accountEntry.Balance), minimumBalance, int64(liabilities.Buying), int64(liabilities.Selling), uint32(accountEntry.NumSubEntries), p.checkpointLedger)
 		p.entries++
 		p.accountCount++
 

--- a/internal/services/checkpoint_test.go
+++ b/internal/services/checkpoint_test.go
@@ -632,13 +632,36 @@ func TestCheckpointProcessor_ProcessEntry(t *testing.T) {
 		assert.Equal(t, 1, proc.trustlineCount)
 	})
 
-	t.Run("trustline_pool_share_skipped", func(t *testing.T) {
+	t.Run("trustline_pool_share_routed_to_liquidity_pool_balances", func(t *testing.T) {
 		proc := newTestCheckpointProcessor()
-		change := makePoolShareTrustlineChange("GAFOZZL77R57WMGES6BO6WJDEIFJ6662GMCVEX6ZESULRX3FRBGSSV5N")
+		address := "GAFOZZL77R57WMGES6BO6WJDEIFJ6662GMCVEX6ZESULRX3FRBGSSV5N"
+		change := makePoolShareTrustlineChange(address)
 		proc.processEntry(change)
 
+		// Pool-share trustlines are shares, not asset balances: they go to liquidity_pool_balances.
 		assert.Empty(t, proc.batch.trustlineBalances)
-		assert.Equal(t, 0, proc.entries)
+		require.Len(t, proc.batch.liquidityPoolBalances, 1)
+		lpb := proc.batch.liquidityPoolBalances[0]
+		assert.Equal(t, address, string(lpb.AccountID))
+		assert.Equal(t, xdr.Hash(xdr.PoolId{1, 2, 3}).HexString(), lpb.PoolID)
+		assert.Equal(t, int64(1000), lpb.Shares)
+		assert.Equal(t, 1, proc.entries)
+	})
+
+	t.Run("liquidity_pool_entry_routed_to_liquidity_pools", func(t *testing.T) {
+		proc := newTestCheckpointProcessor()
+		issuer := "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+		change := makeLpEntryChange(xdr.PoolId{4, 5, 6}, xdr.MustNewNativeAsset(), xdr.MustNewCreditAsset("USDC", issuer), 100, 200)
+		proc.processEntry(change)
+
+		require.Len(t, proc.batch.liquidityPools, 1)
+		lp := proc.batch.liquidityPools[0]
+		assert.Equal(t, xdr.Hash(xdr.PoolId{4, 5, 6}).HexString(), lp.PoolID)
+		assert.Equal(t, "native", lp.AssetA)
+		assert.Equal(t, int64(100), lp.AmountA)
+		assert.Equal(t, "USDC:"+issuer, lp.AssetB)
+		assert.Equal(t, int64(200), lp.AmountB)
+		assert.Equal(t, 1, proc.entries)
 	})
 
 	t.Run("contract_instance_non_sac", func(t *testing.T) {

--- a/internal/services/checkpoint_test.go
+++ b/internal/services/checkpoint_test.go
@@ -87,16 +87,18 @@ func makeContractInstanceChange(contractHash [32]byte, wasmHash xdr.Hash) ingest
 
 // checkpointTestFixture holds a checkpointService and all mocked dependencies.
 type checkpointTestFixture struct {
-	svc                     *checkpointService
-	reader                  *ChangeReaderMock
-	contractMetadataService *ContractMetadataServiceMock
-	trustlineAssetModel     *wbdata.TrustlineAssetModelMock
-	trustlineBalanceModel   *wbdata.TrustlineBalanceModelMock
-	nativeBalanceModel      *wbdata.NativeBalanceModelMock
-	sacBalanceModel         *wbdata.SACBalanceModelMock
-	contractModel           *wbdata.ContractModelMock
-	protocolWasmModel       *wbdata.ProtocolWasmsModelMock
-	protocolContractsModel  *wbdata.ProtocolContractsModelMock
+	svc                       *checkpointService
+	reader                    *ChangeReaderMock
+	contractMetadataService   *ContractMetadataServiceMock
+	trustlineAssetModel       *wbdata.TrustlineAssetModelMock
+	trustlineBalanceModel     *wbdata.TrustlineBalanceModelMock
+	nativeBalanceModel        *wbdata.NativeBalanceModelMock
+	sacBalanceModel           *wbdata.SACBalanceModelMock
+	liquidityPoolModel        *wbdata.LiquidityPoolModelMock
+	liquidityPoolBalanceModel *wbdata.LiquidityPoolBalanceModelMock
+	contractModel             *wbdata.ContractModelMock
+	protocolWasmModel         *wbdata.ProtocolWasmsModelMock
+	protocolContractsModel    *wbdata.ProtocolContractsModelMock
 }
 
 // setupCheckpointTest creates a checkpointService with mocked dependencies and a real DB pool.
@@ -115,38 +117,48 @@ func setupCheckpointTest(t *testing.T) checkpointTestFixture {
 	trustlineBalanceModelMock := wbdata.NewTrustlineBalanceModelMock(t)
 	nativeBalanceModelMock := wbdata.NewNativeBalanceModelMock(t)
 	sacBalanceModelMock := wbdata.NewSACBalanceModelMock(t)
+	liquidityPoolModelMock := wbdata.NewLiquidityPoolModelMock(t)
+	liquidityPoolBalanceModelMock := wbdata.NewLiquidityPoolBalanceModelMock(t)
+	// The batch flush always issues a BatchCopy for the liquidity-pool models (with empty slices
+	// when a checkpoint carries no pool data), so accept any invocation across all checkpoint tests.
+	liquidityPoolModelMock.On("BatchCopy", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	liquidityPoolBalanceModelMock.On("BatchCopy", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	contractModelMock := wbdata.NewContractModelMock(t)
 	protocolWasmModelMock := wbdata.NewProtocolWasmsModelMock(t)
 	protocolContractsModelMock := wbdata.NewProtocolContractsModelMock(t)
 
 	svc := &checkpointService{
-		db:                      dbPool,
-		archive:                 &HistoryArchiveMock{},
-		contractMetadataService: contractMetadataServiceMock,
-		trustlineAssetModel:     trustlineAssetModelMock,
-		trustlineBalanceModel:   trustlineBalanceModelMock,
-		nativeBalanceModel:      nativeBalanceModelMock,
-		sacBalanceModel:         sacBalanceModelMock,
-		contractModel:           contractModelMock,
-		protocolWasmModel:       protocolWasmModelMock,
-		protocolContractsModel:  protocolContractsModelMock,
-		networkPassphrase:       network.TestNetworkPassphrase,
+		db:                        dbPool,
+		archive:                   &HistoryArchiveMock{},
+		contractMetadataService:   contractMetadataServiceMock,
+		trustlineAssetModel:       trustlineAssetModelMock,
+		trustlineBalanceModel:     trustlineBalanceModelMock,
+		nativeBalanceModel:        nativeBalanceModelMock,
+		sacBalanceModel:           sacBalanceModelMock,
+		liquidityPoolModel:        liquidityPoolModelMock,
+		liquidityPoolBalanceModel: liquidityPoolBalanceModelMock,
+		contractModel:             contractModelMock,
+		protocolWasmModel:         protocolWasmModelMock,
+		protocolContractsModel:    protocolContractsModelMock,
+		networkPassphrase:         network.TestNetworkPassphrase,
 		readerFactory: func(_ context.Context, _ historyarchive.ArchiveInterface, _ uint32) (ingest.ChangeReader, error) {
 			return readerMock, nil
 		},
 	}
 
 	return checkpointTestFixture{
-		svc:                     svc,
-		reader:                  readerMock,
-		contractMetadataService: contractMetadataServiceMock,
-		trustlineAssetModel:     trustlineAssetModelMock,
-		trustlineBalanceModel:   trustlineBalanceModelMock,
-		nativeBalanceModel:      nativeBalanceModelMock,
-		sacBalanceModel:         sacBalanceModelMock,
-		contractModel:           contractModelMock,
-		protocolWasmModel:       protocolWasmModelMock,
-		protocolContractsModel:  protocolContractsModelMock,
+		svc:                       svc,
+		reader:                    readerMock,
+		contractMetadataService:   contractMetadataServiceMock,
+		trustlineAssetModel:       trustlineAssetModelMock,
+		trustlineBalanceModel:     trustlineBalanceModelMock,
+		nativeBalanceModel:        nativeBalanceModelMock,
+		sacBalanceModel:           sacBalanceModelMock,
+		liquidityPoolModel:        liquidityPoolModelMock,
+		liquidityPoolBalanceModel: liquidityPoolBalanceModelMock,
+		contractModel:             contractModelMock,
+		protocolWasmModel:         protocolWasmModelMock,
+		protocolContractsModel:    protocolContractsModelMock,
 	}
 }
 
@@ -235,6 +247,100 @@ func TestCheckpointService_PopulateFromCheckpoint_AccountEntry(t *testing.T) {
 	).Return(nil).Once()
 
 	err := f.svc.PopulateFromCheckpoint(context.Background(), 100, func(_ pgx.Tx) error { return nil })
+	require.NoError(t, err)
+}
+
+// makePoolShareChange builds a checkpoint change for a pool_share trustline (per-account shares).
+func makePoolShareChange(account xdr.AccountId, poolID xdr.PoolId, shares int64) ingest.Change {
+	return ingest.Change{
+		Type: xdr.LedgerEntryTypeTrustline,
+		Post: &xdr.LedgerEntry{Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeTrustline,
+			TrustLine: &xdr.TrustLineEntry{
+				AccountId: account,
+				Asset:     xdr.TrustLineAsset{Type: xdr.AssetTypeAssetTypePoolShare, LiquidityPoolId: &poolID},
+				Balance:   xdr.Int64(shares),
+			},
+		}},
+	}
+}
+
+// makeLpEntryChange builds a checkpoint change for a constant-product LiquidityPoolEntry.
+func makeLpEntryChange(poolID xdr.PoolId, assetA, assetB xdr.Asset, reserveA, reserveB int64) ingest.Change {
+	return ingest.Change{
+		Type: xdr.LedgerEntryTypeLiquidityPool,
+		Post: &xdr.LedgerEntry{Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeLiquidityPool,
+			LiquidityPool: &xdr.LiquidityPoolEntry{
+				LiquidityPoolId: poolID,
+				Body: xdr.LiquidityPoolEntryBody{
+					Type: xdr.LiquidityPoolTypeLiquidityPoolConstantProduct,
+					ConstantProduct: &xdr.LiquidityPoolEntryConstantProduct{
+						Params:   xdr.LiquidityPoolConstantProductParameters{AssetA: assetA, AssetB: assetB, Fee: xdr.LiquidityPoolFeeV18},
+						ReserveA: xdr.Int64(reserveA),
+						ReserveB: xdr.Int64(reserveB),
+					},
+				},
+			},
+		}},
+	}
+}
+
+func TestCheckpointService_PopulateFromCheckpoint_LiquidityPoolEntries(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	dbPool, err := db.OpenDBConnectionPool(context.Background(), dbt.DSN)
+	require.NoError(t, err)
+	defer dbPool.Close()
+
+	issuer := "GAFOZZL77R57WMGES6BO6WJDEIFJ6662GMCVEX6ZESULRX3FRBGSSV5N"
+	account := xdr.MustAddress(issuer)
+	poolID := xdr.PoolId{1, 2, 3}
+	expectedPoolID := xdr.Hash(poolID).HexString()
+	usdc := xdr.MustNewCreditAsset("USDC", issuer)
+
+	readerMock := NewChangeReaderMock(t)
+	readerMock.On("Read").Return(makeLpEntryChange(poolID, xdr.MustNewNativeAsset(), usdc, 100, 200), nil).Once()
+	readerMock.On("Read").Return(makePoolShareChange(account, poolID, 5000), nil).Once()
+	readerMock.On("Read").Return(ingest.Change{}, io.EOF).Once()
+	readerMock.On("Close").Return(nil).Once()
+
+	trustlineBalanceModel := wbdata.NewTrustlineBalanceModelMock(t)
+	nativeBalanceModel := wbdata.NewNativeBalanceModelMock(t)
+	sacBalanceModel := wbdata.NewSACBalanceModelMock(t)
+	lpModel := wbdata.NewLiquidityPoolModelMock(t)
+	lpBalanceModel := wbdata.NewLiquidityPoolBalanceModelMock(t)
+
+	// The pool-share trustline and LP entry route to the liquidity-pool models, never to
+	// trustline/native/sac (those flush empty).
+	trustlineBalanceModel.On("BatchCopy", mock.Anything, mock.Anything, mock.MatchedBy(func(b []wbdata.TrustlineBalance) bool { return len(b) == 0 })).Return(nil).Once()
+	nativeBalanceModel.On("BatchCopy", mock.Anything, mock.Anything, mock.MatchedBy(func(b []wbdata.NativeBalance) bool { return len(b) == 0 })).Return(nil).Once()
+	sacBalanceModel.On("BatchCopy", mock.Anything, mock.Anything, mock.MatchedBy(func(b []wbdata.SACBalance) bool { return len(b) == 0 })).Return(nil).Once()
+	lpModel.On("BatchCopy", mock.Anything, mock.Anything, mock.MatchedBy(func(pools []wbdata.LiquidityPool) bool {
+		return len(pools) == 1 && pools[0].PoolID == expectedPoolID &&
+			pools[0].AssetA == "native" && pools[0].AmountA == 100 &&
+			pools[0].AssetB == "USDC:"+issuer && pools[0].AmountB == 200
+	})).Return(nil).Once()
+	lpBalanceModel.On("BatchCopy", mock.Anything, mock.Anything, mock.MatchedBy(func(bals []wbdata.LiquidityPoolBalance) bool {
+		return len(bals) == 1 && bals[0].PoolID == expectedPoolID &&
+			bals[0].Shares == 5000 && bals[0].AccountID == types.AddressBytea(issuer)
+	})).Return(nil).Once()
+
+	svc := &checkpointService{
+		db:                        dbPool,
+		archive:                   &HistoryArchiveMock{},
+		trustlineBalanceModel:     trustlineBalanceModel,
+		nativeBalanceModel:        nativeBalanceModel,
+		sacBalanceModel:           sacBalanceModel,
+		liquidityPoolModel:        lpModel,
+		liquidityPoolBalanceModel: lpBalanceModel,
+		networkPassphrase:         network.TestNetworkPassphrase,
+		readerFactory: func(_ context.Context, _ historyarchive.ArchiveInterface, _ uint32) (ingest.ChangeReader, error) {
+			return readerMock, nil
+		},
+	}
+
+	err = svc.PopulateFromCheckpoint(context.Background(), 100, func(_ pgx.Tx) error { return nil })
 	require.NoError(t, err)
 }
 

--- a/internal/services/ingest_live.go
+++ b/internal/services/ingest_live.go
@@ -196,6 +196,8 @@ func (m *ingestService) persistLedgerData(
 			buffer.GetTrustlineChanges(),
 			buffer.GetAccountChanges(),
 			buffer.GetSACBalanceChanges(),
+			buffer.GetLiquidityPoolShareChanges(),
+			buffer.GetLiquidityPoolChanges(),
 		); txErr != nil {
 			return fmt.Errorf("processing token changes for ledger %d: %w", ledgerSeq, txErr)
 		}

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -1572,9 +1572,10 @@ func Test_ingestProcessedDataWithRetry(t *testing.T) {
 			mock.Anything, // ctx
 			mock.Anything, // dbTx
 			mock.Anything, // trustlineChangesByTrustlineKey
-			mock.Anything, // contractChanges
 			mock.Anything, // accountChangesByAccountID
 			mock.Anything, // sacBalanceChangesByKey
+			mock.Anything, // lpShareChangesByKey
+			mock.Anything, // lpChangesByPoolID
 		).Return(nil)
 
 		svc, err := NewIngestService(IngestServiceConfig{
@@ -1652,9 +1653,10 @@ func Test_ingestProcessedDataWithRetry(t *testing.T) {
 			mock.Anything, // ctx
 			mock.Anything, // dbTx
 			mock.Anything, // trustlineChangesByTrustlineKey
-			mock.Anything, // contractChanges
 			mock.Anything, // accountChangesByAccountID
 			mock.Anything, // sacBalanceChangesByKey
+			mock.Anything, // lpShareChangesByKey
+			mock.Anything, // lpChangesByPoolID
 		).Return(fmt.Errorf("db connection failed"))
 
 		svc, err := NewIngestService(IngestServiceConfig{
@@ -1729,20 +1731,22 @@ func Test_ingestProcessedDataWithRetry(t *testing.T) {
 		// Mock AccountTokenService to fail once then succeed
 		mockTokenIngestionService := NewTokenIngestionServiceMock(t)
 		mockTokenIngestionService.On("ProcessTokenChanges",
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
+			mock.Anything, // ctx
+			mock.Anything, // dbTx
+			mock.Anything, // trustlineChangesByTrustlineKey
+			mock.Anything, // accountChangesByAccountID
+			mock.Anything, // sacBalanceChangesByKey
+			mock.Anything, // lpShareChangesByKey
+			mock.Anything, // lpChangesByPoolID
 		).Return(fmt.Errorf("transient error")).Once()
 		mockTokenIngestionService.On("ProcessTokenChanges",
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
+			mock.Anything, // ctx
+			mock.Anything, // dbTx
+			mock.Anything, // trustlineChangesByTrustlineKey
+			mock.Anything, // accountChangesByAccountID
+			mock.Anything, // sacBalanceChangesByKey
+			mock.Anything, // lpShareChangesByKey
+			mock.Anything, // lpChangesByPoolID
 		).Return(nil).Once()
 
 		svc, err := NewIngestService(IngestServiceConfig{
@@ -1927,7 +1931,13 @@ func Test_PersistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		mockTokenIngestionService := NewTokenIngestionServiceMock(t)
 		mockTokenIngestionService.On("ProcessTokenChanges",
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, // ctx
+			mock.Anything, // dbTx
+			mock.Anything, // trustlineChangesByTrustlineKey
+			mock.Anything, // accountChangesByAccountID
+			mock.Anything, // sacBalanceChangesByKey
+			mock.Anything, // lpShareChangesByKey
+			mock.Anything, // lpChangesByPoolID
 		).Return(nil).Maybe()
 
 		svc, err := NewIngestService(IngestServiceConfig{
@@ -2347,7 +2357,13 @@ func Test_ingestService_ingestLiveLedgers_LagReadDoesNotBlockConsumer(t *testing
 
 	mockTokenIngestionService := NewTokenIngestionServiceMock(t)
 	mockTokenIngestionService.On("ProcessTokenChanges",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, // ctx
+		mock.Anything, // dbTx
+		mock.Anything, // trustlineChangesByTrustlineKey
+		mock.Anything, // accountChangesByAccountID
+		mock.Anything, // sacBalanceChangesByKey
+		mock.Anything, // lpShareChangesByKey
+		mock.Anything, // lpChangesByPoolID
 	).Return(nil).Maybe()
 
 	// GetLedger always returns an empty (tx-less) ledger, so each iteration persists only the

--- a/internal/services/mocks.go
+++ b/internal/services/mocks.go
@@ -126,8 +126,8 @@ type TokenIngestionServiceMock struct {
 
 var _ TokenIngestionService = (*TokenIngestionServiceMock)(nil)
 
-func (m *TokenIngestionServiceMock) ProcessTokenChanges(ctx context.Context, dbTx pgx.Tx, trustlineChangesByTrustlineKey map[indexer.TrustlineChangeKey]types.TrustlineChange, accountChangesByAccountID map[string]types.AccountChange, sacBalanceChangesByKey map[indexer.SACBalanceChangeKey]types.SACBalanceChange) error {
-	args := m.Called(ctx, dbTx, trustlineChangesByTrustlineKey, accountChangesByAccountID, sacBalanceChangesByKey)
+func (m *TokenIngestionServiceMock) ProcessTokenChanges(ctx context.Context, dbTx pgx.Tx, trustlineChangesByTrustlineKey map[indexer.TrustlineChangeKey]types.TrustlineChange, accountChangesByAccountID map[string]types.AccountChange, sacBalanceChangesByKey map[indexer.SACBalanceChangeKey]types.SACBalanceChange, lpShareChangesByKey map[indexer.LiquidityPoolShareChangeKey]types.LiquidityPoolShareChange, lpChangesByPoolID map[string]types.LiquidityPoolChange) error {
+	args := m.Called(ctx, dbTx, trustlineChangesByTrustlineKey, accountChangesByAccountID, sacBalanceChangesByKey, lpShareChangesByKey, lpChangesByPoolID)
 	return args.Error(0)
 }
 

--- a/internal/services/token_ingestion.go
+++ b/internal/services/token_ingestion.go
@@ -16,9 +16,9 @@ import (
 
 // TokenIngestionService provides write access to account token storage during live ingestion.
 type TokenIngestionService interface {
-	// ProcessTokenChanges applies trustline and SAC balance changes to PostgreSQL.
-	// This is called by the indexer for each ledger's state changes during live ingestion.
-	ProcessTokenChanges(ctx context.Context, dbTx pgx.Tx, trustlineChangesByTrustlineKey map[indexer.TrustlineChangeKey]types.TrustlineChange, accountChangesByAccountID map[string]types.AccountChange, sacBalanceChangesByKey map[indexer.SACBalanceChangeKey]types.SACBalanceChange) error
+	// ProcessTokenChanges applies trustline, native, SAC, and liquidity-pool balance changes to
+	// PostgreSQL. This is called by the indexer for each ledger's state changes during live ingestion.
+	ProcessTokenChanges(ctx context.Context, dbTx pgx.Tx, trustlineChangesByTrustlineKey map[indexer.TrustlineChangeKey]types.TrustlineChange, accountChangesByAccountID map[string]types.AccountChange, sacBalanceChangesByKey map[indexer.SACBalanceChangeKey]types.SACBalanceChange, lpShareChangesByKey map[indexer.LiquidityPoolShareChangeKey]types.LiquidityPoolShareChange, lpChangesByPoolID map[string]types.LiquidityPoolChange) error
 }
 
 // Verify interface compliance at compile time
@@ -26,34 +26,40 @@ var _ TokenIngestionService = (*tokenIngestionService)(nil)
 
 // TokenIngestionServiceConfig holds configuration for creating a TokenIngestionService.
 type TokenIngestionServiceConfig struct {
-	TrustlineBalanceModel wbdata.TrustlineBalanceModelInterface
-	NativeBalanceModel    wbdata.NativeBalanceModelInterface
-	SACBalanceModel       wbdata.SACBalanceModelInterface
-	NetworkPassphrase     string
+	TrustlineBalanceModel     wbdata.TrustlineBalanceModelInterface
+	NativeBalanceModel        wbdata.NativeBalanceModelInterface
+	SACBalanceModel           wbdata.SACBalanceModelInterface
+	LiquidityPoolModel        wbdata.LiquidityPoolModelInterface
+	LiquidityPoolBalanceModel wbdata.LiquidityPoolBalanceModelInterface
+	NetworkPassphrase         string
 }
 
 // tokenIngestionService implements TokenIngestionService.
 type tokenIngestionService struct {
-	trustlineBalanceModel wbdata.TrustlineBalanceModelInterface
-	nativeBalanceModel    wbdata.NativeBalanceModelInterface
-	sacBalanceModel       wbdata.SACBalanceModelInterface
-	networkPassphrase     string
+	trustlineBalanceModel     wbdata.TrustlineBalanceModelInterface
+	nativeBalanceModel        wbdata.NativeBalanceModelInterface
+	sacBalanceModel           wbdata.SACBalanceModelInterface
+	liquidityPoolModel        wbdata.LiquidityPoolModelInterface
+	liquidityPoolBalanceModel wbdata.LiquidityPoolBalanceModelInterface
+	networkPassphrase         string
 }
 
 // NewTokenIngestionService creates a TokenIngestionService for ingestion.
 func NewTokenIngestionService(cfg TokenIngestionServiceConfig) *tokenIngestionService {
 	return &tokenIngestionService{
-		trustlineBalanceModel: cfg.TrustlineBalanceModel,
-		nativeBalanceModel:    cfg.NativeBalanceModel,
-		sacBalanceModel:       cfg.SACBalanceModel,
-		networkPassphrase:     cfg.NetworkPassphrase,
+		trustlineBalanceModel:     cfg.TrustlineBalanceModel,
+		nativeBalanceModel:        cfg.NativeBalanceModel,
+		sacBalanceModel:           cfg.SACBalanceModel,
+		liquidityPoolModel:        cfg.LiquidityPoolModel,
+		liquidityPoolBalanceModel: cfg.LiquidityPoolBalanceModel,
+		networkPassphrase:         cfg.NetworkPassphrase,
 	}
 }
 
 // ProcessTokenChanges processes token changes and stores them in PostgreSQL.
 // This is called by the indexer for each ledger's state changes during live ingestion.
-func (s *tokenIngestionService) ProcessTokenChanges(ctx context.Context, dbTx pgx.Tx, trustlineChangesByTrustlineKey map[indexer.TrustlineChangeKey]types.TrustlineChange, accountChangesByAccountID map[string]types.AccountChange, sacBalanceChangesByKey map[indexer.SACBalanceChangeKey]types.SACBalanceChange) error {
-	if len(trustlineChangesByTrustlineKey) == 0 && len(accountChangesByAccountID) == 0 && len(sacBalanceChangesByKey) == 0 {
+func (s *tokenIngestionService) ProcessTokenChanges(ctx context.Context, dbTx pgx.Tx, trustlineChangesByTrustlineKey map[indexer.TrustlineChangeKey]types.TrustlineChange, accountChangesByAccountID map[string]types.AccountChange, sacBalanceChangesByKey map[indexer.SACBalanceChangeKey]types.SACBalanceChange, lpShareChangesByKey map[indexer.LiquidityPoolShareChangeKey]types.LiquidityPoolShareChange, lpChangesByPoolID map[string]types.LiquidityPoolChange) error {
+	if len(trustlineChangesByTrustlineKey) == 0 && len(accountChangesByAccountID) == 0 && len(sacBalanceChangesByKey) == 0 && len(lpShareChangesByKey) == 0 && len(lpChangesByPoolID) == 0 {
 		return nil
 	}
 
@@ -64,6 +70,12 @@ func (s *tokenIngestionService) ProcessTokenChanges(ctx context.Context, dbTx pg
 		return err
 	}
 	if err := s.processSACBalanceChanges(ctx, dbTx, sacBalanceChangesByKey); err != nil {
+		return err
+	}
+	if err := s.processLiquidityPoolChanges(ctx, dbTx, lpChangesByPoolID); err != nil {
+		return err
+	}
+	if err := s.processLiquidityPoolShareChanges(ctx, dbTx, lpShareChangesByKey); err != nil {
 		return err
 	}
 	return nil
@@ -166,6 +178,70 @@ func (s *tokenIngestionService) processSACBalanceChanges(ctx context.Context, db
 			return fmt.Errorf("upserting SAC balances: %w", err)
 		}
 		log.Ctx(ctx).Infof("upserted %d SAC balances, deleted %d SAC balances", len(upserts), len(deletes))
+	}
+	return nil
+}
+
+// processLiquidityPoolChanges handles liquidity pool reserve upserts and deletes.
+func (s *tokenIngestionService) processLiquidityPoolChanges(ctx context.Context, dbTx pgx.Tx, changesByPoolID map[string]types.LiquidityPoolChange) error {
+	if len(changesByPoolID) == 0 {
+		return nil
+	}
+
+	var upserts []wbdata.LiquidityPool
+	var deletes []wbdata.LiquidityPool
+	for _, change := range changesByPoolID {
+		pool := wbdata.LiquidityPool{
+			PoolID:       change.PoolID,
+			AssetA:       change.AssetA,
+			AmountA:      change.ReserveA,
+			AssetB:       change.AssetB,
+			AmountB:      change.ReserveB,
+			LedgerNumber: change.LedgerNumber,
+		}
+		if change.Operation == types.LiquidityPoolOpRemove {
+			deletes = append(deletes, pool)
+		} else {
+			upserts = append(upserts, pool)
+		}
+	}
+
+	if len(upserts) > 0 || len(deletes) > 0 {
+		if err := s.liquidityPoolModel.BatchUpsert(ctx, dbTx, upserts, deletes); err != nil {
+			return fmt.Errorf("upserting liquidity pools: %w", err)
+		}
+		log.Ctx(ctx).Infof("upserted %d liquidity pools, deleted %d liquidity pools", len(upserts), len(deletes))
+	}
+	return nil
+}
+
+// processLiquidityPoolShareChanges handles pool-share balance upserts and deletes.
+func (s *tokenIngestionService) processLiquidityPoolShareChanges(ctx context.Context, dbTx pgx.Tx, changesByKey map[indexer.LiquidityPoolShareChangeKey]types.LiquidityPoolShareChange) error {
+	if len(changesByKey) == 0 {
+		return nil
+	}
+
+	var upserts []wbdata.LiquidityPoolBalance
+	var deletes []wbdata.LiquidityPoolBalance
+	for _, change := range changesByKey {
+		balance := wbdata.LiquidityPoolBalance{
+			AccountID:    types.AddressBytea(change.AccountID),
+			PoolID:       change.PoolID,
+			Shares:       change.Shares,
+			LedgerNumber: change.LedgerNumber,
+		}
+		if change.Operation == types.LiquidityPoolShareOpRemove {
+			deletes = append(deletes, balance)
+		} else {
+			upserts = append(upserts, balance)
+		}
+	}
+
+	if len(upserts) > 0 || len(deletes) > 0 {
+		if err := s.liquidityPoolBalanceModel.BatchUpsert(ctx, dbTx, upserts, deletes); err != nil {
+			return fmt.Errorf("upserting liquidity pool balances: %w", err)
+		}
+		log.Ctx(ctx).Infof("upserted %d liquidity pool balances, deleted %d liquidity pool balances", len(upserts), len(deletes))
 	}
 	return nil
 }

--- a/internal/services/token_ingestion_test.go
+++ b/internal/services/token_ingestion_test.go
@@ -369,7 +369,7 @@ func TestProcessTokenChanges(t *testing.T) {
 		})
 
 		err = db.RunInTransaction(ctx, dbConnectionPool, func(dbTx pgx.Tx) error {
-			return service.ProcessTokenChanges(ctx, dbTx, map[indexer.TrustlineChangeKey]types.TrustlineChange{}, make(map[string]types.AccountChange), make(map[indexer.SACBalanceChangeKey]types.SACBalanceChange))
+			return service.ProcessTokenChanges(ctx, dbTx, map[indexer.TrustlineChangeKey]types.TrustlineChange{}, make(map[string]types.AccountChange), make(map[indexer.SACBalanceChangeKey]types.SACBalanceChange), make(map[indexer.LiquidityPoolShareChangeKey]types.LiquidityPoolShareChange), make(map[string]types.LiquidityPoolChange))
 		})
 		assert.NoError(t, err)
 	})

--- a/pkg/wbclient/queries.go
+++ b/pkg/wbclient/queries.go
@@ -382,6 +382,7 @@ const balanceFragments = `
 			minimumBalance
 			buyingLiabilities
 			sellingLiabilities
+			numSubentries
 			lastModifiedLedger
 		}
 		... on TrustlineBalance {

--- a/pkg/wbclient/queries.go
+++ b/pkg/wbclient/queries.go
@@ -408,6 +408,14 @@ const balanceFragments = `
 			decimals
 			lastModifiedLedger
 		}
+		... on LiquidityPoolBalance {
+			liquidityPoolId
+			reserves {
+				asset
+				amount
+			}
+			lastModifiedLedger
+		}
 	`
 
 // buildAccountBalancesQuery builds the GraphQL query for fetching account balances.

--- a/pkg/wbclient/queries_test.go
+++ b/pkg/wbclient/queries_test.go
@@ -1,0 +1,70 @@
+package wbclient
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/pkg/wbclient/types"
+)
+
+// TestBalanceFragmentRequestsAllFields guards against the recurring bug where a field is
+// added to an SDK balance struct (and the GraphQL schema + resolver) but not to the query
+// fragment: the SDK then never requests it and it silently unmarshals to its zero value.
+// It asserts every concrete balance variant's inline fragment requests each of that
+// struct's JSON fields (balance/tokenId/tokenType come from the shared fragment prefix).
+func TestBalanceFragmentRequestsAllFields(t *testing.T) {
+	shared := map[string]bool{"balance": true, "tokenId": true, "tokenType": true}
+
+	variants := []struct {
+		typeName string
+		sample   any
+	}{
+		{"NativeBalance", types.NativeBalance{}},
+		{"TrustlineBalance", types.TrustlineBalance{}},
+		{"SACBalance", types.SACBalance{}},
+		{"SEP41Balance", types.SEP41Balance{}},
+		{"LiquidityPoolBalance", types.LiquidityPoolBalance{}},
+	}
+
+	for _, v := range variants {
+		block := inlineFragmentBlock(t, balanceFragments, v.typeName)
+		rt := reflect.TypeOf(v.sample)
+		for i := 0; i < rt.NumField(); i++ {
+			name := strings.Split(rt.Field(i).Tag.Get("json"), ",")[0]
+			if name == "" || name == "-" || shared[name] {
+				continue
+			}
+			assert.Contains(t, block, name,
+				"balanceFragments '... on %s' must request %q, else the SDK never fetches it", v.typeName, name)
+		}
+	}
+}
+
+// inlineFragmentBlock returns the body of the `... on <typeName> { ... }` inline fragment,
+// matching braces so nested selection sets (e.g. reserves { ... }) don't terminate it early.
+func inlineFragmentBlock(t *testing.T, fragment, typeName string) string {
+	t.Helper()
+	marker := "... on " + typeName + " {"
+	start := strings.Index(fragment, marker)
+	require.GreaterOrEqual(t, start, 0, "fragment must contain %q", marker)
+
+	body := fragment[start+len(marker):]
+	depth := 1
+	for i, r := range body {
+		switch r {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return body[:i]
+			}
+		}
+	}
+	t.Fatalf("inline fragment for %s is not closed", typeName)
+	return ""
+}

--- a/pkg/wbclient/types/types.go
+++ b/pkg/wbclient/types/types.go
@@ -99,14 +99,17 @@ type Balance interface {
 
 // NativeBalance represents a native XLM balance
 type NativeBalance struct {
-	BalanceValue       string    `json:"balance"`
-	TokenID            string    `json:"tokenId"`
-	TokenType          TokenType `json:"tokenType"`
-	MinimumBalance     string    `json:"minimumBalance"`
-	BuyingLiabilities  string    `json:"buyingLiabilities"`
-	SellingLiabilities string    `json:"sellingLiabilities"`
-	LastModifiedLedger uint32    `json:"lastModifiedLedger"`
-	NumSubentries      uint32    `json:"numSubentries"`
+	BalanceValue string    `json:"balance"`
+	TokenID      string    `json:"tokenId"`
+	TokenType    TokenType `json:"tokenType"`
+	// MinimumBalance is the base reserve requirement (excludes liabilities):
+	// (2 + numSubentries + numSponsoring - numSponsored) * baseReserve; matches stellar-core getMinBalance.
+	// Spendable balance = balance - MinimumBalance - SellingLiabilities.
+	MinimumBalance     string `json:"minimumBalance"`
+	BuyingLiabilities  string `json:"buyingLiabilities"`
+	SellingLiabilities string `json:"sellingLiabilities"`
+	LastModifiedLedger uint32 `json:"lastModifiedLedger"`
+	NumSubentries      uint32 `json:"numSubentries"`
 }
 
 func (b *NativeBalance) GetBalance() string      { return b.BalanceValue }

--- a/pkg/wbclient/types/types.go
+++ b/pkg/wbclient/types/types.go
@@ -82,10 +82,11 @@ const (
 type TokenType string
 
 const (
-	TokenTypeNative  TokenType = "NATIVE"
-	TokenTypeClassic TokenType = "CLASSIC"
-	TokenTypeSAC     TokenType = "SAC"
-	TokenTypeSEP41   TokenType = "SEP41"
+	TokenTypeNative        TokenType = "NATIVE"
+	TokenTypeClassic       TokenType = "CLASSIC"
+	TokenTypeSAC           TokenType = "SAC"
+	TokenTypeSEP41         TokenType = "SEP41"
+	TokenTypeLiquidityPool TokenType = "LIQUIDITY_POOL"
 )
 
 // Balance is an interface representing different types of account balances
@@ -169,6 +170,29 @@ func (b *SEP41Balance) GetTokenID() string      { return b.TokenID }
 func (b *SEP41Balance) GetTokenType() TokenType { return b.TokenType }
 func (b *SEP41Balance) isBalance()              {}
 
+// LiquidityPoolReserve is one constituent asset of a liquidity pool and its reserve amount.
+type LiquidityPoolReserve struct {
+	Asset  string `json:"asset"`
+	Amount string `json:"amount"`
+}
+
+// LiquidityPoolBalance represents an account's liquidity-pool share holding.
+// BalanceValue is the account's pool shares and TokenID is the pool id; Reserves carries
+// the pool's constituent assets and amounts.
+type LiquidityPoolBalance struct {
+	BalanceValue       string                 `json:"balance"`
+	TokenID            string                 `json:"tokenId"`
+	TokenType          TokenType              `json:"tokenType"`
+	LiquidityPoolID    string                 `json:"liquidityPoolId"`
+	Reserves           []LiquidityPoolReserve `json:"reserves"`
+	LastModifiedLedger uint32                 `json:"lastModifiedLedger"`
+}
+
+func (b *LiquidityPoolBalance) GetBalance() string      { return b.BalanceValue }
+func (b *LiquidityPoolBalance) GetTokenID() string      { return b.TokenID }
+func (b *LiquidityPoolBalance) GetTokenType() TokenType { return b.TokenType }
+func (b *LiquidityPoolBalance) isBalance()              {}
+
 // UnmarshalBalance unmarshals a JSON balance into the appropriate concrete type
 // based on the __typename field
 func UnmarshalBalance(data []byte) (Balance, error) {
@@ -205,6 +229,12 @@ func UnmarshalBalance(data []byte) (Balance, error) {
 		var balance SEP41Balance
 		if err := json.Unmarshal(data, &balance); err != nil {
 			return nil, fmt.Errorf("unmarshaling SEP-41 balance: %w", err)
+		}
+		return &balance, nil
+	case "LiquidityPoolBalance":
+		var balance LiquidityPoolBalance
+		if err := json.Unmarshal(data, &balance); err != nil {
+			return nil, fmt.Errorf("unmarshaling liquidity pool balance: %w", err)
 		}
 		return &balance, nil
 	default:

--- a/pkg/wbclient/types/types_test.go
+++ b/pkg/wbclient/types/types_test.go
@@ -85,6 +85,41 @@ func Test_BalanceEdge_UnmarshalJSON_DecodesSEP41Balance(t *testing.T) {
 	assert.Equal(t, uint32(12345), sep41.LastModifiedLedger)
 }
 
+func Test_BalanceEdge_UnmarshalJSON_DecodesLiquidityPoolBalance(t *testing.T) {
+	payload := []byte(`{
+		"cursor": "cur-1",
+		"node": {
+			"__typename": "LiquidityPoolBalance",
+			"balance": "0.0005000",
+			"tokenId": "aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd0",
+			"tokenType": "LIQUIDITY_POOL",
+			"liquidityPoolId": "aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd0",
+			"reserves": [
+				{"asset": "native", "amount": "10.0000000"},
+				{"asset": "USDC:GISSUER", "amount": "25.0000000"}
+			],
+			"lastModifiedLedger": 12345
+		}
+	}`)
+
+	var edge BalanceEdge
+	err := json.Unmarshal(payload, &edge)
+	require.NoError(t, err)
+	require.NotNil(t, edge.Node)
+
+	lp, ok := edge.Node.(*LiquidityPoolBalance)
+	require.True(t, ok, "expected node to decode into *LiquidityPoolBalance, got %T", edge.Node)
+	assert.Equal(t, "0.0005000", lp.BalanceValue)
+	assert.Equal(t, TokenTypeLiquidityPool, lp.TokenType)
+	assert.Equal(t, "aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd0", lp.LiquidityPoolID)
+	require.Len(t, lp.Reserves, 2)
+	assert.Equal(t, "native", lp.Reserves[0].Asset)
+	assert.Equal(t, "10.0000000", lp.Reserves[0].Amount)
+	assert.Equal(t, "USDC:GISSUER", lp.Reserves[1].Asset)
+	assert.Equal(t, "25.0000000", lp.Reserves[1].Amount)
+	assert.Equal(t, uint32(12345), lp.LastModifiedLedger)
+}
+
 func Test_BalanceConnection_Balances(t *testing.T) {
 	cursor1, cursor2 := "c1", "c2"
 	native := &NativeBalance{BalanceValue: "100", TokenID: "native", TokenType: TokenTypeNative}

--- a/pkg/wbclient/types/types_test.go
+++ b/pkg/wbclient/types/types_test.go
@@ -91,9 +91,9 @@ func Test_BalanceEdge_UnmarshalJSON_DecodesLiquidityPoolBalance(t *testing.T) {
 		"node": {
 			"__typename": "LiquidityPoolBalance",
 			"balance": "0.0005000",
-			"tokenId": "aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd0",
+			"tokenId": "aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd",
 			"tokenType": "LIQUIDITY_POOL",
-			"liquidityPoolId": "aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd0",
+			"liquidityPoolId": "aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd",
 			"reserves": [
 				{"asset": "native", "amount": "10.0000000"},
 				{"asset": "USDC:GISSUER", "amount": "25.0000000"}
@@ -111,7 +111,7 @@ func Test_BalanceEdge_UnmarshalJSON_DecodesLiquidityPoolBalance(t *testing.T) {
 	require.True(t, ok, "expected node to decode into *LiquidityPoolBalance, got %T", edge.Node)
 	assert.Equal(t, "0.0005000", lp.BalanceValue)
 	assert.Equal(t, TokenTypeLiquidityPool, lp.TokenType)
-	assert.Equal(t, "aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd0", lp.LiquidityPoolID)
+	assert.Equal(t, "aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd", lp.LiquidityPoolID)
 	require.Len(t, lp.Reserves, 2)
 	assert.Equal(t, "native", lp.Reserves[0].Asset)
 	assert.Equal(t, "10.0000000", lp.Reserves[0].Amount)


### PR DESCRIPTION
## Summary

Exposes an account's **liquidity-pool share balances** through a new `LiquidityPoolBalance` GraphQL/SDK type. Pool shares were previously **dropped at ingestion** (the `pool_share` trustline was skipped and `LiquidityPoolEntry` ledger entries were not routed anywhere). This is part of the Freighter v1→v2 balances-API migration — closing the `liquidity_pool_id` + `reserves` data gap the v1 client reads.

The new balance carries the account's shares (as `balance`), the pool id (as `tokenId` / `liquidityPoolId`), and the pool's `reserves` (constituent assets + amounts), joined at query time from **two ingested sources**:

- **Per-account shares** — the `pool_share` trustline (`TrustLineEntry.Asset.LiquidityPoolId` = pool id, `.Balance` = shares) → `liquidity_pool_balances`.
- **Pool reserves** — the `LiquidityPoolEntry` ledger entry (constant-product body: `Params.AssetA/AssetB`, `ReserveA/ReserveB`) → `liquidity_pools`.

## Changes

**Storage** (new migrations)
- `liquidity_pools(pool_id TEXT PK, asset_a, amount_a, asset_b, amount_b, last_modified_ledger)` — assets stored canonically (`native` / `CODE:ISSUER`). No `total_shares` (unused).
- `liquidity_pool_balances(account_id BYTEA, pool_id TEXT, shares, last_modified_ledger, PK(account_id, pool_id))`.
- Both mirror `trustline_balances`' fillfactor/autovacuum tuning for upsert-heavy ingestion.

**Data models** — `data/liquidity_pools.go` + `data/liquidity_pool_balances.go` (`GetByAccount` keyset-paginated by `pool_id`, JOINing `liquidity_pools` for reserves; `BatchUpsert`; `BatchCopy`; interfaces + mocks).

**Ingestion**
- New `LiquidityPoolSharesProcessor` (pool-share trustline → shares) and `LiquidityPoolsProcessor` (`LiquidityPoolEntry` → reserves), wired into the indexer alongside the trustline/account/SAC processors, with buffer dedup (tombstone-aware, mirrors the existing change types).
- Live persist (`token_ingestion.go`) and checkpoint population (`checkpoint.go`) both handle the two new sources.

**GraphQL / resolver**
- `TokenType.LIQUIDITY_POOL`; `LiquidityPoolReserve` + `LiquidityPoolBalance implements Balance`.
- New `lp` balance source appended for G-addresses; `getLiquidityPoolBalanceNodes` pages by pool id and participates in the multi-source cursor scheme.

**SDK** — `wbclient/types`: `LiquidityPoolBalance` (+ nested reserve type), `UnmarshalBalance` case, `TokenTypeLiquidityPool`.

## Design decisions

- **Two dedicated processors** rather than folding pool-share extraction into `TrustlinesProcessor`: the generic `LedgerChangeProcessor[T]` contract emits a single type per processor, so each new output type (`LiquidityPoolShareChange`, `LiquidityPoolChange`) gets its own processor — matching how accounts/trustlines/SAC each own one output type. `TrustlinesProcessor` still skips pool-shares (they are not asset trustlines).
- **Pool id** rendered via the existing `PoolIDToString` (hex of the 32-byte hash), consistent with Horizon; reserve assets via `xdr.Asset.StringCanonical()`.
- **LP cursor** keys by the pool-id hex string (validated as a 32-byte hex hash) rather than a UUID like the other contract/asset-backed sources.

## Tests
- Processor extraction (ADD/UPDATE/REMOVE) for both pool-shares and pool reserves.
- Data models: `GetByAccount` JOIN + pagination, `BatchUpsert`, `BatchCopy`.
- `buildLiquidityPoolBalanceFromDB`; `getLiquidityPoolBalanceNodes` pagination **across the SEP-41 → LP source boundary** (cursor round-trips) and within the LP keyset.
- Checkpoint routing of pool-shares and LP entries; SDK `__typename` unmarshal.
- `make check` clean; full `make unit-test` (race) green.

Part of the Freighter v2 balances migration; independent of the subentry/SAC PR. Do not merge without review.

Closes #652

---

## Also in this branch: `minimum_balance` is now the pure base reserve

Redefines `minimum_balance` to be the **pure base reserve requirement** — matching stellar-core's
`getMinBalance` and Horizon — instead of bundling selling liabilities:

```
minimum_balance = (2 + numSubEntries + numSponsoring - numSponsored) * baseReserve   # excludes liabilities
```

Selling liabilities remain exposed separately, so **spendable balance is derived downstream** as
`balance - minimum_balance - selling_liabilities` (mirrors how trustlines already work). This makes
native consistent with trustlines and makes `minimum_balance` match core/Horizon for cross-checks.

Pre-release, so no migration (column unchanged; value re-ingested from scratch) and no consumer is
pinned to the old semantics. `freighter-backend-v2`'s balances mapper subtracts selling liabilities,
so the response's `available` value is unchanged.
