### PR TITLE
feat(protocols): Add code to parse and process ContractData entires for Blend processors

### DIFF
--- a/internal/data/mocks.go
+++ b/internal/data/mocks.go
@@ -349,8 +349,8 @@ func (m *ProtocolContractsModelMock) BatchInsert(ctx context.Context, dbTx pgx.T
 	return args.Error(0)
 }
 
-func (m *ProtocolContractsModelMock) GetByProtocolID(ctx context.Context, protocolID string) ([]ProtocolContracts, error) {
-	args := m.Called(ctx, protocolID)
+func (m *ProtocolContractsModelMock) GetByProtocolID(ctx context.Context, q db.Querier, protocolID string) ([]ProtocolContracts, error) {
+	args := m.Called(ctx, q, protocolID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/internal/data/protocol_contracts.go
+++ b/internal/data/protocol_contracts.go
@@ -26,7 +26,7 @@ type ProtocolContracts struct {
 // ProtocolContractsModelInterface defines the interface for protocol_contracts operations.
 type ProtocolContractsModelInterface interface {
 	BatchInsert(ctx context.Context, dbTx pgx.Tx, contracts []ProtocolContracts) error
-	GetByProtocolID(ctx context.Context, protocolID string) ([]ProtocolContracts, error)
+	GetByProtocolID(ctx context.Context, q db.Querier, protocolID string) ([]ProtocolContracts, error)
 	BatchGetByContractIDs(ctx context.Context, contractIDs [][]byte) (map[string][]ProtocolContracts, error)
 	GetByWasmHashes(ctx context.Context, wasmHashes []types.HashBytea) ([]ProtocolContracts, error)
 }
@@ -90,7 +90,9 @@ func (m *ProtocolContractsModel) BatchInsert(ctx context.Context, dbTx pgx.Tx, c
 }
 
 // GetByProtocolID returns all contracts associated with a protocol via protocol_wasms.
-func (m *ProtocolContractsModel) GetByProtocolID(ctx context.Context, protocolID string) ([]ProtocolContracts, error) {
+// The read runs on the given querier, so callers inside a transaction see their own
+// uncommitted writes instead of a separate pool connection's snapshot.
+func (m *ProtocolContractsModel) GetByProtocolID(ctx context.Context, q db.Querier, protocolID string) ([]ProtocolContracts, error) {
 	const query = `
 		SELECT pc.contract_id, pc.wasm_hash, pc.name, pc.created_at
 		FROM protocol_contracts pc
@@ -99,7 +101,7 @@ func (m *ProtocolContractsModel) GetByProtocolID(ctx context.Context, protocolID
 	`
 
 	start := time.Now()
-	contracts, err := db.QueryMany[ProtocolContracts](ctx, m.DB, query, protocolID)
+	contracts, err := db.QueryMany[ProtocolContracts](ctx, q, query, protocolID)
 	duration := time.Since(start).Seconds()
 	m.Metrics.QueryDuration.WithLabelValues("GetByProtocolID", "protocol_contracts").Observe(duration)
 	m.Metrics.QueriesTotal.WithLabelValues("GetByProtocolID", "protocol_contracts").Inc()

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -528,20 +528,30 @@ func ExtractContractEventsForLedger(ledgerMeta xdr.LedgerCloseMeta) (map[Contrac
 
 // ExtractContractDataChangesForLedger walks a ledger's successful transactions
 // and returns every ContractData ledger-entry change grouped by the owning
-// contract's C-address strkey. Unlike ExtractContractEventsForLedger it uses
+// contract's C-address strkey. It materializes the ledger's transactions via
 // the LedgerTransactionReader (GetChanges needs envelope↔meta pairing), so it
-// takes a ctx and the network passphrase and is strictly heavier — callers
-// gate it behind ProtocolProcessor.RequiresContractData.
-//
-// Within a contract, changes preserve transaction application order, so
-// last-write-wins folding per entry key is deterministic. Ledger-level
-// archival evictions are NOT surfaced (GetChanges only walks fee/tx/op meta);
-// per-tx entry removals appear with Post == nil.
+// is strictly heavier than ExtractContractEventsForLedger — callers gate it
+// behind ProtocolProcessor.RequiresContractData. Callers that already hold
+// the ledger's transactions (live ingestion's main pipeline) use
+// ExtractContractDataChangesFromTransactions directly instead of paying for
+// a second reader build.
 func ExtractContractDataChangesForLedger(ctx context.Context, networkPassphrase string, ledgerMeta xdr.LedgerCloseMeta) (map[string][]ingest.Change, error) {
 	transactions, err := GetLedgerTransactions(ctx, networkPassphrase, ledgerMeta)
 	if err != nil {
 		return nil, fmt.Errorf("getting transactions for ledger %d: %w", ledgerMeta.LedgerSequence(), err)
 	}
+	return ExtractContractDataChangesFromTransactions(transactions, ledgerMeta.LedgerSequence())
+}
+
+// ExtractContractDataChangesFromTransactions is
+// ExtractContractDataChangesForLedger over already-materialized transactions;
+// ledgerSeq is used only for error context.
+//
+// Within a contract, changes preserve transaction application order, so
+// last-write-wins folding per entry key is deterministic. Ledger-level
+// archival evictions are NOT surfaced (GetChanges only walks fee/tx/op meta);
+// per-tx entry removals appear with Post == nil.
+func ExtractContractDataChangesFromTransactions(transactions []ingest.LedgerTransaction, ledgerSeq uint32) (map[string][]ingest.Change, error) {
 	out := make(map[string][]ingest.Change)
 	for i := range transactions {
 		tx := transactions[i]
@@ -550,7 +560,7 @@ func ExtractContractDataChangesForLedger(ctx context.Context, networkPassphrase 
 		}
 		changes, chErr := tx.GetChanges()
 		if chErr != nil {
-			return nil, fmt.Errorf("getting changes for ledger %d tx %d: %w", ledgerMeta.LedgerSequence(), tx.Index, chErr)
+			return nil, fmt.Errorf("getting changes for ledger %d tx %d: %w", ledgerSeq, tx.Index, chErr)
 		}
 		for _, change := range changes {
 			if change.Type != xdr.LedgerEntryTypeContractData {
@@ -575,7 +585,7 @@ func ExtractContractDataChangesForLedger(ctx context.Context, networkPassphrase 
 			if encErr != nil {
 				// Callers rely on this function returning every ContractData
 				// change; silently dropping one would corrupt downstream state.
-				return nil, fmt.Errorf("encoding contract id for ledger %d tx %d: %w", ledgerMeta.LedgerSequence(), tx.Index, encErr)
+				return nil, fmt.Errorf("encoding contract id for ledger %d tx %d: %w", ledgerSeq, tx.Index, encErr)
 			}
 			out[addr] = append(out[addr], change)
 		}
@@ -584,18 +594,22 @@ func ExtractContractDataChangesForLedger(ctx context.Context, networkPassphrase 
 }
 
 // ProcessLedger extracts transactions from a ledger and indexes them.
-// Returns the participant count for optional metrics recording.
-func ProcessLedger(ctx context.Context, networkPassphrase string, ledgerMeta xdr.LedgerCloseMeta, ledgerIndexer *Indexer, buffer *IndexerBuffer) (int, error) {
+// Returns the participant count for optional metrics recording, plus the
+// materialized transactions so callers with further per-transaction work
+// (live ingestion's ContractData extraction) can reuse them instead of
+// paying for a second LedgerTransactionReader build — its constructor
+// re-hashes every transaction envelope.
+func ProcessLedger(ctx context.Context, networkPassphrase string, ledgerMeta xdr.LedgerCloseMeta, ledgerIndexer *Indexer, buffer *IndexerBuffer) (int, []ingest.LedgerTransaction, error) {
 	ledgerSeq := ledgerMeta.LedgerSequence()
 	transactions, err := GetLedgerTransactions(ctx, networkPassphrase, ledgerMeta)
 	if err != nil {
-		return 0, fmt.Errorf("getting transactions for ledger %d: %w", ledgerSeq, err)
+		return 0, nil, fmt.Errorf("getting transactions for ledger %d: %w", ledgerSeq, err)
 	}
 
 	participantCount, err := ledgerIndexer.ProcessLedgerTransactions(ctx, transactions, buffer)
 	if err != nil {
-		return 0, fmt.Errorf("processing transactions for ledger %d: %w", ledgerSeq, err)
+		return 0, nil, fmt.Errorf("processing transactions for ledger %d: %w", ledgerSeq, err)
 	}
 
-	return participantCount, nil
+	return participantCount, transactions, nil
 }

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -556,17 +556,21 @@ func ExtractContractDataChangesForLedger(ledgerMeta xdr.LedgerCloseMeta, tracked
 		if !resultPair.Result.Successful() {
 			continue
 		}
-		// A minimal LedgerTransaction: GetChanges touches only these fields
-		// (verified by the fixture equivalence test against the reader-based
-		// reference) — the envelope is deliberately absent. Result pairs and
-		// TxApplyProcessing share application order, the same index alignment
-		// ExtractContractEventsForLedger relies on.
+		// A minimal LedgerTransaction: GetChanges touches only these fields —
+		// the envelope is deliberately absent, while Hash mirrors the reader's
+		// value because GetChanges attaches this transaction to every Change
+		// it returns. The fixture equivalence test compares the change fields
+		// (type, reason, operation index, pre/post entries) against the
+		// reader-based reference; the attached transaction is not compared.
+		// Result pairs and TxApplyProcessing share application order, the same
+		// index alignment ExtractContractEventsForLedger relies on.
 		tx := ingest.LedgerTransaction{
 			Index:         uint32(i + 1),
 			Result:        resultPair,
 			UnsafeMeta:    ledgerMeta.TxApplyProcessing(i),
 			LedgerVersion: ledgerMeta.ProtocolVersion(),
 			Ledger:        ledgerMeta,
+			Hash:          resultPair.TransactionHash,
 		}
 		if err := collectContractDataChanges(&tx, ledgerSeq, out); err != nil {
 			return nil, err

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -526,31 +526,103 @@ func ExtractContractEventsForLedger(ledgerMeta xdr.LedgerCloseMeta) (map[Contrac
 	return out, nil
 }
 
-// ExtractContractDataChangesForLedger walks a ledger's successful transactions
-// and returns every ContractData ledger-entry change grouped by the owning
-// contract's C-address strkey. It materializes the ledger's transactions via
-// the LedgerTransactionReader (GetChanges needs envelope↔meta pairing), so it
-// is strictly heavier than ExtractContractEventsForLedger — callers gate it
-// behind ProtocolProcessor.RequiresContractData. Callers that already hold
-// the ledger's transactions (live ingestion's main pipeline) use
-// ExtractContractDataChangesFromTransactions directly instead of paying for
-// a second reader build.
-func ExtractContractDataChangesForLedger(ctx context.Context, networkPassphrase string, ledgerMeta xdr.LedgerCloseMeta) (map[string][]ingest.Change, error) {
-	transactions, err := GetLedgerTransactions(ctx, networkPassphrase, ledgerMeta)
-	if err != nil {
-		return nil, fmt.Errorf("getting transactions for ledger %d: %w", ledgerMeta.LedgerSequence(), err)
+// ExtractContractDataChangesForLedger returns every ContractData ledger-entry
+// change from a ledger's successful transactions, grouped by the owning
+// contract's C-address strkey — but only after a cheap footprint gate: if no
+// transaction's read-write footprint contains a ContractData key owned by a
+// tracked contract, the ledger is skipped outright (empty map). Soroban
+// guarantees writes ⊆ the declared read-write footprint (host storage is
+// footprint-seeded and a write outside it traps; RestoreFootprint restores
+// exactly the read-write keys; protocol-23 auto-restores are indices into it),
+// so the gate can never skip a ledger that actually changes a tracked
+// contract's entries.
+//
+// Both the gate and the extraction walk the already-decoded LedgerCloseMeta
+// directly — GetChanges reads only the transaction meta, result, and ledger
+// version, so no LedgerTransactionReader (which re-hashes every envelope just
+// to pair envelopes with metas) is ever built. When the gate passes, the FULL
+// ledger's ContractData changes are returned, not just the tracked subset:
+// the map is shared across protocols and each processor filters by its own
+// membership.
+func ExtractContractDataChangesForLedger(ledgerMeta xdr.LedgerCloseMeta, trackedContracts map[xdr.ContractId]struct{}) (map[string][]ingest.Change, error) {
+	if !ledgerTouchesTrackedContractData(ledgerMeta, trackedContracts) {
+		return map[string][]ingest.Change{}, nil
 	}
-	return ExtractContractDataChangesFromTransactions(transactions, ledgerMeta.LedgerSequence())
+
+	ledgerSeq := ledgerMeta.LedgerSequence()
+	out := make(map[string][]ingest.Change)
+	for i := 0; i < ledgerMeta.CountTransactions(); i++ {
+		resultPair := ledgerMeta.TransactionResultPair(i)
+		if !resultPair.Result.Successful() {
+			continue
+		}
+		// A minimal LedgerTransaction: GetChanges touches only these fields
+		// (verified by the fixture equivalence test against the reader-based
+		// reference) — the envelope is deliberately absent. Result pairs and
+		// TxApplyProcessing share application order, the same index alignment
+		// ExtractContractEventsForLedger relies on.
+		tx := ingest.LedgerTransaction{
+			Index:         uint32(i + 1),
+			Result:        resultPair,
+			UnsafeMeta:    ledgerMeta.TxApplyProcessing(i),
+			LedgerVersion: ledgerMeta.ProtocolVersion(),
+			Ledger:        ledgerMeta,
+		}
+		if err := collectContractDataChanges(&tx, ledgerSeq, out); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
 }
 
-// ExtractContractDataChangesFromTransactions is
-// ExtractContractDataChangesForLedger over already-materialized transactions;
-// ledgerSeq is used only for error context.
-//
-// Within a contract, changes preserve transaction application order, so
-// last-write-wins folding per entry key is deterministic. Ledger-level
-// archival evictions are NOT surfaced (GetChanges only walks fee/tx/op meta);
-// per-tx entry removals appear with Post == nil.
+// ledgerTouchesTrackedContractData reports whether any transaction in the
+// ledger declares a read-write footprint ContractData key owned by a tracked
+// contract. It walks envelopes in whatever order the ledger stores them —
+// fine for a ledger-level boolean, which is exactly why the gate is
+// per-ledger rather than per-transaction: envelopes are in tx-set order while
+// metas are in application order, and matching the two is the expensive
+// pairing this function exists to avoid.
+func ledgerTouchesTrackedContractData(ledgerMeta xdr.LedgerCloseMeta, trackedContracts map[xdr.ContractId]struct{}) bool {
+	if len(trackedContracts) == 0 {
+		return false
+	}
+	for _, env := range ledgerMeta.TransactionEnvelopes() {
+		var ext xdr.TransactionExt
+		switch env.Type {
+		case xdr.EnvelopeTypeEnvelopeTypeTx:
+			ext = env.V1.Tx.Ext
+		case xdr.EnvelopeTypeEnvelopeTypeTxFeeBump:
+			ext = env.FeeBump.Tx.InnerTx.V1.Tx.Ext
+		default:
+			// V0 envelopes predate Soroban: no footprint, no ContractData.
+			continue
+		}
+		sorobanData, ok := ext.GetSorobanData()
+		if !ok {
+			continue
+		}
+		for _, key := range sorobanData.Resources.Footprint.ReadWrite {
+			if key.Type != xdr.LedgerEntryTypeContractData {
+				continue
+			}
+			contractID, ok := key.ContractData.Contract.GetContractId()
+			if !ok {
+				continue
+			}
+			if _, tracked := trackedContracts[contractID]; tracked {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ExtractContractDataChangesFromTransactions extracts the same
+// contract-grouped ContractData changes as ExtractContractDataChangesForLedger
+// over already-materialized transactions, ungated — live ingestion's main
+// pipeline has the transactions in hand and processes one ledger per close,
+// so a footprint gate buys nothing there. ledgerSeq is used only for error
+// context.
 func ExtractContractDataChangesFromTransactions(transactions []ingest.LedgerTransaction, ledgerSeq uint32) (map[string][]ingest.Change, error) {
 	out := make(map[string][]ingest.Change)
 	for i := range transactions {
@@ -558,39 +630,53 @@ func ExtractContractDataChangesFromTransactions(transactions []ingest.LedgerTran
 		if !tx.Result.Successful() {
 			continue
 		}
-		changes, chErr := tx.GetChanges()
-		if chErr != nil {
-			return nil, fmt.Errorf("getting changes for ledger %d tx %d: %w", ledgerSeq, tx.Index, chErr)
-		}
-		for _, change := range changes {
-			if change.Type != xdr.LedgerEntryTypeContractData {
-				continue
-			}
-			entry := change.Post
-			if entry == nil {
-				entry = change.Pre
-			}
-			if entry == nil {
-				continue
-			}
-			contractData, ok := entry.Data.GetContractData()
-			if !ok {
-				continue
-			}
-			contractIDBytes, ok := contractData.Contract.GetContractId()
-			if !ok {
-				continue
-			}
-			addr, encErr := strkey.Encode(strkey.VersionByteContract, contractIDBytes[:])
-			if encErr != nil {
-				// Callers rely on this function returning every ContractData
-				// change; silently dropping one would corrupt downstream state.
-				return nil, fmt.Errorf("encoding contract id for ledger %d tx %d: %w", ledgerSeq, tx.Index, encErr)
-			}
-			out[addr] = append(out[addr], change)
+		if err := collectContractDataChanges(&tx, ledgerSeq, out); err != nil {
+			return nil, err
 		}
 	}
 	return out, nil
+}
+
+// collectContractDataChanges appends tx's ContractData changes into out,
+// grouped by the owning contract's C-address strkey.
+//
+// Within a contract, changes preserve transaction application order, so
+// last-write-wins folding per entry key is deterministic. Ledger-level
+// archival evictions are NOT surfaced (GetChanges only walks fee/tx/op meta);
+// per-tx entry removals appear with Post == nil.
+func collectContractDataChanges(tx *ingest.LedgerTransaction, ledgerSeq uint32, out map[string][]ingest.Change) error {
+	changes, chErr := tx.GetChanges()
+	if chErr != nil {
+		return fmt.Errorf("getting changes for ledger %d tx %d: %w", ledgerSeq, tx.Index, chErr)
+	}
+	for _, change := range changes {
+		if change.Type != xdr.LedgerEntryTypeContractData {
+			continue
+		}
+		entry := change.Post
+		if entry == nil {
+			entry = change.Pre
+		}
+		if entry == nil {
+			continue
+		}
+		contractData, ok := entry.Data.GetContractData()
+		if !ok {
+			continue
+		}
+		contractIDBytes, ok := contractData.Contract.GetContractId()
+		if !ok {
+			continue
+		}
+		addr, encErr := strkey.Encode(strkey.VersionByteContract, contractIDBytes[:])
+		if encErr != nil {
+			// Callers rely on this function returning every ContractData
+			// change; silently dropping one would corrupt downstream state.
+			return fmt.Errorf("encoding contract id for ledger %d tx %d: %w", ledgerSeq, tx.Index, encErr)
+		}
+		out[addr] = append(out[addr], change)
+	}
+	return nil
 }
 
 // ProcessLedger extracts transactions from a ledger and indexes them.

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -573,7 +573,9 @@ func ExtractContractDataChangesForLedger(ctx context.Context, networkPassphrase 
 			}
 			addr, encErr := strkey.Encode(strkey.VersionByteContract, contractIDBytes[:])
 			if encErr != nil {
-				continue
+				// Callers rely on this function returning every ContractData
+				// change; silently dropping one would corrupt downstream state.
+				return nil, fmt.Errorf("encoding contract id for ledger %d tx %d: %w", ledgerMeta.LedgerSequence(), tx.Index, encErr)
 			}
 			out[addr] = append(out[addr], change)
 		}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alitto/pond/v2"
 	set "github.com/deckarep/golang-set/v2"
 	"github.com/stellar/go-stellar-sdk/ingest"
+	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
@@ -520,6 +521,61 @@ func ExtractContractEventsForLedger(ledgerMeta xdr.LedgerCloseMeta) (map[Contrac
 				continue
 			}
 			out[ContractEventKey{TxIdx: uint32(i + 1), OpIdx: uint32(opIdx)}] = events
+		}
+	}
+	return out, nil
+}
+
+// ExtractContractDataChangesForLedger walks a ledger's successful transactions
+// and returns every ContractData ledger-entry change grouped by the owning
+// contract's C-address strkey. Unlike ExtractContractEventsForLedger it uses
+// the LedgerTransactionReader (GetChanges needs envelope↔meta pairing), so it
+// takes a ctx and the network passphrase and is strictly heavier — callers
+// gate it behind ProtocolProcessor.RequiresContractData.
+//
+// Within a contract, changes preserve transaction application order, so
+// last-write-wins folding per entry key is deterministic. Ledger-level
+// archival evictions are NOT surfaced (GetChanges only walks fee/tx/op meta);
+// per-tx entry removals appear with Post == nil.
+func ExtractContractDataChangesForLedger(ctx context.Context, networkPassphrase string, ledgerMeta xdr.LedgerCloseMeta) (map[string][]ingest.Change, error) {
+	transactions, err := GetLedgerTransactions(ctx, networkPassphrase, ledgerMeta)
+	if err != nil {
+		return nil, fmt.Errorf("getting transactions for ledger %d: %w", ledgerMeta.LedgerSequence(), err)
+	}
+	out := make(map[string][]ingest.Change)
+	for i := range transactions {
+		tx := transactions[i]
+		if !tx.Result.Successful() {
+			continue
+		}
+		changes, chErr := tx.GetChanges()
+		if chErr != nil {
+			return nil, fmt.Errorf("getting changes for ledger %d tx %d: %w", ledgerMeta.LedgerSequence(), tx.Index, chErr)
+		}
+		for _, change := range changes {
+			if change.Type != xdr.LedgerEntryTypeContractData {
+				continue
+			}
+			entry := change.Post
+			if entry == nil {
+				entry = change.Pre
+			}
+			if entry == nil {
+				continue
+			}
+			contractData, ok := entry.Data.GetContractData()
+			if !ok {
+				continue
+			}
+			contractIDBytes, ok := contractData.Contract.GetContractId()
+			if !ok {
+				continue
+			}
+			addr, encErr := strkey.Encode(strkey.VersionByteContract, contractIDBytes[:])
+			if encErr != nil {
+				continue
+			}
+			out[addr] = append(out[addr], change)
 		}
 	}
 	return out, nil

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -16,6 +16,7 @@ import (
 	set "github.com/deckarep/golang-set/v2"
 	"github.com/stellar/go-stellar-sdk/ingest"
 	"github.com/stellar/go-stellar-sdk/network"
+	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -1417,6 +1418,98 @@ func TestExtractContractEventsForLedger_CorpusCoversWrapperVersions(t *testing.T
 	}
 	require.True(t, wrapperWithEvents[1], "corpus must include a wrapper-V1 (Protocol 20-22) ledger with extracted contract events")
 	require.True(t, wrapperWithEvents[2], "corpus must include a wrapper-V2 (Protocol 23+) ledger with extracted contract events")
+}
+
+// TestExtractContractDataChangesForLedger_Fixtures checks
+// ExtractContractDataChangesForLedger against the same real-ledger fixture
+// corpus used for contract events: every returned group key must be a valid
+// C-address, every change must be a ContractData change grouped under its own
+// owning contract, every change must originate from a successful transaction,
+// and the whole corpus must yield at least one change (otherwise the corpus
+// wouldn't exercise the extractor at all).
+func TestExtractContractDataChangesForLedger_Fixtures(t *testing.T) {
+	ctx := context.Background()
+
+	paths, err := filepath.Glob("testdata/*.xdr.gz")
+	require.NoError(t, err)
+	require.NotEmpty(t, paths, "no ledger fixtures under testdata/ — regenerate per the loadLedgerFixture recipe")
+
+	totalChanges := 0
+	for _, path := range paths {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			lcm := loadLedgerFixture(t, path)
+
+			got, extractErr := ExtractContractDataChangesForLedger(ctx, network.PublicNetworkPassphrase, lcm)
+			require.NoError(t, extractErr)
+
+			transactions, txErr := GetLedgerTransactions(ctx, network.PublicNetworkPassphrase, lcm)
+			require.NoError(t, txErr)
+
+			// Independently derive the expected ContractData change count from
+			// the successful transactions, without calling the function under
+			// test, so the "only successful txs" assertion is meaningful rather
+			// than tautological. A handful of historical (pre-CAP-0046-11)
+			// ContractData entries are keyed by a classic account address rather
+			// than a contract address; those have no owning contract to group
+			// under, so, like the extractor, they're excluded here too.
+			wantCount := 0
+			for i := range transactions {
+				tx := transactions[i]
+				if !tx.Result.Successful() {
+					continue
+				}
+				changes, chErr := tx.GetChanges()
+				require.NoError(t, chErr)
+				for _, change := range changes {
+					if change.Type != xdr.LedgerEntryTypeContractData {
+						continue
+					}
+					entry := change.Post
+					if entry == nil {
+						entry = change.Pre
+					}
+					require.NotNil(t, entry)
+					contractData, ok := entry.Data.GetContractData()
+					require.True(t, ok)
+					if _, ok := contractData.Contract.GetContractId(); ok {
+						wantCount++
+					}
+				}
+			}
+
+			gotCount := 0
+			for groupKey, changes := range got {
+				_, decodeErr := strkey.Decode(strkey.VersionByteContract, groupKey)
+				assert.NoError(t, decodeErr, "group key %q must be a valid C-address strkey", groupKey)
+
+				for _, change := range changes {
+					assert.Equal(t, xdr.LedgerEntryTypeContractData, change.Type, "change must be a ContractData change")
+
+					entry := change.Post
+					if entry == nil {
+						entry = change.Pre
+					}
+					require.NotNil(t, entry, "change must have a Pre or Post entry")
+
+					contractData, ok := entry.Data.GetContractData()
+					require.True(t, ok, "entry must decode as ContractData")
+
+					contractIDBytes, ok := contractData.Contract.GetContractId()
+					require.True(t, ok, "ContractData.Contract must be a contract address")
+
+					wantAddr, encErr := strkey.Encode(strkey.VersionByteContract, contractIDBytes[:])
+					require.NoError(t, encErr)
+					assert.Equal(t, wantAddr, groupKey, "change must be grouped under its owning contract")
+				}
+				gotCount += len(changes)
+			}
+
+			assert.Equal(t, wantCount, gotCount, "extractor must return exactly the ContractData changes from successful transactions")
+			totalChanges += gotCount
+		})
+	}
+
+	require.Greater(t, totalChanges, 0, "fixture corpus must produce at least one ContractData change")
 }
 
 func TestAssignStateChangeStream_SubNamespaces(t *testing.T) {

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -1420,13 +1420,67 @@ func TestExtractContractEventsForLedger_CorpusCoversWrapperVersions(t *testing.T
 	require.True(t, wrapperWithEvents[2], "corpus must include a wrapper-V2 (Protocol 23+) ledger with extracted contract events")
 }
 
-// TestExtractContractDataChangesForLedger_Fixtures checks
-// ExtractContractDataChangesForLedger against the same real-ledger fixture
-// corpus used for contract events: every returned group key must be a valid
-// C-address, every change must be a ContractData change grouped under its own
-// owning contract, every change must originate from a successful transaction,
-// and the whole corpus must yield at least one change (otherwise the corpus
-// wouldn't exercise the extractor at all).
+// contractDataChangeProjection is the payload-relevant subset of an
+// ingest.Change used to compare the reader-based and meta-based extraction
+// paths: the two build different LedgerTransaction carriers (the meta-based
+// one has no envelope), so whole-Change equality would compare carrier
+// internals no consumer reads.
+type contractDataChangeProjection struct {
+	Type           xdr.LedgerEntryType
+	Reason         ingest.LedgerEntryChangeReason
+	OperationIndex uint32
+	Pre            *xdr.LedgerEntry
+	Post           *xdr.LedgerEntry
+}
+
+func projectContractDataChanges(m map[string][]ingest.Change) map[string][]contractDataChangeProjection {
+	out := make(map[string][]contractDataChangeProjection, len(m))
+	for k, changes := range m {
+		ps := make([]contractDataChangeProjection, 0, len(changes))
+		for _, c := range changes {
+			ps = append(ps, contractDataChangeProjection{
+				Type:           c.Type,
+				Reason:         c.Reason,
+				OperationIndex: c.OperationIndex,
+				Pre:            c.Pre,
+				Post:           c.Post,
+			})
+		}
+		out[k] = ps
+	}
+	return out
+}
+
+// extractContractDataChangesViaReader is the reader-based reference
+// implementation: materialize transactions through the
+// LedgerTransactionReader (envelope↔meta pairing via hashing) and extract
+// from those. Kept test-only as the merge gate for the production meta-based
+// path, mirroring extractContractEventsViaReader.
+func extractContractDataChangesViaReader(ctx context.Context, networkPassphrase string, ledgerMeta xdr.LedgerCloseMeta) ([]ingest.LedgerTransaction, map[string][]ingest.Change, error) {
+	transactions, err := GetLedgerTransactions(ctx, networkPassphrase, ledgerMeta)
+	if err != nil {
+		return nil, nil, err
+	}
+	changes, err := ExtractContractDataChangesFromTransactions(transactions, ledgerMeta.LedgerSequence())
+	return transactions, changes, err
+}
+
+// TestExtractContractDataChangesForLedger_Fixtures checks the ContractData
+// extraction paths against the same real-ledger fixture corpus used for
+// contract events: every returned group key must be a valid C-address, every
+// change must be a ContractData change grouped under its own owning contract,
+// every change must originate from a successful transaction, and the whole
+// corpus must yield at least one change (otherwise the corpus wouldn't
+// exercise the extractor at all).
+//
+// It also pins the two load-bearing properties of the production
+// (footprint-gated, meta-based) ExtractContractDataChangesForLedger:
+//   - Equivalence: gated extraction with every changed contract tracked
+//     returns exactly the reader-based reference output.
+//   - Gate soundness: for EVERY contract that has changes, tracking just that
+//     contract must trigger the gate — i.e. on real ledgers, a ContractData
+//     change always has its key in some transaction's read-write footprint
+//     (the Soroban writes ⊆ footprint guarantee the gate relies on).
 func TestExtractContractDataChangesForLedger_Fixtures(t *testing.T) {
 	ctx := context.Background()
 
@@ -1439,18 +1493,41 @@ func TestExtractContractDataChangesForLedger_Fixtures(t *testing.T) {
 		t.Run(filepath.Base(path), func(t *testing.T) {
 			lcm := loadLedgerFixture(t, path)
 
-			got, extractErr := ExtractContractDataChangesForLedger(ctx, network.PublicNetworkPassphrase, lcm)
+			transactions, got, extractErr := extractContractDataChangesViaReader(ctx, network.PublicNetworkPassphrase, lcm)
 			require.NoError(t, extractErr)
+			wantProjection := projectContractDataChanges(got)
 
-			transactions, txErr := GetLedgerTransactions(ctx, network.PublicNetworkPassphrase, lcm)
-			require.NoError(t, txErr)
+			// Tracked set = every contract with changes this ledger.
+			trackedAll := map[xdr.ContractId]struct{}{}
+			for groupKey := range got {
+				raw, decodeErr := strkey.Decode(strkey.VersionByteContract, groupKey)
+				require.NoError(t, decodeErr)
+				trackedAll[xdr.ContractId(raw)] = struct{}{}
+			}
 
-			// The slice-based variant (what live ingestion uses, sharing the main
-			// pipeline's already-materialized transactions) must be exactly
-			// equivalent to the ledger-based wrapper.
-			fromTxs, fromTxsErr := ExtractContractDataChangesFromTransactions(transactions, lcm.LedgerSequence())
-			require.NoError(t, fromTxsErr)
-			assert.Equal(t, got, fromTxs)
+			// Equivalence: the production gated+meta-based path returns the
+			// reference output when every changed contract is tracked.
+			gated, gatedErr := ExtractContractDataChangesForLedger(lcm, trackedAll)
+			require.NoError(t, gatedErr)
+			assert.Equal(t, wantProjection, projectContractDataChanges(gated),
+				"meta-based extraction must match the reader-based reference")
+
+			// Gate soundness: each changed contract, tracked alone, must
+			// trigger the gate via some transaction's read-write footprint.
+			for contractID := range trackedAll {
+				alone, aloneErr := ExtractContractDataChangesForLedger(lcm, map[xdr.ContractId]struct{}{contractID: {}})
+				require.NoError(t, aloneErr)
+				assert.Equal(t, wantProjection, projectContractDataChanges(alone),
+					"tracking contract %x alone must trigger the gate (footprint ⊇ writes)", contractID)
+			}
+
+			// Gate negative: an untracked-only set skips the ledger outright.
+			empty, emptyErr := ExtractContractDataChangesForLedger(lcm, map[xdr.ContractId]struct{}{{0xde, 0xad, 0xbe, 0xef}: {}})
+			require.NoError(t, emptyErr)
+			assert.Empty(t, empty, "a ledger touching no tracked contract must be skipped")
+			none, noneErr := ExtractContractDataChangesForLedger(lcm, nil)
+			require.NoError(t, noneErr)
+			assert.Empty(t, none, "an empty tracked set must skip every ledger")
 
 			// Independently derive the expected ContractData change count from
 			// the successful transactions, without calling the function under

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -1445,6 +1445,13 @@ func TestExtractContractDataChangesForLedger_Fixtures(t *testing.T) {
 			transactions, txErr := GetLedgerTransactions(ctx, network.PublicNetworkPassphrase, lcm)
 			require.NoError(t, txErr)
 
+			// The slice-based variant (what live ingestion uses, sharing the main
+			// pipeline's already-materialized transactions) must be exactly
+			// equivalent to the ledger-based wrapper.
+			fromTxs, fromTxsErr := ExtractContractDataChangesFromTransactions(transactions, lcm.LedgerSequence())
+			require.NoError(t, fromTxsErr)
+			assert.Equal(t, got, fromTxs)
+
 			// Independently derive the expected ContractData change count from
 			// the successful transactions, without calling the function under
 			// test, so the "only successful txs" assertion is meaningful rather

--- a/internal/ingest/datastore_backend.go
+++ b/internal/ingest/datastore_backend.go
@@ -271,9 +271,8 @@ func (b *datastoreBackend) GetLedger(ctx context.Context, sequence uint32) (xdr.
 // GetLatestLedgerSequence returns the highest ledger the buffer has delivered so far — its
 // prefetch frontier — mirroring the SDK BufferedStorageBackend. During bulk consumption the
 // frontier runs ahead of the consumer; at the live tip it stalls at the last available ledger.
-// Returns 0 before any batch has been delivered. This is what lets the migration's
-// flushWindowsAtTip coalesce in bulk (seq <= frontier) and flush at the tip (seq > frontier),
-// instead of flushing every ledger as it would if this returned the unbounded range's zero To().
+// Returns 0 before any batch has been delivered. Live ingestion's lag gauge polls this off
+// the consumer goroutine, which is why the read is lock-free (see the buffer field docs).
 func (b *datastoreBackend) GetLatestLedgerSequence(_ context.Context) (uint32, error) {
 	if b.closed {
 		return 0, fmt.Errorf("datastoreBackend is closed")

--- a/internal/integrationtests/data_migration_test.go
+++ b/internal/integrationtests/data_migration_test.go
@@ -91,7 +91,7 @@ func (s *DataMigrationTestSuite) TestProtocolSetupThenCurrentStateMigration() {
 	s.Require().NoError(err)
 	s.Require().Zerof(exitCode, "protocol-setup should exit 0 (see `docker logs wallet-backend-protocol-setup`); logs:\n%s", logs)
 
-	classifiedContracts, err := models.ProtocolContracts.GetByProtocolID(ctx, sep41ProtocolID)
+	classifiedContracts, err := models.ProtocolContracts.GetByProtocolID(ctx, pool, sep41ProtocolID)
 	s.Require().NoError(err)
 	s.Require().NotEmpty(classifiedContracts, "protocol-setup should classify at least one SEP-41 contract")
 

--- a/internal/metrics/ingestion.go
+++ b/internal/metrics/ingestion.go
@@ -135,7 +135,7 @@ func newIngestionMetrics(reg prometheus.Registerer) *IngestionMetrics {
 		}, []string{"type", "category"}),
 		ProtocolStateProcessingDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "wallet_ingestion_protocol_state_processing_duration_seconds",
-			Help:    "Duration of protocol state persistence by protocol ID and phase (process_ledger, load_current_state, persist_history, persist_current_state).",
+			Help:    "Duration of protocol state persistence by protocol ID and phase (process_ledger, persist_history, persist_current_state).",
 			Buckets: []float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2, 5},
 		}, []string{"protocol_id", "phase"}),
 		WasmClassificationFailuresTotal: prometheus.NewCounterVec(prometheus.CounterOpts{

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -12,6 +12,7 @@ import (
 	set "github.com/deckarep/golang-set/v2"
 	"github.com/jackc/pgx/v5"
 	"github.com/stellar/go-stellar-sdk/historyarchive"
+	"github.com/stellar/go-stellar-sdk/ingest"
 	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
 	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/xdr"
@@ -251,14 +252,17 @@ func (m *ingestService) Close() {
 	}
 }
 
-// processLedger processes a single ledger - gets the transactions and processes them using indexer processors.
-func (m *ingestService) processLedger(ctx context.Context, ledgerMeta xdr.LedgerCloseMeta, buffer *indexer.IndexerBuffer) error {
-	participantCount, err := indexer.ProcessLedger(ctx, m.networkPassphrase, ledgerMeta, m.ledgerIndexer, buffer)
+// processLedger processes a single ledger - gets the transactions and
+// processes them using indexer processors. The materialized transactions are
+// returned so the live path can reuse them for ContractData extraction
+// instead of building a second LedgerTransactionReader for the same ledger.
+func (m *ingestService) processLedger(ctx context.Context, ledgerMeta xdr.LedgerCloseMeta, buffer *indexer.IndexerBuffer) ([]ingest.LedgerTransaction, error) {
+	participantCount, transactions, err := indexer.ProcessLedger(ctx, m.networkPassphrase, ledgerMeta, m.ledgerIndexer, buffer)
 	if err != nil {
-		return fmt.Errorf("processing ledger %d: %w", ledgerMeta.LedgerSequence(), err)
+		return nil, fmt.Errorf("processing ledger %d: %w", ledgerMeta.LedgerSequence(), err)
 	}
 	m.appMetrics.Ingestion.ParticipantsCount.Observe(float64(participantCount))
-	return nil
+	return transactions, nil
 }
 
 // insertIntoDB persists the processed data from the buffer to the database.

--- a/internal/services/ingest_backfill.go
+++ b/internal/services/ingest_backfill.go
@@ -346,7 +346,7 @@ func (m *ingestService) processLedgersInBatch(
 		}
 		endTime = ledgerTime
 
-		if err := m.processLedger(ctx, ledgerMeta, batchBuffer); err != nil {
+		if _, err := m.processLedger(ctx, ledgerMeta, batchBuffer); err != nil {
 			return ledgersProcessed, startTime, endTime, fmt.Errorf("processing ledger %d: %w", ledgerSeq, err)
 		}
 		ledgersProcessed++

--- a/internal/services/ingest_live.go
+++ b/internal/services/ingest_live.go
@@ -157,16 +157,31 @@ func (m *ingestService) persistLedgerData(
 					continue
 				}
 
-				if processor.RequiresContractData() && !contractDataExtracted {
-					var cdErr error
-					contractDataChanges, cdErr = indexer.ExtractContractDataChangesForLedger(ctx, m.networkPassphrase, *ledgerMeta)
-					if cdErr != nil {
-						return fmt.Errorf("extracting contract data changes for ledger %d: %w", ledgerSeq, cdErr)
+				committed := committedByProtocol[protocolID]
+				if processor.RequiresContractData() {
+					if !contractDataExtracted {
+						var cdErr error
+						contractDataChanges, cdErr = indexer.ExtractContractDataChangesForLedger(ctx, m.networkPassphrase, *ledgerMeta)
+						if cdErr != nil {
+							return fmt.Errorf("extracting contract data changes for ledger %d: %w", ledgerSeq, cdErr)
+						}
+						contractDataExtracted = true
 					}
-					contractDataExtracted = true
+
+					// ContractData-driven processors need the protocol's FULL committed
+					// membership, not just this ledger's event emitters: entries can
+					// change on a contract that emitted no event this ledger, and event
+					// decoding may disambiguate against tracked contracts that appear
+					// only in another contract's topics. Protocols requiring contract
+					// data have bounded membership, so the per-ledger query stays cheap.
+					var fullErr error
+					committed, fullErr = m.models.ProtocolContracts.GetByProtocolID(ctx, dbTx, protocolID)
+					if fullErr != nil {
+						return fmt.Errorf("resolving full protocol contracts for ledger %d protocol %s: %w", ledgerSeq, protocolID, fullErr)
+					}
 				}
 
-				contracts := getEffectiveProtocolContracts(protocolID, committedByProtocol[protocolID], bufferedContracts, classification)
+				contracts := getEffectiveProtocolContracts(protocolID, committed, bufferedContracts, classification)
 				input := ProtocolProcessorInput{
 					LedgerSequence:      ledgerSeq,
 					LedgerCloseTime:     ledgerCloseTime,

--- a/internal/services/ingest_live.go
+++ b/internal/services/ingest_live.go
@@ -212,7 +212,12 @@ func (m *ingestService) persistLedgerData(
 				if !historySwapped && !currentStateSwapped {
 					// Behind tip (value mismatch), not yet set up (both cursors known
 					// missing), or the value mismatch a live CAS returns when another
-					// process already owns this ledger: nothing to stage.
+					// process already owns this ledger: nothing to stage. Skipping is
+					// lossless: the migrate engine folds a ledger only after this
+					// cursor's transaction commits (its frontier gate), so a ledger
+					// lost here is folded later by a winner that sees every
+					// classification this transaction commits — including contracts
+					// classified this very ledger.
 					continue
 				}
 

--- a/internal/services/ingest_live.go
+++ b/internal/services/ingest_live.go
@@ -76,9 +76,11 @@ func (m *ingestService) persistLedgerData(
 		// so any RPC calls (e.g. SEP-41 metadata) already happened;
 		// ApplyClassificationPlan only performs each validator's DB writes
 		// here, atomically with the classification verdict and wasm/contract
-		// rows below. Live protocol processors then stage ledger state from
-		// the classification result before the generic protocol_wasms /
-		// protocol_contracts rows are persisted below.
+		// rows below. Wasm rows are persisted next, then live protocol
+		// processors stage ledger state from the classification result, and
+		// the generic protocol_contracts rows are persisted after them so a
+		// processor's name-enriched row lands first (the generic insert's
+		// COALESCE preserves it).
 		bufferedWasms := buffer.GetProtocolWasms()
 		bufferedContracts := buffer.GetProtocolContracts()
 
@@ -93,6 +95,25 @@ func (m *ingestService) persistLedgerData(
 		}
 		if txErr = ApplyClassificationPlan(ctx, dbTx, m.models, plan, m.appMetrics.Ingestion.WasmClassificationFailuresTotal); txErr != nil {
 			return fmt.Errorf("applying classification for ledger %d: %w", ledgerSeq, txErr)
+		}
+
+		// Persist this ledger's wasm rows BEFORE processors run: a processor
+		// enriching protocol_contracts (e.g. contract names decoded from
+		// instance storage) inserts rows that are FK-filtered against
+		// protocol_wasms, so a contract deployed in the same ledger as its
+		// wasm upload would otherwise be silently dropped.
+		if len(bufferedWasms) > 0 {
+			wasmSlice := make([]data.ProtocolWasms, 0, len(bufferedWasms))
+			for hash, wasm := range bufferedWasms {
+				if pid, ok := classification[types.HashBytea(hash)]; ok {
+					stamped := pid
+					wasm.ProtocolID = &stamped
+				}
+				wasmSlice = append(wasmSlice, wasm)
+			}
+			if txErr = m.models.ProtocolWasms.BatchInsert(ctx, dbTx, wasmSlice); txErr != nil {
+				return fmt.Errorf("inserting protocol wasms for ledger %d: %w", ledgerSeq, txErr)
+			}
 		}
 
 		// 2.6: Per-protocol CAS-gated state production. The compare-and-swap on each
@@ -220,19 +241,6 @@ func (m *ingestService) persistLedgerData(
 			}
 		}
 
-		if len(bufferedWasms) > 0 {
-			wasmSlice := make([]data.ProtocolWasms, 0, len(bufferedWasms))
-			for hash, wasm := range bufferedWasms {
-				if pid, ok := classification[types.HashBytea(hash)]; ok {
-					stamped := pid
-					wasm.ProtocolID = &stamped
-				}
-				wasmSlice = append(wasmSlice, wasm)
-			}
-			if txErr = m.models.ProtocolWasms.BatchInsert(ctx, dbTx, wasmSlice); txErr != nil {
-				return fmt.Errorf("inserting protocol wasms for ledger %d: %w", ledgerSeq, txErr)
-			}
-		}
 		if len(contractSlice) > 0 {
 			if txErr = m.models.ProtocolContracts.BatchInsert(ctx, dbTx, contractSlice); txErr != nil {
 				return fmt.Errorf("inserting protocol contracts for ledger %d: %w", ledgerSeq, txErr)

--- a/internal/services/ingest_live.go
+++ b/internal/services/ingest_live.go
@@ -11,6 +11,7 @@ import (
 	set "github.com/deckarep/golang-set/v2"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stellar/go-stellar-sdk/ingest"
 	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
 	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/xdr"
@@ -118,6 +119,12 @@ func (m *ingestService) persistLedgerData(
 				}
 			}
 
+			// ContractData extraction is lazy and memoized: it runs at most once
+			// per ledger, and only when a processor that won a CAS requires it —
+			// a protocol still backfilling costs nothing extra.
+			var contractDataChanges map[string][]ingest.Change
+			contractDataExtracted := false
+
 			for protocolID, processor := range m.protocolProcessors {
 				// Only attempt the CAS for a cursor m.protocolCursors believes exists (see
 				// snapshotProtocolCursors/reprobeProtocolCursors): a cursor known not yet
@@ -150,13 +157,23 @@ func (m *ingestService) persistLedgerData(
 					continue
 				}
 
+				if processor.RequiresContractData() && !contractDataExtracted {
+					var cdErr error
+					contractDataChanges, cdErr = indexer.ExtractContractDataChangesForLedger(ctx, m.networkPassphrase, *ledgerMeta)
+					if cdErr != nil {
+						return fmt.Errorf("extracting contract data changes for ledger %d: %w", ledgerSeq, cdErr)
+					}
+					contractDataExtracted = true
+				}
+
 				contracts := getEffectiveProtocolContracts(protocolID, committedByProtocol[protocolID], bufferedContracts, classification)
 				input := ProtocolProcessorInput{
-					LedgerSequence:    ledgerSeq,
-					LedgerCloseTime:   ledgerCloseTime,
-					ContractEvents:    contractEvents,
-					ProtocolContracts: contracts,
-					StagingMode:       StagingModeBoth,
+					LedgerSequence:      ledgerSeq,
+					LedgerCloseTime:     ledgerCloseTime,
+					ContractEvents:      contractEvents,
+					ProtocolContracts:   contracts,
+					StagingMode:         StagingModeBoth,
+					ContractDataChanges: contractDataChanges,
 				}
 				// Reset before staging so a retried transaction (ingestProcessedDataWithRetry)
 				// re-stages cleanly; the processor is long-lived and accumulates across

--- a/internal/services/ingest_live.go
+++ b/internal/services/ingest_live.go
@@ -33,6 +33,44 @@ const (
 	advisoryUnlockTimeout = 10 * time.Second
 )
 
+// contractDataMemo lazily extracts ContractData changes from a ledger's
+// already-materialized transactions (from the processLedger staging pass) and
+// memoizes the result. Extraction is pure over (transactions, ledgerSeq), so
+// one memo shared across ingestProcessedDataWithRetry's attempts means the
+// extraction walk runs at most once per ledger — never inside a retried
+// attempt's open transaction — and only when a CAS-winning processor
+// requires it, so a protocol still backfilling costs nothing extra.
+type contractDataMemo struct {
+	transactions []ingest.LedgerTransaction
+	ledgerSeq    uint32
+	changes      map[string][]ingest.Change
+	extracted    bool
+}
+
+func newContractDataMemo(transactions []ingest.LedgerTransaction, ledgerSeq uint32) *contractDataMemo {
+	return &contractDataMemo{transactions: transactions, ledgerSeq: ledgerSeq}
+}
+
+// get returns the memoized extraction, running it on first use. A nil
+// receiver yields an empty result — callers with no materialized
+// transactions pass a nil memo, and a RequiresContractData processor must
+// still receive a non-nil (empty) ContractDataChanges map, same as an
+// extraction over zero transactions produces.
+func (c *contractDataMemo) get() (map[string][]ingest.Change, error) {
+	if c == nil {
+		return map[string][]ingest.Change{}, nil
+	}
+	if !c.extracted {
+		changes, err := indexer.ExtractContractDataChangesFromTransactions(c.transactions, c.ledgerSeq)
+		if err != nil {
+			return nil, fmt.Errorf("extracting contract data changes for ledger %d: %w", c.ledgerSeq, err)
+		}
+		c.changes = changes
+		c.extracted = true
+	}
+	return c.changes, nil
+}
+
 // persistLedgerData persists processed ledger data to the database in a single
 // atomic transaction. It handles: trustline assets, contract tokens, filtered
 // data insertion, token changes, and cursor update. plan is this ledger's
@@ -40,11 +78,15 @@ const (
 // transaction opens (RPC calls already resolved); pass the same plan across
 // ingestProcessedDataWithRetry's retry attempts so a retry never re-issues
 // RPC calls. plan may be nil when there was nothing to classify this ledger.
+// contractData carries the ledger's ContractData extraction memo; like plan,
+// the same memo is shared across retry attempts so a retry never re-runs the
+// extraction walk. It is nil exactly when ledgerMeta is.
 func (m *ingestService) persistLedgerData(
 	ctx context.Context,
 	ledgerSeq uint32,
 	ledgerMeta *xdr.LedgerCloseMeta,
 	plan *ClassificationPlan,
+	contractData *contractDataMemo,
 	buffer *indexer.IndexerBuffer,
 	cursorName string,
 ) (int, int, error) {
@@ -140,11 +182,7 @@ func (m *ingestService) persistLedgerData(
 				}
 			}
 
-			// ContractData extraction is lazy and memoized: it runs at most once
-			// per ledger, and only when a processor that won a CAS requires it —
-			// a protocol still backfilling costs nothing extra.
 			var contractDataChanges map[string][]ingest.Change
-			contractDataExtracted := false
 
 			for protocolID, processor := range m.protocolProcessors {
 				// Only attempt the CAS for a cursor m.protocolCursors believes exists (see
@@ -180,13 +218,10 @@ func (m *ingestService) persistLedgerData(
 
 				committed := committedByProtocol[protocolID]
 				if processor.RequiresContractData() {
-					if !contractDataExtracted {
-						var cdErr error
-						contractDataChanges, cdErr = indexer.ExtractContractDataChangesForLedger(ctx, m.networkPassphrase, *ledgerMeta)
-						if cdErr != nil {
-							return fmt.Errorf("extracting contract data changes for ledger %d: %w", ledgerSeq, cdErr)
-						}
-						contractDataExtracted = true
+					var cdErr error
+					contractDataChanges, cdErr = contractData.get()
+					if cdErr != nil {
+						return cdErr
 					}
 
 					// ContractData-driven processors need the protocol's FULL committed
@@ -486,7 +521,7 @@ func (m *ingestService) ingestLiveLedgers(ctx context.Context, startLedger uint3
 		// Clearing here rather than after the persist keeps the reset unconditional: processLedger
 		// always starts from an empty buffer regardless of how the previous iteration ended.
 		buffer.Clear()
-		err := m.processLedger(ctx, ledgerMeta, buffer)
+		transactions, err := m.processLedger(ctx, ledgerMeta, buffer)
 		if err != nil {
 			m.appMetrics.Ingestion.ErrorsTotal.WithLabelValues("ingest_live").Inc()
 			return fmt.Errorf("processing ledger %d: %w", currentLedger, err)
@@ -507,7 +542,7 @@ func (m *ingestService) ingestLiveLedgers(ctx context.Context, startLedger uint3
 
 		// All DB operations in a single atomic transaction with retry
 		dbStart := time.Now()
-		numTransactionProcessed, numOperationProcessed, err := m.ingestProcessedDataWithRetry(ctx, currentLedger, ledgerMeta, plan, buffer)
+		numTransactionProcessed, numOperationProcessed, err := m.ingestProcessedDataWithRetry(ctx, currentLedger, ledgerMeta, plan, transactions, buffer)
 		if err != nil {
 			m.appMetrics.Ingestion.ErrorsTotal.WithLabelValues("ingest_live").Inc()
 			return fmt.Errorf("processing ledger %d: %w", currentLedger, err)
@@ -704,14 +739,18 @@ func getEffectiveProtocolContracts(
 // ingestProcessedDataWithRetry wraps persistLedgerData with retry logic.
 // plan was computed once by the caller before this loop started and is reused
 // verbatim across every attempt, so a retried attempt never re-issues the
-// classification RPC calls plan already resolved.
+// classification RPC calls plan already resolved. The ContractData extraction
+// memo is likewise shared across attempts, so a retry never re-runs the
+// extraction walk over the ledger's transactions.
 func (m *ingestService) ingestProcessedDataWithRetry(
 	ctx context.Context,
 	currentLedger uint32,
 	ledgerMeta xdr.LedgerCloseMeta,
 	plan *ClassificationPlan,
+	transactions []ingest.LedgerTransaction,
 	buffer *indexer.IndexerBuffer,
 ) (int, int, error) {
+	contractData := newContractDataMemo(transactions, currentLedger)
 	var lastErr error
 	for attempt := 0; attempt < maxIngestProcessedDataRetries; attempt++ {
 		select {
@@ -720,7 +759,7 @@ func (m *ingestService) ingestProcessedDataWithRetry(
 		default:
 		}
 
-		numTxs, numOps, err := m.persistLedgerData(ctx, currentLedger, &ledgerMeta, plan, buffer, data.LatestLedgerCursorName)
+		numTxs, numOps, err := m.persistLedgerData(ctx, currentLedger, &ledgerMeta, plan, contractData, buffer, data.LatestLedgerCursorName)
 		if err == nil {
 			return numTxs, numOps, nil
 		}

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -2352,6 +2352,67 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("J: RequiresContractData true — full committed membership reaches the processor", func(t *testing.T) {
+		// A classified contract that emits NO events this ledger must still be
+		// in a ContractData-requiring processor's ProtocolContracts (entries can
+		// change without events, and event decoding disambiguates against the
+		// full tracked set). Event-only processors keep the cheaper
+		// event-derived membership, which is empty for this event-less ledger.
+		contractID := []byte("contract_no_events_this_ledger33")
+		wasmHash := []byte("wasm_hash_for_membership_test333")
+
+		requiring := NewProtocolProcessorMock(t)
+		requiring.On("ProtocolID").Return("testproto")
+		requiring.On("RequiresContractData").Return(true)
+		requiring.On("Reset").Return()
+		// ContractID scans BYTEA into its hex form (the same convention
+		// bufferedContracts keys use), so compare against the hex encoding.
+		wantContractID := hex.EncodeToString(contractID)
+		requiring.On("ProcessLedger", mock.Anything, mock.MatchedBy(func(in ProtocolProcessorInput) bool {
+			for _, c := range in.ProtocolContracts {
+				if string(c.ContractID) == wantContractID {
+					return true
+				}
+			}
+			return false
+		})).Return(nil)
+		requiring.On("PersistHistory", mock.Anything, mock.Anything).Return(nil)
+		requiring.On("PersistCurrentState", mock.Anything, mock.Anything).Return(nil)
+
+		eventOnly := NewProtocolProcessorMock(t)
+		eventOnly.On("ProtocolID").Return("otherproto")
+		eventOnly.On("RequiresContractData").Return(false)
+		eventOnly.On("Reset").Return()
+		eventOnly.On("ProcessLedger", mock.Anything, mock.MatchedBy(func(in ProtocolProcessorInput) bool {
+			return len(in.ProtocolContracts) == 0
+		})).Return(nil)
+		eventOnly.On("PersistHistory", mock.Anything, mock.Anything).Return(nil)
+		eventOnly.On("PersistCurrentState", mock.Anything, mock.Anything).Return(nil)
+
+		ctx, svc, _, pool := setupTest(t, []ProtocolProcessor{requiring, eventOnly})
+		setupDBCursors(t, ctx, pool, 99, 99)
+		setupProtocolCursors(t, ctx, pool, 99, 99)
+		// setupProtocolCursors seeds "testproto" only; otherproto needs its own
+		// cursors for the CAS swap to succeed.
+		_, err := pool.Exec(ctx,
+			`INSERT INTO ingest_store (key, value) VALUES ($1, '99'), ($2, '99')`,
+			utils.ProtocolHistoryCursorName("otherproto"), utils.ProtocolCurrentStateCursorName("otherproto"))
+		require.NoError(t, err)
+		require.NoError(t, svc.snapshotProtocolCursors(ctx))
+
+		_, err = pool.Exec(ctx, `INSERT INTO protocols (id) VALUES ('testproto'), ('otherproto') ON CONFLICT (id) DO NOTHING`)
+		require.NoError(t, err)
+		_, err = pool.Exec(ctx, `INSERT INTO protocol_wasms (wasm_hash, protocol_id) VALUES ($1, 'testproto')`, wasmHash)
+		require.NoError(t, err)
+		_, err = pool.Exec(ctx, `INSERT INTO protocol_contracts (contract_id, wasm_hash) VALUES ($1, $2)`, contractID, wasmHash)
+		require.NoError(t, err)
+
+		buffer := indexer.NewIndexerBuffer()
+		meta := dummyLedgerMeta(100)
+		_, _, err = svc.persistLedgerData(ctx, 100, &meta, buffer, "latest_ledger_cursor")
+		require.NoError(t, err)
+	})
+
 	t.Run("G: contract-id lookup failure fails the ledger", func(t *testing.T) {
 		processor := &testProtocolProcessor{id: "testproto"}
 		ctx, svc, models, pool := setupTest(t, []ProtocolProcessor{processor})

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -1609,7 +1609,7 @@ func Test_ingestProcessedDataWithRetry(t *testing.T) {
 
 		// Call ingestProcessedDataWithRetry - should succeed
 		// Note: assetIDMap and contractIDMap are no longer passed - operations use direct DB queries
-		numTx, numOps, err := svc.ingestProcessedDataWithRetry(ctx, 100, xdr.LedgerCloseMeta{}, nil, buffer)
+		numTx, numOps, err := svc.ingestProcessedDataWithRetry(ctx, 100, xdr.LedgerCloseMeta{}, nil, nil, buffer)
 
 		// Verify success
 		require.NoError(t, err)
@@ -1690,7 +1690,7 @@ func Test_ingestProcessedDataWithRetry(t *testing.T) {
 
 		// Call ingestProcessedDataWithRetry - should fail after retries due to DB error
 		// Note: assetIDMap and contractIDMap are no longer passed - operations use direct DB queries
-		_, _, err = svc.ingestProcessedDataWithRetry(ctx, 100, xdr.LedgerCloseMeta{}, nil, buffer)
+		_, _, err = svc.ingestProcessedDataWithRetry(ctx, 100, xdr.LedgerCloseMeta{}, nil, nil, buffer)
 
 		// Verify error propagates with retry failure message
 		require.Error(t, err)
@@ -1780,7 +1780,7 @@ func Test_ingestProcessedDataWithRetry(t *testing.T) {
 
 		// Call ingestProcessedDataWithRetry - should succeed after retry
 		// Note: assetIDMap and contractIDMap are no longer passed - operations use direct DB queries
-		numTx, numOps, err := svc.ingestProcessedDataWithRetry(ctx, 100, xdr.LedgerCloseMeta{}, nil, buffer)
+		numTx, numOps, err := svc.ingestProcessedDataWithRetry(ctx, 100, xdr.LedgerCloseMeta{}, nil, nil, buffer)
 
 		// Verify success after retry
 		require.NoError(t, err)
@@ -1985,7 +1985,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, buffer, "latest_ledger_cursor")
+		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, nil, buffer, "latest_ledger_cursor")
 		require.NoError(t, err)
 
 		// Both protocol cursors should advance to 100
@@ -2018,7 +2018,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, buffer, "latest_ledger_cursor")
+		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, nil, buffer, "latest_ledger_cursor")
 		require.NoError(t, err)
 
 		// Cursors should stay at 100 (CAS expected 99 but found 100)
@@ -2051,7 +2051,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, buffer, "latest_ledger_cursor")
+		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, nil, buffer, "latest_ledger_cursor")
 		require.NoError(t, err)
 
 		// Cursors should stay at 98 (behind, so entire block is skipped)
@@ -2088,7 +2088,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, buffer, "latest_ledger_cursor")
+		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, nil, buffer, "latest_ledger_cursor")
 		require.NoError(t, err)
 
 		// Main cursor advances; protocol persist methods were not called and
@@ -2126,7 +2126,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		require.NoError(t, svc.snapshotProtocolCursors(ctx))
 
 		meta := dummyLedgerMeta(100)
-		_, _, err = svc.persistLedgerData(ctx, 100, &meta, nil, indexer.NewIndexerBuffer(), "latest_ledger_cursor")
+		_, _, err = svc.persistLedgerData(ctx, 100, &meta, nil, nil, indexer.NewIndexerBuffer(), "latest_ledger_cursor")
 		require.NoError(t, err)
 
 		// History CAS succeeded.
@@ -2166,7 +2166,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		require.NoError(t, svc.snapshotProtocolCursors(ctx))
 
 		meta := dummyLedgerMeta(100)
-		_, _, err = svc.persistLedgerData(ctx, 100, &meta, nil, indexer.NewIndexerBuffer(), "latest_ledger_cursor")
+		_, _, err = svc.persistLedgerData(ctx, 100, &meta, nil, nil, indexer.NewIndexerBuffer(), "latest_ledger_cursor")
 		require.NoError(t, err)
 
 		// Current-state CAS succeeded.
@@ -2195,7 +2195,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, buffer, "latest_ledger_cursor")
+		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, nil, buffer, "latest_ledger_cursor")
 		require.NoError(t, err)
 
 		// Main cursor should advance
@@ -2215,14 +2215,14 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		// First ledger succeeds and advances the current-state cursor to 100.
 		processor.processedLedger = 100
 		meta100 := dummyLedgerMeta(100)
-		_, _, err := svc.persistLedgerData(ctx, 100, &meta100, nil, indexer.NewIndexerBuffer(), "latest_ledger_cursor")
+		_, _, err := svc.persistLedgerData(ctx, 100, &meta100, nil, nil, indexer.NewIndexerBuffer(), "latest_ledger_cursor")
 		require.NoError(t, err)
 
 		// Next ledger fails inside PersistCurrentState, rolling back the whole
 		// transaction — the current-state cursor must stay at 100.
 		processor.processedLedger = 101
 		meta101 := dummyLedgerMeta(101)
-		_, _, err = svc.persistLedgerData(ctx, 101, &meta101, nil, indexer.NewIndexerBuffer(), "latest_ledger_cursor")
+		_, _, err = svc.persistLedgerData(ctx, 101, &meta101, nil, nil, indexer.NewIndexerBuffer(), "latest_ledger_cursor")
 		require.Error(t, err)
 
 		currentStateCursor, err := models.IngestStore.Get(ctx, "protocol_testproto_current_state_cursor")
@@ -2232,7 +2232,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		// Retrying the same ledger succeeds and advances the cursor.
 		processor.failPersistCurrentStateAt = 0
 		processor.processedLedger = 101
-		_, _, err = svc.persistLedgerData(ctx, 101, &meta101, nil, indexer.NewIndexerBuffer(), "latest_ledger_cursor")
+		_, _, err = svc.persistLedgerData(ctx, 101, &meta101, nil, nil, indexer.NewIndexerBuffer(), "latest_ledger_cursor")
 		require.NoError(t, err)
 
 		currentStateCursor, err = models.IngestStore.Get(ctx, "protocol_testproto_current_state_cursor")
@@ -2264,7 +2264,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, buffer, "latest_ledger_cursor")
+		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, nil, buffer, "latest_ledger_cursor")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, data.ErrCASCursorMissing)
 
@@ -2300,7 +2300,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		processor.processedLedger = 100
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, buffer, "latest_ledger_cursor")
+		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, nil, buffer, "latest_ledger_cursor")
 		require.NoError(t, err)
 
 		histCursor, getErr := models.IngestStore.Get(ctx, "protocol_testproto_history_cursor")
@@ -2326,7 +2326,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, buffer, "latest_ledger_cursor")
+		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, nil, buffer, "latest_ledger_cursor")
 		require.NoError(t, err)
 	})
 
@@ -2348,7 +2348,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, buffer, "latest_ledger_cursor")
+		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, nil, buffer, "latest_ledger_cursor")
 		require.NoError(t, err)
 	})
 
@@ -2409,7 +2409,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		_, _, err = svc.persistLedgerData(ctx, 100, &meta, nil, buffer, "latest_ledger_cursor")
+		_, _, err = svc.persistLedgerData(ctx, 100, &meta, nil, nil, buffer, "latest_ledger_cursor")
 		require.NoError(t, err)
 	})
 
@@ -2437,7 +2437,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		)
 
 		meta := dummyLedgerMeta(100)
-		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, buffer, "latest_ledger_cursor")
+		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, nil, buffer, "latest_ledger_cursor")
 		require.ErrorContains(t, err, "resolving protocol contracts for ledger 100")
 
 		// The transaction rolled back: the protocol history cursor stayed at 99.
@@ -2731,7 +2731,7 @@ func Test_persistLedgerData_ClassificationPlan(t *testing.T) {
 		}
 
 		meta := dummyLedgerMeta(100)
-		_, _, err = svc.persistLedgerData(ctx, 100, &meta, plan, buffer, "latest_ledger_cursor")
+		_, _, err = svc.persistLedgerData(ctx, 100, &meta, plan, nil, buffer, "latest_ledger_cursor")
 		require.NoError(t, err)
 
 		// The validator's Apply ran inside the transaction.
@@ -2796,7 +2796,7 @@ func Test_persistLedgerData_ClassificationPlan(t *testing.T) {
 		plan := &ClassificationPlan{Matches: map[types.HashBytea]string{w2: "otherproto"}}
 
 		meta := dummyLedgerMeta(100)
-		_, _, err = svc.persistLedgerData(ctx, 100, &meta, plan, buffer, "latest_ledger_cursor")
+		_, _, err = svc.persistLedgerData(ctx, 100, &meta, plan, nil, buffer, "latest_ledger_cursor")
 		require.NoError(t, err)
 
 		// The processor staged the ledger but saw no testproto contracts: the

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -1883,6 +1883,8 @@ func (p *testProtocolProcessor) StateChangeOrdinalBase() int64 {
 	return types.StateChangeOrdinalBaseSEP41
 }
 
+func (p *testProtocolProcessor) RequiresContractData() bool { return false }
+
 func (p *testProtocolProcessor) Reset() { p.stagedLedgerCount = 0 }
 
 func (p *testProtocolProcessor) ProcessLedger(_ context.Context, input ProtocolProcessorInput) error {

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -2409,7 +2409,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		_, _, err = svc.persistLedgerData(ctx, 100, &meta, buffer, "latest_ledger_cursor")
+		_, _, err = svc.persistLedgerData(ctx, 100, &meta, nil, buffer, "latest_ledger_cursor")
 		require.NoError(t, err)
 	})
 

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -2308,6 +2308,50 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		assert.Equal(t, uint32(100), histCursor)
 	})
 
+	t.Run("H: RequiresContractData true — processor receives non-nil ContractDataChanges", func(t *testing.T) {
+		processor := NewProtocolProcessorMock(t)
+		processor.On("ProtocolID").Return("testproto")
+		processor.On("RequiresContractData").Return(true)
+		processor.On("Reset").Return()
+		processor.On("ProcessLedger", mock.Anything, mock.MatchedBy(func(in ProtocolProcessorInput) bool {
+			return in.ContractDataChanges != nil
+		})).Return(nil)
+		processor.On("PersistHistory", mock.Anything, mock.Anything).Return(nil)
+		processor.On("PersistCurrentState", mock.Anything, mock.Anything).Return(nil)
+
+		ctx, svc, _, pool := setupTest(t, []ProtocolProcessor{processor})
+		setupDBCursors(t, ctx, pool, 99, 99)
+		setupProtocolCursors(t, ctx, pool, 99, 99)
+		require.NoError(t, svc.snapshotProtocolCursors(ctx))
+
+		buffer := indexer.NewIndexerBuffer()
+		meta := dummyLedgerMeta(100)
+		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, buffer, "latest_ledger_cursor")
+		require.NoError(t, err)
+	})
+
+	t.Run("I: RequiresContractData false — processor receives nil ContractDataChanges", func(t *testing.T) {
+		processor := NewProtocolProcessorMock(t)
+		processor.On("ProtocolID").Return("testproto")
+		processor.On("RequiresContractData").Return(false)
+		processor.On("Reset").Return()
+		processor.On("ProcessLedger", mock.Anything, mock.MatchedBy(func(in ProtocolProcessorInput) bool {
+			return in.ContractDataChanges == nil
+		})).Return(nil)
+		processor.On("PersistHistory", mock.Anything, mock.Anything).Return(nil)
+		processor.On("PersistCurrentState", mock.Anything, mock.Anything).Return(nil)
+
+		ctx, svc, _, pool := setupTest(t, []ProtocolProcessor{processor})
+		setupDBCursors(t, ctx, pool, 99, 99)
+		setupProtocolCursors(t, ctx, pool, 99, 99)
+		require.NoError(t, svc.snapshotProtocolCursors(ctx))
+
+		buffer := indexer.NewIndexerBuffer()
+		meta := dummyLedgerMeta(100)
+		_, _, err := svc.persistLedgerData(ctx, 100, &meta, nil, buffer, "latest_ledger_cursor")
+		require.NoError(t, err)
+	})
+
 	t.Run("G: contract-id lookup failure fails the ledger", func(t *testing.T) {
 		processor := &testProtocolProcessor{id: "testproto"}
 		ctx, svc, models, pool := setupTest(t, []ProtocolProcessor{processor})

--- a/internal/services/mocks.go
+++ b/internal/services/mocks.go
@@ -274,6 +274,11 @@ func (m *ProtocolProcessorMock) ProcessLedger(ctx context.Context, input Protoco
 	return args.Error(0)
 }
 
+func (m *ProtocolProcessorMock) RequiresContractData() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
 func (m *ProtocolProcessorMock) Reset() {
 	m.Called()
 }

--- a/internal/services/processor_registry_test.go
+++ b/internal/services/processor_registry_test.go
@@ -26,6 +26,13 @@ func registerStub(id string, base int64) {
 	})
 }
 
+func TestProtocolProcessor_RequiresContractData(t *testing.T) {
+	m := NewProtocolProcessorMock(t)
+	m.On("RequiresContractData").Return(false).Once()
+	var p ProtocolProcessor = m
+	assert.False(t, p.RequiresContractData())
+}
+
 func withCleanProcessorRegistry(t *testing.T) {
 	t.Helper()
 	original := processorRegistry

--- a/internal/services/processor_registry_test.go
+++ b/internal/services/processor_registry_test.go
@@ -26,13 +26,6 @@ func registerStub(id string, base int64) {
 	})
 }
 
-func TestProtocolProcessor_RequiresContractData(t *testing.T) {
-	m := NewProtocolProcessorMock(t)
-	m.On("RequiresContractData").Return(false).Once()
-	var p ProtocolProcessor = m
-	assert.False(t, p.RequiresContractData())
-}
-
 func withCleanProcessorRegistry(t *testing.T) {
 	t.Helper()
 	original := processorRegistry

--- a/internal/services/protocol_migrate.go
+++ b/internal/services/protocol_migrate.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/stellar/go-stellar-sdk/ingest"
 	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
 	"github.com/stellar/go-stellar-sdk/support/log"
+	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/wallet-backend/internal/data"
 	"github.com/stellar/wallet-backend/internal/db"
@@ -378,12 +380,19 @@ func (s *protocolMigrateEngine) processAllProtocols(ctx context.Context, protoco
 		ledgerCloseTime := ledgerMeta.LedgerCloseTime()
 
 		// Extract ContractData changes once per ledger, only when a tracker that
-		// will fold this ledger requires them; all trackers share the map.
+		// will fold this ledger requires them; all trackers share the map. The
+		// union of those trackers' memberships gates the extraction: ledgers
+		// whose transaction footprints touch no tracked contract skip the
+		// change walk entirely (the overwhelmingly common case).
 		var ledgerContractDataChanges map[string][]ingest.Change
 		if trackersRequireContractData(trackers, seq) {
 			cdStart := time.Now()
+			tracked, trackErr := trackedContractIDSet(trackers, seq, contractsByProtocol)
+			if trackErr != nil {
+				return handedOffProtocolIDs(trackers), trackErr
+			}
 			var cdErr error
-			ledgerContractDataChanges, cdErr = indexer.ExtractContractDataChangesForLedger(ctx, s.networkPassphrase, ledgerMeta)
+			ledgerContractDataChanges, cdErr = indexer.ExtractContractDataChangesForLedger(ledgerMeta, tracked)
 			cdDur := time.Since(cdStart)
 			timers.extract += cdDur
 			// Distinct phase label: the events extraction already observes one
@@ -615,6 +624,29 @@ func trackersRequireContractData(trackers []*protocolTracker, seq uint32) bool {
 		}
 	}
 	return false
+}
+
+// trackedContractIDSet unions the classified-contract membership of every
+// ContractData-requiring tracker that will fold seq, as raw 32-byte contract
+// IDs — the footprint gate's lookup key. Rebuilt per ledger so a membership
+// refresh (refreshTrackerContracts) takes effect immediately; the sets are
+// small (a protocol requiring ContractData has bounded membership), so the
+// per-ledger cost is noise.
+func trackedContractIDSet(trackers []*protocolTracker, seq uint32, contractsByProtocol map[string][]data.ProtocolContracts) (map[xdr.ContractId]struct{}, error) {
+	tracked := map[xdr.ContractId]struct{}{}
+	for _, t := range trackers {
+		if t.handedOff || t.cursorValue+t.pending >= seq || !t.processor.RequiresContractData() {
+			continue
+		}
+		for _, c := range contractsByProtocol[t.protocolID] {
+			idBytes, err := hex.DecodeString(string(c.ContractID))
+			if err != nil || len(idBytes) != len(xdr.ContractId{}) {
+				return nil, fmt.Errorf("protocol %s contract id %q is not a 32-byte hex hash: %w", t.protocolID, c.ContractID, err)
+			}
+			tracked[xdr.ContractId(idBytes)] = struct{}{}
+		}
+	}
+	return tracked, nil
 }
 
 // handedOffProtocolIDs returns the IDs of trackers that have been handed off to live ingestion.

--- a/internal/services/protocol_migrate.go
+++ b/internal/services/protocol_migrate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stellar/go-stellar-sdk/ingest"
 	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
 	"github.com/stellar/go-stellar-sdk/support/log"
 
@@ -369,16 +370,32 @@ func (s *protocolMigrateEngine) processAllProtocols(ctx context.Context, protoco
 		}
 		ledgerCloseTime := ledgerMeta.LedgerCloseTime()
 
+		// Extract ContractData changes once per ledger, only when a tracker that
+		// will fold this ledger requires them; all trackers share the map.
+		var ledgerContractDataChanges map[string][]ingest.Change
+		if trackersRequireContractData(trackers, seq) {
+			cdStart := time.Now()
+			var cdErr error
+			ledgerContractDataChanges, cdErr = indexer.ExtractContractDataChangesForLedger(ctx, s.networkPassphrase, ledgerMeta)
+			cdDur := time.Since(cdStart)
+			timers.extract += cdDur
+			s.metrics.PhaseDuration.WithLabelValues("extract").Observe(cdDur.Seconds())
+			if cdErr != nil {
+				return handedOffProtocolIDs(trackers), fmt.Errorf("extracting contract data changes for ledger %d: %w", seq, cdErr)
+			}
+		}
+
 		for _, t := range trackers {
 			if t.handedOff || t.cursorValue+t.pending >= seq {
 				continue
 			}
 			input := ProtocolProcessorInput{
-				LedgerSequence:    seq,
-				LedgerCloseTime:   ledgerCloseTime,
-				ContractEvents:    ledgerEvents,
-				ProtocolContracts: contractsByProtocol[t.protocolID],
-				StagingMode:       s.strategy.Mode,
+				LedgerSequence:      seq,
+				LedgerCloseTime:     ledgerCloseTime,
+				ContractEvents:      ledgerEvents,
+				ProtocolContracts:   contractsByProtocol[t.protocolID],
+				StagingMode:         s.strategy.Mode,
+				ContractDataChanges: ledgerContractDataChanges,
 			}
 			processStart := time.Now()
 			processErr := t.processor.ProcessLedger(ctx, input)
@@ -550,6 +567,20 @@ func allHandedOff(trackers []*protocolTracker) bool {
 		}
 	}
 	return true
+}
+
+// trackersRequireContractData reports whether any tracker that will fold this
+// ledger has a processor needing ContractData changes.
+func trackersRequireContractData(trackers []*protocolTracker, seq uint32) bool {
+	for _, t := range trackers {
+		if t.handedOff || t.cursorValue+t.pending >= seq {
+			continue
+		}
+		if t.processor.RequiresContractData() {
+			return true
+		}
+	}
+	return false
 }
 
 // handedOffProtocolIDs returns the IDs of trackers that have been handed off to live ingestion.

--- a/internal/services/protocol_migrate.go
+++ b/internal/services/protocol_migrate.go
@@ -379,7 +379,9 @@ func (s *protocolMigrateEngine) processAllProtocols(ctx context.Context, protoco
 			ledgerContractDataChanges, cdErr = indexer.ExtractContractDataChangesForLedger(ctx, s.networkPassphrase, ledgerMeta)
 			cdDur := time.Since(cdStart)
 			timers.extract += cdDur
-			s.metrics.PhaseDuration.WithLabelValues("extract").Observe(cdDur.Seconds())
+			// Distinct phase label: the events extraction already observes one
+			// "extract" sample per ledger, and dashboards assume that cardinality.
+			s.metrics.PhaseDuration.WithLabelValues("extract_contract_data").Observe(cdDur.Seconds())
 			if cdErr != nil {
 				return handedOffProtocolIDs(trackers), fmt.Errorf("extracting contract data changes for ledger %d: %w", seq, cdErr)
 			}

--- a/internal/services/protocol_migrate.go
+++ b/internal/services/protocol_migrate.go
@@ -222,7 +222,7 @@ func (s *protocolMigrateEngine) validate(ctx context.Context, protocolIDs []stri
 // less often than the progress-log interval.
 type stageTimers struct {
 	fetch   time.Duration // GetLedger wait (consumer stall, not download time); ≈0 while the datastore prefetch keeps up, rises only when it can't
-	extract time.Duration // ExtractContractEventsForLedger
+	extract time.Duration // ExtractContractEventsForLedger + ExtractContractDataChangesForLedger
 	process time.Duration // ProcessLedger across all trackers
 	flush   time.Duration // flushWindow (CAS + Persist), including tip flushes
 }
@@ -275,8 +275,15 @@ func (s *protocolMigrateEngine) processAllProtocols(ctx context.Context, protoco
 		})
 	}
 
-	// Load contracts once — all relevant contracts are in the DB before migration starts
-	// (validate() requires ClassificationStatus == StatusSuccess).
+	// Load each tracker's classified-contract membership. For event-only
+	// processors this run-start snapshot is final — validate() requires
+	// ClassificationStatus == StatusSuccess, so everything classified before
+	// the run is already here. Processors that require ContractData get their
+	// membership refreshed after every committed window instead (see
+	// refreshTrackerContracts): live ingestion's validator classifies newly
+	// deployed contracts concurrently with this run, and those processors
+	// interpret events and entries by membership, so folding the rest of the
+	// run against a stale snapshot would silently drop that contract's state.
 	contractsByProtocol := make(map[string][]data.ProtocolContracts, len(trackers))
 	for _, t := range trackers {
 		contracts, loadErr := s.protocolContractsModel.GetByProtocolID(ctx, s.db, t.protocolID)
@@ -339,7 +346,7 @@ func (s *protocolMigrateEngine) processAllProtocols(ctx context.Context, protoco
 		// next (blocking) GetLedger never strands the cursor behind the frontier.
 		var flushErr error
 		tipFlushStart := time.Now()
-		cachedTip, flushErr = s.flushWindowsAtTip(ctx, trackers, seq, cachedTip)
+		cachedTip, flushErr = s.flushWindowsAtTip(ctx, trackers, seq, cachedTip, contractsByProtocol)
 		timers.flush += time.Since(tipFlushStart)
 		if flushErr != nil {
 			return handedOffProtocolIDs(trackers), flushErr
@@ -415,6 +422,9 @@ func (s *protocolMigrateEngine) processAllProtocols(ctx context.Context, protoco
 				if flushWinErr != nil {
 					return handedOffProtocolIDs(trackers), flushWinErr
 				}
+				if refreshErr := s.refreshTrackerContracts(ctx, t, contractsByProtocol); refreshErr != nil {
+					return handedOffProtocolIDs(trackers), refreshErr
+				}
 			}
 		}
 
@@ -484,7 +494,7 @@ func (s *protocolMigrateEngine) refreshTargetTip(ctx context.Context) {
 // GetLatestLedgerSequence call per ledger; the tip is monotonic, so a stale value at worst
 // costs one extra refresh. The updated cachedTip is returned for the next iteration. A
 // flush can hand off the last active tracker, so callers must re-check allHandedOff after.
-func (s *protocolMigrateEngine) flushWindowsAtTip(ctx context.Context, trackers []*protocolTracker, seq, cachedTip uint32) (uint32, error) {
+func (s *protocolMigrateEngine) flushWindowsAtTip(ctx context.Context, trackers []*protocolTracker, seq, cachedTip uint32, contractsByProtocol map[string][]data.ProtocolContracts) (uint32, error) {
 	if seq <= cachedTip {
 		return cachedTip, nil
 	}
@@ -498,8 +508,30 @@ func (s *protocolMigrateEngine) flushWindowsAtTip(ctx context.Context, trackers 
 		if err := s.flushWindow(ctx, t); err != nil {
 			return cachedTip, err
 		}
+		if err := s.refreshTrackerContracts(ctx, t, contractsByProtocol); err != nil {
+			return cachedTip, err
+		}
 	}
 	return cachedTip, nil
+}
+
+// refreshTrackerContracts re-reads a tracker's classified-contract membership
+// after a window commit, but only for processors that require ContractData —
+// they interpret events and entries by classified-set membership, so a
+// contract classified mid-run (live ingestion's validator runs concurrently)
+// must reach them on the next window rather than never. Event-only processors
+// keep the cheaper run-start snapshot. Handed-off trackers fold no further
+// ledgers, so their membership no longer matters.
+func (s *protocolMigrateEngine) refreshTrackerContracts(ctx context.Context, t *protocolTracker, contractsByProtocol map[string][]data.ProtocolContracts) error {
+	if t.handedOff || !t.processor.RequiresContractData() {
+		return nil
+	}
+	contracts, err := s.protocolContractsModel.GetByProtocolID(ctx, s.db, t.protocolID)
+	if err != nil {
+		return fmt.Errorf("refreshing contracts for %s: %w", t.protocolID, err)
+	}
+	contractsByProtocol[t.protocolID] = contracts
+	return nil
 }
 
 // flushWindow commits a tracker's open window [cursorValue+1, cursorValue+pending] in a

--- a/internal/services/protocol_migrate.go
+++ b/internal/services/protocol_migrate.go
@@ -286,15 +286,13 @@ func (s *protocolMigrateEngine) processAllProtocols(ctx context.Context, protoco
 		})
 	}
 
-	// Load each tracker's classified-contract membership. For event-only
-	// processors this run-start snapshot is final — validate() requires
-	// ClassificationStatus == StatusSuccess, so everything classified before
-	// the run is already here. Processors that require ContractData get their
-	// membership refreshed after every committed window instead (see
-	// refreshTrackerContracts): live ingestion's validator classifies newly
-	// deployed contracts concurrently with this run, and those processors
-	// interpret events and entries by membership, so folding the rest of the
-	// run against a stale snapshot would silently drop that contract's state.
+	// Load each tracker's classified-contract membership. This is only the
+	// run-start snapshot — every tracker's membership is re-read at each
+	// window start (see refreshTrackerContracts): live ingestion's validator
+	// classifies newly deployed contracts concurrently with this run, and
+	// processors interpret events and entries by membership, so folding the
+	// rest of the run against a stale snapshot would silently drop such a
+	// contract's state.
 	contractsByProtocol := make(map[string][]data.ProtocolContracts, len(trackers))
 	for _, t := range trackers {
 		contracts, loadErr := s.protocolContractsModel.GetByProtocolID(ctx, s.db, t.protocolID)
@@ -356,10 +354,11 @@ func (s *protocolMigrateEngine) processAllProtocols(ctx context.Context, protoco
 		// Fold seq only after live ingestion has committed it: live's cursor advances in
 		// the same transaction as the ledger's protocol_contracts classifications, so
 		// cursor >= seq is atomic proof that every classification discoverable at seq is
-		// committed and visible to the membership refresh below. The gate also flushes
-		// open windows before it waits, so the next (blocking) fetch never strands a
-		// cursor behind the frontier. A flush can hand off the last active tracker, so
-		// re-check after.
+		// committed and visible to the membership refresh below. The gate flushes open
+		// windows whenever seq crosses its cached frontier value — before it even learns
+		// the new one — so no window outgrows the membership snapshot it opened with,
+		// and the next (blocking) fetch never strands a cursor behind the frontier. A
+		// flush can hand off the last active tracker, so re-check after.
 		var gateErr error
 		gateStart := time.Now()
 		cachedLiveCursor, gateErr = s.gateOnLiveFrontier(ctx, trackers, seq, cachedLiveCursor)
@@ -525,12 +524,12 @@ func (s *protocolMigrateEngine) refreshTargetTip(ctx context.Context) {
 // guarantees:
 //
 //   - Complete membership: a window's start-of-window membership refresh runs after this
-//     gate admitted the window's first ledger, and the flush-before-wait means no window
-//     outlives the cursor value that admitted it — so every folded ledger's membership
-//     includes all classifications up to and including that ledger. Folding past the
-//     frontier is how a contract deployed in live's lag window went missing for the rest
-//     of that window (#680).
-//   - Handoff arming: the flush commits each cursor to the last folded ledger before the
+//     gate admitted the window's first ledger, and the flush-at-crossing means no window
+//     ever contains a ledger past the cursor value that was current when it opened — so
+//     every folded ledger's membership includes all classifications up to and including
+//     that ledger. Folding past the frontier is how a contract deployed in live's lag
+//     window went missing for the rest of that window (#680).
+//   - Handoff arming: the flush commits each cursor to the last folded ledger before any
 //     wait, so live's CAS(cursor -> cursor+1) matches as soon as it reaches the frontier
 //     and takes over cleanly instead of contesting a window held open across the wait.
 //
@@ -545,20 +544,31 @@ func (s *protocolMigrateEngine) gateOnLiveFrontier(ctx context.Context, trackers
 	if seq <= cachedLiveCursor {
 		return cachedLiveCursor, nil
 	}
+
+	// seq is crossing the last known frontier: close every open window BEFORE
+	// learning the new frontier value. A window's start-of-window membership
+	// refresh covers classifications committed up to the cursor value current
+	// when the window opened, so a window that slid past that value would fold
+	// a contract classified mid-window without it — the #680 loss shape inside
+	// a window. Flushing at the crossing (rather than only before a wait) is
+	// what pins every window at or below the cursor value that opened it.
+	// flushWindow no-ops when nothing is pending, so a bulk-backfill crossing
+	// (rare: once per cache refill) costs one committed window, and frontier
+	// crossings (every ledger) are exactly the intended shrink-to-one cadence.
+	for _, t := range trackers {
+		if flushErr := s.flushWindow(ctx, t); flushErr != nil {
+			return cachedLiveCursor, flushErr
+		}
+	}
+	if allHandedOff(trackers) {
+		return cachedLiveCursor, nil
+	}
+
 	liveCursor, err := s.ingestStore.Get(ctx, data.LatestLedgerCursorName)
 	if err != nil {
 		return cachedLiveCursor, fmt.Errorf("reading live ingestion cursor before folding ledger %d: %w", seq, err)
 	}
 	if seq <= liveCursor {
-		return liveCursor, nil
-	}
-
-	for _, t := range trackers {
-		if flushErr := s.flushWindow(ctx, t); flushErr != nil {
-			return liveCursor, flushErr
-		}
-	}
-	if allHandedOff(trackers) {
 		return liveCursor, nil
 	}
 
@@ -589,14 +599,15 @@ func (s *protocolMigrateEngine) gateOnLiveFrontier(ctx context.Context, trackers
 // refreshTrackerContracts re-reads a tracker's classified-contract membership
 // at the start of each window — after the window's first ledger has been
 // fetched (see the call site in processAllProtocols for why that ordering is
-// load-bearing at the frontier) — but only for processors that require
-// ContractData: they interpret events and entries by classified-set
-// membership, so a contract classified mid-run (live ingestion's validator
-// runs concurrently) must reach them on the next window rather than never.
-// Event-only processors keep the cheaper run-start snapshot. Handed-off
-// trackers fold no further ledgers, so their membership no longer matters.
+// load-bearing at the frontier). Every tracker refreshes, event-only ones
+// included: processors interpret events (and, where required, entries) by
+// classified-set membership, so a contract classified mid-run (live
+// ingestion's validator runs concurrently) must reach them on the next window
+// rather than never — a run-start-only snapshot would silently drop such a
+// contract's events for the rest of the run. Handed-off trackers fold no
+// further ledgers, so their membership no longer matters.
 func (s *protocolMigrateEngine) refreshTrackerContracts(ctx context.Context, t *protocolTracker, contractsByProtocol map[string][]data.ProtocolContracts) error {
-	if t.handedOff || !t.processor.RequiresContractData() {
+	if t.handedOff {
 		return nil
 	}
 	contracts, err := s.protocolContractsModel.GetByProtocolID(ctx, s.db, t.protocolID)

--- a/internal/services/protocol_migrate.go
+++ b/internal/services/protocol_migrate.go
@@ -31,6 +31,12 @@ const progressLogInterval uint32 = 1000
 // and the chain tip advances ~1 ledger every few seconds.
 const tipRefreshInterval = 15 * time.Second
 
+// frontierPollInterval is how often gateOnLiveFrontier re-reads live ingestion's cursor while
+// the fold loop waits at the classification frontier. Live commits roughly one ledger every
+// few seconds at the tip, so a 1s poll adds at most one idle round trip per ledger there and
+// none at all during the bulk backfill (the gate is a cached comparison below the frontier).
+const frontierPollInterval = time.Second
+
 // protocolTracker holds per-protocol state for the ledger-first migration loop.
 type protocolTracker struct {
 	protocolID  string
@@ -223,23 +229,26 @@ func (s *protocolMigrateEngine) validate(ctx context.Context, protocolIDs []stri
 // cumulative share — stable line-to-line and fairly amortizing costs (like flush) that occur far
 // less often than the progress-log interval.
 type stageTimers struct {
+	gate    time.Duration // gateOnLiveFrontier (flush + wait for live ingestion's cursor); ≈0 while live is ahead
 	fetch   time.Duration // GetLedger wait (consumer stall, not download time); ≈0 while the datastore prefetch keeps up, rises only when it can't
 	extract time.Duration // ExtractContractEventsForLedger + ExtractContractDataChangesForLedger
 	process time.Duration // ProcessLedger across all trackers
-	flush   time.Duration // flushWindow (CAS + Persist), including tip flushes
+	flush   time.Duration // flushWindow (CAS + Persist) from the fold loop's window-size trigger
 }
 
-func (t stageTimers) total() time.Duration { return t.fetch + t.extract + t.process + t.flush }
+func (t stageTimers) total() time.Duration {
+	return t.gate + t.fetch + t.extract + t.process + t.flush
+}
 
 // breakdown renders each stage's share of the cumulative staged total as a percentage.
 func (t stageTimers) breakdown() string {
 	total := t.total()
 	if total == 0 {
-		return "fetch-wait=0% extract=0% process=0% flush=0%"
+		return "gate-wait=0% fetch-wait=0% extract=0% process=0% flush=0%"
 	}
 	pct := func(d time.Duration) float64 { return 100 * float64(d) / float64(total) }
-	return fmt.Sprintf("fetch-wait=%.0f%% extract=%.0f%% process=%.0f%% flush=%.0f%%",
-		pct(t.fetch), pct(t.extract), pct(t.process), pct(t.flush))
+	return fmt.Sprintf("gate-wait=%.0f%% fetch-wait=%.0f%% extract=%.0f%% process=%.0f%% flush=%.0f%%",
+		pct(t.gate), pct(t.fetch), pct(t.extract), pct(t.process), pct(t.flush))
 }
 
 // processAllProtocols runs migration for all protocols using ledger-first iteration.
@@ -331,10 +340,10 @@ func (s *protocolMigrateEngine) processAllProtocols(ctx context.Context, protoco
 	}
 
 	var (
-		cachedTip       uint32
-		timers          stageTimers
-		intervalStart   = time.Now()
-		intervalLedgers uint32
+		cachedLiveCursor uint32
+		timers           stageTimers
+		intervalStart    = time.Now()
+		intervalLedgers  uint32
 	)
 	for seq := startLedger; ; seq++ {
 		if err := ctx.Err(); err != nil {
@@ -344,14 +353,19 @@ func (s *protocolMigrateEngine) processAllProtocols(ctx context.Context, protoco
 			return handedOffProtocolIDs(trackers), nil
 		}
 
-		// Before fetching seq, flush any open windows once we reach the live tip so the
-		// next (blocking) GetLedger never strands the cursor behind the frontier.
-		var flushErr error
-		tipFlushStart := time.Now()
-		cachedTip, flushErr = s.flushWindowsAtTip(ctx, trackers, seq, cachedTip)
-		timers.flush += time.Since(tipFlushStart)
-		if flushErr != nil {
-			return handedOffProtocolIDs(trackers), flushErr
+		// Fold seq only after live ingestion has committed it: live's cursor advances in
+		// the same transaction as the ledger's protocol_contracts classifications, so
+		// cursor >= seq is atomic proof that every classification discoverable at seq is
+		// committed and visible to the membership refresh below. The gate also flushes
+		// open windows before it waits, so the next (blocking) fetch never strands a
+		// cursor behind the frontier. A flush can hand off the last active tracker, so
+		// re-check after.
+		var gateErr error
+		gateStart := time.Now()
+		cachedLiveCursor, gateErr = s.gateOnLiveFrontier(ctx, trackers, seq, cachedLiveCursor)
+		timers.gate += time.Since(gateStart)
+		if gateErr != nil {
+			return handedOffProtocolIDs(trackers), gateErr
 		}
 		if allHandedOff(trackers) {
 			return handedOffProtocolIDs(trackers), nil
@@ -381,13 +395,15 @@ func (s *protocolMigrateEngine) processAllProtocols(ctx context.Context, protoco
 
 		// Refresh each tracker's classified-contract membership at window start —
 		// after the window's first ledger has been FETCHED, not after the previous
-		// window's commit. GetLedger blocks until seq has closed, so this read runs
-		// after any concurrent live-ingestion transaction for seq-1 — including the
-		// classification it commits — has finished; a post-commit refresh instead
-		// races that transaction and can fold seq with a membership missing a
-		// contract classified at seq-1, silently skipping its events and entries
-		// for this window (additive fold columns never heal from a missed ledger).
-		// Same cadence either way: once per window per requiring tracker.
+		// window's commit. The frontier gate above guarantees live has committed
+		// this ledger (and, via the flush-before-wait, every ledger this window
+		// will ever contain) before this read runs, so the membership here
+		// includes every classification the window can encounter; a post-commit
+		// refresh instead races live's transaction and can fold seq with a
+		// membership missing a contract classified at seq-1, silently skipping
+		// its events and entries for this window (additive fold columns never
+		// heal from a missed ledger). Same cadence either way: once per window
+		// per requiring tracker.
 		for _, t := range trackers {
 			if t.handedOff || t.cursorValue+t.pending >= seq || t.pending != 0 {
 				continue
@@ -499,41 +515,75 @@ func (s *protocolMigrateEngine) refreshTargetTip(ctx context.Context) {
 	}
 }
 
-// flushWindowsAtTip flushes every tracker's open window once seq reaches the live tip,
-// so a coalescing window never straddles the migration<->live frontier.
+// gateOnLiveFrontier blocks until live ingestion's committed cursor reaches seq, flushing
+// every tracker's open window first so no coalescing window ever extends past the live
+// classification frontier.
 //
-// Below the tip it is a no-op: GetLedger(seq) returns immediately and an open window is
-// harmless, so the bulk backfill keeps committing windowSize ledgers per transaction. At
-// the tip, GetLedger(seq) blocks until the ledger closes — and a window held open across
-// that block pins the cursor behind the frontier, so live ingestion's CAS(tip-1 -> tip)
-// can never match and the handoff (hence migration termination) can never happen. Flushing
-// first advances each cursor to the last closed ledger, arming the handoff and shrinking
-// the window to 1 at the tip.
+// Live's cursor advances in the same transaction that commits a ledger's
+// protocol_contracts classifications, so cursor >= seq is atomic proof that every
+// classification discoverable at seq is committed. That gives the fold loop two
+// guarantees:
 //
-// Termination depends on live ingestion running concurrently: migration hands off only by
-// losing a CAS at the tip, so if it always wins (e.g. live ingestion is down) it keeps
-// producing rather than handing off — the correct degraded-mode behavior, not a hang.
+//   - Complete membership: a window's start-of-window membership refresh runs after this
+//     gate admitted the window's first ledger, and the flush-before-wait means no window
+//     outlives the cursor value that admitted it — so every folded ledger's membership
+//     includes all classifications up to and including that ledger. Folding past the
+//     frontier is how a contract deployed in live's lag window went missing for the rest
+//     of that window (#680).
+//   - Handoff arming: the flush commits each cursor to the last folded ledger before the
+//     wait, so live's CAS(cursor -> cursor+1) matches as soon as it reaches the frontier
+//     and takes over cleanly instead of contesting a window held open across the wait.
 //
-// The tip is cached and only re-read once seq catches up to it, sparing the bulk a
-// GetLatestLedgerSequence call per ledger; the tip is monotonic, so a stale value at worst
-// costs one extra refresh. The updated cachedTip is returned for the next iteration. A
-// flush can hand off the last active tracker, so callers must re-check allHandedOff after.
-func (s *protocolMigrateEngine) flushWindowsAtTip(ctx context.Context, trackers []*protocolTracker, seq, cachedTip uint32) (uint32, error) {
-	if seq <= cachedTip {
-		return cachedTip, nil
+// Below the frontier the gate is one cached comparison: the cursor is re-read only when
+// seq catches up to the cached value, sparing the bulk backfill a read per ledger. The
+// cursor is monotonic, so a stale cache at worst costs one early flush. Termination still
+// depends on live ingestion running concurrently: migration hands off only by losing a
+// CAS at the frontier, and with live down the engine idles here (logged) rather than
+// folding ledgers whose classifications are not yet committed. A flush can hand off the
+// last active tracker, so this returns early — and callers must re-check allHandedOff.
+func (s *protocolMigrateEngine) gateOnLiveFrontier(ctx context.Context, trackers []*protocolTracker, seq, cachedLiveCursor uint32) (uint32, error) {
+	if seq <= cachedLiveCursor {
+		return cachedLiveCursor, nil
 	}
-	if tip, tipErr := s.ledgerBackend.GetLatestLedgerSequence(ctx); tipErr == nil {
-		cachedTip = tip
+	liveCursor, err := s.ingestStore.Get(ctx, data.LatestLedgerCursorName)
+	if err != nil {
+		return cachedLiveCursor, fmt.Errorf("reading live ingestion cursor before folding ledger %d: %w", seq, err)
 	}
-	if seq <= cachedTip {
-		return cachedTip, nil
+	if seq <= liveCursor {
+		return liveCursor, nil
 	}
+
 	for _, t := range trackers {
-		if err := s.flushWindow(ctx, t); err != nil {
-			return cachedTip, err
+		if flushErr := s.flushWindow(ctx, t); flushErr != nil {
+			return liveCursor, flushErr
 		}
 	}
-	return cachedTip, nil
+	if allHandedOff(trackers) {
+		return liveCursor, nil
+	}
+
+	log.Ctx(ctx).Infof("migration gated on live ingestion's classification frontier: ledger %d not yet committed by live (cursor at %d); waiting", seq, liveCursor)
+	waitStart := time.Now()
+	ticker := time.NewTicker(frontierPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return liveCursor, fmt.Errorf("context cancelled while gated on live ingestion's frontier at ledger %d: %w", seq, ctx.Err())
+		case <-ticker.C:
+		}
+		liveCursor, err = s.ingestStore.Get(ctx, data.LatestLedgerCursorName)
+		if err != nil {
+			return liveCursor, fmt.Errorf("reading live ingestion cursor while gated at ledger %d: %w", seq, err)
+		}
+		if seq <= liveCursor {
+			waited := time.Since(waitStart)
+			s.metrics.PhaseDuration.WithLabelValues("frontier_gate").Observe(waited.Seconds())
+			log.Ctx(ctx).Infof("live ingestion frontier reached ledger %d; migration resuming at ledger %d after %s gated",
+				liveCursor, seq, waited.Round(time.Millisecond))
+			return liveCursor, nil
+		}
+	}
 }
 
 // refreshTrackerContracts re-reads a tracker's classified-contract membership

--- a/internal/services/protocol_migrate.go
+++ b/internal/services/protocol_migrate.go
@@ -348,7 +348,7 @@ func (s *protocolMigrateEngine) processAllProtocols(ctx context.Context, protoco
 		// next (blocking) GetLedger never strands the cursor behind the frontier.
 		var flushErr error
 		tipFlushStart := time.Now()
-		cachedTip, flushErr = s.flushWindowsAtTip(ctx, trackers, seq, cachedTip, contractsByProtocol)
+		cachedTip, flushErr = s.flushWindowsAtTip(ctx, trackers, seq, cachedTip)
 		timers.flush += time.Since(tipFlushStart)
 		if flushErr != nil {
 			return handedOffProtocolIDs(trackers), flushErr
@@ -378,6 +378,24 @@ func (s *protocolMigrateEngine) processAllProtocols(ctx context.Context, protoco
 			return handedOffProtocolIDs(trackers), fmt.Errorf("extracting contract events for ledger %d: %w", seq, eventsErr)
 		}
 		ledgerCloseTime := ledgerMeta.LedgerCloseTime()
+
+		// Refresh each tracker's classified-contract membership at window start —
+		// after the window's first ledger has been FETCHED, not after the previous
+		// window's commit. GetLedger blocks until seq has closed, so this read runs
+		// after any concurrent live-ingestion transaction for seq-1 — including the
+		// classification it commits — has finished; a post-commit refresh instead
+		// races that transaction and can fold seq with a membership missing a
+		// contract classified at seq-1, silently skipping its events and entries
+		// for this window (additive fold columns never heal from a missed ledger).
+		// Same cadence either way: once per window per requiring tracker.
+		for _, t := range trackers {
+			if t.handedOff || t.cursorValue+t.pending >= seq || t.pending != 0 {
+				continue
+			}
+			if refreshErr := s.refreshTrackerContracts(ctx, t, contractsByProtocol); refreshErr != nil {
+				return handedOffProtocolIDs(trackers), refreshErr
+			}
+		}
 
 		// Extract ContractData changes once per ledger, only when a tracker that
 		// will fold this ledger requires them; all trackers share the map. The
@@ -430,9 +448,6 @@ func (s *protocolMigrateEngine) processAllProtocols(ctx context.Context, protoco
 				timers.flush += time.Since(flushStart)
 				if flushWinErr != nil {
 					return handedOffProtocolIDs(trackers), flushWinErr
-				}
-				if refreshErr := s.refreshTrackerContracts(ctx, t, contractsByProtocol); refreshErr != nil {
-					return handedOffProtocolIDs(trackers), refreshErr
 				}
 			}
 		}
@@ -503,7 +518,7 @@ func (s *protocolMigrateEngine) refreshTargetTip(ctx context.Context) {
 // GetLatestLedgerSequence call per ledger; the tip is monotonic, so a stale value at worst
 // costs one extra refresh. The updated cachedTip is returned for the next iteration. A
 // flush can hand off the last active tracker, so callers must re-check allHandedOff after.
-func (s *protocolMigrateEngine) flushWindowsAtTip(ctx context.Context, trackers []*protocolTracker, seq, cachedTip uint32, contractsByProtocol map[string][]data.ProtocolContracts) (uint32, error) {
+func (s *protocolMigrateEngine) flushWindowsAtTip(ctx context.Context, trackers []*protocolTracker, seq, cachedTip uint32) (uint32, error) {
 	if seq <= cachedTip {
 		return cachedTip, nil
 	}
@@ -517,20 +532,19 @@ func (s *protocolMigrateEngine) flushWindowsAtTip(ctx context.Context, trackers 
 		if err := s.flushWindow(ctx, t); err != nil {
 			return cachedTip, err
 		}
-		if err := s.refreshTrackerContracts(ctx, t, contractsByProtocol); err != nil {
-			return cachedTip, err
-		}
 	}
 	return cachedTip, nil
 }
 
 // refreshTrackerContracts re-reads a tracker's classified-contract membership
-// after a window commit, but only for processors that require ContractData —
-// they interpret events and entries by classified-set membership, so a
-// contract classified mid-run (live ingestion's validator runs concurrently)
-// must reach them on the next window rather than never. Event-only processors
-// keep the cheaper run-start snapshot. Handed-off trackers fold no further
-// ledgers, so their membership no longer matters.
+// at the start of each window — after the window's first ledger has been
+// fetched (see the call site in processAllProtocols for why that ordering is
+// load-bearing at the frontier) — but only for processors that require
+// ContractData: they interpret events and entries by classified-set
+// membership, so a contract classified mid-run (live ingestion's validator
+// runs concurrently) must reach them on the next window rather than never.
+// Event-only processors keep the cheaper run-start snapshot. Handed-off
+// trackers fold no further ledgers, so their membership no longer matters.
 func (s *protocolMigrateEngine) refreshTrackerContracts(ctx context.Context, t *protocolTracker, contractsByProtocol map[string][]data.ProtocolContracts) error {
 	if t.handedOff || !t.processor.RequiresContractData() {
 		return nil

--- a/internal/services/protocol_migrate.go
+++ b/internal/services/protocol_migrate.go
@@ -279,7 +279,7 @@ func (s *protocolMigrateEngine) processAllProtocols(ctx context.Context, protoco
 	// (validate() requires ClassificationStatus == StatusSuccess).
 	contractsByProtocol := make(map[string][]data.ProtocolContracts, len(trackers))
 	for _, t := range trackers {
-		contracts, loadErr := s.protocolContractsModel.GetByProtocolID(ctx, t.protocolID)
+		contracts, loadErr := s.protocolContractsModel.GetByProtocolID(ctx, s.db, t.protocolID)
 		if loadErr != nil {
 			return nil, fmt.Errorf("loading contracts for %s: %w", t.protocolID, loadErr)
 		}

--- a/internal/services/protocol_migrate_current_state_test.go
+++ b/internal/services/protocol_migrate_current_state_test.go
@@ -76,7 +76,7 @@ func TestCurrentStateStrategySpecifics(t *testing.T) {
 	protocolsModel.On("UpdateCurrentStateMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusInProgress).Return(nil)
 	// After context cancellation the engine marks the protocol as failed
 	protocolsModel.On("UpdateCurrentStateMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusFailed).Return(nil)
-	protocolContractsModel.On("GetByProtocolID", mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
+	protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
 
 	backend := &multiLedgerBackend{
 		ledgers: map[uint32]xdr.LedgerCloseMeta{
@@ -170,7 +170,7 @@ func TestCurrentStateRecordsMetrics(t *testing.T) {
 	}, nil)
 	protocolsModel.On("UpdateCurrentStateMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusInProgress).Return(nil)
 	protocolsModel.On("UpdateCurrentStateMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusFailed).Return(nil)
-	protocolContractsModel.On("GetByProtocolID", mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
+	protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
 
 	backend := &multiLedgerBackend{
 		ledgers: map[uint32]xdr.LedgerCloseMeta{100: dummyLedgerMeta(100)},

--- a/internal/services/protocol_migrate_history_test.go
+++ b/internal/services/protocol_migrate_history_test.go
@@ -66,7 +66,7 @@ func TestHistoryStrategySpecifics(t *testing.T) {
 	// Verify it calls UpdateHistoryMigrationStatus (not current state)
 	protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusInProgress).Return(nil)
 	protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusSuccess).Return(nil)
-	protocolContractsModel.On("GetByProtocolID", mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
+	protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
 
 	backend := &multiLedgerBackend{
 		ledgers: map[uint32]xdr.LedgerCloseMeta{

--- a/internal/services/protocol_migrate_test.go
+++ b/internal/services/protocol_migrate_test.go
@@ -181,6 +181,7 @@ type testRecordingProcessor struct {
 	persistedCurrentStateSeqs []uint32
 	lastProcessed             uint32
 	resetCount                int
+	requiresContractData      bool
 }
 
 func (p *testRecordingProcessor) ProtocolID() string { return p.id }
@@ -188,6 +189,8 @@ func (p *testRecordingProcessor) ProtocolID() string { return p.id }
 func (p *testRecordingProcessor) StateChangeOrdinalBase() int64 {
 	return types.StateChangeOrdinalBaseSEP41
 }
+
+func (p *testRecordingProcessor) RequiresContractData() bool { return p.requiresContractData }
 
 func (p *testRecordingProcessor) Reset() { p.resetCount++ }
 

--- a/internal/services/protocol_migrate_test.go
+++ b/internal/services/protocol_migrate_test.go
@@ -217,6 +217,39 @@ func (p *testCursorAdvancingProcessor) ProcessLedger(ctx context.Context, input 
 	return p.testRecordingProcessor.ProcessLedger(ctx, input)
 }
 
+// testMidWindowClassificationProcessor embeds testRecordingProcessor and
+// simulates live ingestion running concurrently with the engine's window: at
+// advanceLiveAtSeq it commits live's cursor to liveCursorTarget (standing in
+// for live's transaction that classifies a new contract and advances
+// latest_ingest_ledger together), and at handoffAtSeq it moves the protocol
+// cursor so the engine's next window CAS fails and the run terminates.
+type testMidWindowClassificationProcessor struct {
+	testRecordingProcessor
+	dbPool           *pgxpool.Pool
+	advanceLiveAtSeq uint32
+	liveCursorTarget uint32
+	handoffAtSeq     uint32
+}
+
+func (p *testMidWindowClassificationProcessor) ProcessLedger(ctx context.Context, input ProtocolProcessorInput) error {
+	switch input.LedgerSequence {
+	case p.advanceLiveAtSeq:
+		if _, err := p.dbPool.Exec(ctx,
+			`UPDATE ingest_store SET value = $1 WHERE key = 'latest_ingest_ledger'`,
+			strconv.FormatUint(uint64(p.liveCursorTarget), 10)); err != nil {
+			return fmt.Errorf("advancing live cursor for test: %w", err)
+		}
+	case p.handoffAtSeq:
+		if _, err := p.dbPool.Exec(ctx,
+			`UPDATE ingest_store SET value = $1 WHERE key = $2`,
+			strconv.FormatUint(uint64(p.handoffAtSeq), 10),
+			utils.ProtocolHistoryCursorName(p.id)); err != nil {
+			return fmt.Errorf("advancing protocol cursor for test: %w", err)
+		}
+	}
+	return p.testRecordingProcessor.ProcessLedger(ctx, input)
+}
+
 // testErrorAtSeqProcessor embeds testRecordingProcessor and returns an error
 // when ProcessLedger is called for a specific ledger sequence.
 type testErrorAtSeqProcessor struct {
@@ -1226,16 +1259,18 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		// hex-decodes tracked contract IDs and fails the run on malformed ones.
 		contractA := data.ProtocolContracts{ContractID: types.HashBytea(strings.Repeat("aa", 32))}
 		contractB := data.ProtocolContracts{ContractID: types.HashBytea(strings.Repeat("bb", 32))}
-		// The requiring tracker's membership is re-read at the start of every
-		// window, after the window's first ledger has been fetched (WindowSize
-		// defaults to 1, so before every ledger's fold): the run-start snapshot
-		// returns only A, every window-start refresh returns A+B — simulating
-		// live ingestion classifying B between the snapshot and the first
-		// window. The event-only tracker keeps the run-start snapshot: exactly
-		// one load.
+		// Every tracker's membership is re-read at the start of every window,
+		// after the window's first ledger has been fetched (WindowSize defaults
+		// to 1, so before every ledger's fold): the run-start snapshot returns
+		// only A, every window-start refresh returns A+B — simulating live
+		// ingestion classifying B between the snapshot and the first window.
+		// The event-only tracker refreshes on the same cadence: its processor
+		// filters events by membership, so a run-start-only snapshot would
+		// silently drop B's events for the rest of the run.
 		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "cdproto").Return([]data.ProtocolContracts{contractA}, nil).Once()
 		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "cdproto").Return([]data.ProtocolContracts{contractA, contractB}, nil)
 		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "noproto").Return([]data.ProtocolContracts{contractA}, nil).Once()
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "noproto").Return([]data.ProtocolContracts{contractA, contractB}, nil)
 
 		backend := &multiLedgerBackend{
 			ledgers: map[uint32]xdr.LedgerCloseMeta{
@@ -1268,11 +1303,11 @@ func TestProtocolMigrateEngine(t *testing.T) {
 			assert.Len(t, input.ProtocolContracts, 2, "ledger %d: window-start membership must include the newly classified contract", input.LedgerSequence)
 		}
 
-		// Event-only processor: the run-start snapshot is never refreshed (its
-		// single .Once() mock expectation also fails the test on extra calls).
+		// Event-only processor: same window-start refresh cadence — every fold
+		// sees the newly classified contract too.
 		require.Len(t, noProc.processedInputs, 3)
 		for _, input := range noProc.processedInputs {
-			assert.Len(t, input.ProtocolContracts, 1, "ledger %d: event-only membership stays the snapshot", input.LedgerSequence)
+			assert.Len(t, input.ProtocolContracts, 2, "ledger %d: event-only membership must include the newly classified contract", input.LedgerSequence)
 		}
 	})
 
@@ -1744,5 +1779,93 @@ func TestProtocolMigrateEngine_FrontierGate(t *testing.T) {
 		case <-time.After(30 * time.Second):
 			t.Fatal("engine did not return after cancellation while gated")
 		}
+	})
+
+	t.Run("a window never outlives the frontier value that opened it", func(t *testing.T) {
+		// Live commits a ledger that classifies a new contract while the engine is
+		// mid-window. The crossing at that ledger must close the open window and
+		// re-read membership, so the engine folds the new frontier ledgers WITH the
+		// new contract — not off the stale window-start snapshot. Uses an event-only
+		// processor, so this also pins that membership refresh is not limited to
+		// ContractData-requiring trackers.
+		ctx := context.Background()
+		dbPool, ingestStore := setupTestDB(t)
+
+		setIngestStoreValue(t, ctx, dbPool, "oldest_ingest_ledger", 100)
+		// Live has committed through 102 when the run starts.
+		setIngestStoreValue(t, ctx, dbPool, "latest_ingest_ledger", 102)
+
+		_, err := dbPool.Exec(ctx, `INSERT INTO protocols (id, classification_status) VALUES ('testproto', 'success') ON CONFLICT (id) DO UPDATE SET classification_status = 'success'`)
+		require.NoError(t, err)
+
+		protocolsModel := data.NewProtocolsModelMock(t)
+		protocolContractsModel := data.NewProtocolContractsModelMock(t)
+		protocolsModel.On("GetByIDs", mock.Anything, []string{"testproto"}).Return([]data.Protocols{
+			{ID: "testproto", ClassificationStatus: data.StatusSuccess, HistoryMigrationStatus: data.StatusNotStarted},
+		}, nil)
+		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusInProgress).Return(nil)
+		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusSuccess).Return(nil)
+		// Membership: empty at the run-start load and at the first window's refresh;
+		// contract X exists from the refresh after the crossing onward (live's
+		// transaction for ledger 104 classified it).
+		contractX := data.ProtocolContracts{ContractID: "78787878"}
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil).Twice()
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{contractX}, nil)
+
+		// During the fold of 102, "live" commits ledger 104 (classification of X +
+		// cursor together); during the fold of 104, live takes the protocol cursor
+		// so the run terminates via handoff at the next crossing.
+		processor := &testMidWindowClassificationProcessor{
+			testRecordingProcessor: testRecordingProcessor{id: "testproto", ingestStore: ingestStore},
+			dbPool:                 dbPool,
+			advanceLiveAtSeq:       102,
+			liveCursorTarget:       104,
+			handoffAtSeq:           104,
+		}
+
+		backend := &multiLedgerBackend{ledgers: map[uint32]xdr.LedgerCloseMeta{
+			100: dummyLedgerMeta(100), 101: dummyLedgerMeta(101), 102: dummyLedgerMeta(102),
+			103: dummyLedgerMeta(103), 104: dummyLedgerMeta(104),
+		}}
+
+		svc, err := NewProtocolMigrateHistoryService(ProtocolMigrateHistoryConfig{
+			DB: dbPool, LedgerBackend: backend,
+			ProtocolsModel: protocolsModel, ProtocolContractsModel: protocolContractsModel,
+			IngestStore: ingestStore, NetworkPassphrase: "Test SDF Network ; September 2015",
+			Processors: []ProtocolProcessor{processor}, WindowSize: 10,
+		})
+		require.NoError(t, err)
+		require.NoError(t, svc.Run(ctx, []string{"testproto"}))
+
+		// The crossing at 103 must have flushed [100,102] as its own window: the
+		// engine's committed cursor reached 102 there, and the window's persist ran
+		// (sentinel at the window end). Without the flush-at-crossing, 100-104 would
+		// have folded as one window whose CAS fails at the handoff — no sentinel at
+		// all — and 103-104 would have used the stale membership below.
+		val, ok := getHistorySentinel(t, ctx, dbPool, "testproto", 102)
+		require.True(t, ok, "the crossing at 103 should have flushed the open window [100,102]")
+		assert.Equal(t, uint32(102), val)
+		assert.Equal(t, []uint32{102}, processor.persistedHistorySeqs)
+
+		// Ledgers up to the crossing folded without X; the new window's refresh must
+		// deliver X to every ledger after it — the engine saw the classification that
+		// committed mid-window.
+		membershipByLedger := map[uint32][]data.ProtocolContracts{}
+		for _, in := range processor.processedInputs {
+			membershipByLedger[in.LedgerSequence] = in.ProtocolContracts
+		}
+		for _, seq := range []uint32{100, 101, 102} {
+			assert.Empty(t, membershipByLedger[seq], "ledger %d folded before X was classified", seq)
+		}
+		for _, seq := range []uint32{103, 104} {
+			require.Len(t, membershipByLedger[seq], 1, "ledger %d must fold with the refreshed membership", seq)
+			assert.Equal(t, contractX.ContractID, membershipByLedger[seq][0].ContractID)
+		}
+
+		// Handoff: live took 104's cursor mid-fold, so the [103,104] window's CAS
+		// failed and its persist was discarded.
+		_, ok = getHistorySentinel(t, ctx, dbPool, "testproto", 104)
+		assert.False(t, ok, "the handed-off window must not persist")
+		assert.Equal(t, uint32(104), getIngestStoreValue(t, ctx, dbPool, "protocol_testproto_history_cursor"))
 	})
 }

--- a/internal/services/protocol_migrate_test.go
+++ b/internal/services/protocol_migrate_test.go
@@ -110,22 +110,6 @@ func (b *transientErrorBackend) GetLedger(ctx context.Context, sequence uint32) 
 	return b.multiLedgerBackend.GetLedger(ctx, sequence)
 }
 
-// tipUnavailableBackend wraps multiLedgerBackend and fails GetLatestLedgerSequence a
-// configurable number of times (set latestLedgerFailsLeft to a large value to always fail).
-// With the tip read failing, flushWindowsAtTip leaves cachedTip stale (0), so it flushes on
-// every iteration — exercising the degradation to per-ledger commits (effective window 1).
-type tipUnavailableBackend struct {
-	multiLedgerBackend
-	latestLedgerFailsLeft atomic.Int32
-}
-
-func (b *tipUnavailableBackend) GetLatestLedgerSequence(ctx context.Context) (uint32, error) {
-	if b.latestLedgerFailsLeft.Add(-1) >= 0 {
-		return 0, fmt.Errorf("transient RPC error: latest ledger unavailable")
-	}
-	return b.multiLedgerBackend.GetLatestLedgerSequence(ctx)
-}
-
 func dummyLedgerMeta(seq uint32) xdr.LedgerCloseMeta {
 	return xdr.LedgerCloseMeta{
 		V: 0,
@@ -1632,13 +1616,14 @@ func TestProtocolMigrateEngine_HeterogeneousCursorResume(t *testing.T) {
 	})
 }
 
-func TestProtocolMigrateEngine_TipUnavailable(t *testing.T) {
-	t.Run("GetLatestLedgerSequence error degrades to per-ledger commits (K=1)", func(t *testing.T) {
+func TestProtocolMigrateEngine_FrontierGate(t *testing.T) {
+	t.Run("gate flushes the open window, waits, and resumes when live's cursor advances", func(t *testing.T) {
 		ctx := context.Background()
 		dbPool, ingestStore := setupTestDB(t)
 
 		setIngestStoreValue(t, ctx, dbPool, "oldest_ingest_ledger", 100)
-		setIngestStoreValue(t, ctx, dbPool, "latest_ingest_ledger", 102)
+		// Live has committed through 101: the engine may fold 100-101 but must gate at 102.
+		setIngestStoreValue(t, ctx, dbPool, "latest_ingest_ledger", 101)
 
 		_, err := dbPool.Exec(ctx, `INSERT INTO protocols (id, classification_status) VALUES ('testproto', 'success') ON CONFLICT (id) DO UPDATE SET classification_status = 'success'`)
 		require.NoError(t, err)
@@ -1652,20 +1637,18 @@ func TestProtocolMigrateEngine_TipUnavailable(t *testing.T) {
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusSuccess).Return(nil)
 		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
 
-		// Hand off at 102 so the loop terminates; WindowSize=10 would coalesce all three
-		// ledgers if the tip were readable.
+		// Hand off at 103 (the fold hook bumps the cursor to 203, simulating live
+		// winning that ledger) so the run terminates after the gate releases.
 		processor := &testCursorAdvancingProcessor{
 			testRecordingProcessor: testRecordingProcessor{id: "testproto", ingestStore: ingestStore},
 			dbPool:                 dbPool,
-			advanceAtSeq:           102,
+			advanceAtSeq:           103,
 			cursorNameFunc:         utils.ProtocolHistoryCursorName,
 		}
 
-		// Tip read always fails -> cachedTip stays 0 -> flushWindowsAtTip flushes every iteration.
-		backend := &tipUnavailableBackend{multiLedgerBackend: multiLedgerBackend{ledgers: map[uint32]xdr.LedgerCloseMeta{
-			100: dummyLedgerMeta(100), 101: dummyLedgerMeta(101), 102: dummyLedgerMeta(102),
-		}}}
-		backend.latestLedgerFailsLeft.Store(1 << 30)
+		backend := &multiLedgerBackend{ledgers: map[uint32]xdr.LedgerCloseMeta{
+			100: dummyLedgerMeta(100), 101: dummyLedgerMeta(101), 102: dummyLedgerMeta(102), 103: dummyLedgerMeta(103),
+		}}
 
 		svc, err := NewProtocolMigrateHistoryService(ProtocolMigrateHistoryConfig{
 			DB: dbPool, LedgerBackend: backend,
@@ -1674,19 +1657,92 @@ func TestProtocolMigrateEngine_TipUnavailable(t *testing.T) {
 			Processors: []ProtocolProcessor{processor}, WindowSize: 10,
 		})
 		require.NoError(t, err)
-		require.NoError(t, svc.Run(ctx, []string{"testproto"}))
 
-		// Despite WindowSize=10, each ledger commits individually because the unreadable tip
-		// forces a flush every iteration. Per-ledger sentinels at 100 AND 101 prove K=1
-		// (with a working tip they would coalesce into one window and neither would exist).
-		for _, seq := range []uint32{100, 101} {
-			val, ok := getHistorySentinel(t, ctx, dbPool, "testproto", seq)
-			require.True(t, ok, "per-ledger sentinel for %d should exist (K=1 degradation)", seq)
-			assert.Equal(t, seq, val)
+		done := make(chan error, 1)
+		go func() { done <- svc.Run(ctx, []string{"testproto"}) }()
+
+		// The engine coalesces 100-101 into one open window (WindowSize 10), then gates
+		// at 102. The gate must flush that window before waiting: the sentinel for the
+		// window end (101) appearing while live's cursor still sits at 101 proves the
+		// flush-before-wait ordering.
+		require.Eventually(t, func() bool {
+			_, ok := getHistorySentinel(t, ctx, dbPool, "testproto", 101)
+			return ok
+		}, 10*time.Second, 50*time.Millisecond, "gate should flush the open window before waiting")
+		_, ok := getHistorySentinel(t, ctx, dbPool, "testproto", 100)
+		assert.False(t, ok, "100 should have no per-ledger sentinel: it coalesced into the window flushed at 101")
+		assert.Equal(t, uint32(101), getIngestStoreValue(t, ctx, dbPool, "protocol_testproto_history_cursor"),
+			"the gate's flush should commit the cursor to the window end before waiting")
+
+		// Live advances past 103; the gate must release and the engine resume folding.
+		setIngestStoreValue(t, ctx, dbPool, "latest_ingest_ledger", 103)
+
+		select {
+		case runErr := <-done:
+			require.NoError(t, runErr)
+		case <-time.After(30 * time.Second):
+			t.Fatal("engine did not resume after live's cursor advanced past the gate")
 		}
-		_, ok := getHistorySentinel(t, ctx, dbPool, "testproto", 102)
+
+		// After resuming it folded 102-103; the fold hook at 103 moved the cursor to 203,
+		// so the [102,103] window's CAS failed -> handoff, window discarded.
+		_, ok = getHistorySentinel(t, ctx, dbPool, "testproto", 102)
 		assert.False(t, ok, "sentinel for 102 should NOT exist (CAS failed -> handoff)")
-		assert.Equal(t, []uint32{100, 101}, processor.persistedHistorySeqs)
-		assert.Equal(t, uint32(202), getIngestStoreValue(t, ctx, dbPool, "protocol_testproto_history_cursor"))
+		assert.Equal(t, []uint32{101}, processor.persistedHistorySeqs)
+		assert.Equal(t, uint32(203), getIngestStoreValue(t, ctx, dbPool, "protocol_testproto_history_cursor"))
+	})
+
+	t.Run("context cancellation while gated returns cleanly", func(t *testing.T) {
+		ctx := context.Background()
+		dbPool, ingestStore := setupTestDB(t)
+
+		setIngestStoreValue(t, ctx, dbPool, "oldest_ingest_ledger", 100)
+		setIngestStoreValue(t, ctx, dbPool, "latest_ingest_ledger", 101)
+
+		_, err := dbPool.Exec(ctx, `INSERT INTO protocols (id, classification_status) VALUES ('testproto', 'success') ON CONFLICT (id) DO UPDATE SET classification_status = 'success'`)
+		require.NoError(t, err)
+
+		protocolsModel := data.NewProtocolsModelMock(t)
+		protocolContractsModel := data.NewProtocolContractsModelMock(t)
+		protocolsModel.On("GetByIDs", mock.Anything, []string{"testproto"}).Return([]data.Protocols{
+			{ID: "testproto", ClassificationStatus: data.StatusSuccess, HistoryMigrationStatus: data.StatusNotStarted},
+		}, nil)
+		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusInProgress).Return(nil)
+		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusFailed).Return(nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
+
+		processor := &testRecordingProcessor{id: "testproto", ingestStore: ingestStore}
+		backend := &multiLedgerBackend{ledgers: map[uint32]xdr.LedgerCloseMeta{
+			100: dummyLedgerMeta(100), 101: dummyLedgerMeta(101),
+		}}
+
+		svc, err := NewProtocolMigrateHistoryService(ProtocolMigrateHistoryConfig{
+			DB: dbPool, LedgerBackend: backend,
+			ProtocolsModel: protocolsModel, ProtocolContractsModel: protocolContractsModel,
+			IngestStore: ingestStore, NetworkPassphrase: "Test SDF Network ; September 2015",
+			Processors: []ProtocolProcessor{processor}, WindowSize: 10,
+		})
+		require.NoError(t, err)
+
+		runCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		done := make(chan error, 1)
+		go func() { done <- svc.Run(runCtx, []string{"testproto"}) }()
+
+		// Wait until the engine is gated at 102 (its window flush at the gate is the signal),
+		// then cancel and require a prompt, descriptive error.
+		require.Eventually(t, func() bool {
+			_, ok := getHistorySentinel(t, ctx, dbPool, "testproto", 101)
+			return ok
+		}, 10*time.Second, 50*time.Millisecond, "engine should reach the gate and flush before waiting")
+		cancel()
+
+		select {
+		case runErr := <-done:
+			require.Error(t, runErr)
+			assert.ErrorContains(t, runErr, "gated on live ingestion's frontier at ledger 102")
+		case <-time.After(30 * time.Second):
+			t.Fatal("engine did not return after cancellation while gated")
+		}
 	})
 }

--- a/internal/services/protocol_migrate_test.go
+++ b/internal/services/protocol_migrate_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1237,8 +1238,10 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"cdproto", "noproto"}, data.StatusInProgress).Return(nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"cdproto", "noproto"}, data.StatusSuccess).Return(nil)
 
-		contractA := data.ProtocolContracts{ContractID: types.HashBytea("contract-a")}
-		contractB := data.ProtocolContracts{ContractID: types.HashBytea("contract-b")}
+		// Realistic 32-byte hex IDs (the BYTEA scan form): the footprint gate
+		// hex-decodes tracked contract IDs and fails the run on malformed ones.
+		contractA := data.ProtocolContracts{ContractID: types.HashBytea(strings.Repeat("aa", 32))}
+		contractB := data.ProtocolContracts{ContractID: types.HashBytea(strings.Repeat("bb", 32))}
 		// The requiring tracker's membership is re-read after every committed
 		// window (WindowSize defaults to 1, so after every ledger): the run-start
 		// snapshot returns only A, every refresh returns A+B — simulating live

--- a/internal/services/protocol_migrate_test.go
+++ b/internal/services/protocol_migrate_test.go
@@ -627,6 +627,7 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		protocolContractsModel.On("GetByProtocolID", mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
 
 		processorMock.On("ProtocolID").Return("testproto")
+		processorMock.On("RequiresContractData").Return(false)
 		processorMock.On("ProcessLedger", mock.Anything, mock.Anything).Return(fmt.Errorf("simulated ProcessLedger error"))
 
 		backend := &multiLedgerBackend{
@@ -671,6 +672,7 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		protocolContractsModel.On("GetByProtocolID", mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
 
 		processorMock.On("ProtocolID").Return("testproto")
+		processorMock.On("RequiresContractData").Return(false)
 		processorMock.On("ProcessLedger", mock.Anything, mock.Anything).Return(nil)
 		processorMock.On("PersistHistory", mock.Anything, mock.Anything).Return(fmt.Errorf("simulated PersistHistory error"))
 
@@ -1128,6 +1130,130 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		cursorVal := getIngestStoreValue(t, ctx, dbPool, "protocol_testproto_history_cursor")
 		assert.Equal(t, uint32(201), cursorVal)
 		assert.Equal(t, []uint32{100}, processor.persistedHistorySeqs)
+	})
+
+	t.Run("ContractDataChanges populated when a selected processor requires it", func(t *testing.T) {
+		ctx := context.Background()
+		dbPool, ingestStore := setupTestDB(t)
+
+		setIngestStoreValue(t, ctx, dbPool, "oldest_ingest_ledger", 100)
+		setIngestStoreValue(t, ctx, dbPool, "latest_ingest_ledger", 101)
+
+		_, err := dbPool.Exec(ctx, `INSERT INTO protocols (id, classification_status) VALUES ('cdproto', 'success') ON CONFLICT (id) DO UPDATE SET classification_status = 'success'`)
+		require.NoError(t, err)
+		_, err = dbPool.Exec(ctx, `INSERT INTO protocols (id, classification_status) VALUES ('noproto', 'success') ON CONFLICT (id) DO UPDATE SET classification_status = 'success'`)
+		require.NoError(t, err)
+
+		protocolsModel := data.NewProtocolsModelMock(t)
+		protocolContractsModel := data.NewProtocolContractsModelMock(t)
+		// cdProc requires ContractData; noProc does not. Both use testCursorAdvancingProcessor
+		// to trigger CAS handoff on the last ledger, allowing the unbounded loop to terminate.
+		cdProc := &testCursorAdvancingProcessor{
+			testRecordingProcessor: testRecordingProcessor{id: "cdproto", ingestStore: ingestStore, requiresContractData: true},
+			dbPool:                 dbPool,
+			advanceAtSeq:           101,
+			cursorNameFunc:         utils.ProtocolHistoryCursorName,
+		}
+		noProc := &testCursorAdvancingProcessor{
+			testRecordingProcessor: testRecordingProcessor{id: "noproto", ingestStore: ingestStore, requiresContractData: false},
+			dbPool:                 dbPool,
+			advanceAtSeq:           101,
+			cursorNameFunc:         utils.ProtocolHistoryCursorName,
+		}
+
+		protocolsModel.On("GetByIDs", mock.Anything, []string{"cdproto", "noproto"}).Return([]data.Protocols{
+			{ID: "cdproto", ClassificationStatus: data.StatusSuccess, HistoryMigrationStatus: data.StatusNotStarted},
+			{ID: "noproto", ClassificationStatus: data.StatusSuccess, HistoryMigrationStatus: data.StatusNotStarted},
+		}, nil)
+		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"cdproto", "noproto"}, data.StatusInProgress).Return(nil)
+		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"cdproto", "noproto"}, data.StatusSuccess).Return(nil)
+
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, "cdproto").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, "noproto").Return([]data.ProtocolContracts{}, nil)
+
+		backend := &multiLedgerBackend{
+			ledgers: map[uint32]xdr.LedgerCloseMeta{
+				100: dummyLedgerMeta(100),
+				101: dummyLedgerMeta(101),
+			},
+		}
+
+		svc, err := NewProtocolMigrateHistoryService(ProtocolMigrateHistoryConfig{
+			DB: dbPool, LedgerBackend: backend,
+			ProtocolsModel: protocolsModel, ProtocolContractsModel: protocolContractsModel,
+			IngestStore: ingestStore, NetworkPassphrase: "Test SDF Network ; September 2015",
+			Processors: []ProtocolProcessor{cdProc, noProc},
+		})
+		require.NoError(t, err)
+
+		err = svc.Run(ctx, []string{"cdproto", "noproto"})
+		require.NoError(t, err)
+
+		// The requiring processor sees a non-nil (extraction ran) map on every ledger it folded.
+		require.Len(t, cdProc.processedInputs, 2)
+		for _, input := range cdProc.processedInputs {
+			assert.NotNil(t, input.ContractDataChanges, "ledger %d: requiring processor must see non-nil ContractDataChanges", input.LedgerSequence)
+		}
+
+		// The map is computed once per ledger and shared across trackers, so the
+		// non-requiring processor also receives it (and is expected to ignore it).
+		require.Len(t, noProc.processedInputs, 2)
+		for _, input := range noProc.processedInputs {
+			assert.NotNil(t, input.ContractDataChanges, "ledger %d: shared map must also reach the non-requiring processor", input.LedgerSequence)
+		}
+	})
+
+	t.Run("ContractDataChanges left nil when no selected processor requires it", func(t *testing.T) {
+		ctx := context.Background()
+		dbPool, ingestStore := setupTestDB(t)
+
+		setIngestStoreValue(t, ctx, dbPool, "oldest_ingest_ledger", 100)
+		setIngestStoreValue(t, ctx, dbPool, "latest_ingest_ledger", 101)
+
+		_, err := dbPool.Exec(ctx, `INSERT INTO protocols (id, classification_status) VALUES ('noproto2', 'success') ON CONFLICT (id) DO UPDATE SET classification_status = 'success'`)
+		require.NoError(t, err)
+
+		protocolsModel := data.NewProtocolsModelMock(t)
+		protocolContractsModel := data.NewProtocolContractsModelMock(t)
+		noProc := &testCursorAdvancingProcessor{
+			testRecordingProcessor: testRecordingProcessor{id: "noproto2", ingestStore: ingestStore, requiresContractData: false},
+			dbPool:                 dbPool,
+			advanceAtSeq:           101,
+			cursorNameFunc:         utils.ProtocolHistoryCursorName,
+		}
+
+		protocolsModel.On("GetByIDs", mock.Anything, []string{"noproto2"}).Return([]data.Protocols{
+			{ID: "noproto2", ClassificationStatus: data.StatusSuccess, HistoryMigrationStatus: data.StatusNotStarted},
+		}, nil)
+		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"noproto2"}, data.StatusInProgress).Return(nil)
+		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"noproto2"}, data.StatusSuccess).Return(nil)
+
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, "noproto2").Return([]data.ProtocolContracts{}, nil)
+
+		backend := &multiLedgerBackend{
+			ledgers: map[uint32]xdr.LedgerCloseMeta{
+				100: dummyLedgerMeta(100),
+				101: dummyLedgerMeta(101),
+			},
+		}
+
+		svc, err := NewProtocolMigrateHistoryService(ProtocolMigrateHistoryConfig{
+			DB: dbPool, LedgerBackend: backend,
+			ProtocolsModel: protocolsModel, ProtocolContractsModel: protocolContractsModel,
+			IngestStore: ingestStore, NetworkPassphrase: "Test SDF Network ; September 2015",
+			Processors: []ProtocolProcessor{noProc},
+		})
+		require.NoError(t, err)
+
+		err = svc.Run(ctx, []string{"noproto2"})
+		require.NoError(t, err)
+
+		// No selected processor requires ContractData, so extraction never ran — the
+		// field must stay nil for every recorded input.
+		require.Len(t, noProc.processedInputs, 2)
+		for _, input := range noProc.processedInputs {
+			assert.Nil(t, input.ContractDataChanges, "ledger %d: extraction must be skipped", input.LedgerSequence)
+		}
 	})
 }
 

--- a/internal/services/protocol_migrate_test.go
+++ b/internal/services/protocol_migrate_test.go
@@ -1204,7 +1204,7 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		}
 	})
 
-	t.Run("ProtocolContracts membership refreshed per flushed window for requiring processors", func(t *testing.T) {
+	t.Run("ProtocolContracts membership refreshed at window start for requiring processors", func(t *testing.T) {
 		ctx := context.Background()
 		dbPool, ingestStore := setupTestDB(t)
 
@@ -1242,11 +1242,13 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		// hex-decodes tracked contract IDs and fails the run on malformed ones.
 		contractA := data.ProtocolContracts{ContractID: types.HashBytea(strings.Repeat("aa", 32))}
 		contractB := data.ProtocolContracts{ContractID: types.HashBytea(strings.Repeat("bb", 32))}
-		// The requiring tracker's membership is re-read after every committed
-		// window (WindowSize defaults to 1, so after every ledger): the run-start
-		// snapshot returns only A, every refresh returns A+B — simulating live
-		// ingestion classifying B while the migration is in flight. The
-		// event-only tracker keeps the run-start snapshot: exactly one load.
+		// The requiring tracker's membership is re-read at the start of every
+		// window, after the window's first ledger has been fetched (WindowSize
+		// defaults to 1, so before every ledger's fold): the run-start snapshot
+		// returns only A, every window-start refresh returns A+B — simulating
+		// live ingestion classifying B between the snapshot and the first
+		// window. The event-only tracker keeps the run-start snapshot: exactly
+		// one load.
 		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "cdproto").Return([]data.ProtocolContracts{contractA}, nil).Once()
 		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "cdproto").Return([]data.ProtocolContracts{contractA, contractB}, nil)
 		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "noproto").Return([]data.ProtocolContracts{contractA}, nil).Once()
@@ -1270,12 +1272,16 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		err = svc.Run(ctx, []string{"cdproto", "noproto"})
 		require.NoError(t, err)
 
-		// Requiring processor: ledger 100 folded with the run-start snapshot,
-		// ledgers 101-102 with the refreshed membership including contract B.
+		// Requiring processor: every ledger — including the first — folds with
+		// the refreshed membership, because the refresh runs at window start,
+		// BEFORE the window's first fold, not after the previous window's
+		// commit. A post-commit refresh would fold ledger 100 with the stale
+		// run-start snapshot (one contract), so these assertions pin the
+		// ordering that closes the frontier race with live's classification
+		// commit.
 		require.Len(t, cdProc.processedInputs, 3)
-		assert.Len(t, cdProc.processedInputs[0].ProtocolContracts, 1, "ledger 100 folds with the run-start snapshot")
-		for _, input := range cdProc.processedInputs[1:] {
-			assert.Len(t, input.ProtocolContracts, 2, "ledger %d: refreshed membership must include the newly classified contract", input.LedgerSequence)
+		for _, input := range cdProc.processedInputs {
+			assert.Len(t, input.ProtocolContracts, 2, "ledger %d: window-start membership must include the newly classified contract", input.LedgerSequence)
 		}
 
 		// Event-only processor: the run-start snapshot is never refreshed (its

--- a/internal/services/protocol_migrate_test.go
+++ b/internal/services/protocol_migrate_test.go
@@ -305,7 +305,7 @@ func TestProtocolMigrateEngine(t *testing.T) {
 			{ID: "testproto", ClassificationStatus: data.StatusSuccess, HistoryMigrationStatus: data.StatusNotStarted},
 		}, nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusInProgress).Return(nil)
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusSuccess).Return(nil)
 
 		backend := &multiLedgerBackend{
@@ -378,7 +378,7 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusInProgress).Return(nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusSuccess).Return(nil)
 
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil).Maybe()
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil).Maybe()
 
 		backend := &multiLedgerBackend{
 			ledgers: map[uint32]xdr.LedgerCloseMeta{
@@ -503,7 +503,7 @@ func TestProtocolMigrateEngine(t *testing.T) {
 			{ID: "testproto", ClassificationStatus: data.StatusSuccess, HistoryMigrationStatus: data.StatusNotStarted},
 		}, nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusInProgress).Return(nil)
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusSuccess).Return(nil)
 
 		backend := &multiLedgerBackend{
@@ -565,7 +565,7 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusInProgress).Return(nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusSuccess).Return(nil)
 
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
 
 		backend := &multiLedgerBackend{
 			ledgers: map[uint32]xdr.LedgerCloseMeta{
@@ -624,7 +624,7 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusInProgress).Return(nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusFailed).Return(nil)
 
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
 
 		processorMock.On("ProtocolID").Return("testproto")
 		processorMock.On("RequiresContractData").Return(false)
@@ -669,7 +669,7 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusInProgress).Return(nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusFailed).Return(nil)
 
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
 
 		processorMock.On("ProtocolID").Return("testproto")
 		processorMock.On("RequiresContractData").Return(false)
@@ -722,7 +722,7 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		// causes the run to fail, so the engine marks it as failed.
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusFailed).Return(nil)
 
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
 
 		backend := &multiLedgerBackend{ledgers: map[uint32]xdr.LedgerCloseMeta{}}
 
@@ -783,8 +783,8 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"proto1", "proto2"}, data.StatusInProgress).Return(nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"proto1", "proto2"}, data.StatusSuccess).Return(nil)
 
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "proto1").Return([]data.ProtocolContracts{}, nil)
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "proto2").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "proto1").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "proto2").Return([]data.ProtocolContracts{}, nil)
 
 		backend := &multiLedgerBackend{
 			ledgers: map[uint32]xdr.LedgerCloseMeta{
@@ -860,8 +860,8 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"proto1", "proto2"}, data.StatusInProgress).Return(nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"proto1", "proto2"}, data.StatusSuccess).Return(nil)
 
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "proto1").Return([]data.ProtocolContracts{}, nil)
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "proto2").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "proto1").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "proto2").Return([]data.ProtocolContracts{}, nil)
 
 		backend := &multiLedgerBackend{
 			ledgers: map[uint32]xdr.LedgerCloseMeta{
@@ -940,8 +940,8 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"proto1", "proto2"}, data.StatusInProgress).Return(nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"proto1", "proto2"}, data.StatusSuccess).Return(nil)
 
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "proto1").Return([]data.ProtocolContracts{}, nil)
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "proto2").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "proto1").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "proto2").Return([]data.ProtocolContracts{}, nil)
 
 		backend := &multiLedgerBackend{
 			ledgers: map[uint32]xdr.LedgerCloseMeta{
@@ -1021,8 +1021,8 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		// proto2 should be marked failed (ProcessLedger error)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"proto2"}, data.StatusFailed).Return(nil)
 
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "proto1").Return([]data.ProtocolContracts{}, nil)
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "proto2").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "proto1").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "proto2").Return([]data.ProtocolContracts{}, nil)
 
 		backend := &multiLedgerBackend{
 			ledgers: map[uint32]xdr.LedgerCloseMeta{
@@ -1100,7 +1100,7 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		}, nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusInProgress).Return(nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusSuccess).Return(nil)
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
 
 		backend := &transientErrorBackend{
 			multiLedgerBackend: multiLedgerBackend{
@@ -1168,8 +1168,8 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"cdproto", "noproto"}, data.StatusInProgress).Return(nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"cdproto", "noproto"}, data.StatusSuccess).Return(nil)
 
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "cdproto").Return([]data.ProtocolContracts{}, nil)
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "noproto").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "cdproto").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "noproto").Return([]data.ProtocolContracts{}, nil)
 
 		backend := &multiLedgerBackend{
 			ledgers: map[uint32]xdr.LedgerCloseMeta{
@@ -1228,7 +1228,7 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"noproto2"}, data.StatusInProgress).Return(nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"noproto2"}, data.StatusSuccess).Return(nil)
 
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "noproto2").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "noproto2").Return([]data.ProtocolContracts{}, nil)
 
 		backend := &multiLedgerBackend{
 			ledgers: map[uint32]xdr.LedgerCloseMeta{
@@ -1275,7 +1275,7 @@ func TestProtocolMigrateEngine_WindowedCoalescing(t *testing.T) {
 		}, nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusInProgress).Return(nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusSuccess).Return(nil)
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
 
 		// Advancing the cursor at 105 makes the second window's CAS fail -> handoff -> loop ends.
 		processor := &testCursorAdvancingProcessor{
@@ -1334,7 +1334,7 @@ func TestProtocolMigrateEngine_WindowedCoalescing(t *testing.T) {
 		}, nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusInProgress).Return(nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusSuccess).Return(nil)
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
 
 		processor := &testCursorAdvancingProcessor{
 			testRecordingProcessor: testRecordingProcessor{id: "testproto", ingestStore: ingestStore},
@@ -1379,7 +1379,7 @@ func TestProtocolMigrateEngine_WindowedCoalescing(t *testing.T) {
 		// GetLedger(102) blocks (102 never closes) -> ctx timeout -> run fails. No handoff
 		// happened (the partial window's CAS succeeded), so the active protocol is marked failed.
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusFailed).Return(nil)
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
 
 		// Plain recording processor (no cursor advance): the partial window's CAS succeeds,
 		// so we observe a committed partial flush rather than a handoff.
@@ -1432,7 +1432,7 @@ func TestProtocolMigrateEngine_WindowedCoalescing(t *testing.T) {
 		}, nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusInProgress).Return(nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusSuccess).Return(nil)
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
 
 		// Hands off only on the 4th window (at 111); the first three windows commit cleanly.
 		processor := &testCursorAdvancingProcessor{
@@ -1499,8 +1499,8 @@ func TestProtocolMigrateEngine_HeterogeneousCursorResume(t *testing.T) {
 		}, nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"proto1", "proto2"}, data.StatusInProgress).Return(nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"proto1", "proto2"}, data.StatusSuccess).Return(nil)
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "proto1").Return([]data.ProtocolContracts{}, nil)
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "proto2").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "proto1").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "proto2").Return([]data.ProtocolContracts{}, nil)
 
 		// Both processors advance at 104 (last available ledger) so both hand off,
 		// terminating the loop via tip-shrink+handoff (WindowSize=10 never fills).
@@ -1561,7 +1561,7 @@ func TestProtocolMigrateEngine_TipUnavailable(t *testing.T) {
 		}, nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusInProgress).Return(nil)
 		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"testproto"}, data.StatusSuccess).Return(nil)
-		protocolContractsModel.On("GetByProtocolID", mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "testproto").Return([]data.ProtocolContracts{}, nil)
 
 		// Hand off at 102 so the loop terminates; WindowSize=10 would coalesce all three
 		// ledgers if the tip were readable.

--- a/internal/services/protocol_migrate_test.go
+++ b/internal/services/protocol_migrate_test.go
@@ -1203,6 +1203,86 @@ func TestProtocolMigrateEngine(t *testing.T) {
 		}
 	})
 
