### PR TITLE
fix(serve): allow disabling client auth with empty public keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ The JWT is signed using an Ed25519 private key derived from a Stellar secret see
 
 The server can be configured to accept multiple (comma-separated) public keys through the `CLIENT_AUTH_PUBLIC_KEYS` environment variable.
 
+If `CLIENT_AUTH_PUBLIC_KEYS` is not set or empty, request authentication is disabled.
+
 ### JWT Claims
 
 The JWT payload field should contain the following fields:

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -176,11 +176,10 @@ func initHandlerDeps(ctx context.Context, cfg Configs) (handlerDeps, error) {
 		return handlerDeps{}, fmt.Errorf("creating models for Serve: %w", err)
 	}
 
-	jwtTokenParser, err := auth.NewMultiJWTTokenParser(time.Duration(cfg.ClientAuthMaxTimeoutSeconds)*time.Second, cfg.ClientAuthPublicKeys...)
+	requestAuthVerifier, err := buildRequestAuthVerifier(ctx, cfg)
 	if err != nil {
-		return handlerDeps{}, fmt.Errorf("instantiating multi JWT token parser: %w", err)
+		return handlerDeps{}, err
 	}
-	requestAuthVerifier := auth.NewHTTPRequestVerifier(jwtTokenParser, int64(cfg.ClientAuthMaxBodySizeBytes))
 
 	httpClient := http.Client{Timeout: 30 * time.Second}
 	rpcService, err := services.NewRPCService(cfg.RPCURL, cfg.NetworkPassphrase, &httpClient, m.RPC)
@@ -204,6 +203,21 @@ func initHandlerDeps(ctx context.Context, cfg Configs) (handlerDeps, error) {
 		NetworkPassphrase:         cfg.NetworkPassphrase,
 		GraphQLComplexityLimit:    cfg.GraphQLComplexityLimit,
 	}, nil
+}
+
+// buildRequestAuthVerifier returns nil when no client auth public keys are
+// configured, which makes handler() skip the authentication middleware entirely.
+func buildRequestAuthVerifier(ctx context.Context, cfg Configs) (auth.HTTPRequestVerifier, error) {
+	if len(cfg.ClientAuthPublicKeys) == 0 {
+		log.Ctx(ctx).Warn("client-auth-public-keys is empty: request authentication is disabled")
+		return nil, nil
+	}
+
+	jwtTokenParser, err := auth.NewMultiJWTTokenParser(time.Duration(cfg.ClientAuthMaxTimeoutSeconds)*time.Second, cfg.ClientAuthPublicKeys...)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating multi JWT token parser: %w", err)
+	}
+	return auth.NewHTTPRequestVerifier(jwtTokenParser, int64(cfg.ClientAuthMaxBodySizeBytes)), nil
 }
 
 func handler(deps handlerDeps) http.Handler {

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -1,0 +1,44 @@
+package serve
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildRequestAuthVerifier(t *testing.T) {
+	baseCfg := Configs{
+		ClientAuthMaxTimeoutSeconds: 15,
+		ClientAuthMaxBodySizeBytes:  102_400,
+	}
+
+	t.Run("auth disabled when no public keys are provided", func(t *testing.T) {
+		cfg := baseCfg
+		cfg.ClientAuthPublicKeys = nil
+
+		verifier, err := buildRequestAuthVerifier(context.Background(), cfg)
+		require.NoError(t, err)
+		assert.Nil(t, verifier)
+	})
+
+	t.Run("auth enabled when public keys are provided", func(t *testing.T) {
+		cfg := baseCfg
+		cfg.ClientAuthPublicKeys = []string{keypair.MustRandom().Address()}
+
+		verifier, err := buildRequestAuthVerifier(context.Background(), cfg)
+		require.NoError(t, err)
+		assert.NotNil(t, verifier)
+	})
+
+	t.Run("invalid public key returns error", func(t *testing.T) {
+		cfg := baseCfg
+		cfg.ClientAuthPublicKeys = []string{"not-a-stellar-public-key"}
+
+		verifier, err := buildRequestAuthVerifier(context.Background(), cfg)
+		require.ErrorContains(t, err, "instantiating multi JWT token parser")
+		assert.Nil(t, verifier)
+	})
+}


### PR DESCRIPTION
### What

When `CLIENT_AUTH_PUBLIC_KEYS` is not set or empty, `serve` now starts with request authentication disabled (with a startup warning) instead of panicking. The verifier construction is extracted into `buildRequestAuthVerifier()`, which returns nil when no keys are configured so `handler()` skips the auth middleware. 

### Why

The flag help, the config parser, and the router all advertise that an empty key list disables authentication, but `initHandlerDeps` unconditionally instantiated the JWT token parser, which rejects an empty key list, so the server crashed at startup and the documented no-auth mode was unreachable:

    instantiating multi JWT token parser: no Stellar public keys provided

### Known limitations

N/A

### Issue that this PR addresses

Fixes #655 

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (N/A — no SQL queries changed).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not reaempty key list itself is the opt-in).