+	t.Run("ProtocolContracts membership refreshed per flushed window for requiring processors", func(t *testing.T) {
+		ctx := context.Background()
+		dbPool, ingestStore := setupTestDB(t)
+
+		setIngestStoreValue(t, ctx, dbPool, "oldest_ingest_ledger", 100)
+		setIngestStoreValue(t, ctx, dbPool, "latest_ingest_ledger", 102)
+
+		_, err := dbPool.Exec(ctx, `INSERT INTO protocols (id, classification_status) VALUES ('cdproto', 'success') ON CONFLICT (id) DO UPDATE SET classification_status = 'success'`)
+		require.NoError(t, err)
+		_, err = dbPool.Exec(ctx, `INSERT INTO protocols (id, classification_status) VALUES ('noproto', 'success') ON CONFLICT (id) DO UPDATE SET classification_status = 'success'`)
+		require.NoError(t, err)
+
+		protocolsModel := data.NewProtocolsModelMock(t)
+		protocolContractsModel := data.NewProtocolContractsModelMock(t)
+		cdProc := &testCursorAdvancingProcessor{
+			testRecordingProcessor: testRecordingProcessor{id: "cdproto", ingestStore: ingestStore, requiresContractData: true},
+			dbPool:                 dbPool,
+			advanceAtSeq:           102,
+			cursorNameFunc:         utils.ProtocolHistoryCursorName,
+		}
+		noProc := &testCursorAdvancingProcessor{
+			testRecordingProcessor: testRecordingProcessor{id: "noproto", ingestStore: ingestStore, requiresContractData: false},
+			dbPool:                 dbPool,
+			advanceAtSeq:           102,
+			cursorNameFunc:         utils.ProtocolHistoryCursorName,
+		}
+
+		protocolsModel.On("GetByIDs", mock.Anything, []string{"cdproto", "noproto"}).Return([]data.Protocols{
+			{ID: "cdproto", ClassificationStatus: data.StatusSuccess, HistoryMigrationStatus: data.StatusNotStarted},
+			{ID: "noproto", ClassificationStatus: data.StatusSuccess, HistoryMigrationStatus: data.StatusNotStarted},
+		}, nil)
+		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"cdproto", "noproto"}, data.StatusInProgress).Return(nil)
+		protocolsModel.On("UpdateHistoryMigrationStatus", mock.Anything, mock.Anything, []string{"cdproto", "noproto"}, data.StatusSuccess).Return(nil)
+
+		contractA := data.ProtocolContracts{ContractID: types.HashBytea("contract-a")}
+		contractB := data.ProtocolContracts{ContractID: types.HashBytea("contract-b")}
+		// The requiring tracker's membership is re-read after every committed
+		// window (WindowSize defaults to 1, so after every ledger): the run-start
+		// snapshot returns only A, every refresh returns A+B — simulating live
+		// ingestion classifying B while the migration is in flight. The
+		// event-only tracker keeps the run-start snapshot: exactly one load.
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "cdproto").Return([]data.ProtocolContracts{contractA}, nil).Once()
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "cdproto").Return([]data.ProtocolContracts{contractA, contractB}, nil)
+		protocolContractsModel.On("GetByProtocolID", mock.Anything, mock.Anything, "noproto").Return([]data.ProtocolContracts{contractA}, nil).Once()
+
+		backend := &multiLedgerBackend{
+			ledgers: map[uint32]xdr.LedgerCloseMeta{
+				100: dummyLedgerMeta(100),
+				101: dummyLedgerMeta(101),
+				102: dummyLedgerMeta(102),
+			},
+		}
+
+		svc, err := NewProtocolMigrateHistoryService(ProtocolMigrateHistoryConfig{
+			DB: dbPool, LedgerBackend: backend,
+			ProtocolsModel: protocolsModel, ProtocolContractsModel: protocolContractsModel,
+			IngestStore: ingestStore, NetworkPassphrase: "Test SDF Network ; September 2015",
+			Processors: []ProtocolProcessor{cdProc, noProc},
+		})
+		require.NoError(t, err)
+
+		err = svc.Run(ctx, []string{"cdproto", "noproto"})
+		require.NoError(t, err)
+
+		// Requiring processor: ledger 100 folded with the run-start snapshot,
+		// ledgers 101-102 with the refreshed membership including contract B.
+		require.Len(t, cdProc.processedInputs, 3)
+		assert.Len(t, cdProc.processedInputs[0].ProtocolContracts, 1, "ledger 100 folds with the run-start snapshot")
+		for _, input := range cdProc.processedInputs[1:] {
+			assert.Len(t, input.ProtocolContracts, 2, "ledger %d: refreshed membership must include the newly classified contract", input.LedgerSequence)
+		}
+
+		// Event-only processor: the run-start snapshot is never refreshed (its
+		// single .Once() mock expectation also fails the test on extra calls).
+		require.Len(t, noProc.processedInputs, 3)
+		for _, input := range noProc.processedInputs {
+			assert.Len(t, input.ProtocolContracts, 1, "ledger %d: event-only membership stays the snapshot", input.LedgerSequence)
+		}
+	})
+
 	t.Run("ContractDataChanges left nil when no selected processor requires it", func(t *testing.T) {
 		ctx := context.Background()
 		dbPool, ingestStore := setupTestDB(t)

--- a/internal/services/protocol_processor.go
+++ b/internal/services/protocol_processor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/stellar/go-stellar-sdk/ingest"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/wallet-backend/internal/data"
@@ -106,4 +107,10 @@ type ProtocolProcessorInput struct {
 	ProtocolContracts []data.ProtocolContracts
 	// StagingMode selects which staged sets the processor builds for this ledger.
 	StagingMode StagingMode
+	// ContractDataChanges groups this ledger's ContractData ledger-entry
+	// changes (successful transactions only) by owning contract C-address.
+	// Populated only when some selected processor's RequiresContractData()
+	// returns true; nil otherwise. Processors that do not require it must
+	// ignore it.
+	ContractDataChanges map[string][]ingest.Change
 }

--- a/internal/services/protocol_processor.go
+++ b/internal/services/protocol_processor.go
@@ -69,6 +69,13 @@ type ProtocolProcessor interface {
 	// migrated with --window-size=1.
 	ProcessLedger(ctx context.Context, input ProtocolProcessorInput) error
 
+	// RequiresContractData reports whether ProcessLedger needs
+	// ProtocolProcessorInput.ContractDataChanges populated. The migration
+	// engine and live ingestion run the (heavier) ContractData extraction
+	// only when a selected processor returns true, so event-only protocols
+	// pay nothing for it.
+	RequiresContractData() bool
+
 	// Reset clears the staged sets after a window commits or hands off. The caller
 	// (engine per window; live ingestion per ledger) invokes it.
 	Reset()

--- a/internal/services/sep41/processor.go
+++ b/internal/services/sep41/processor.go
@@ -95,6 +95,10 @@ func (p *processor) ProtocolID() string { return ProtocolID }
 // StateChangeOrdinalBase returns the SEP-41 state_change_id namespace base.
 func (p *processor) StateChangeOrdinalBase() int64 { return types.StateChangeOrdinalBaseSEP41 }
 
+// RequiresContractData reports false: SEP-41 folds contract events only and
+// never reads ProtocolProcessorInput.ContractDataChanges.
+func (p *processor) RequiresContractData() bool { return false }
+
 // ProcessLedger consumes contract events that the indexer (or
 // ExtractContractEventsForLedger in the migration path) has already
 // extracted into the buffer. The processor never touches LedgerCloseMeta —


### PR DESCRIPTION
### Framework: `ContractDataChanges` + capability gate

First of 5 stacked PRs adding Blend Capital v2 lending support.

**TL;DR:** Two things. (1) Protocol processors can now receive ContractData ledger-entry changes, extracted with a footprint gate instead of a reader. (2) The migrate engine now folds a ledger **only after live ingestion has committed it** — one ordering rule that makes every "the writer didn't see this ledger's classifications" bug impossible by construction. Fixes #680. The in-transaction repair path this PR previously carried is gone: with the gate, there is nothing left to repair.

#### ContractData plumbing

- `RequiresContractData() bool` on `ProtocolProcessor` and a `ContractDataChanges map[string][]ingest.Change` field on `ProtocolProcessorInput`. SEP-41 returns `false` — event-only protocols are unaffected.
- **Extractor** walks a ledger's successful transactions and groups every ContractData ledger-entry change by owning contract C-address, preserving tx application order (last-write-wins folding per entry key stays deterministic). Per-tx entry removals surface as `Post == nil`; ledger-level archival evictions are not surfaced. Contract-id encode errors fail fast instead of silently dropping changes. Synthesized transactions carry the reader-identical `Hash` (`TxProcessing[i].Result.TransactionHash`), since `GetChanges` attaches the transaction to every change it returns.
- **Footprint gate, no reader:** Soroban guarantees writes ⊆ the declared read-write footprint, so a skim of the already-decoded envelopes' footprints skips ledgers that touch no tracked contract outright (protocol-migrate previously paid ~7ms/ledger building a `LedgerTransactionReader` — SHA-256 of every envelope — on every ledger of the range); a hit extracts directly from transaction meta. A fixture corpus over real pubnet ledgers (169 grouped changes across 5 ledgers, one pre-CAP-46-11 classic-account-owned entry documented as skipped) pins meta-based output ≡ the reader-based reference on the change fields, and that every changed contract, tracked alone, triggers the gate.
- **Live ingestion** (§2.6) extracts lazily and memoized from the transactions the staging pass already materialized — at most once per ledger, only when a CAS-winning processor requires it; a protocol still backfilling costs nothing. `RequiresContractData()` processors receive the FULL committed protocol membership (`GetByProtocolID`), not just this ledger's event emitters: entries can change without events, and event decoding disambiguates against the full tracked set.

#### The frontier gate (replaces the repair)

The problem: live ingestion is the sole classifier — `protocol_contracts` rows commit inside live's per-ledger transaction, together with live's cursor. The engine snapshots membership from committed rows only. So any ledger the engine folded **before live committed it** could be missing contracts classified at that very ledger, and cursor-passed ledgers are never replayed. That's a permanent, silent gap (#680), and the CAS-race variant of it is what the previous revision's `repairClassificationGap` healed one ledger at a time.

The fix: the engine's fold loop now waits until `latest_ingest_ledger >= seq` before fetching ledger `seq`. Live's cursor advances in the same transaction as the ledger's classifications, so `cursor >= seq` is atomic proof that every classification discoverable at `seq` is committed and visible.

What that buys, all by construction:

- **Complete membership everywhere.** The gate closes every open window whenever `seq` crosses the last known frontier value — before it even reads the new one — so no window ever contains a ledger past the cursor value it opened under, which is exactly the bound the window-start membership refresh covers (`flushWindow` no-ops when nothing is pending, so this is free in bulk and the intended shrink-to-one cadence at the frontier). Membership refreshes per window for **every** tracker, event-only ones included: their processors filter events by membership too, so a run-start-only snapshot had the same silent-drop failure through a different door.
- **The repair is deleted, not fixed.** A live CAS loss now only ever means "the engine is behind and will fold this ledger later, seeing everything this transaction commits" or "restart replay of an already-committed ledger". The winner-folded-without-membership case cannot occur, so `repairClassificationGap`, its M1–M4 test scenarios, and `IngestStore.GetInTx` are gone (~490 lines). This also closes the previously documented mid-window residual gap — it required the engine running ahead of live.
- **Clean handoff.** The gate's flush commits each cursor to the last folded ledger before waiting, so live's `CAS(cursor → cursor+1)` matches the moment it reaches the frontier. The gate subsumes the old tip-flush (`flushWindowsAtTip`): the live cursor never exceeds the chain tip, so the frontier flush always fires first, and the engine's only `GetLatestLedgerSequence` call disappears.
- **Cost:** one cached comparison per ledger during bulk; a logged 1s poll only at the frontier. If live is down, the engine idles at live's cursor instead of folding ledgers whose classifications aren't committed — waiting is the correct behavior, folding ahead is exactly the #680 bug.

Also in this PR: the protocol-state metric's Help text no longer lists a `load_current_state` phase that nothing emits.

**Deviations register (reviewer sign-off):**
| # | Item |
|---|---|
| 10 | PR adds a method to a public interface — in-repo implementers enumerated and compile/vet-verified: sep41 `processor`, `ProtocolProcessorMock`, `testRecordingProcessor`, plus `testProtocolProcessor` (`ingest_test.go`, discovered via `go vet`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
