### PR TITLE
feat(db): Blend v2 schema — entity-category enums, blend_* tables, data models

### DIFF
--- a/internal/data/blend/auctions.go
+++ b/internal/data/blend/auctions.go
@@ -117,7 +117,7 @@ func (m *AuctionModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []Auct
 			bid                  = EXCLUDED.bid,
 			lot                  = EXCLUDED.lot,
 			start_block          = EXCLUDED.start_block,
-			last_modified_ledger = EXCLUDED.last_modified_ledger`
+			last_modified_ledger = GREATEST(blend_auctions.last_modified_ledger, EXCLUDED.last_modified_ledger)`
 	if _, err := dbTx.Exec(ctx, upsertQuery, pools, users, auctionTypes, bids, lots, startBlocks, ledgers); err != nil {
 		m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", auctionsTable, utils.GetDBErrorType(err)).Inc()
 		return fmt.Errorf("upserting blend auctions: %w", err)

--- a/internal/data/blend/auctions.go
+++ b/internal/data/blend/auctions.go
@@ -1,0 +1,172 @@
+// Active auction storage for Blend v2 (blend_auctions).
+package blend
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+	"github.com/stellar/wallet-backend/internal/utils"
+)
+
+// auctionsTable is the metrics label for blend_auctions queries.
+const auctionsTable = "blend_auctions"
+
+// AuctionKey identifies one active auction row.
+type AuctionKey struct {
+	Pool        types.AddressBytea
+	User        types.AddressBytea
+	AuctionType int32
+}
+
+// Auction mirrors one blend_auctions row. Bid and Lot map asset C-addresses to
+// decimal-string amounts (JSONB).
+type Auction struct {
+	Pool               types.AddressBytea
+	User               types.AddressBytea
+	AuctionType        int32
+	Bid                map[string]string
+	Lot                map[string]string
+	StartBlock         int32
+	LastModifiedLedger int32
+}
+
+// AuctionModelInterface exposes Blend v2 active-auction storage operations.
+type AuctionModelInterface interface {
+	// BatchUpsert full-row replaces each auction (partial fills rewrite bid/lot).
+	BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []Auction) error
+	// DeleteByKey removes exactly the given (pool, user, auction_type) rows.
+	DeleteByKey(ctx context.Context, dbTx pgx.Tx, keys []AuctionKey) error
+}
+
+// AuctionModel implements AuctionModelInterface against blend_auctions.
+type AuctionModel struct {
+	DB      *pgxpool.Pool
+	Metrics *metrics.DBMetrics
+}
+
+var _ AuctionModelInterface = (*AuctionModel)(nil)
+
+// marshalAuctionAmounts serializes a bid/lot asset-amount map for storage in a
+// JSONB column. A nil/empty map serializes as "{}" (not SQL NULL or JSON null)
+// so readers can always unmarshal the column into map[string]string without a
+// null check.
+func marshalAuctionAmounts(amounts map[string]string) (string, error) {
+	if len(amounts) == 0 {
+		return "{}", nil
+	}
+	b, err := json.Marshal(amounts)
+	if err != nil {
+		return "", fmt.Errorf("marshalling auction amounts: %w", err)
+	}
+	return string(b), nil
+}
+
+// BatchUpsert inserts or fully replaces blend_auctions rows. See
+// AuctionModelInterface.
+func (m *AuctionModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []Auction) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	pools := make([][]byte, len(rows))
+	users := make([][]byte, len(rows))
+	auctionTypes := make([]int32, len(rows))
+	bids := make([]string, len(rows))
+	lots := make([]string, len(rows))
+	startBlocks := make([]int32, len(rows))
+	ledgers := make([]int32, len(rows))
+	for i, r := range rows {
+		poolBytes, err := addressToBytes(string(r.Pool))
+		if err != nil {
+			return fmt.Errorf("converting pool address for auction upsert: %w", err)
+		}
+		userBytes, err := addressToBytes(string(r.User))
+		if err != nil {
+			return fmt.Errorf("converting user address for auction upsert: %w", err)
+		}
+		bidJSON, err := marshalAuctionAmounts(r.Bid)
+		if err != nil {
+			return fmt.Errorf("marshalling bid for auction upsert: %w", err)
+		}
+		lotJSON, err := marshalAuctionAmounts(r.Lot)
+		if err != nil {
+			return fmt.Errorf("marshalling lot for auction upsert: %w", err)
+		}
+		pools[i] = poolBytes
+		users[i] = userBytes
+		auctionTypes[i] = r.AuctionType
+		bids[i] = bidJSON
+		lots[i] = lotJSON
+		startBlocks[i] = r.StartBlock
+		ledgers[i] = r.LastModifiedLedger
+	}
+
+	const upsertQuery = `
+		INSERT INTO blend_auctions (pool_contract_id, user_account_id, auction_type, bid, lot, start_block, last_modified_ledger)
+		SELECT * FROM UNNEST($1::bytea[], $2::bytea[], $3::integer[], $4::text[]::jsonb[], $5::text[]::jsonb[], $6::integer[], $7::integer[])
+		ON CONFLICT (pool_contract_id, user_account_id, auction_type) DO UPDATE SET
+			bid                  = EXCLUDED.bid,
+			lot                  = EXCLUDED.lot,
+			start_block          = EXCLUDED.start_block,
+			last_modified_ledger = EXCLUDED.last_modified_ledger`
+	if _, err := dbTx.Exec(ctx, upsertQuery, pools, users, auctionTypes, bids, lots, startBlocks, ledgers); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", auctionsTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("upserting blend auctions: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", auctionsTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", auctionsTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("BatchUpsert", auctionsTable).Observe(float64(len(rows)))
+	return nil
+}
+
+// DeleteByKey removes exactly the given (pool, user, auction_type) rows from
+// blend_auctions (auction fill or cancellation).
+func (m *AuctionModel) DeleteByKey(ctx context.Context, dbTx pgx.Tx, keys []AuctionKey) error {
+	if len(keys) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	pools := make([][]byte, len(keys))
+	users := make([][]byte, len(keys))
+	auctionTypes := make([]int32, len(keys))
+	for i, k := range keys {
+		poolBytes, err := addressToBytes(string(k.Pool))
+		if err != nil {
+			return fmt.Errorf("converting pool address for auction delete: %w", err)
+		}
+		userBytes, err := addressToBytes(string(k.User))
+		if err != nil {
+			return fmt.Errorf("converting user address for auction delete: %w", err)
+		}
+		pools[i] = poolBytes
+		users[i] = userBytes
+		auctionTypes[i] = k.AuctionType
+	}
+
+	const deleteQuery = `
+		DELETE FROM blend_auctions
+		WHERE (pool_contract_id, user_account_id, auction_type) IN (SELECT * FROM UNNEST($1::bytea[], $2::bytea[], $3::integer[]))`
+	if _, err := dbTx.Exec(ctx, deleteQuery, pools, users, auctionTypes); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("DeleteByKey", auctionsTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("deleting blend auctions: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("DeleteByKey", auctionsTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("DeleteByKey", auctionsTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("DeleteByKey", auctionsTable).Observe(float64(len(keys)))
+	return nil
+}

--- a/internal/data/blend/auctions.go
+++ b/internal/data/blend/auctions.go
@@ -33,8 +33,8 @@ type Auction struct {
 	AuctionType        int32
 	Bid                map[string]string
 	Lot                map[string]string
-	StartBlock         int32
-	LastModifiedLedger int32
+	StartBlock         uint32
+	LastModifiedLedger uint32
 }
 
 // AuctionModelInterface exposes Blend v2 active-auction storage operations.
@@ -106,8 +106,8 @@ func (m *AuctionModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []Auct
 		auctionTypes[i] = r.AuctionType
 		bids[i] = bidJSON
 		lots[i] = lotJSON
-		startBlocks[i] = r.StartBlock
-		ledgers[i] = r.LastModifiedLedger
+		startBlocks[i] = int32(r.StartBlock)
+		ledgers[i] = int32(r.LastModifiedLedger)
 	}
 
 	const upsertQuery = `

--- a/internal/data/blend/auctions_test.go
+++ b/internal/data/blend/auctions_test.go
@@ -1,0 +1,194 @@
+// Unit tests for the Blend v2 AuctionModel.
+// These tests exercise real SQL and require a PostgreSQL test database.
+// Uses an external test package to avoid an import cycle with internal/data.
+package blend_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/data/blend"
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+)
+
+func newAuctionsFixture(t *testing.T) (context.Context, *pgxpool.Pool, *blend.AuctionModel, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	dbt := dbtest.Open(t)
+	pool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+
+	m := &blend.AuctionModel{
+		DB:      pool,
+		Metrics: metrics.NewMetrics(prometheus.NewRegistry()).DB,
+	}
+
+	cleanup := func() {
+		pool.Close()
+		dbt.Close()
+	}
+	return ctx, pool, m, cleanup
+}
+
+type auctionRow struct {
+	Bid                map[string]string
+	Lot                map[string]string
+	StartBlock         int32
+	LastModifiedLedger int32
+}
+
+func getAuction(t *testing.T, ctx context.Context, pool *pgxpool.Pool, poolAddr, userAddr string, auctionType int32) (auctionRow, bool) {
+	t.Helper()
+	var bidRaw, lotRaw []byte
+	var startBlock, ledger int32
+	err := pool.QueryRow(ctx, `
+		SELECT bid, lot, start_block, last_modified_ledger
+		FROM blend_auctions WHERE pool_contract_id = $1 AND user_account_id = $2 AND auction_type = $3
+	`, types.AddressBytea(poolAddr), types.AddressBytea(userAddr), auctionType).Scan(&bidRaw, &lotRaw, &startBlock, &ledger)
+	if err != nil {
+		return auctionRow{}, false
+	}
+	var bid, lot map[string]string
+	require.NoError(t, json.Unmarshal(bidRaw, &bid))
+	require.NoError(t, json.Unmarshal(lotRaw, &lot))
+	return auctionRow{Bid: bid, Lot: lot, StartBlock: startBlock, LastModifiedLedger: ledger}, true
+}
+
+func TestAuctionModel_BatchUpsert(t *testing.T) {
+	ctx, pool, m, cleanup := newAuctionsFixture(t)
+	defer cleanup()
+
+	poolAddr := keypair.MustRandom().Address()
+
+	t.Run("round-trips bid/lot maps through JSONB", func(t *testing.T) {
+		userAddr := keypair.MustRandom().Address()
+		assetA := keypair.MustRandom().Address()
+		assetB := keypair.MustRandom().Address()
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsert(ctx, tx, []blend.Auction{{
+				Pool:        types.AddressBytea(poolAddr),
+				User:        types.AddressBytea(userAddr),
+				AuctionType: 0,
+				Bid: map[string]string{
+					assetA: "100",
+					assetB: "200",
+				},
+				Lot: map[string]string{
+					assetA: "300",
+					assetB: "400",
+				},
+				StartBlock:         1000,
+				LastModifiedLedger: 5,
+			}}))
+		})
+
+		row, ok := getAuction(t, ctx, pool, poolAddr, userAddr, 0)
+		require.True(t, ok)
+		require.Len(t, row.Bid, 2)
+		assert.Equal(t, "100", row.Bid[assetA])
+		assert.Equal(t, "200", row.Bid[assetB])
+		require.Len(t, row.Lot, 2)
+		assert.Equal(t, "300", row.Lot[assetA])
+		assert.Equal(t, "400", row.Lot[assetB])
+		assert.Equal(t, int32(1000), row.StartBlock)
+		assert.Equal(t, int32(5), row.LastModifiedLedger)
+	})
+
+	t.Run("re-upsert with fewer assets fully replaces bid/lot", func(t *testing.T) {
+		userAddr := keypair.MustRandom().Address()
+		assetA := keypair.MustRandom().Address()
+		assetB := keypair.MustRandom().Address()
+		assetC := keypair.MustRandom().Address()
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsert(ctx, tx, []blend.Auction{{
+				Pool:        types.AddressBytea(poolAddr),
+				User:        types.AddressBytea(userAddr),
+				AuctionType: 0,
+				Bid:         map[string]string{assetA: "100", assetB: "200"},
+				Lot:         map[string]string{assetA: "300", assetB: "400"},
+				StartBlock:  1000,
+			}}))
+		})
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsert(ctx, tx, []blend.Auction{{
+				Pool:               types.AddressBytea(poolAddr),
+				User:               types.AddressBytea(userAddr),
+				AuctionType:        0,
+				Bid:                map[string]string{assetC: "50"},
+				Lot:                map[string]string{assetC: "70"},
+				StartBlock:         1000,
+				LastModifiedLedger: 10,
+			}}))
+		})
+
+		row, ok := getAuction(t, ctx, pool, poolAddr, userAddr, 0)
+		require.True(t, ok)
+		require.Len(t, row.Bid, 1)
+		assert.Equal(t, "50", row.Bid[assetC])
+		_, hasOldAsset := row.Bid[assetA]
+		assert.False(t, hasOldAsset, "old bid asset keys must be gone after full replace")
+		require.Len(t, row.Lot, 1)
+		assert.Equal(t, "70", row.Lot[assetC])
+		assert.Equal(t, int32(10), row.LastModifiedLedger)
+	})
+
+	t.Run("is a no-op when no rows are staged", func(t *testing.T) {
+		require.NoError(t, m.BatchUpsert(ctx, nil, nil))
+	})
+}
+
+func TestAuctionModel_DeleteByKey(t *testing.T) {
+	ctx, pool, m, cleanup := newAuctionsFixture(t)
+	defer cleanup()
+
+	poolX := keypair.MustRandom().Address()
+	userA := keypair.MustRandom().Address()
+	userB := keypair.MustRandom().Address()
+
+	runInTx(t, ctx, pool, func(tx pgx.Tx) {
+		require.NoError(t, m.BatchUpsert(ctx, tx, []blend.Auction{
+			{Pool: types.AddressBytea(poolX), User: types.AddressBytea(userA), AuctionType: 0, Bid: map[string]string{}, Lot: map[string]string{}, StartBlock: 1},
+			{Pool: types.AddressBytea(poolX), User: types.AddressBytea(userA), AuctionType: 2, Bid: map[string]string{}, Lot: map[string]string{}, StartBlock: 1},
+			{Pool: types.AddressBytea(poolX), User: types.AddressBytea(userB), AuctionType: 0, Bid: map[string]string{}, Lot: map[string]string{}, StartBlock: 1},
+		}))
+	})
+
+	runInTx(t, ctx, pool, func(tx pgx.Tx) {
+		require.NoError(t, m.DeleteByKey(ctx, tx, []blend.AuctionKey{
+			{Pool: types.AddressBytea(poolX), User: types.AddressBytea(userA), AuctionType: 0},
+		}))
+	})
+
+	_, ok := getAuction(t, ctx, pool, poolX, userA, 0)
+	assert.False(t, ok, "(poolX, userA, type0) should be deleted")
+	_, ok = getAuction(t, ctx, pool, poolX, userA, 2)
+	assert.True(t, ok, "a different auction_type for the same user must be untouched")
+	_, ok = getAuction(t, ctx, pool, poolX, userB, 0)
+	assert.True(t, ok, "a different user must be untouched")
+
+	t.Run("deleting a non-existent key is a no-op", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.DeleteByKey(ctx, tx, []blend.AuctionKey{
+				{Pool: types.AddressBytea(poolX), User: types.AddressBytea(userB), AuctionType: 2},
+			}))
+		})
+		_, ok := getAuction(t, ctx, pool, poolX, userB, 0)
+		assert.True(t, ok, "unrelated row must remain untouched by a no-match delete")
+	})
+
+	t.Run("is a no-op when no keys are staged", func(t *testing.T) {
+		require.NoError(t, m.DeleteByKey(ctx, nil, nil))
+	})
+}

--- a/internal/data/blend/backstop_pools.go
+++ b/internal/data/blend/backstop_pools.go
@@ -1,0 +1,161 @@
+// Pool-level backstop totals + emission accrual storage for Blend v2 (blend_backstop_pools).
+package blend
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+	"github.com/stellar/wallet-backend/internal/utils"
+)
+
+// backstopPoolsTable is the metrics label for blend_backstop_pools queries.
+const backstopPoolsTable = "blend_backstop_pools"
+
+// BackstopPool is a row of blend_backstop_pools: pool-level backstop totals
+// (PoolBalance(pool) on the backstop contract) plus that pool's backstop
+// emission accrual (BEmisData(pool)). The emis_* fields are pointers because
+// BatchUpsertBalances and BatchUpsertEmissions each only ever know one half of
+// the row.
+type BackstopPool struct {
+	PoolContractID types.AddressBytea
+	Shares         string
+	Tokens         string
+	Q4W            string
+	EmisEps        *int64
+	EmisIndex      *string
+	EmisExpiration *int64
+	EmisLastTime   *int64
+	// LedgerNumber is written to last_modified_ledger.
+	LastModifiedLedger uint32
+}
+
+// BackstopPoolEmission carries only the emis_* columns of blend_backstop_pools,
+// keyed by Pool. It is narrower than BackstopPool so a backstop emission update
+// doesn't need to know or preserve the pool's shares/tokens/q4w balances.
+type BackstopPoolEmission struct {
+	Pool           string
+	EmisEps        *int64
+	EmisIndex      *string
+	EmisExpiration *int64
+	EmisLastTime   *int64
+	LedgerNumber   uint32
+}
+
+// BackstopPoolModelInterface exposes Blend v2 backstop pool storage operations.
+type BackstopPoolModelInterface interface {
+	// BatchUpsertBalances inserts or updates only the shares/tokens/q4w columns.
+	// On a fresh insert the emis_* columns are left NULL.
+	BatchUpsertBalances(ctx context.Context, dbTx pgx.Tx, rows []BackstopPool) error
+	// BatchUpsertEmissions inserts or updates only the emis_* columns. On a
+	// fresh insert the shares/tokens/q4w columns fall to their table DEFAULT '0'.
+	BatchUpsertEmissions(ctx context.Context, dbTx pgx.Tx, rows []BackstopPoolEmission) error
+}
+
+// BackstopPoolModel implements BackstopPoolModelInterface against blend_backstop_pools.
+type BackstopPoolModel struct {
+	DB      *pgxpool.Pool
+	Metrics *metrics.DBMetrics
+}
+
+var _ BackstopPoolModelInterface = (*BackstopPoolModel)(nil)
+
+// BatchUpsertBalances inserts or updates only shares/tokens/q4w. See
+// BackstopPoolModelInterface.
+func (m *BackstopPoolModel) BatchUpsertBalances(ctx context.Context, dbTx pgx.Tx, rows []BackstopPool) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	pools := make([][]byte, len(rows))
+	shares := make([]string, len(rows))
+	tokens := make([]string, len(rows))
+	q4ws := make([]string, len(rows))
+	ledgers := make([]int32, len(rows))
+	for i, r := range rows {
+		poolBytes, err := addressToBytes(string(r.PoolContractID))
+		if err != nil {
+			return fmt.Errorf("converting pool address for backstop pool balance upsert: %w", err)
+		}
+		pools[i] = poolBytes
+		shares[i] = r.Shares
+		tokens[i] = r.Tokens
+		q4ws[i] = r.Q4W
+		ledgers[i] = int32(r.LastModifiedLedger)
+	}
+
+	const upsertQuery = `
+		INSERT INTO blend_backstop_pools (pool_contract_id, shares, tokens, q4w, last_modified_ledger)
+		SELECT * FROM UNNEST($1::bytea[], $2::text[], $3::text[], $4::text[], $5::integer[])
+		ON CONFLICT (pool_contract_id) DO UPDATE SET
+			shares               = EXCLUDED.shares,
+			tokens               = EXCLUDED.tokens,
+			q4w                  = EXCLUDED.q4w,
+			last_modified_ledger = EXCLUDED.last_modified_ledger`
+	if _, err := dbTx.Exec(ctx, upsertQuery, pools, shares, tokens, q4ws, ledgers); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("BatchUpsertBalances", backstopPoolsTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("upserting blend backstop pool balances: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("BatchUpsertBalances", backstopPoolsTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("BatchUpsertBalances", backstopPoolsTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("BatchUpsertBalances", backstopPoolsTable).Observe(float64(len(rows)))
+	return nil
+}
+
+// BatchUpsertEmissions inserts or updates only the emis_* columns. See
+// BackstopPoolModelInterface.
+func (m *BackstopPoolModel) BatchUpsertEmissions(ctx context.Context, dbTx pgx.Tx, rows []BackstopPoolEmission) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	pools := make([][]byte, len(rows))
+	emisEps := make([]*int64, len(rows))
+	emisIndexes := make([]*string, len(rows))
+	emisExpirations := make([]*int64, len(rows))
+	emisLastTimes := make([]*int64, len(rows))
+	ledgers := make([]int32, len(rows))
+	for i, r := range rows {
+		poolBytes, err := addressToBytes(r.Pool)
+		if err != nil {
+			return fmt.Errorf("converting pool address for backstop pool emission upsert: %w", err)
+		}
+		pools[i] = poolBytes
+		emisEps[i] = r.EmisEps
+		emisIndexes[i] = r.EmisIndex
+		emisExpirations[i] = r.EmisExpiration
+		emisLastTimes[i] = r.EmisLastTime
+		ledgers[i] = int32(r.LedgerNumber)
+	}
+
+	const upsertQuery = `
+		INSERT INTO blend_backstop_pools (pool_contract_id, emis_eps, emis_index, emis_expiration, emis_last_time, last_modified_ledger)
+		SELECT * FROM UNNEST($1::bytea[], $2::bigint[], $3::text[], $4::bigint[], $5::bigint[], $6::integer[])
+		ON CONFLICT (pool_contract_id) DO UPDATE SET
+			emis_eps             = EXCLUDED.emis_eps,
+			emis_index           = EXCLUDED.emis_index,
+			emis_expiration      = EXCLUDED.emis_expiration,
+			emis_last_time       = EXCLUDED.emis_last_time,
+			last_modified_ledger = EXCLUDED.last_modified_ledger`
+	if _, err := dbTx.Exec(ctx, upsertQuery, pools, emisEps, emisIndexes, emisExpirations, emisLastTimes, ledgers); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("BatchUpsertEmissions", backstopPoolsTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("upserting blend backstop pool emissions: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("BatchUpsertEmissions", backstopPoolsTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("BatchUpsertEmissions", backstopPoolsTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("BatchUpsertEmissions", backstopPoolsTable).Observe(float64(len(rows)))
+	return nil
+}

--- a/internal/data/blend/backstop_pools.go
+++ b/internal/data/blend/backstop_pools.go
@@ -98,7 +98,7 @@ func (m *BackstopPoolModel) BatchUpsertBalances(ctx context.Context, dbTx pgx.Tx
 			shares               = EXCLUDED.shares,
 			tokens               = EXCLUDED.tokens,
 			q4w                  = EXCLUDED.q4w,
-			last_modified_ledger = EXCLUDED.last_modified_ledger`
+			last_modified_ledger = GREATEST(blend_backstop_pools.last_modified_ledger, EXCLUDED.last_modified_ledger)`
 	if _, err := dbTx.Exec(ctx, upsertQuery, pools, shares, tokens, q4ws, ledgers); err != nil {
 		m.Metrics.QueryErrors.WithLabelValues("BatchUpsertBalances", backstopPoolsTable, utils.GetDBErrorType(err)).Inc()
 		return fmt.Errorf("upserting blend backstop pool balances: %w", err)
@@ -147,7 +147,7 @@ func (m *BackstopPoolModel) BatchUpsertEmissions(ctx context.Context, dbTx pgx.T
 			emis_index           = EXCLUDED.emis_index,
 			emis_expiration      = EXCLUDED.emis_expiration,
 			emis_last_time       = EXCLUDED.emis_last_time,
-			last_modified_ledger = EXCLUDED.last_modified_ledger`
+			last_modified_ledger = GREATEST(blend_backstop_pools.last_modified_ledger, EXCLUDED.last_modified_ledger)`
 	if _, err := dbTx.Exec(ctx, upsertQuery, pools, emisEps, emisIndexes, emisExpirations, emisLastTimes, ledgers); err != nil {
 		m.Metrics.QueryErrors.WithLabelValues("BatchUpsertEmissions", backstopPoolsTable, utils.GetDBErrorType(err)).Inc()
 		return fmt.Errorf("upserting blend backstop pool emissions: %w", err)

--- a/internal/data/blend/backstop_pools_test.go
+++ b/internal/data/blend/backstop_pools_test.go
@@ -1,0 +1,201 @@
+// Unit tests for the Blend v2 BackstopPoolModel.
+// These tests exercise real SQL and require a PostgreSQL test database.
+// Uses an external test package to avoid an import cycle with internal/data.
+package blend_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/data/blend"
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+)
+
+func newBackstopPoolsFixture(t *testing.T) (context.Context, *pgxpool.Pool, *blend.BackstopPoolModel, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	dbt := dbtest.Open(t)
+	pool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+
+	m := &blend.BackstopPoolModel{
+		DB:      pool,
+		Metrics: metrics.NewMetrics(prometheus.NewRegistry()).DB,
+	}
+
+	cleanup := func() {
+		pool.Close()
+		dbt.Close()
+	}
+	return ctx, pool, m, cleanup
+}
+
+type backstopPoolRow struct {
+	Shares, Tokens, Q4W string
+	EmisEps             *int64
+	EmisIndex           *string
+	EmisExpiration      *int64
+	EmisLastTime        *int64
+	LastModifiedLedger  int32
+}
+
+func getBackstopPool(t *testing.T, ctx context.Context, pool *pgxpool.Pool, poolAddr string) (backstopPoolRow, bool) {
+	t.Helper()
+	var row backstopPoolRow
+	err := pool.QueryRow(ctx, `
+		SELECT shares, tokens, q4w, emis_eps, emis_index, emis_expiration, emis_last_time, last_modified_ledger
+		FROM blend_backstop_pools WHERE pool_contract_id = $1
+	`, types.AddressBytea(poolAddr)).Scan(
+		&row.Shares, &row.Tokens, &row.Q4W, &row.EmisEps, &row.EmisIndex, &row.EmisExpiration, &row.EmisLastTime, &row.LastModifiedLedger,
+	)
+	if err != nil {
+		return backstopPoolRow{}, false
+	}
+	return row, true
+}
+
+func i64Ptr(i int64) *int64 { return &i }
+
+func TestBackstopPoolModel_BatchUpsertBalances(t *testing.T) {
+	ctx, pool, m, cleanup := newBackstopPoolsFixture(t)
+	defer cleanup()
+
+	poolAddr := keypair.MustRandom().Address()
+
+	t.Run("inserts a fresh row with balances only; emis_* columns stay NULL", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsertBalances(ctx, tx, []blend.BackstopPool{{
+				PoolContractID:     types.AddressBytea(poolAddr),
+				Shares:             "1000",
+				Tokens:             "2000",
+				Q4W:                "50",
+				LastModifiedLedger: 1,
+			}}))
+		})
+
+		row, ok := getBackstopPool(t, ctx, pool, poolAddr)
+		require.True(t, ok)
+		assert.Equal(t, "1000", row.Shares)
+		assert.Equal(t, "2000", row.Tokens)
+		assert.Equal(t, "50", row.Q4W)
+		assert.Nil(t, row.EmisEps)
+	})
+
+	t.Run("updating balances after emissions were set leaves emis_* columns untouched", func(t *testing.T) {
+		poolAddr := keypair.MustRandom().Address()
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsertEmissions(ctx, tx, []blend.BackstopPoolEmission{{
+				Pool: poolAddr, EmisEps: i64Ptr(42), EmisIndex: strPtr("7"), EmisExpiration: i64Ptr(999), EmisLastTime: i64Ptr(100),
+				LedgerNumber: 1,
+			}}))
+		})
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsertBalances(ctx, tx, []blend.BackstopPool{{
+				PoolContractID:     types.AddressBytea(poolAddr),
+				Shares:             "10",
+				Tokens:             "20",
+				Q4W:                "0",
+				LastModifiedLedger: 2,
+			}}))
+		})
+
+		row, ok := getBackstopPool(t, ctx, pool, poolAddr)
+		require.True(t, ok)
+		assert.Equal(t, "10", row.Shares)
+		require.NotNil(t, row.EmisEps, "emis columns set earlier must survive a balances-only upsert")
+		assert.Equal(t, int64(42), *row.EmisEps)
+	})
+
+	t.Run("is a no-op when no rows are staged", func(t *testing.T) {
+		require.NoError(t, m.BatchUpsertBalances(ctx, nil, nil))
+	})
+}
+
+func TestBackstopPoolModel_BatchUpsertEmissions(t *testing.T) {
+	ctx, pool, m, cleanup := newBackstopPoolsFixture(t)
+	defer cleanup()
+
+	t.Run("fresh insert via emissions: balance columns take their DEFAULT '0'", func(t *testing.T) {
+		poolAddr := keypair.MustRandom().Address()
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsertEmissions(ctx, tx, []blend.BackstopPoolEmission{{
+				Pool: poolAddr, EmisEps: i64Ptr(5), EmisIndex: strPtr("1"), EmisExpiration: i64Ptr(200), EmisLastTime: i64Ptr(50),
+				LedgerNumber: 1,
+			}}))
+		})
+
+		row, ok := getBackstopPool(t, ctx, pool, poolAddr)
+		require.True(t, ok)
+		assert.Equal(t, "0", row.Shares)
+		assert.Equal(t, "0", row.Tokens)
+		assert.Equal(t, "0", row.Q4W)
+		require.NotNil(t, row.EmisEps)
+		assert.Equal(t, int64(5), *row.EmisEps)
+		require.NotNil(t, row.EmisIndex)
+		assert.Equal(t, "1", *row.EmisIndex)
+	})
+
+	t.Run("updating emissions after balances were set leaves balance columns untouched", func(t *testing.T) {
+		poolAddr := keypair.MustRandom().Address()
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsertBalances(ctx, tx, []blend.BackstopPool{{
+				PoolContractID:     types.AddressBytea(poolAddr),
+				Shares:             "777",
+				Tokens:             "888",
+				Q4W:                "1",
+				LastModifiedLedger: 1,
+			}}))
+		})
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsertEmissions(ctx, tx, []blend.BackstopPoolEmission{{
+				Pool: poolAddr, EmisEps: i64Ptr(9), EmisIndex: strPtr("3"), EmisExpiration: i64Ptr(300), EmisLastTime: i64Ptr(150),
+				LedgerNumber: 2,
+			}}))
+		})
+
+		row, ok := getBackstopPool(t, ctx, pool, poolAddr)
+		require.True(t, ok)
+		assert.Equal(t, "777", row.Shares, "balances set earlier must survive an emissions-only upsert")
+		assert.Equal(t, "888", row.Tokens)
+		require.NotNil(t, row.EmisEps)
+		assert.Equal(t, int64(9), *row.EmisEps)
+	})
+
+	t.Run("re-upsert replaces emis_* columns", func(t *testing.T) {
+		poolAddr := keypair.MustRandom().Address()
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsertEmissions(ctx, tx, []blend.BackstopPoolEmission{{
+				Pool: poolAddr, EmisEps: i64Ptr(1), EmisIndex: strPtr("a"), EmisExpiration: i64Ptr(1), EmisLastTime: i64Ptr(1),
+				LedgerNumber: 1,
+			}}))
+		})
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsertEmissions(ctx, tx, []blend.BackstopPoolEmission{{
+				Pool: poolAddr, EmisEps: i64Ptr(2), EmisIndex: strPtr("b"), EmisExpiration: i64Ptr(2), EmisLastTime: i64Ptr(2),
+				LedgerNumber: 2,
+			}}))
+		})
+
+		row, ok := getBackstopPool(t, ctx, pool, poolAddr)
+		require.True(t, ok)
+		require.NotNil(t, row.EmisEps)
+		assert.Equal(t, int64(2), *row.EmisEps)
+		require.NotNil(t, row.EmisIndex)
+		assert.Equal(t, "b", *row.EmisIndex)
+	})
+
+	t.Run("is a no-op when no rows are staged", func(t *testing.T) {
+		require.NoError(t, m.BatchUpsertEmissions(ctx, nil, nil))
+	})
+}

--- a/internal/data/blend/backstop_positions.go
+++ b/internal/data/blend/backstop_positions.go
@@ -1,0 +1,159 @@
+// Per-user backstop position storage for Blend v2 (blend_backstop_positions).
+package blend
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+	"github.com/stellar/wallet-backend/internal/utils"
+)
+
+// backstopPositionsTable is the metrics label for blend_backstop_positions queries.
+const backstopPositionsTable = "blend_backstop_positions"
+
+// Q4W is one queued withdrawal inside blend_backstop_positions.q4w (JSONB).
+type Q4W struct {
+	Amount     string `json:"amount"`
+	Expiration int64  `json:"expiration"`
+}
+
+// BackstopPosition is a row of blend_backstop_positions: a user's backstop
+// shares and queued-withdrawal list for one pool (UserBalance(pool, user)).
+type BackstopPosition struct {
+	PoolContractID     types.AddressBytea
+	UserAccountID      types.AddressBytea
+	Shares             string
+	Q4W                []Q4W
+	LastModifiedLedger uint32
+}
+
+// BackstopPositionModelInterface exposes Blend v2 backstop position storage operations.
+type BackstopPositionModelInterface interface {
+	// BatchUpsert inserts or fully replaces backstop position rows keyed by
+	// (pool_contract_id, user_account_id).
+	BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []BackstopPosition) error
+	// DeleteByPoolUser removes every backstop position row for the given
+	// (pool, user) pairs (full exit).
+	DeleteByPoolUser(ctx context.Context, dbTx pgx.Tx, keys []PoolUserKey) error
+}
+
+// BackstopPositionModel implements BackstopPositionModelInterface against blend_backstop_positions.
+type BackstopPositionModel struct {
+	DB      *pgxpool.Pool
+	Metrics *metrics.DBMetrics
+}
+
+var _ BackstopPositionModelInterface = (*BackstopPositionModel)(nil)
+
+// marshalQ4W serializes a queued-withdrawal list for storage in the q4w JSONB
+// column. A nil/empty slice serializes as "[]" (not SQL NULL or JSON null) so
+// readers can always unmarshal the column into []Q4W without a null check.
+func marshalQ4W(q4w []Q4W) (string, error) {
+	if len(q4w) == 0 {
+		return "[]", nil
+	}
+	b, err := json.Marshal(q4w)
+	if err != nil {
+		return "", fmt.Errorf("marshalling q4w: %w", err)
+	}
+	return string(b), nil
+}
+
+// BatchUpsert inserts or fully replaces blend_backstop_positions rows. See
+// BackstopPositionModelInterface.
+func (m *BackstopPositionModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []BackstopPosition) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	pools := make([][]byte, len(rows))
+	users := make([][]byte, len(rows))
+	shares := make([]string, len(rows))
+	q4ws := make([]string, len(rows))
+	ledgers := make([]int32, len(rows))
+	for i, r := range rows {
+		poolBytes, err := addressToBytes(string(r.PoolContractID))
+		if err != nil {
+			return fmt.Errorf("converting pool address for backstop position upsert: %w", err)
+		}
+		userBytes, err := addressToBytes(string(r.UserAccountID))
+		if err != nil {
+			return fmt.Errorf("converting user address for backstop position upsert: %w", err)
+		}
+		q4wJSON, err := marshalQ4W(r.Q4W)
+		if err != nil {
+			return fmt.Errorf("marshalling q4w for backstop position upsert: %w", err)
+		}
+		pools[i] = poolBytes
+		users[i] = userBytes
+		shares[i] = r.Shares
+		q4ws[i] = q4wJSON
+		ledgers[i] = int32(r.LastModifiedLedger)
+	}
+
+	const upsertQuery = `
+		INSERT INTO blend_backstop_positions (pool_contract_id, user_account_id, shares, q4w, last_modified_ledger)
+		SELECT * FROM UNNEST($1::bytea[], $2::bytea[], $3::text[], $4::text[]::jsonb[], $5::integer[])
+		ON CONFLICT (pool_contract_id, user_account_id) DO UPDATE SET
+			shares               = EXCLUDED.shares,
+			q4w                  = EXCLUDED.q4w,
+			last_modified_ledger = EXCLUDED.last_modified_ledger`
+	if _, err := dbTx.Exec(ctx, upsertQuery, pools, users, shares, q4ws, ledgers); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", backstopPositionsTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("upserting blend backstop positions: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", backstopPositionsTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", backstopPositionsTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("BatchUpsert", backstopPositionsTable).Observe(float64(len(rows)))
+	return nil
+}
+
+// DeleteByPoolUser removes every blend_backstop_positions row for the given
+// (pool, user) pairs.
+func (m *BackstopPositionModel) DeleteByPoolUser(ctx context.Context, dbTx pgx.Tx, keys []PoolUserKey) error {
+	if len(keys) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	pools := make([][]byte, len(keys))
+	users := make([][]byte, len(keys))
+	for i, k := range keys {
+		poolBytes, err := addressToBytes(k.Pool)
+		if err != nil {
+			return fmt.Errorf("converting pool address for backstop position delete: %w", err)
+		}
+		userBytes, err := addressToBytes(k.User)
+		if err != nil {
+			return fmt.Errorf("converting user address for backstop position delete: %w", err)
+		}
+		pools[i] = poolBytes
+		users[i] = userBytes
+	}
+
+	const deleteQuery = `
+		DELETE FROM blend_backstop_positions
+		WHERE (pool_contract_id, user_account_id) IN (SELECT * FROM UNNEST($1::bytea[], $2::bytea[]))`
+	if _, err := dbTx.Exec(ctx, deleteQuery, pools, users); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("DeleteByPoolUser", backstopPositionsTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("deleting blend backstop positions: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("DeleteByPoolUser", backstopPositionsTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("DeleteByPoolUser", backstopPositionsTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("DeleteByPoolUser", backstopPositionsTable).Observe(float64(len(keys)))
+	return nil
+}

--- a/internal/data/blend/backstop_positions.go
+++ b/internal/data/blend/backstop_positions.go
@@ -106,7 +106,7 @@ func (m *BackstopPositionModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, ro
 		ON CONFLICT (pool_contract_id, user_account_id) DO UPDATE SET
 			shares               = EXCLUDED.shares,
 			q4w                  = EXCLUDED.q4w,
-			last_modified_ledger = EXCLUDED.last_modified_ledger`
+			last_modified_ledger = GREATEST(blend_backstop_positions.last_modified_ledger, EXCLUDED.last_modified_ledger)`
 	if _, err := dbTx.Exec(ctx, upsertQuery, pools, users, shares, q4ws, ledgers); err != nil {
 		m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", backstopPositionsTable, utils.GetDBErrorType(err)).Inc()
 		return fmt.Errorf("upserting blend backstop positions: %w", err)

--- a/internal/data/blend/backstop_positions_test.go
+++ b/internal/data/blend/backstop_positions_test.go
@@ -1,0 +1,181 @@
+// Unit tests for the Blend v2 BackstopPositionModel.
+// These tests exercise real SQL and require a PostgreSQL test database.
+// Uses an external test package to avoid an import cycle with internal/data.
+package blend_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/data/blend"
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+)
+
+func newBackstopPositionsFixture(t *testing.T) (context.Context, *pgxpool.Pool, *blend.BackstopPositionModel, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	dbt := dbtest.Open(t)
+	pool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+
+	m := &blend.BackstopPositionModel{
+		DB:      pool,
+		Metrics: metrics.NewMetrics(prometheus.NewRegistry()).DB,
+	}
+
+	cleanup := func() {
+		pool.Close()
+		dbt.Close()
+	}
+	return ctx, pool, m, cleanup
+}
+
+type backstopPositionRow struct {
+	Shares             string
+	Q4W                []blend.Q4W
+	LastModifiedLedger int32
+}
+
+func getBackstopPosition(t *testing.T, ctx context.Context, pool *pgxpool.Pool, poolAddr, userAddr string) (backstopPositionRow, bool) {
+	t.Helper()
+	var shares string
+	var q4wRaw []byte
+	var ledger int32
+	err := pool.QueryRow(ctx, `
+		SELECT shares, q4w, last_modified_ledger
+		FROM blend_backstop_positions WHERE pool_contract_id = $1 AND user_account_id = $2
+	`, types.AddressBytea(poolAddr), types.AddressBytea(userAddr)).Scan(&shares, &q4wRaw, &ledger)
+	if err != nil {
+		return backstopPositionRow{}, false
+	}
+	var q4w []blend.Q4W
+	require.NoError(t, json.Unmarshal(q4wRaw, &q4w))
+	return backstopPositionRow{Shares: shares, Q4W: q4w, LastModifiedLedger: ledger}, true
+}
+
+func TestBackstopPositionModel_BatchUpsert(t *testing.T) {
+	ctx, pool, m, cleanup := newBackstopPositionsFixture(t)
+	defer cleanup()
+
+	poolAddr := keypair.MustRandom().Address()
+
+	t.Run("round-trips a Q4W list through JSONB", func(t *testing.T) {
+		userAddr := keypair.MustRandom().Address()
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsert(ctx, tx, []blend.BackstopPosition{{
+				PoolContractID: types.AddressBytea(poolAddr),
+				UserAccountID:  types.AddressBytea(userAddr),
+				Shares:         "1000",
+				Q4W: []blend.Q4W{
+					{Amount: "100", Expiration: 111},
+					{Amount: "200", Expiration: 222},
+				},
+				LastModifiedLedger: 5,
+			}}))
+		})
+
+		row, ok := getBackstopPosition(t, ctx, pool, poolAddr, userAddr)
+		require.True(t, ok)
+		assert.Equal(t, "1000", row.Shares)
+		require.Len(t, row.Q4W, 2)
+		assert.Equal(t, "100", row.Q4W[0].Amount)
+		assert.Equal(t, int64(111), row.Q4W[0].Expiration)
+		assert.Equal(t, "200", row.Q4W[1].Amount)
+		assert.Equal(t, int64(222), row.Q4W[1].Expiration)
+		assert.Equal(t, int32(5), row.LastModifiedLedger)
+	})
+
+	t.Run("an empty Q4W slice round-trips as an empty list", func(t *testing.T) {
+		userAddr := keypair.MustRandom().Address()
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsert(ctx, tx, []blend.BackstopPosition{{
+				PoolContractID:     types.AddressBytea(poolAddr),
+				UserAccountID:      types.AddressBytea(userAddr),
+				Shares:             "500",
+				Q4W:                nil,
+				LastModifiedLedger: 6,
+			}}))
+		})
+
+		row, ok := getBackstopPosition(t, ctx, pool, poolAddr, userAddr)
+		require.True(t, ok)
+		assert.Empty(t, row.Q4W)
+	})
+
+	t.Run("re-upsert fully replaces shares and q4w", func(t *testing.T) {
+		userAddr := keypair.MustRandom().Address()
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsert(ctx, tx, []blend.BackstopPosition{{
+				PoolContractID:     types.AddressBytea(poolAddr),
+				UserAccountID:      types.AddressBytea(userAddr),
+				Shares:             "10",
+				Q4W:                []blend.Q4W{{Amount: "1", Expiration: 1}},
+				LastModifiedLedger: 1,
+			}}))
+		})
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsert(ctx, tx, []blend.BackstopPosition{{
+				PoolContractID:     types.AddressBytea(poolAddr),
+				UserAccountID:      types.AddressBytea(userAddr),
+				Shares:             "999",
+				Q4W:                nil,
+				LastModifiedLedger: 2,
+			}}))
+		})
+
+		row, ok := getBackstopPosition(t, ctx, pool, poolAddr, userAddr)
+		require.True(t, ok)
+		assert.Equal(t, "999", row.Shares)
+		assert.Empty(t, row.Q4W)
+		assert.Equal(t, int32(2), row.LastModifiedLedger)
+	})
+
+	t.Run("is a no-op when no rows are staged", func(t *testing.T) {
+		require.NoError(t, m.BatchUpsert(ctx, nil, nil))
+	})
+}
+
+func TestBackstopPositionModel_DeleteByPoolUser(t *testing.T) {
+	ctx, pool, m, cleanup := newBackstopPositionsFixture(t)
+	defer cleanup()
+
+	poolA := keypair.MustRandom().Address()
+	poolB := keypair.MustRandom().Address()
+	userA := keypair.MustRandom().Address()
+	userB := keypair.MustRandom().Address()
+
+	runInTx(t, ctx, pool, func(tx pgx.Tx) {
+		require.NoError(t, m.BatchUpsert(ctx, tx, []blend.BackstopPosition{
+			{PoolContractID: types.AddressBytea(poolA), UserAccountID: types.AddressBytea(userA), Shares: "1", LastModifiedLedger: 1},
+			{PoolContractID: types.AddressBytea(poolA), UserAccountID: types.AddressBytea(userB), Shares: "2", LastModifiedLedger: 1},
+			{PoolContractID: types.AddressBytea(poolB), UserAccountID: types.AddressBytea(userA), Shares: "3", LastModifiedLedger: 1},
+		}))
+	})
+
+	runInTx(t, ctx, pool, func(tx pgx.Tx) {
+		require.NoError(t, m.DeleteByPoolUser(ctx, tx, []blend.PoolUserKey{{Pool: poolA, User: userA}}))
+	})
+
+	_, ok := getBackstopPosition(t, ctx, pool, poolA, userA)
+	assert.False(t, ok, "(poolA, userA) should be deleted")
+	_, ok = getBackstopPosition(t, ctx, pool, poolA, userB)
+	assert.True(t, ok, "a different user in the same pool must be untouched")
+	_, ok = getBackstopPosition(t, ctx, pool, poolB, userA)
+	assert.True(t, ok, "the same user in a different pool must be untouched")
+
+	t.Run("is a no-op when no keys are staged", func(t *testing.T) {
+		require.NoError(t, m.DeleteByPoolUser(ctx, nil, nil))
+	})
+}

--- a/internal/data/blend/claimed.go
+++ b/internal/data/blend/claimed.go
@@ -1,0 +1,196 @@
+// Lifetime claimed-emissions accumulators for Blend v2 (blend_pool_claimed,
+// blend_backstop_claimed). Unlike blend_emissions (which mirrors the current
+// on-chain accrued/index snapshot, i.e. claimable-now), these tables hold the
+// cumulative amount a user has already claimed. The contracts store no running
+// claimed total — claims zero out accrued — so the figure exists only as the
+// sequence of `claim` events and is folded additively here during current-state
+// indexing, exactly like blend_positions.net_supplied/net_borrowed.
+package blend
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+	"github.com/stellar/wallet-backend/internal/utils"
+)
+
+// poolClaimedTable is the metrics label for blend_pool_claimed queries.
+const poolClaimedTable = "blend_pool_claimed"
+
+// backstopClaimedTable is the metrics label for blend_backstop_claimed queries.
+const backstopClaimedTable = "blend_backstop_claimed"
+
+// PoolClaimed is a full row of blend_pool_claimed: one user's lifetime pool-source
+// BLND claims for a single pool. Writers use PoolClaimedDelta; this type exists for
+// readers to scan a full row into.
+type PoolClaimed struct {
+	PoolContractID     types.AddressBytea
+	UserAccountID      types.AddressBytea
+	ClaimedBlnd        string
+	LastModifiedLedger uint32
+}
+
+// BackstopClaimed is a full row of blend_backstop_claimed: one user's account-wide
+// lifetime backstop-source claims, denominated in Comet LP tokens.
+type BackstopClaimed struct {
+	UserAccountID      types.AddressBytea
+	ClaimedLp          string
+	LastModifiedLedger uint32
+}
+
+// PoolClaimedDelta is an additive claim amount for one (pool, user), summed into
+// blend_pool_claimed.claimed_blnd.
+type PoolClaimedDelta struct {
+	Pool, User   string // Pool: C-address, User: G-address
+	ClaimedBlnd  string
+	LedgerNumber uint32
+}
+
+// BackstopClaimedDelta is an additive claim amount for one user, summed into
+// blend_backstop_claimed.claimed_lp.
+type BackstopClaimedDelta struct {
+	User         string // G-address
+	ClaimedLp    string
+	LedgerNumber uint32
+}
+
+// PoolClaimedModelInterface exposes Blend v2 pool-source claimed-total storage.
+type PoolClaimedModelInterface interface {
+	// BatchApplyDeltas adds each delta's claimed_blnd into the (pool, user) row,
+	// inserting it at 0 on first claim.
+	BatchApplyDeltas(ctx context.Context, dbTx pgx.Tx, deltas []PoolClaimedDelta) error
+}
+
+// BackstopClaimedModelInterface exposes Blend v2 backstop-source claimed-total storage.
+type BackstopClaimedModelInterface interface {
+	// BatchApplyDeltas adds each delta's claimed_lp into the user's row, inserting
+	// it at 0 on first claim.
+	BatchApplyDeltas(ctx context.Context, dbTx pgx.Tx, deltas []BackstopClaimedDelta) error
+}
+
+// PoolClaimedModel implements PoolClaimedModelInterface against blend_pool_claimed.
+type PoolClaimedModel struct {
+	DB      *pgxpool.Pool
+	Metrics *metrics.DBMetrics
+}
+
+// BackstopClaimedModel implements BackstopClaimedModelInterface against blend_backstop_claimed.
+type BackstopClaimedModel struct {
+	DB      *pgxpool.Pool
+	Metrics *metrics.DBMetrics
+}
+
+var (
+	_ PoolClaimedModelInterface     = (*PoolClaimedModel)(nil)
+	_ BackstopClaimedModelInterface = (*BackstopClaimedModel)(nil)
+)
+
+// BatchApplyDeltas accumulates pool-source claim amounts server-side
+// (claimed_blnd := existing + delta), inserting the row at the delta value on
+// first claim.
+//
+// Each (Pool, User) key must appear at most once per batch: ON CONFLICT applies
+// only ONE conflicting row per statement, so a duplicate key would silently drop
+// a claim. The caller pre-aggregates (the processor's staged fold does); duplicates
+// are rejected with an error.
+func (m *PoolClaimedModel) BatchApplyDeltas(ctx context.Context, dbTx pgx.Tx, deltas []PoolClaimedDelta) error {
+	if len(deltas) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	pools := make([][]byte, len(deltas))
+	users := make([][]byte, len(deltas))
+	claimed := make([]string, len(deltas))
+	ledgers := make([]int32, len(deltas))
+	seen := make(map[PoolUserKey]struct{}, len(deltas))
+	for i, d := range deltas {
+		poolBytes, err := addressToBytes(d.Pool)
+		if err != nil {
+			return fmt.Errorf("converting pool address for pool-claimed apply: %w", err)
+		}
+		userBytes, err := addressToBytes(d.User)
+		if err != nil {
+			return fmt.Errorf("converting user address for pool-claimed apply: %w", err)
+		}
+		key := PoolUserKey{Pool: d.Pool, User: d.User}
+		if _, dup := seen[key]; dup {
+			return fmt.Errorf("duplicate pool-claimed delta for pool=%s user=%s: deltas must be pre-aggregated per key", d.Pool, d.User)
+		}
+		seen[key] = struct{}{}
+		pools[i] = poolBytes
+		users[i] = userBytes
+		claimed[i] = d.ClaimedBlnd
+		ledgers[i] = int32(d.LedgerNumber)
+	}
+
+	const applyQuery = `
+		INSERT INTO blend_pool_claimed (pool_contract_id, user_account_id, claimed_blnd, last_modified_ledger)
+		SELECT * FROM UNNEST($1::bytea[], $2::bytea[], $3::text[], $4::integer[])
+		ON CONFLICT (pool_contract_id, user_account_id) DO UPDATE SET
+			claimed_blnd         = (blend_pool_claimed.claimed_blnd::numeric + EXCLUDED.claimed_blnd::numeric)::text,
+			last_modified_ledger = GREATEST(blend_pool_claimed.last_modified_ledger, EXCLUDED.last_modified_ledger)`
+	if _, err := dbTx.Exec(ctx, applyQuery, pools, users, claimed, ledgers); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("BatchApplyDeltas", poolClaimedTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("applying blend pool claimed deltas: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("BatchApplyDeltas", poolClaimedTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("BatchApplyDeltas", poolClaimedTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("BatchApplyDeltas", poolClaimedTable).Observe(float64(len(deltas)))
+	return nil
+}
+
+// BatchApplyDeltas accumulates backstop-source claim amounts server-side
+// (claimed_lp := existing + delta), inserting the row at the delta value on first
+// claim. Each User key must appear at most once per batch (see PoolClaimedModel).
+func (m *BackstopClaimedModel) BatchApplyDeltas(ctx context.Context, dbTx pgx.Tx, deltas []BackstopClaimedDelta) error {
+	if len(deltas) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	users := make([][]byte, len(deltas))
+	claimed := make([]string, len(deltas))
+	ledgers := make([]int32, len(deltas))
+	seen := make(map[string]struct{}, len(deltas))
+	for i, d := range deltas {
+		userBytes, err := addressToBytes(d.User)
+		if err != nil {
+			return fmt.Errorf("converting user address for backstop-claimed apply: %w", err)
+		}
+		if _, dup := seen[d.User]; dup {
+			return fmt.Errorf("duplicate backstop-claimed delta for user=%s: deltas must be pre-aggregated per key", d.User)
+		}
+		seen[d.User] = struct{}{}
+		users[i] = userBytes
+		claimed[i] = d.ClaimedLp
+		ledgers[i] = int32(d.LedgerNumber)
+	}
+
+	const applyQuery = `
+		INSERT INTO blend_backstop_claimed (user_account_id, claimed_lp, last_modified_ledger)
+		SELECT * FROM UNNEST($1::bytea[], $2::text[], $3::integer[])
+		ON CONFLICT (user_account_id) DO UPDATE SET
+			claimed_lp           = (blend_backstop_claimed.claimed_lp::numeric + EXCLUDED.claimed_lp::numeric)::text,
+			last_modified_ledger = GREATEST(blend_backstop_claimed.last_modified_ledger, EXCLUDED.last_modified_ledger)`
+	if _, err := dbTx.Exec(ctx, applyQuery, users, claimed, ledgers); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("BatchApplyDeltas", backstopClaimedTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("applying blend backstop claimed deltas: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("BatchApplyDeltas", backstopClaimedTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("BatchApplyDeltas", backstopClaimedTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("BatchApplyDeltas", backstopClaimedTable).Observe(float64(len(deltas)))
+	return nil
+}

--- a/internal/data/blend/claimed_test.go
+++ b/internal/data/blend/claimed_test.go
@@ -1,0 +1,174 @@
+// Unit tests for the Blend v2 PoolClaimedModel and BackstopClaimedModel.
+// These tests exercise real SQL and require a PostgreSQL test database.
+// Uses an external test package to avoid an import cycle with internal/data.
+package blend_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/data/blend"
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+)
+
+func newClaimedFixture(t *testing.T) (context.Context, *pgxpool.Pool, *blend.PoolClaimedModel, *blend.BackstopClaimedModel, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	dbt := dbtest.Open(t)
+	pool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+
+	dbMetrics := metrics.NewMetrics(prometheus.NewRegistry()).DB
+	pm := &blend.PoolClaimedModel{DB: pool, Metrics: dbMetrics}
+	bm := &blend.BackstopClaimedModel{DB: pool, Metrics: dbMetrics}
+
+	cleanup := func() {
+		pool.Close()
+		dbt.Close()
+	}
+	return ctx, pool, pm, bm, cleanup
+}
+
+func getPoolClaimed(t *testing.T, ctx context.Context, pool *pgxpool.Pool, poolAddr, userAddr string) (claimed string, ledger int32, ok bool) {
+	t.Helper()
+	err := pool.QueryRow(ctx, `
+		SELECT claimed_blnd, last_modified_ledger FROM blend_pool_claimed
+		WHERE pool_contract_id = $1 AND user_account_id = $2
+	`, types.AddressBytea(poolAddr), types.AddressBytea(userAddr)).Scan(&claimed, &ledger)
+	if err != nil {
+		return "", 0, false
+	}
+	return claimed, ledger, true
+}
+
+func getBackstopClaimed(t *testing.T, ctx context.Context, pool *pgxpool.Pool, userAddr string) (claimed string, ledger int32, ok bool) {
+	t.Helper()
+	err := pool.QueryRow(ctx, `
+		SELECT claimed_lp, last_modified_ledger FROM blend_backstop_claimed
+		WHERE user_account_id = $1
+	`, types.AddressBytea(userAddr)).Scan(&claimed, &ledger)
+	if err != nil {
+		return "", 0, false
+	}
+	return claimed, ledger, true
+}
+
+func TestPoolClaimedModel_BatchApplyDeltas(t *testing.T) {
+	ctx, pool, pm, _, cleanup := newClaimedFixture(t)
+	defer cleanup()
+
+	poolAddr := keypair.MustRandom().Address() // C-address stand-in; only its bytes matter here
+	userA := keypair.MustRandom().Address()
+	userB := keypair.MustRandom().Address()
+
+	t.Run("empty input is a no-op", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, pm.BatchApplyDeltas(ctx, tx, nil))
+		})
+	})
+
+	t.Run("first delta inserts, second accumulates", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, pm.BatchApplyDeltas(ctx, tx, []blend.PoolClaimedDelta{
+				{Pool: poolAddr, User: userA, ClaimedBlnd: "100", LedgerNumber: 5},
+			}))
+		})
+		claimed, ledger, ok := getPoolClaimed(t, ctx, pool, poolAddr, userA)
+		require.True(t, ok)
+		assert.Equal(t, "100", claimed)
+		assert.Equal(t, int32(5), ledger)
+
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, pm.BatchApplyDeltas(ctx, tx, []blend.PoolClaimedDelta{
+				{Pool: poolAddr, User: userA, ClaimedBlnd: "40", LedgerNumber: 9},
+			}))
+		})
+		claimed, ledger, ok = getPoolClaimed(t, ctx, pool, poolAddr, userA)
+		require.True(t, ok)
+		assert.Equal(t, "140", claimed, "second claim accumulates onto the first")
+		assert.Equal(t, int32(9), ledger, "ledger advances to the newer claim")
+	})
+
+	t.Run("distinct users are independent", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, pm.BatchApplyDeltas(ctx, tx, []blend.PoolClaimedDelta{
+				{Pool: poolAddr, User: userB, ClaimedBlnd: "7", LedgerNumber: 3},
+			}))
+		})
+		claimed, _, ok := getPoolClaimed(t, ctx, pool, poolAddr, userB)
+		require.True(t, ok)
+		assert.Equal(t, "7", claimed)
+		// userA untouched.
+		claimedA, _, _ := getPoolClaimed(t, ctx, pool, poolAddr, userA)
+		assert.Equal(t, "140", claimedA)
+	})
+
+	t.Run("duplicate key in one batch is rejected", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			err := pm.BatchApplyDeltas(ctx, tx, []blend.PoolClaimedDelta{
+				{Pool: poolAddr, User: userA, ClaimedBlnd: "1", LedgerNumber: 10},
+				{Pool: poolAddr, User: userA, ClaimedBlnd: "2", LedgerNumber: 10},
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "pre-aggregated")
+		})
+	})
+}
+
+func TestBackstopClaimedModel_BatchApplyDeltas(t *testing.T) {
+	ctx, pool, _, bm, cleanup := newClaimedFixture(t)
+	defer cleanup()
+
+	userA := keypair.MustRandom().Address()
+	userB := keypair.MustRandom().Address()
+
+	t.Run("empty input is a no-op", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, bm.BatchApplyDeltas(ctx, tx, nil))
+		})
+	})
+
+	t.Run("accumulates per user account-wide", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, bm.BatchApplyDeltas(ctx, tx, []blend.BackstopClaimedDelta{
+				{User: userA, ClaimedLp: "1000", LedgerNumber: 4},
+				{User: userB, ClaimedLp: "50", LedgerNumber: 4},
+			}))
+		})
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, bm.BatchApplyDeltas(ctx, tx, []blend.BackstopClaimedDelta{
+				{User: userA, ClaimedLp: "250", LedgerNumber: 8},
+			}))
+		})
+		claimedA, ledgerA, ok := getBackstopClaimed(t, ctx, pool, userA)
+		require.True(t, ok)
+		assert.Equal(t, "1250", claimedA)
+		assert.Equal(t, int32(8), ledgerA)
+
+		claimedB, _, ok := getBackstopClaimed(t, ctx, pool, userB)
+		require.True(t, ok)
+		assert.Equal(t, "50", claimedB)
+	})
+
+	t.Run("duplicate key in one batch is rejected", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			err := bm.BatchApplyDeltas(ctx, tx, []blend.BackstopClaimedDelta{
+				{User: userA, ClaimedLp: "1", LedgerNumber: 9},
+				{User: userA, ClaimedLp: "2", LedgerNumber: 9},
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "pre-aggregated")
+		})
+	})
+}

--- a/internal/data/blend/emissions.go
+++ b/internal/data/blend/emissions.go
@@ -1,0 +1,192 @@
+// Reserve-level emission config and raw user emission accrual storage for
+// Blend v2 (blend_reserve_emissions, blend_emissions).
+package blend
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+	"github.com/stellar/wallet-backend/internal/utils"
+)
+
+// reserveEmissionsTable is the metrics label for blend_reserve_emissions queries.
+const reserveEmissionsTable = "blend_reserve_emissions"
+
+// emissionsTable is the metrics label for blend_emissions queries.
+const emissionsTable = "blend_emissions"
+
+// BackstopEmissionTokenID is the blend_emissions.token_id sentinel for a user's
+// backstop emission stream; those rows carry the backstopped POOL as
+// source_contract_id. Reserve-emission rows use token_id = reserve_index*2
+// (+1 for bToken) >= 0, so the key spaces stay disjoint.
+const BackstopEmissionTokenID int32 = -1
+
+// ReserveEmission is a row of blend_reserve_emissions: a pool's per-reserve-token
+// emission config/accrual (EmisData(reserve_token_id) on the pool contract).
+type ReserveEmission struct {
+	PoolContractID     types.AddressBytea
+	ReserveTokenID     int32
+	Eps                int64
+	EmissionIndex      string
+	Expiration         int64
+	LastTime           int64
+	LastModifiedLedger uint32
+}
+
+// ReserveEmissionModelInterface exposes Blend v2 reserve emission storage operations.
+type ReserveEmissionModelInterface interface {
+	// BatchUpsert inserts or fully replaces reserve emission rows keyed by
+	// (pool_contract_id, reserve_token_id).
+	BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []ReserveEmission) error
+}
+
+// ReserveEmissionModel implements ReserveEmissionModelInterface against blend_reserve_emissions.
+type ReserveEmissionModel struct {
+	DB      *pgxpool.Pool
+	Metrics *metrics.DBMetrics
+}
+
+var _ ReserveEmissionModelInterface = (*ReserveEmissionModel)(nil)
+
+// BatchUpsert inserts or fully replaces blend_reserve_emissions rows. See
+// ReserveEmissionModelInterface.
+func (m *ReserveEmissionModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []ReserveEmission) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	pools := make([][]byte, len(rows))
+	tokenIDs := make([]int32, len(rows))
+	epsValues := make([]int64, len(rows))
+	emissionIndexes := make([]string, len(rows))
+	expirations := make([]int64, len(rows))
+	lastTimes := make([]int64, len(rows))
+	ledgers := make([]int32, len(rows))
+	for i, r := range rows {
+		poolBytes, err := addressToBytes(string(r.PoolContractID))
+		if err != nil {
+			return fmt.Errorf("converting pool address for reserve emission upsert: %w", err)
+		}
+		pools[i] = poolBytes
+		tokenIDs[i] = r.ReserveTokenID
+		epsValues[i] = r.Eps
+		emissionIndexes[i] = r.EmissionIndex
+		expirations[i] = r.Expiration
+		lastTimes[i] = r.LastTime
+		ledgers[i] = int32(r.LastModifiedLedger)
+	}
+
+	const upsertQuery = `
+		INSERT INTO blend_reserve_emissions (
+			pool_contract_id, reserve_token_id, eps, emission_index, expiration, last_time, last_modified_ledger
+		)
+		SELECT * FROM UNNEST(
+			$1::bytea[], $2::integer[], $3::bigint[], $4::text[], $5::bigint[], $6::bigint[], $7::integer[]
+		)
+		ON CONFLICT (pool_contract_id, reserve_token_id) DO UPDATE SET
+			eps                  = EXCLUDED.eps,
+			emission_index       = EXCLUDED.emission_index,
+			expiration           = EXCLUDED.expiration,
+			last_time            = EXCLUDED.last_time,
+			last_modified_ledger = EXCLUDED.last_modified_ledger`
+	if _, err := dbTx.Exec(ctx, upsertQuery, pools, tokenIDs, epsValues, emissionIndexes, expirations, lastTimes, ledgers); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", reserveEmissionsTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("upserting blend reserve emissions: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", reserveEmissionsTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", reserveEmissionsTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("BatchUpsert", reserveEmissionsTable).Observe(float64(len(rows)))
+	return nil
+}
+
+// Emission is a row of blend_emissions: a user's raw emission accrual for one
+// token stream, either reserve emissions on a pool (TokenID >= 0) or backstop
+// emissions on a backstop (TokenID == BackstopEmissionTokenID).
+type Emission struct {
+	SourceContractID   types.AddressBytea
+	UserAccountID      types.AddressBytea
+	TokenID            int32
+	EmissionIndex      string
+	Accrued            string
+	LastModifiedLedger uint32
+}
+
+// EmissionModelInterface exposes Blend v2 user emission storage operations.
+type EmissionModelInterface interface {
+	// BatchUpsert inserts or fully replaces emission rows keyed by
+	// (source_contract_id, user_account_id, token_id).
+	BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []Emission) error
+}
+
+// EmissionModel implements EmissionModelInterface against blend_emissions.
+type EmissionModel struct {
+	DB      *pgxpool.Pool
+	Metrics *metrics.DBMetrics
+}
+
+var _ EmissionModelInterface = (*EmissionModel)(nil)
+
+// BatchUpsert inserts or fully replaces blend_emissions rows. See
+// EmissionModelInterface.
+func (m *EmissionModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []Emission) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	sources := make([][]byte, len(rows))
+	users := make([][]byte, len(rows))
+	tokenIDs := make([]int32, len(rows))
+	emissionIndexes := make([]string, len(rows))
+	accrueds := make([]string, len(rows))
+	ledgers := make([]int32, len(rows))
+	for i, r := range rows {
+		sourceBytes, err := addressToBytes(string(r.SourceContractID))
+		if err != nil {
+			return fmt.Errorf("converting source address for emission upsert: %w", err)
+		}
+		userBytes, err := addressToBytes(string(r.UserAccountID))
+		if err != nil {
+			return fmt.Errorf("converting user address for emission upsert: %w", err)
+		}
+		sources[i] = sourceBytes
+		users[i] = userBytes
+		tokenIDs[i] = r.TokenID
+		emissionIndexes[i] = r.EmissionIndex
+		accrueds[i] = r.Accrued
+		ledgers[i] = int32(r.LastModifiedLedger)
+	}
+
+	const upsertQuery = `
+		INSERT INTO blend_emissions (
+			source_contract_id, user_account_id, token_id, emission_index, accrued, last_modified_ledger
+		)
+		SELECT * FROM UNNEST(
+			$1::bytea[], $2::bytea[], $3::integer[], $4::text[], $5::text[], $6::integer[]
+		)
+		ON CONFLICT (source_contract_id, user_account_id, token_id) DO UPDATE SET
+			emission_index       = EXCLUDED.emission_index,
+			accrued              = EXCLUDED.accrued,
+			last_modified_ledger = EXCLUDED.last_modified_ledger`
+	if _, err := dbTx.Exec(ctx, upsertQuery, sources, users, tokenIDs, emissionIndexes, accrueds, ledgers); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", emissionsTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("upserting blend emissions: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", emissionsTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", emissionsTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("BatchUpsert", emissionsTable).Observe(float64(len(rows)))
+	return nil
+}

--- a/internal/data/blend/emissions.go
+++ b/internal/data/blend/emissions.go
@@ -96,7 +96,7 @@ func (m *ReserveEmissionModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, row
 			emission_index       = EXCLUDED.emission_index,
 			expiration           = EXCLUDED.expiration,
 			last_time            = EXCLUDED.last_time,
-			last_modified_ledger = EXCLUDED.last_modified_ledger`
+			last_modified_ledger = GREATEST(blend_reserve_emissions.last_modified_ledger, EXCLUDED.last_modified_ledger)`
 	if _, err := dbTx.Exec(ctx, upsertQuery, pools, tokenIDs, epsValues, emissionIndexes, expirations, lastTimes, ledgers); err != nil {
 		m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", reserveEmissionsTable, utils.GetDBErrorType(err)).Inc()
 		return fmt.Errorf("upserting blend reserve emissions: %w", err)
@@ -178,7 +178,7 @@ func (m *EmissionModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []Emi
 		ON CONFLICT (source_contract_id, user_account_id, token_id) DO UPDATE SET
 			emission_index       = EXCLUDED.emission_index,
 			accrued              = EXCLUDED.accrued,
-			last_modified_ledger = EXCLUDED.last_modified_ledger`
+			last_modified_ledger = GREATEST(blend_emissions.last_modified_ledger, EXCLUDED.last_modified_ledger)`
 	if _, err := dbTx.Exec(ctx, upsertQuery, sources, users, tokenIDs, emissionIndexes, accrueds, ledgers); err != nil {
 		m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", emissionsTable, utils.GetDBErrorType(err)).Inc()
 		return fmt.Errorf("upserting blend emissions: %w", err)

--- a/internal/data/blend/emissions_test.go
+++ b/internal/data/blend/emissions_test.go
@@ -1,0 +1,208 @@
+// Unit tests for the Blend v2 ReserveEmissionModel and EmissionModel.
+// These tests exercise real SQL and require a PostgreSQL test database.
+// Uses an external test package to avoid an import cycle with internal/data.
+package blend_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/data/blend"
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+)
+
+func newReserveEmissionsFixture(t *testing.T) (context.Context, *pgxpool.Pool, *blend.ReserveEmissionModel, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	dbt := dbtest.Open(t)
+	pool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+
+	m := &blend.ReserveEmissionModel{
+		DB:      pool,
+		Metrics: metrics.NewMetrics(prometheus.NewRegistry()).DB,
+	}
+
+	cleanup := func() {
+		pool.Close()
+		dbt.Close()
+	}
+	return ctx, pool, m, cleanup
+}
+
+func newEmissionsFixture(t *testing.T) (context.Context, *pgxpool.Pool, *blend.EmissionModel, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	dbt := dbtest.Open(t)
+	pool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+
+	m := &blend.EmissionModel{
+		DB:      pool,
+		Metrics: metrics.NewMetrics(prometheus.NewRegistry()).DB,
+	}
+
+	cleanup := func() {
+		pool.Close()
+		dbt.Close()
+	}
+	return ctx, pool, m, cleanup
+}
+
+type reserveEmissionRow struct {
+	Eps                int64
+	EmissionIndex      string
+	Expiration         int64
+	LastTime           int64
+	LastModifiedLedger int32
+}
+
+func getReserveEmission(t *testing.T, ctx context.Context, pool *pgxpool.Pool, poolAddr string, tokenID int32) (reserveEmissionRow, bool) {
+	t.Helper()
+	var row reserveEmissionRow
+	err := pool.QueryRow(ctx, `
+		SELECT eps, emission_index, expiration, last_time, last_modified_ledger
+		FROM blend_reserve_emissions WHERE pool_contract_id = $1 AND reserve_token_id = $2
+	`, types.AddressBytea(poolAddr), tokenID).Scan(&row.Eps, &row.EmissionIndex, &row.Expiration, &row.LastTime, &row.LastModifiedLedger)
+	if err != nil {
+		return reserveEmissionRow{}, false
+	}
+	return row, true
+}
+
+func TestReserveEmissionModel_BatchUpsert(t *testing.T) {
+	ctx, pool, m, cleanup := newReserveEmissionsFixture(t)
+	defer cleanup()
+
+	poolAddr := keypair.MustRandom().Address()
+
+	t.Run("inserts a fresh row", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsert(ctx, tx, []blend.ReserveEmission{{
+				PoolContractID: types.AddressBytea(poolAddr), ReserveTokenID: 0,
+				Eps: 100, EmissionIndex: "1", Expiration: 5000, LastTime: 100,
+				LastModifiedLedger: 1,
+			}}))
+		})
+
+		row, ok := getReserveEmission(t, ctx, pool, poolAddr, 0)
+		require.True(t, ok)
+		assert.Equal(t, int64(100), row.Eps)
+		assert.Equal(t, "1", row.EmissionIndex)
+		assert.Equal(t, int64(5000), row.Expiration)
+	})
+
+	t.Run("re-upsert replaces every column", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsert(ctx, tx, []blend.ReserveEmission{{
+				PoolContractID: types.AddressBytea(poolAddr), ReserveTokenID: 0,
+				Eps: 200, EmissionIndex: "2", Expiration: 6000, LastTime: 200,
+				LastModifiedLedger: 2,
+			}}))
+		})
+
+		row, ok := getReserveEmission(t, ctx, pool, poolAddr, 0)
+		require.True(t, ok)
+		assert.Equal(t, int64(200), row.Eps)
+		assert.Equal(t, "2", row.EmissionIndex)
+		assert.Equal(t, int64(6000), row.Expiration)
+		assert.Equal(t, int32(2), row.LastModifiedLedger)
+	})
+
+	t.Run("is a no-op when no rows are staged", func(t *testing.T) {
+		require.NoError(t, m.BatchUpsert(ctx, nil, nil))
+	})
+}
+
+type emissionRow struct {
+	EmissionIndex      string
+	Accrued            string
+	LastModifiedLedger int32
+}
+
+func getEmission(t *testing.T, ctx context.Context, pool *pgxpool.Pool, sourceAddr, userAddr string, tokenID int32) (emissionRow, bool) {
+	t.Helper()
+	var row emissionRow
+	err := pool.QueryRow(ctx, `
+		SELECT emission_index, accrued, last_modified_ledger
+		FROM blend_emissions WHERE source_contract_id = $1 AND user_account_id = $2 AND token_id = $3
+	`, types.AddressBytea(sourceAddr), types.AddressBytea(userAddr), tokenID).Scan(&row.EmissionIndex, &row.Accrued, &row.LastModifiedLedger)
+	if err != nil {
+		return emissionRow{}, false
+	}
+	return row, true
+}
+
+func TestEmissionModel_BatchUpsert(t *testing.T) {
+	ctx, pool, m, cleanup := newEmissionsFixture(t)
+	defer cleanup()
+
+	sourceAddr := keypair.MustRandom().Address()
+	userAddr := keypair.MustRandom().Address()
+
+	t.Run("inserts a fresh reserve-emission row", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsert(ctx, tx, []blend.Emission{{
+				SourceContractID: types.AddressBytea(sourceAddr), UserAccountID: types.AddressBytea(userAddr),
+				TokenID: 0, EmissionIndex: "1", Accrued: "100",
+				LastModifiedLedger: 1,
+			}}))
+		})
+
+		row, ok := getEmission(t, ctx, pool, sourceAddr, userAddr, 0)
+		require.True(t, ok)
+		assert.Equal(t, "1", row.EmissionIndex)
+		assert.Equal(t, "100", row.Accrued)
+	})
+
+	t.Run("backstop emission stream uses the sentinel token id and stays distinct", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsert(ctx, tx, []blend.Emission{{
+				SourceContractID: types.AddressBytea(sourceAddr), UserAccountID: types.AddressBytea(userAddr),
+				TokenID: blend.BackstopEmissionTokenID, EmissionIndex: "9", Accrued: "999",
+				LastModifiedLedger: 1,
+			}}))
+		})
+
+		backstopRow, ok := getEmission(t, ctx, pool, sourceAddr, userAddr, blend.BackstopEmissionTokenID)
+		require.True(t, ok)
+		assert.Equal(t, "999", backstopRow.Accrued)
+
+		// The reserve-emission row (token_id 0) from the previous subtest must be untouched.
+		reserveRow, ok := getEmission(t, ctx, pool, sourceAddr, userAddr, 0)
+		require.True(t, ok)
+		assert.Equal(t, "100", reserveRow.Accrued)
+	})
+
+	t.Run("re-upsert replaces emission_index and accrued", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsert(ctx, tx, []blend.Emission{{
+				SourceContractID: types.AddressBytea(sourceAddr), UserAccountID: types.AddressBytea(userAddr),
+				TokenID: 0, EmissionIndex: "5", Accrued: "555",
+				LastModifiedLedger: 3,
+			}}))
+		})
+
+		row, ok := getEmission(t, ctx, pool, sourceAddr, userAddr, 0)
+		require.True(t, ok)
+		assert.Equal(t, "5", row.EmissionIndex)
+		assert.Equal(t, "555", row.Accrued)
+		assert.Equal(t, int32(3), row.LastModifiedLedger)
+	})
+
+	t.Run("is a no-op when no rows are staged", func(t *testing.T) {
+		require.NoError(t, m.BatchUpsert(ctx, nil, nil))
+	})
+}

--- a/internal/data/blend/enums_test.go
+++ b/internal/data/blend/enums_test.go
@@ -69,3 +69,28 @@ func TestStateChangeEnums(t *testing.T) {
 		require.ErrorContains(t, err, "state_changes_state_change_reason_check")
 	})
 }
+
+func TestBlendTablesExist(t *testing.T) {
+	ctx, pool, cleanup := newStateChangesFixture(t)
+	defer cleanup()
+
+	tables := []string{
+		"blend_pools",
+		"blend_positions",
+		"blend_reserves",
+		"blend_backstop_positions",
+		"blend_backstop_pools",
+		"blend_reserve_emissions",
+		"blend_emissions",
+		"blend_oracle_prices",
+	}
+
+	for _, table := range tables {
+		t.Run(table, func(t *testing.T) {
+			var count int
+			err := pool.QueryRow(ctx, "SELECT COUNT(*) FROM "+table).Scan(&count)
+			require.NoError(t, err)
+			require.Zero(t, count)
+		})
+	}
+}

--- a/internal/data/blend/enums_test.go
+++ b/internal/data/blend/enums_test.go
@@ -83,6 +83,7 @@ func TestBlendTablesExist(t *testing.T) {
 		"blend_reserve_emissions",
 		"blend_emissions",
 		"blend_oracle_prices",
+		"blend_auctions",
 	}
 
 	for _, table := range tables {

--- a/internal/data/blend/enums_test.go
+++ b/internal/data/blend/enums_test.go
@@ -1,0 +1,71 @@
+// Unit tests for the state_changes LENDING category/reason CHECK constraints.
+// These tests exercise real SQL and require a PostgreSQL test database.
+// Uses an external test package to avoid an import cycle with internal/data.
+package blend_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+)
+
+func newStateChangesFixture(t *testing.T) (context.Context, *pgxpool.Pool, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	dbt := dbtest.Open(t)
+	pool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		pool.Close()
+		dbt.Close()
+	}
+	return ctx, pool, cleanup
+}
+
+func insertStateChange(ctx context.Context, pool *pgxpool.Pool, category, reason string) error {
+	acct := keypair.MustRandom().Address()
+	_, err := pool.Exec(ctx, `
+		INSERT INTO state_changes (
+			to_id, operation_id, state_change_id, state_change_category, state_change_reason,
+			ledger_number, account_id, ledger_created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`, int64(1), int64(1), int64(1), category, reason, int32(1), types.AddressBytea(acct), time.Now())
+	return err
+}
+
+func TestStateChangeEnums(t *testing.T) {
+	ctx, pool, cleanup := newStateChangesFixture(t)
+	defer cleanup()
+
+	t.Run("accepts BLEND_SUPPLY category with generic CREDIT reason", func(t *testing.T) {
+		err := insertStateChange(ctx, pool, "BLEND_SUPPLY", "CREDIT")
+		require.NoError(t, err)
+	})
+
+	t.Run("accepts BLEND_DEBT category with BORROW reason", func(t *testing.T) {
+		err := insertStateChange(ctx, pool, "BLEND_DEBT", "BORROW")
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects the retired LENDING category", func(t *testing.T) {
+		err := insertStateChange(ctx, pool, "LENDING", "CREDIT")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "state_changes_state_change_category_check")
+	})
+
+	t.Run("rejects a Blend category with an unknown reason", func(t *testing.T) {
+		err := insertStateChange(ctx, pool, "BLEND_SUPPLY", "BOGUS")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "state_changes_state_change_reason_check")
+	})
+}

--- a/internal/data/blend/models.go
+++ b/internal/data/blend/models.go
@@ -18,6 +18,7 @@ type Models struct {
 	ReserveEmissions  *ReserveEmissionModel
 	PoolClaimed       *PoolClaimedModel
 	BackstopClaimed   *BackstopClaimedModel
+	Auctions          *AuctionModel
 	// OraclePrices *OraclePriceModel is added in PR4 alongside oracle_prices.go.
 }
 
@@ -33,5 +34,6 @@ func NewModels(pool *pgxpool.Pool, dbMetrics *metrics.DBMetrics) Models {
 		ReserveEmissions:  &ReserveEmissionModel{DB: pool, Metrics: dbMetrics},
 		PoolClaimed:       &PoolClaimedModel{DB: pool, Metrics: dbMetrics},
 		BackstopClaimed:   &BackstopClaimedModel{DB: pool, Metrics: dbMetrics},
+		Auctions:          &AuctionModel{DB: pool, Metrics: dbMetrics},
 	}
 }

--- a/internal/data/blend/models.go
+++ b/internal/data/blend/models.go
@@ -16,6 +16,8 @@ type Models struct {
 	BackstopPools     *BackstopPoolModel
 	Emissions         *EmissionModel
 	ReserveEmissions  *ReserveEmissionModel
+	PoolClaimed       *PoolClaimedModel
+	BackstopClaimed   *BackstopClaimedModel
 	// OraclePrices *OraclePriceModel is added in PR4 alongside oracle_prices.go.
 }
 

--- a/internal/data/blend/models.go
+++ b/internal/data/blend/models.go
@@ -31,5 +31,7 @@ func NewModels(pool *pgxpool.Pool, dbMetrics *metrics.DBMetrics) Models {
 		BackstopPools:     &BackstopPoolModel{DB: pool, Metrics: dbMetrics},
 		Emissions:         &EmissionModel{DB: pool, Metrics: dbMetrics},
 		ReserveEmissions:  &ReserveEmissionModel{DB: pool, Metrics: dbMetrics},
+		PoolClaimed:       &PoolClaimedModel{DB: pool, Metrics: dbMetrics},
+		BackstopClaimed:   &BackstopClaimedModel{DB: pool, Metrics: dbMetrics},
 	}
 }

--- a/internal/data/blend/models.go
+++ b/internal/data/blend/models.go
@@ -1,0 +1,33 @@
+package blend
+
+import (
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/stellar/wallet-backend/internal/metrics"
+)
+
+// Models aggregates Blend v2 data models so callers can reach them via a single
+// field on data.Models (e.g., models.Blend.Pools).
+type Models struct {
+	Pools             *PoolModel
+	Positions         *PositionModel
+	Reserves          *ReserveModel
+	BackstopPositions *BackstopPositionModel
+	BackstopPools     *BackstopPoolModel
+	Emissions         *EmissionModel
+	ReserveEmissions  *ReserveEmissionModel
+	// OraclePrices *OraclePriceModel is added in PR4 alongside oracle_prices.go.
+}
+
+// NewModels constructs the Blend Models aggregate wired to the given pool/metrics.
+func NewModels(pool *pgxpool.Pool, dbMetrics *metrics.DBMetrics) Models {
+	return Models{
+		Pools:             &PoolModel{DB: pool, Metrics: dbMetrics},
+		Positions:         &PositionModel{DB: pool, Metrics: dbMetrics},
+		Reserves:          &ReserveModel{DB: pool, Metrics: dbMetrics},
+		BackstopPositions: &BackstopPositionModel{DB: pool, Metrics: dbMetrics},
+		BackstopPools:     &BackstopPoolModel{DB: pool, Metrics: dbMetrics},
+		Emissions:         &EmissionModel{DB: pool, Metrics: dbMetrics},
+		ReserveEmissions:  &ReserveEmissionModel{DB: pool, Metrics: dbMetrics},
+	}
+}

--- a/internal/data/blend/models_test.go
+++ b/internal/data/blend/models_test.go
@@ -2,6 +2,7 @@
 package blend_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -14,11 +15,10 @@ import (
 func TestNewModels(t *testing.T) {
 	m := blend.NewModels(nil, metrics.NewMetrics(prometheus.NewRegistry()).DB)
 
-	assert.NotNil(t, m.Pools)
-	assert.NotNil(t, m.Positions)
-	assert.NotNil(t, m.Reserves)
-	assert.NotNil(t, m.BackstopPositions)
-	assert.NotNil(t, m.BackstopPools)
-	assert.NotNil(t, m.Emissions)
-	assert.NotNil(t, m.ReserveEmissions)
+	// Walk every field reflectively so a model added to the struct but not to
+	// NewModels fails here instead of nil-panicking at runtime.
+	v := reflect.ValueOf(m)
+	for i := range v.NumField() {
+		assert.False(t, v.Field(i).IsNil(), "Models.%s is not constructed by NewModels", v.Type().Field(i).Name)
+	}
 }

--- a/internal/data/blend/models_test.go
+++ b/internal/data/blend/models_test.go
@@ -1,0 +1,24 @@
+// Unit tests for the Blend v2 Models aggregate.
+package blend_test
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stellar/wallet-backend/internal/data/blend"
+	"github.com/stellar/wallet-backend/internal/metrics"
+)
+
+func TestNewModels(t *testing.T) {
+	m := blend.NewModels(nil, metrics.NewMetrics(prometheus.NewRegistry()).DB)
+
+	assert.NotNil(t, m.Pools)
+	assert.NotNil(t, m.Positions)
+	assert.NotNil(t, m.Reserves)
+	assert.NotNil(t, m.BackstopPositions)
+	assert.NotNil(t, m.BackstopPools)
+	assert.NotNil(t, m.Emissions)
+	assert.NotNil(t, m.ReserveEmissions)
+}

--- a/internal/data/blend/pools.go
+++ b/internal/data/blend/pools.go
@@ -1,0 +1,124 @@
+// Pool-level config/metadata storage for Blend v2 (blend_pools).
+package blend
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+	"github.com/stellar/wallet-backend/internal/utils"
+)
+
+// poolsTable is the metrics label for blend_pools queries.
+const poolsTable = "blend_pools"
+
+// Pool is a row of blend_pools: pool-level config parsed from PoolConfig
+// instance storage plus the pool's display name. Config fields are pointers
+// because a single event often reveals only some of them (e.g. a name comes
+// from a different source than PoolConfig); BatchUpsert preserves whichever
+// fields aren't supplied.
+type Pool struct {
+	PoolContractID types.AddressBytea
+	Name           *string
+	// OracleContractID is stored as SQL NULL when empty (no oracle wired for
+	// this pool yet, or not known from the current event).
+	OracleContractID   types.AddressBytea
+	BackstopRate       *int32
+	Status             *int32
+	MaxPositions       *int32
+	MinCollateral      *string
+	LastModifiedLedger uint32
+}
+
+// PoolModelInterface exposes Blend v2 pool storage operations.
+type PoolModelInterface interface {
+	// BatchUpsert inserts or partially updates pool config rows. Every nullable
+	// column uses COALESCE(EXCLUDED.col, blend_pools.col) so a nil field (not
+	// known/changed by the event that produced this row) never clobbers a
+	// previously known value. last_modified_ledger is always taken from EXCLUDED.
+	BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []Pool) error
+}
+
+// PoolModel implements PoolModelInterface against blend_pools.
+type PoolModel struct {
+	DB      *pgxpool.Pool
+	Metrics *metrics.DBMetrics
+}
+
+var _ PoolModelInterface = (*PoolModel)(nil)
+
+// BatchUpsert inserts or partially updates blend_pools rows. See PoolModelInterface.
+func (m *PoolModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []Pool) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	poolIDs := make([][]byte, len(rows))
+	names := make([]*string, len(rows))
+	oracleIDs := make([][]byte, len(rows))
+	backstopRates := make([]*int32, len(rows))
+	statuses := make([]*int32, len(rows))
+	maxPositions := make([]*int32, len(rows))
+	minCollaterals := make([]*string, len(rows))
+	ledgers := make([]int32, len(rows))
+	for i, r := range rows {
+		poolBytes, err := addressToBytes(string(r.PoolContractID))
+		if err != nil {
+			return fmt.Errorf("converting pool address for pool upsert: %w", err)
+		}
+		poolIDs[i] = poolBytes
+
+		var oracleBytes []byte
+		if r.OracleContractID != "" {
+			oracleBytes, err = addressToBytes(string(r.OracleContractID))
+			if err != nil {
+				return fmt.Errorf("converting oracle address for pool upsert: %w", err)
+			}
+		}
+		oracleIDs[i] = oracleBytes
+
+		names[i] = r.Name
+		backstopRates[i] = r.BackstopRate
+		statuses[i] = r.Status
+		maxPositions[i] = r.MaxPositions
+		minCollaterals[i] = r.MinCollateral
+		ledgers[i] = int32(r.LastModifiedLedger)
+	}
+
+	const upsertQuery = `
+		INSERT INTO blend_pools (
+			pool_contract_id, name, oracle_contract_id, backstop_rate,
+			status, max_positions, min_collateral, last_modified_ledger
+		)
+		SELECT * FROM UNNEST(
+			$1::bytea[], $2::text[], $3::bytea[], $4::integer[],
+			$5::integer[], $6::integer[], $7::text[], $8::integer[]
+		)
+		ON CONFLICT (pool_contract_id) DO UPDATE SET
+			name                 = COALESCE(EXCLUDED.name, blend_pools.name),
+			oracle_contract_id   = COALESCE(EXCLUDED.oracle_contract_id, blend_pools.oracle_contract_id),
+			backstop_rate        = COALESCE(EXCLUDED.backstop_rate, blend_pools.backstop_rate),
+			status               = COALESCE(EXCLUDED.status, blend_pools.status),
+			max_positions        = COALESCE(EXCLUDED.max_positions, blend_pools.max_positions),
+			min_collateral       = COALESCE(EXCLUDED.min_collateral, blend_pools.min_collateral),
+			last_modified_ledger = EXCLUDED.last_modified_ledger`
+	if _, err := dbTx.Exec(ctx, upsertQuery,
+		poolIDs, names, oracleIDs, backstopRates, statuses, maxPositions, minCollaterals, ledgers,
+	); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", poolsTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("upserting blend pools: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", poolsTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", poolsTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("BatchUpsert", poolsTable).Observe(float64(len(rows)))
+	return nil
+}

--- a/internal/data/blend/pools.go
+++ b/internal/data/blend/pools.go
@@ -27,11 +27,13 @@ type Pool struct {
 	Name           *string
 	// OracleContractID is stored as SQL NULL when empty (no oracle wired for
 	// this pool yet, or not known from the current event).
-	OracleContractID   types.AddressBytea
-	BackstopRate       *int32
-	Status             *int32
-	MaxPositions       *int32
-	MinCollateral      *string
+	OracleContractID types.AddressBytea
+	BackstopRate     *int32
+	Status           *int32
+	MaxPositions     *int32
+	MinCollateral    *string
+	// Admin is stored as SQL NULL when empty, identically to OracleContractID.
+	Admin              types.AddressBytea
 	LastModifiedLedger uint32
 }
 
@@ -42,6 +44,11 @@ type PoolModelInterface interface {
 	// known/changed by the event that produced this row) never clobbers a
 	// previously known value. last_modified_ledger is always taken from EXCLUDED.
 	BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []Pool) error
+	// SetRewardZone makes poolIDs the exact reward-zone membership set: listed
+	// pools become members, all other rows non-members. Rows whose membership
+	// already matches are left untouched (their last_modified_ledger keeps its
+	// value). An empty poolIDs is valid and clears membership everywhere.
+	SetRewardZone(ctx context.Context, dbTx pgx.Tx, poolIDs []types.AddressBytea, ledger int32) error
 }
 
 // PoolModel implements PoolModelInterface against blend_pools.
@@ -67,6 +74,7 @@ func (m *PoolModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []Pool) e
 	statuses := make([]*int32, len(rows))
 	maxPositions := make([]*int32, len(rows))
 	minCollaterals := make([]*string, len(rows))
+	admins := make([][]byte, len(rows))
 	ledgers := make([]int32, len(rows))
 	for i, r := range rows {
 		poolBytes, err := addressToBytes(string(r.PoolContractID))
@@ -84,6 +92,15 @@ func (m *PoolModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []Pool) e
 		}
 		oracleIDs[i] = oracleBytes
 
+		var adminBytes []byte
+		if r.Admin != "" {
+			adminBytes, err = addressToBytes(string(r.Admin))
+			if err != nil {
+				return fmt.Errorf("converting admin address for pool upsert: %w", err)
+			}
+		}
+		admins[i] = adminBytes
+
 		names[i] = r.Name
 		backstopRates[i] = r.BackstopRate
 		statuses[i] = r.Status
@@ -95,11 +112,11 @@ func (m *PoolModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []Pool) e
 	const upsertQuery = `
 		INSERT INTO blend_pools (
 			pool_contract_id, name, oracle_contract_id, backstop_rate,
-			status, max_positions, min_collateral, last_modified_ledger
+			status, max_positions, min_collateral, admin, last_modified_ledger
 		)
 		SELECT * FROM UNNEST(
 			$1::bytea[], $2::text[], $3::bytea[], $4::integer[],
-			$5::integer[], $6::integer[], $7::text[], $8::integer[]
+			$5::integer[], $6::integer[], $7::text[], $8::bytea[], $9::integer[]
 		)
 		ON CONFLICT (pool_contract_id) DO UPDATE SET
 			name                 = COALESCE(EXCLUDED.name, blend_pools.name),
@@ -108,9 +125,10 @@ func (m *PoolModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []Pool) e
 			status               = COALESCE(EXCLUDED.status, blend_pools.status),
 			max_positions        = COALESCE(EXCLUDED.max_positions, blend_pools.max_positions),
 			min_collateral       = COALESCE(EXCLUDED.min_collateral, blend_pools.min_collateral),
+			admin                = COALESCE(EXCLUDED.admin, blend_pools.admin),
 			last_modified_ledger = EXCLUDED.last_modified_ledger`
 	if _, err := dbTx.Exec(ctx, upsertQuery,
-		poolIDs, names, oracleIDs, backstopRates, statuses, maxPositions, minCollaterals, ledgers,
+		poolIDs, names, oracleIDs, backstopRates, statuses, maxPositions, minCollaterals, admins, ledgers,
 	); err != nil {
 		m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", poolsTable, utils.GetDBErrorType(err)).Inc()
 		return fmt.Errorf("upserting blend pools: %w", err)
@@ -120,5 +138,36 @@ func (m *PoolModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []Pool) e
 	m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", poolsTable).Observe(duration)
 	m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", poolsTable).Inc()
 	m.Metrics.BatchSize.WithLabelValues("BatchUpsert", poolsTable).Observe(float64(len(rows)))
+	return nil
+}
+
+// SetRewardZone makes poolIDs the exact reward-zone membership set. See
+// PoolModelInterface.
+func (m *PoolModel) SetRewardZone(ctx context.Context, dbTx pgx.Tx, poolIDs []types.AddressBytea, ledger int32) error {
+	start := time.Now()
+
+	pools := make([][]byte, len(poolIDs))
+	for i, p := range poolIDs {
+		poolBytes, err := addressToBytes(string(p))
+		if err != nil {
+			return fmt.Errorf("converting pool address for reward-zone set: %w", err)
+		}
+		pools[i] = poolBytes
+	}
+
+	const setQuery = `
+		UPDATE blend_pools SET
+			in_reward_zone = (pool_contract_id = ANY($1)),
+			last_modified_ledger = GREATEST(last_modified_ledger, $2)
+		WHERE in_reward_zone <> (pool_contract_id = ANY($1))`
+	if _, err := dbTx.Exec(ctx, setQuery, pools, ledger); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("SetRewardZone", poolsTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("setting blend pool reward zone: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("SetRewardZone", poolsTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("SetRewardZone", poolsTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("SetRewardZone", poolsTable).Observe(float64(len(poolIDs)))
 	return nil
 }

--- a/internal/data/blend/pools.go
+++ b/internal/data/blend/pools.go
@@ -126,7 +126,7 @@ func (m *PoolModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []Pool) e
 			max_positions        = COALESCE(EXCLUDED.max_positions, blend_pools.max_positions),
 			min_collateral       = COALESCE(EXCLUDED.min_collateral, blend_pools.min_collateral),
 			admin                = COALESCE(EXCLUDED.admin, blend_pools.admin),
-			last_modified_ledger = EXCLUDED.last_modified_ledger`
+			last_modified_ledger = GREATEST(blend_pools.last_modified_ledger, EXCLUDED.last_modified_ledger)`
 	if _, err := dbTx.Exec(ctx, upsertQuery,
 		poolIDs, names, oracleIDs, backstopRates, statuses, maxPositions, minCollaterals, admins, ledgers,
 	); err != nil {

--- a/internal/data/blend/pools_test.go
+++ b/internal/data/blend/pools_test.go
@@ -1,0 +1,150 @@
+// Unit tests for the Blend v2 PoolModel.
+// These tests exercise real SQL and require a PostgreSQL test database.
+// Uses an external test package to avoid an import cycle with internal/data.
+package blend_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/data/blend"
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+)
+
+func newPoolsFixture(t *testing.T) (context.Context, *pgxpool.Pool, *blend.PoolModel, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	dbt := dbtest.Open(t)
+	pool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+
+	m := &blend.PoolModel{
+		DB:      pool,
+		Metrics: metrics.NewMetrics(prometheus.NewRegistry()).DB,
+	}
+
+	cleanup := func() {
+		pool.Close()
+		dbt.Close()
+	}
+	return ctx, pool, m, cleanup
+}
+
+type poolRow struct {
+	Name               *string
+	OracleContractID   *string
+	BackstopRate       *int32
+	Status             *int32
+	MaxPositions       *int32
+	MinCollateral      *string
+	LastModifiedLedger int32
+}
+
+func getPool(t *testing.T, ctx context.Context, pool *pgxpool.Pool, poolAddr string) (poolRow, bool) {
+	t.Helper()
+	var row poolRow
+	var oracle *types.AddressBytea
+	err := pool.QueryRow(ctx, `
+		SELECT name, oracle_contract_id, backstop_rate, status, max_positions, min_collateral, last_modified_ledger
+		FROM blend_pools WHERE pool_contract_id = $1
+	`, types.AddressBytea(poolAddr)).Scan(
+		&row.Name, &oracle, &row.BackstopRate, &row.Status, &row.MaxPositions, &row.MinCollateral, &row.LastModifiedLedger,
+	)
+	if err != nil {
+		return poolRow{}, false
+	}
+	if oracle != nil {
+		s := string(*oracle)
+		row.OracleContractID = &s
+	}
+	return row, true
+}
+
+func strPtr(s string) *string { return &s }
+func i32Ptr(i int32) *int32   { return &i }
+
+func TestPoolModel_BatchUpsert(t *testing.T) {
+	ctx, pool, m, cleanup := newPoolsFixture(t)
+	defer cleanup()
+
+	poolAddr := keypair.MustRandom().Address()
+	oracleAddr := keypair.MustRandom().Address()
+
+	t.Run("inserts a fresh row with all fields", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsert(ctx, tx, []blend.Pool{{
+				PoolContractID:     types.AddressBytea(poolAddr),
+				Name:               strPtr("Fixed Pool v2"),
+				OracleContractID:   types.AddressBytea(oracleAddr),
+				BackstopRate:       i32Ptr(2000),
+				Status:             i32Ptr(0),
+				MaxPositions:       i32Ptr(4),
+				MinCollateral:      strPtr("100"),
+				LastModifiedLedger: 10,
+			}}))
+		})
+
+		row, ok := getPool(t, ctx, pool, poolAddr)
+		require.True(t, ok)
+		require.NotNil(t, row.Name)
+		assert.Equal(t, "Fixed Pool v2", *row.Name)
+		require.NotNil(t, row.OracleContractID)
+		assert.Equal(t, oracleAddr, *row.OracleContractID)
+		require.NotNil(t, row.BackstopRate)
+		assert.Equal(t, int32(2000), *row.BackstopRate)
+		require.NotNil(t, row.Status)
+		assert.Equal(t, int32(0), *row.Status)
+		assert.Equal(t, int32(10), row.LastModifiedLedger)
+	})
+
+	t.Run("re-upsert with a nil field preserves the existing value (COALESCE)", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsert(ctx, tx, []blend.Pool{{
+				PoolContractID:     types.AddressBytea(poolAddr),
+				Name:               nil, // not known by this event
+				Status:             i32Ptr(3),
+				LastModifiedLedger: 11,
+			}}))
+		})
+
+		row, ok := getPool(t, ctx, pool, poolAddr)
+		require.True(t, ok)
+		require.NotNil(t, row.Name, "name must be preserved when the update carries nil")
+		assert.Equal(t, "Fixed Pool v2", *row.Name)
+		require.NotNil(t, row.Status)
+		assert.Equal(t, int32(3), *row.Status, "status must be updated")
+		assert.Equal(t, int32(11), row.LastModifiedLedger, "last_modified_ledger is always taken")
+	})
+
+	t.Run("empty OracleContractID is stored as SQL NULL", func(t *testing.T) {
+		poolAddr := keypair.MustRandom().Address()
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsert(ctx, tx, []blend.Pool{{
+				PoolContractID:     types.AddressBytea(poolAddr),
+				OracleContractID:   "",
+				LastModifiedLedger: 1,
+			}}))
+		})
+
+		var isNull bool
+		err := pool.QueryRow(ctx, `SELECT oracle_contract_id IS NULL FROM blend_pools WHERE pool_contract_id = $1`,
+			types.AddressBytea(poolAddr)).Scan(&isNull)
+		require.NoError(t, err)
+		assert.True(t, isNull, "empty OracleContractID must be stored as NULL")
+	})
+
+	t.Run("is a no-op when no rows are staged", func(t *testing.T) {
+		require.NoError(t, m.BatchUpsert(ctx, nil, nil))
+	})
+}

--- a/internal/data/blend/pools_test.go
+++ b/internal/data/blend/pools_test.go
@@ -48,18 +48,22 @@ type poolRow struct {
 	Status             *int32
 	MaxPositions       *int32
 	MinCollateral      *string
+	Admin              *string
+	InRewardZone       bool
 	LastModifiedLedger int32
 }
 
 func getPool(t *testing.T, ctx context.Context, pool *pgxpool.Pool, poolAddr string) (poolRow, bool) {
 	t.Helper()
 	var row poolRow
-	var oracle *types.AddressBytea
+	var oracle, admin *types.AddressBytea
 	err := pool.QueryRow(ctx, `
-		SELECT name, oracle_contract_id, backstop_rate, status, max_positions, min_collateral, last_modified_ledger
+		SELECT name, oracle_contract_id, backstop_rate, status, max_positions, min_collateral,
+			admin, in_reward_zone, last_modified_ledger
 		FROM blend_pools WHERE pool_contract_id = $1
 	`, types.AddressBytea(poolAddr)).Scan(
-		&row.Name, &oracle, &row.BackstopRate, &row.Status, &row.MaxPositions, &row.MinCollateral, &row.LastModifiedLedger,
+		&row.Name, &oracle, &row.BackstopRate, &row.Status, &row.MaxPositions, &row.MinCollateral,
+		&admin, &row.InRewardZone, &row.LastModifiedLedger,
 	)
 	if err != nil {
 		return poolRow{}, false
@@ -67,6 +71,10 @@ func getPool(t *testing.T, ctx context.Context, pool *pgxpool.Pool, poolAddr str
 	if oracle != nil {
 		s := string(*oracle)
 		row.OracleContractID = &s
+	}
+	if admin != nil {
+		s := string(*admin)
+		row.Admin = &s
 	}
 	return row, true
 }
@@ -80,6 +88,7 @@ func TestPoolModel_BatchUpsert(t *testing.T) {
 
 	poolAddr := keypair.MustRandom().Address()
 	oracleAddr := keypair.MustRandom().Address()
+	adminAddr := keypair.MustRandom().Address()
 
 	t.Run("inserts a fresh row with all fields", func(t *testing.T) {
 		runInTx(t, ctx, pool, func(tx pgx.Tx) {
@@ -91,6 +100,7 @@ func TestPoolModel_BatchUpsert(t *testing.T) {
 				Status:             i32Ptr(0),
 				MaxPositions:       i32Ptr(4),
 				MinCollateral:      strPtr("100"),
+				Admin:              types.AddressBytea(adminAddr),
 				LastModifiedLedger: 10,
 			}}))
 		})
@@ -105,6 +115,8 @@ func TestPoolModel_BatchUpsert(t *testing.T) {
 		assert.Equal(t, int32(2000), *row.BackstopRate)
 		require.NotNil(t, row.Status)
 		assert.Equal(t, int32(0), *row.Status)
+		require.NotNil(t, row.Admin)
+		assert.Equal(t, adminAddr, *row.Admin)
 		assert.Equal(t, int32(10), row.LastModifiedLedger)
 	})
 
@@ -124,6 +136,8 @@ func TestPoolModel_BatchUpsert(t *testing.T) {
 		assert.Equal(t, "Fixed Pool v2", *row.Name)
 		require.NotNil(t, row.Status)
 		assert.Equal(t, int32(3), *row.Status, "status must be updated")
+		require.NotNil(t, row.Admin, "admin must be preserved when the update carries empty")
+		assert.Equal(t, adminAddr, *row.Admin)
 		assert.Equal(t, int32(11), row.LastModifiedLedger, "last_modified_ledger is always taken")
 	})
 
@@ -146,5 +160,83 @@ func TestPoolModel_BatchUpsert(t *testing.T) {
 
 	t.Run("is a no-op when no rows are staged", func(t *testing.T) {
 		require.NoError(t, m.BatchUpsert(ctx, nil, nil))
+	})
+}
+
+func TestPoolModel_SetRewardZone(t *testing.T) {
+	ctx, pool, m, cleanup := newPoolsFixture(t)
+	defer cleanup()
+
+	poolA := keypair.MustRandom().Address()
+	poolB := keypair.MustRandom().Address()
+	poolC := keypair.MustRandom().Address()
+
+	runInTx(t, ctx, pool, func(tx pgx.Tx) {
+		require.NoError(t, m.BatchUpsert(ctx, tx, []blend.Pool{
+			{PoolContractID: types.AddressBytea(poolA), LastModifiedLedger: 1},
+			{PoolContractID: types.AddressBytea(poolB), LastModifiedLedger: 1},
+			{PoolContractID: types.AddressBytea(poolC), LastModifiedLedger: 1},
+		}))
+	})
+
+	t.Run("marks the given pools as reward-zone members, others as non-members", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.SetRewardZone(ctx, tx, []types.AddressBytea{
+				types.AddressBytea(poolA), types.AddressBytea(poolB),
+			}, 100))
+		})
+
+		rowA, ok := getPool(t, ctx, pool, poolA)
+		require.True(t, ok)
+		assert.True(t, rowA.InRewardZone)
+		assert.Equal(t, int32(100), rowA.LastModifiedLedger, "membership changed, ledger bumped")
+
+		rowB, ok := getPool(t, ctx, pool, poolB)
+		require.True(t, ok)
+		assert.True(t, rowB.InRewardZone)
+		assert.Equal(t, int32(100), rowB.LastModifiedLedger)
+
+		rowC, ok := getPool(t, ctx, pool, poolC)
+		require.True(t, ok)
+		assert.False(t, rowC.InRewardZone)
+		assert.Equal(t, int32(1), rowC.LastModifiedLedger, "not a member before or after, unchanged")
+	})
+
+	t.Run("dropping a pool from the set flips it false; unchanged members keep their ledger", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.SetRewardZone(ctx, tx, []types.AddressBytea{
+				types.AddressBytea(poolB),
+			}, 200))
+		})
+
+		rowA, ok := getPool(t, ctx, pool, poolA)
+		require.True(t, ok)
+		assert.False(t, rowA.InRewardZone, "A dropped from the set")
+		assert.Equal(t, int32(200), rowA.LastModifiedLedger, "membership changed, ledger bumped")
+
+		rowB, ok := getPool(t, ctx, pool, poolB)
+		require.True(t, ok)
+		assert.True(t, rowB.InRewardZone, "B stays a member")
+		assert.Equal(t, int32(100), rowB.LastModifiedLedger, "membership unchanged, ledger not bumped")
+	})
+
+	t.Run("an empty set clears membership everywhere (not a no-op)", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.SetRewardZone(ctx, tx, []types.AddressBytea{}, 300))
+		})
+
+		rowA, ok := getPool(t, ctx, pool, poolA)
+		require.True(t, ok)
+		assert.False(t, rowA.InRewardZone)
+
+		rowB, ok := getPool(t, ctx, pool, poolB)
+		require.True(t, ok)
+		assert.False(t, rowB.InRewardZone)
+		assert.Equal(t, int32(300), rowB.LastModifiedLedger, "B's membership changed (true->false), ledger bumped")
+
+		rowC, ok := getPool(t, ctx, pool, poolC)
+		require.True(t, ok)
+		assert.False(t, rowC.InRewardZone)
+		assert.Equal(t, int32(1), rowC.LastModifiedLedger, "C was never a member, unchanged")
 	})
 }

--- a/internal/data/blend/positions.go
+++ b/internal/data/blend/positions.go
@@ -216,7 +216,7 @@ func (m *PositionModel) ZeroAbsentReserves(ctx context.Context, dbTx pgx.Tx, pre
 	const zeroQuery = `
 		UPDATE blend_positions p SET
 			supply_b_tokens = '0', collateral_b_tokens = '0', liability_d_tokens = '0',
-			last_modified_ledger = u.ledger
+			last_modified_ledger = GREATEST(p.last_modified_ledger, u.ledger)
 		FROM UNNEST($1::bytea[], $2::bytea[], $3::text[], $4::integer[]) AS u(pool, usr, present_csv, ledger)
 		WHERE p.pool_contract_id = u.pool AND p.user_account_id = u.usr
 		  AND NOT (p.reserve_index = ANY (string_to_array(u.present_csv, ',')::integer[]))`
@@ -275,7 +275,7 @@ func (m *PositionModel) BatchUpsertSnapshots(ctx context.Context, dbTx pgx.Tx, r
 			supply_b_tokens = EXCLUDED.supply_b_tokens,
 			collateral_b_tokens = EXCLUDED.collateral_b_tokens,
 			liability_d_tokens = EXCLUDED.liability_d_tokens,
-			last_modified_ledger = EXCLUDED.last_modified_ledger`
+			last_modified_ledger = GREATEST(blend_positions.last_modified_ledger, EXCLUDED.last_modified_ledger)`
 	if _, err := dbTx.Exec(ctx, upsertQuery, pools, users, indexes, supplyBTokens, collateralBTokens, liabilityDTokens, ledgers); err != nil {
 		m.Metrics.QueryErrors.WithLabelValues("BatchUpsertSnapshots", positionsTable, utils.GetDBErrorType(err)).Inc()
 		return fmt.Errorf("upserting blend position snapshots: %w", err)

--- a/internal/data/blend/positions.go
+++ b/internal/data/blend/positions.go
@@ -31,6 +31,21 @@ type PoolUserKey struct {
 	Pool, User string // Pool: C-address, User: G-address
 }
 
+// Position is a full row of blend_positions, mirroring every column. Writers
+// operate on the narrower structs below instead; this type exists for PR5
+// readers to scan a full row into.
+type Position struct {
+	PoolContractID     types.AddressBytea
+	UserAccountID      types.AddressBytea
+	ReserveIndex       int32
+	SupplyBTokens      string
+	CollateralBTokens  string
+	LiabilityDTokens   string
+	NetSupplied        string
+	NetBorrowed        string
+	LastModifiedLedger uint32
+}
+
 // PositionPresence carries the set of reserve indexes still present in a user's
 // Positions entry for a pool, so absent indexes can be zeroed (a partial exit
 // keeps the row for cost-basis history instead of deleting it).

--- a/internal/data/blend/positions.go
+++ b/internal/data/blend/positions.go
@@ -373,14 +373,21 @@ func (m *PositionModel) BatchApplyNetDeltas(ctx context.Context, dbTx pgx.Tx, de
 // applyAuctionAdjustmentsSQL divides by rateScalar to convert protocol-token
 // amounts (lot/bid, scaled by b_rate/d_rate) to underlying-asset amounts.
 //
+// The conversion is truncated toward zero (trunc), matching the contract's
+// fixed_mul_floor, which floors the magnitude of a positive token amount. Because
+// lot_b/bid_d are signed (the liquidated user's deltas are negative, the filler's
+// positive), trunc — not floor — reproduces "floor the magnitude, keep the sign":
+// trunc(-x.y) == -floor(x.y). This keeps cost basis in the same floored-integer
+// form as BatchApplyNetDeltas instead of accruing a fractional tail.
+//
 // The UNNEST rows are pre-aggregated per (pool, user, asset): Postgres's
 // UPDATE ... FROM applies only ONE matching source row per target row, so two
 // fills against the same position in one batch would otherwise silently drop
 // an adjustment. Auction deltas are purely additive, so summing is exact.
 var applyAuctionAdjustmentsSQL = fmt.Sprintf(`
 	UPDATE blend_positions p SET
-		net_supplied = (p.net_supplied::numeric + u.lot_b * r.b_rate::numeric / %[1]s)::text,
-		net_borrowed = (p.net_borrowed::numeric + u.bid_d * r.d_rate::numeric / %[1]s)::text,
+		net_supplied = (p.net_supplied::numeric + trunc(u.lot_b * r.b_rate::numeric / %[1]s))::text,
+		net_borrowed = (p.net_borrowed::numeric + trunc(u.bid_d * r.d_rate::numeric / %[1]s))::text,
 		last_modified_ledger = GREATEST(p.last_modified_ledger, u.ledger)
 	FROM (
 		SELECT raw.pool, raw.usr, raw.asset,

--- a/internal/data/blend/positions.go
+++ b/internal/data/blend/positions.go
@@ -296,6 +296,13 @@ func (m *PositionModel) BatchUpsertSnapshots(ctx context.Context, dbTx pgx.Tx, r
 // ZeroBorrowed, when true, replaces net_borrowed with NetBorrowedDelta instead
 // of adding to it — used to fold a bad_debt event, which resets the borrower's
 // liability cost basis rather than accumulating against it.
+//
+// Each (Pool, User, Asset) key must appear at most once per batch: Postgres's
+// UPDATE ... FROM applies only ONE matching source row per target row, so a
+// duplicate key would silently drop deltas. Duplicates can't be merged here
+// either — ZeroBorrowed makes combination order-dependent, and the batch
+// carries no ordering — so the caller must pre-aggregate (the processor's
+// staged fold does) and duplicates are rejected with an error.
 func (m *PositionModel) BatchApplyNetDeltas(ctx context.Context, dbTx pgx.Tx, deltas []PositionNetDelta) error {
 	if len(deltas) == 0 {
 		return nil
@@ -310,6 +317,7 @@ func (m *PositionModel) BatchApplyNetDeltas(ctx context.Context, dbTx pgx.Tx, de
 	netBorrowedDeltas := make([]string, len(deltas))
 	zeroBorrowedFlags := make([]bool, len(deltas))
 	ledgers := make([]int32, len(deltas))
+	seen := make(map[PoolUserKey]map[string]struct{}, len(deltas))
 	for i, d := range deltas {
 		poolBytes, err := addressToBytes(d.Pool)
 		if err != nil {
@@ -323,6 +331,14 @@ func (m *PositionModel) BatchApplyNetDeltas(ctx context.Context, dbTx pgx.Tx, de
 		if err != nil {
 			return fmt.Errorf("converting asset address for net-delta apply: %w", err)
 		}
+		groupKey := PoolUserKey{Pool: d.Pool, User: d.User}
+		if _, dup := seen[groupKey][d.Asset]; dup {
+			return fmt.Errorf("duplicate net delta for pool=%s user=%s asset=%s: deltas must be pre-aggregated per key", d.Pool, d.User, d.Asset)
+		}
+		if seen[groupKey] == nil {
+			seen[groupKey] = make(map[string]struct{})
+		}
+		seen[groupKey][d.Asset] = struct{}{}
 		pools[i] = poolBytes
 		users[i] = userBytes
 		assets[i] = assetBytes
@@ -356,13 +372,24 @@ func (m *PositionModel) BatchApplyNetDeltas(ctx context.Context, dbTx pgx.Tx, de
 
 // applyAuctionAdjustmentsSQL divides by rateScalar to convert protocol-token
 // amounts (lot/bid, scaled by b_rate/d_rate) to underlying-asset amounts.
+//
+// The UNNEST rows are pre-aggregated per (pool, user, asset): Postgres's
+// UPDATE ... FROM applies only ONE matching source row per target row, so two
+// fills against the same position in one batch would otherwise silently drop
+// an adjustment. Auction deltas are purely additive, so summing is exact.
 var applyAuctionAdjustmentsSQL = fmt.Sprintf(`
 	UPDATE blend_positions p SET
-		net_supplied = (p.net_supplied::numeric + u.lot_b::numeric * r.b_rate::numeric / %[1]s)::text,
-		net_borrowed = (p.net_borrowed::numeric + u.bid_d::numeric * r.d_rate::numeric / %[1]s)::text,
+		net_supplied = (p.net_supplied::numeric + u.lot_b * r.b_rate::numeric / %[1]s)::text,
+		net_borrowed = (p.net_borrowed::numeric + u.bid_d * r.d_rate::numeric / %[1]s)::text,
 		last_modified_ledger = GREATEST(p.last_modified_ledger, u.ledger)
-	FROM UNNEST($1::bytea[], $2::bytea[], $3::bytea[], $4::text[], $5::text[], $6::integer[])
-		AS u(pool, usr, asset, lot_b, bid_d, ledger)
+	FROM (
+		SELECT raw.pool, raw.usr, raw.asset,
+			SUM(raw.lot_b::numeric) AS lot_b, SUM(raw.bid_d::numeric) AS bid_d,
+			MAX(raw.ledger) AS ledger
+		FROM UNNEST($1::bytea[], $2::bytea[], $3::bytea[], $4::text[], $5::text[], $6::integer[])
+			AS raw(pool, usr, asset, lot_b, bid_d, ledger)
+		GROUP BY raw.pool, raw.usr, raw.asset
+	) u
 	JOIN blend_reserves r ON r.pool_contract_id = u.pool AND r.asset_contract_id = u.asset
 	WHERE p.pool_contract_id = u.pool AND p.user_account_id = u.usr AND p.reserve_index = r.reserve_index`,
 	rateScalar,
@@ -371,7 +398,9 @@ var applyAuctionAdjustmentsSQL = fmt.Sprintf(`
 // ApplyAuctionAdjustments values protocol-token auction fills (lot/bid amounts)
 // at the reserve's current b_rate/d_rate and applies the resulting underlying
 // amount to cost basis. Adjustments whose asset has no matching blend_reserves
-// row for the pool are silently skipped (0 rows affected).
+// row for the pool are silently skipped (0 rows affected). Multiple
+// adjustments for the same (pool, user, asset) in one batch are summed
+// server-side before applying.
 func (m *PositionModel) ApplyAuctionAdjustments(ctx context.Context, dbTx pgx.Tx, adjs []PositionAuctionAdjustment) error {
 	if len(adjs) == 0 {
 		return nil

--- a/internal/data/blend/positions.go
+++ b/internal/data/blend/positions.go
@@ -1,0 +1,404 @@
+// Package blend provides data access for Blend v2 lending protocol state:
+// per-pool-per-user positions, reserve config/rates, backstop positions, and
+// emissions. This file covers the positions model.
+package blend
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+	"github.com/stellar/wallet-backend/internal/utils"
+)
+
+// positionsTable is the metrics label for blend_positions queries.
+const positionsTable = "blend_positions"
+
+// rateScalar is Blend v2's 12-decimal fixed-point base for b_rate/d_rate,
+// inlined into SQL that converts protocol-token amounts to underlying.
+// Pinned against blend-contracts-v2 in Task 3.0.
+const rateScalar = "1000000000000"
+
+// PoolUserKey identifies a single (pool, user) position group for deletion.
+type PoolUserKey struct {
+	Pool, User string // Pool: C-address, User: G-address
+}
+
+// PositionPresence carries the set of reserve indexes still present in a user's
+// Positions entry for a pool, so absent indexes can be zeroed (a partial exit
+// keeps the row for cost-basis history instead of deleting it).
+type PositionPresence struct {
+	Pool, User     string
+	PresentIndexes []int32
+	LedgerNumber   uint32
+}
+
+// PositionSnapshot is a last-write-wins snapshot of current token holdings for
+// one (pool, user, reserve_index). It never touches the net_supplied/net_borrowed
+// cost-basis columns.
+type PositionSnapshot struct {
+	Pool, User        string
+	ReserveIndex      int32
+	SupplyBTokens     string
+	CollateralBTokens string
+	LiabilityDTokens  string
+	LedgerNumber      uint32
+}
+
+// PositionNetDelta is a signed, additive delta against the cost-basis columns
+// for one (pool, user, asset). ZeroBorrowed, when true, replaces net_borrowed
+// with NetBorrowedDelta instead of adding to it (used to fold a bad_debt event,
+// which resets liability cost basis rather than accumulating against it).
+type PositionNetDelta struct {
+	Pool, User, Asset string
+	NetSuppliedDelta  string
+	NetBorrowedDelta  string
+	ZeroBorrowed      bool
+	LedgerNumber      uint32
+}
+
+// PositionAuctionAdjustment values a protocol-token delta (lot/bid amounts from
+// an auction fill) at the reserve's current b_rate/d_rate and applies the
+// resulting underlying-asset amount to the cost-basis columns.
+type PositionAuctionAdjustment struct {
+	Pool, User, Asset string
+	LotBTokensDelta   string // protocol-token units, signed
+	BidDTokensDelta   string // protocol-token units, signed
+	LedgerNumber      uint32
+}
+
+// PositionModelInterface exposes Blend v2 position storage operations.
+type PositionModelInterface interface {
+	// DeleteByPoolUser removes every reserve row for the given (pool, user) pairs.
+	// Used when a Positions entry is removed entirely (full exit).
+	DeleteByPoolUser(ctx context.Context, dbTx pgx.Tx, keys []PoolUserKey) error
+	// ZeroAbsentReserves zeroes the token columns (supply/collateral/liability) of
+	// any existing row whose reserve_index is not present in PresentIndexes. Cost
+	// basis (net_supplied/net_borrowed) is left untouched.
+	ZeroAbsentReserves(ctx context.Context, dbTx pgx.Tx, presences []PositionPresence) error
+	// BatchUpsertSnapshots upserts current token holdings. Cost-basis columns are
+	// left at their existing (or default) value.
+	BatchUpsertSnapshots(ctx context.Context, dbTx pgx.Tx, rows []PositionSnapshot) error
+	// BatchApplyNetDeltas accumulates signed cost-basis deltas server-side, resolving
+	// each delta's asset to a reserve_index via blend_reserves.
+	BatchApplyNetDeltas(ctx context.Context, dbTx pgx.Tx, deltas []PositionNetDelta) error
+	// ApplyAuctionAdjustments values protocol-token auction fills at the reserve's
+	// current rates and applies the resulting underlying amounts to cost basis.
+	ApplyAuctionAdjustments(ctx context.Context, dbTx pgx.Tx, adjs []PositionAuctionAdjustment) error
+}
+
+// PositionModel implements PositionModelInterface against blend_positions.
+type PositionModel struct {
+	DB      *pgxpool.Pool
+	Metrics *metrics.DBMetrics
+}
+
+var _ PositionModelInterface = (*PositionModel)(nil)
+
+// addressToBytes converts a strkey address (G... or C...) to the 33-byte BYTEA
+// representation used by the address columns, identically to how sep41 models
+// convert AddressBytea at the write boundary.
+func addressToBytes(addr string) ([]byte, error) {
+	raw, err := types.AddressBytea(addr).Value()
+	if err != nil {
+		return nil, fmt.Errorf("converting address %s to bytes: %w", addr, err)
+	}
+	b, ok := raw.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("converting address %s to bytes: expected []byte, got %T", addr, raw)
+	}
+	return b, nil
+}
+
+// presentIndexesCSV joins reserve indexes into a comma-separated string for the
+// ZeroAbsentReserves query, which unpacks it server-side via string_to_array.
+// An empty slice yields "", and string_to_array(”, ',') yields an empty array
+// — i.e. every reserve_index is considered absent.
+func presentIndexesCSV(indexes []int32) string {
+	if len(indexes) == 0 {
+		return ""
+	}
+	parts := make([]string, len(indexes))
+	for i, idx := range indexes {
+		parts[i] = strconv.FormatInt(int64(idx), 10)
+	}
+	return strings.Join(parts, ",")
+}
+
+// DeleteByPoolUser removes every blend_positions row for the given (pool, user) pairs.
+func (m *PositionModel) DeleteByPoolUser(ctx context.Context, dbTx pgx.Tx, keys []PoolUserKey) error {
+	if len(keys) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	pools := make([][]byte, len(keys))
+	users := make([][]byte, len(keys))
+	for i, k := range keys {
+		poolBytes, err := addressToBytes(k.Pool)
+		if err != nil {
+			return fmt.Errorf("converting pool address for delete: %w", err)
+		}
+		userBytes, err := addressToBytes(k.User)
+		if err != nil {
+			return fmt.Errorf("converting user address for delete: %w", err)
+		}
+		pools[i] = poolBytes
+		users[i] = userBytes
+	}
+
+	const deleteQuery = `
+		DELETE FROM blend_positions
+		WHERE (pool_contract_id, user_account_id) IN (SELECT * FROM UNNEST($1::bytea[], $2::bytea[]))`
+	if _, err := dbTx.Exec(ctx, deleteQuery, pools, users); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("DeleteByPoolUser", positionsTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("deleting blend positions: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("DeleteByPoolUser", positionsTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("DeleteByPoolUser", positionsTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("DeleteByPoolUser", positionsTable).Observe(float64(len(keys)))
+	return nil
+}
+
+// ZeroAbsentReserves zeroes token columns for any reserve_index not present in
+// each presence's PresentIndexes list. Cost-basis columns are untouched.
+func (m *PositionModel) ZeroAbsentReserves(ctx context.Context, dbTx pgx.Tx, presences []PositionPresence) error {
+	if len(presences) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	pools := make([][]byte, len(presences))
+	users := make([][]byte, len(presences))
+	presentCSVs := make([]string, len(presences))
+	ledgers := make([]int32, len(presences))
+	for i, p := range presences {
+		poolBytes, err := addressToBytes(p.Pool)
+		if err != nil {
+			return fmt.Errorf("converting pool address for zero-absent-reserves: %w", err)
+		}
+		userBytes, err := addressToBytes(p.User)
+		if err != nil {
+			return fmt.Errorf("converting user address for zero-absent-reserves: %w", err)
+		}
+		pools[i] = poolBytes
+		users[i] = userBytes
+		presentCSVs[i] = presentIndexesCSV(p.PresentIndexes)
+		ledgers[i] = int32(p.LedgerNumber)
+	}
+
+	const zeroQuery = `
+		UPDATE blend_positions p SET
+			supply_b_tokens = '0', collateral_b_tokens = '0', liability_d_tokens = '0',
+			last_modified_ledger = u.ledger
+		FROM UNNEST($1::bytea[], $2::bytea[], $3::text[], $4::integer[]) AS u(pool, usr, present_csv, ledger)
+		WHERE p.pool_contract_id = u.pool AND p.user_account_id = u.usr
+		  AND NOT (p.reserve_index = ANY (string_to_array(u.present_csv, ',')::integer[]))`
+	if _, err := dbTx.Exec(ctx, zeroQuery, pools, users, presentCSVs, ledgers); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("ZeroAbsentReserves", positionsTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("zeroing absent blend reserves: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("ZeroAbsentReserves", positionsTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("ZeroAbsentReserves", positionsTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("ZeroAbsentReserves", positionsTable).Observe(float64(len(presences)))
+	return nil
+}
+
+// BatchUpsertSnapshots upserts current token holdings (supply/collateral/liability)
+// as absolute, last-write-wins values. Cost-basis columns (net_supplied/net_borrowed)
+// are left at their existing or default value.
+func (m *PositionModel) BatchUpsertSnapshots(ctx context.Context, dbTx pgx.Tx, rows []PositionSnapshot) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	pools := make([][]byte, len(rows))
+	users := make([][]byte, len(rows))
+	indexes := make([]int32, len(rows))
+	supplyBTokens := make([]string, len(rows))
+	collateralBTokens := make([]string, len(rows))
+	liabilityDTokens := make([]string, len(rows))
+	ledgers := make([]int32, len(rows))
+	for i, r := range rows {
+		poolBytes, err := addressToBytes(r.Pool)
+		if err != nil {
+			return fmt.Errorf("converting pool address for snapshot upsert: %w", err)
+		}
+		userBytes, err := addressToBytes(r.User)
+		if err != nil {
+			return fmt.Errorf("converting user address for snapshot upsert: %w", err)
+		}
+		pools[i] = poolBytes
+		users[i] = userBytes
+		indexes[i] = r.ReserveIndex
+		supplyBTokens[i] = r.SupplyBTokens
+		collateralBTokens[i] = r.CollateralBTokens
+		liabilityDTokens[i] = r.LiabilityDTokens
+		ledgers[i] = int32(r.LedgerNumber)
+	}
+
+	const upsertQuery = `
+		INSERT INTO blend_positions (pool_contract_id, user_account_id, reserve_index,
+			supply_b_tokens, collateral_b_tokens, liability_d_tokens, last_modified_ledger)
+		SELECT * FROM UNNEST($1::bytea[], $2::bytea[], $3::integer[], $4::text[], $5::text[], $6::text[], $7::integer[])
+		ON CONFLICT (pool_contract_id, user_account_id, reserve_index) DO UPDATE SET
+			supply_b_tokens = EXCLUDED.supply_b_tokens,
+			collateral_b_tokens = EXCLUDED.collateral_b_tokens,
+			liability_d_tokens = EXCLUDED.liability_d_tokens,
+			last_modified_ledger = EXCLUDED.last_modified_ledger`
+	if _, err := dbTx.Exec(ctx, upsertQuery, pools, users, indexes, supplyBTokens, collateralBTokens, liabilityDTokens, ledgers); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("BatchUpsertSnapshots", positionsTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("upserting blend position snapshots: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("BatchUpsertSnapshots", positionsTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("BatchUpsertSnapshots", positionsTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("BatchUpsertSnapshots", positionsTable).Observe(float64(len(rows)))
+	return nil
+}
+
+// BatchApplyNetDeltas accumulates signed cost-basis deltas server-side
+// (net_supplied/net_borrowed := existing + delta), resolving each delta's asset
+// to a reserve_index via blend_reserves. Deltas whose asset has no matching
+// blend_reserves row for the pool are silently skipped (0 rows affected).
+//
+// ZeroBorrowed, when true, replaces net_borrowed with NetBorrowedDelta instead
+// of adding to it — used to fold a bad_debt event, which resets the borrower's
+// liability cost basis rather than accumulating against it.
+func (m *PositionModel) BatchApplyNetDeltas(ctx context.Context, dbTx pgx.Tx, deltas []PositionNetDelta) error {
+	if len(deltas) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	pools := make([][]byte, len(deltas))
+	users := make([][]byte, len(deltas))
+	assets := make([][]byte, len(deltas))
+	netSuppliedDeltas := make([]string, len(deltas))
+	netBorrowedDeltas := make([]string, len(deltas))
+	zeroBorrowedFlags := make([]bool, len(deltas))
+	ledgers := make([]int32, len(deltas))
+	for i, d := range deltas {
+		poolBytes, err := addressToBytes(d.Pool)
+		if err != nil {
+			return fmt.Errorf("converting pool address for net-delta apply: %w", err)
+		}
+		userBytes, err := addressToBytes(d.User)
+		if err != nil {
+			return fmt.Errorf("converting user address for net-delta apply: %w", err)
+		}
+		assetBytes, err := addressToBytes(d.Asset)
+		if err != nil {
+			return fmt.Errorf("converting asset address for net-delta apply: %w", err)
+		}
+		pools[i] = poolBytes
+		users[i] = userBytes
+		assets[i] = assetBytes
+		netSuppliedDeltas[i] = d.NetSuppliedDelta
+		netBorrowedDeltas[i] = d.NetBorrowedDelta
+		zeroBorrowedFlags[i] = d.ZeroBorrowed
+		ledgers[i] = int32(d.LedgerNumber)
+	}
+
+	const applyQuery = `
+		UPDATE blend_positions p SET
+			net_supplied = (p.net_supplied::numeric + u.ns_delta::numeric)::text,
+			net_borrowed = CASE WHEN u.zero_borrowed THEN u.nb_delta
+				ELSE (p.net_borrowed::numeric + u.nb_delta::numeric)::text END,
+			last_modified_ledger = GREATEST(p.last_modified_ledger, u.ledger)
+		FROM UNNEST($1::bytea[], $2::bytea[], $3::bytea[], $4::text[], $5::text[], $6::boolean[], $7::integer[])
+			AS u(pool, usr, asset, ns_delta, nb_delta, zero_borrowed, ledger)
+		JOIN blend_reserves r ON r.pool_contract_id = u.pool AND r.asset_contract_id = u.asset
+		WHERE p.pool_contract_id = u.pool AND p.user_account_id = u.usr AND p.reserve_index = r.reserve_index`
+	if _, err := dbTx.Exec(ctx, applyQuery, pools, users, assets, netSuppliedDeltas, netBorrowedDeltas, zeroBorrowedFlags, ledgers); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("BatchApplyNetDeltas", positionsTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("applying blend position net deltas: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("BatchApplyNetDeltas", positionsTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("BatchApplyNetDeltas", positionsTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("BatchApplyNetDeltas", positionsTable).Observe(float64(len(deltas)))
+	return nil
+}
+
+// applyAuctionAdjustmentsSQL divides by rateScalar to convert protocol-token
+// amounts (lot/bid, scaled by b_rate/d_rate) to underlying-asset amounts.
+var applyAuctionAdjustmentsSQL = fmt.Sprintf(`
+	UPDATE blend_positions p SET
+		net_supplied = (p.net_supplied::numeric + u.lot_b::numeric * r.b_rate::numeric / %[1]s)::text,
+		net_borrowed = (p.net_borrowed::numeric + u.bid_d::numeric * r.d_rate::numeric / %[1]s)::text,
+		last_modified_ledger = GREATEST(p.last_modified_ledger, u.ledger)
+	FROM UNNEST($1::bytea[], $2::bytea[], $3::bytea[], $4::text[], $5::text[], $6::integer[])
+		AS u(pool, usr, asset, lot_b, bid_d, ledger)
+	JOIN blend_reserves r ON r.pool_contract_id = u.pool AND r.asset_contract_id = u.asset
+	WHERE p.pool_contract_id = u.pool AND p.user_account_id = u.usr AND p.reserve_index = r.reserve_index`,
+	rateScalar,
+)
+
+// ApplyAuctionAdjustments values protocol-token auction fills (lot/bid amounts)
+// at the reserve's current b_rate/d_rate and applies the resulting underlying
+// amount to cost basis. Adjustments whose asset has no matching blend_reserves
+// row for the pool are silently skipped (0 rows affected).
+func (m *PositionModel) ApplyAuctionAdjustments(ctx context.Context, dbTx pgx.Tx, adjs []PositionAuctionAdjustment) error {
+	if len(adjs) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	pools := make([][]byte, len(adjs))
+	users := make([][]byte, len(adjs))
+	assets := make([][]byte, len(adjs))
+	lotBTokensDeltas := make([]string, len(adjs))
+	bidDTokensDeltas := make([]string, len(adjs))
+	ledgers := make([]int32, len(adjs))
+	for i, a := range adjs {
+		poolBytes, err := addressToBytes(a.Pool)
+		if err != nil {
+			return fmt.Errorf("converting pool address for auction adjustment: %w", err)
+		}
+		userBytes, err := addressToBytes(a.User)
+		if err != nil {
+			return fmt.Errorf("converting user address for auction adjustment: %w", err)
+		}
+		assetBytes, err := addressToBytes(a.Asset)
+		if err != nil {
+			return fmt.Errorf("converting asset address for auction adjustment: %w", err)
+		}
+		pools[i] = poolBytes
+		users[i] = userBytes
+		assets[i] = assetBytes
+		lotBTokensDeltas[i] = a.LotBTokensDelta
+		bidDTokensDeltas[i] = a.BidDTokensDelta
+		ledgers[i] = int32(a.LedgerNumber)
+	}
+
+	if _, err := dbTx.Exec(ctx, applyAuctionAdjustmentsSQL, pools, users, assets, lotBTokensDeltas, bidDTokensDeltas, ledgers); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("ApplyAuctionAdjustments", positionsTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("applying blend position auction adjustments: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("ApplyAuctionAdjustments", positionsTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("ApplyAuctionAdjustments", positionsTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("ApplyAuctionAdjustments", positionsTable).Observe(float64(len(adjs)))
+	return nil
+}

--- a/internal/data/blend/positions.go
+++ b/internal/data/blend/positions.go
@@ -293,6 +293,12 @@ func (m *PositionModel) BatchUpsertSnapshots(ctx context.Context, dbTx pgx.Tx, r
 // to a reserve_index via blend_reserves. Deltas whose asset has no matching
 // blend_reserves row for the pool are silently skipped (0 rows affected).
 //
+// This is UPDATE-only: it mutates existing rows and never inserts. A delta for a
+// (pool, user, reserve) with no row yet is a no-op, so callers must persist the
+// absolute Positions snapshot (BatchUpsertSnapshots) — and the reserves it joins
+// against — before applying deltas in the same transaction. PersistCurrentState
+// enforces this ordering (reserves -> snapshots -> net deltas).
+//
 // ZeroBorrowed, when true, replaces net_borrowed with NetBorrowedDelta instead
 // of adding to it — used to fold a bad_debt event, which resets the borrower's
 // liability cost basis rather than accumulating against it.
@@ -408,6 +414,21 @@ var applyAuctionAdjustmentsSQL = fmt.Sprintf(`
 // row for the pool are silently skipped (0 rows affected). Multiple
 // adjustments for the same (pool, user, asset) in one batch are summed
 // server-side before applying.
+//
+// Like BatchApplyNetDeltas this is UPDATE-only: the position snapshot (and its
+// reserve) must already exist for the adjustment to land. PersistCurrentState
+// runs it after BatchUpsertSnapshots for that reason.
+//
+// The rates are the ones blend_reserves holds when this runs, i.e. the rates as
+// of the end of the batch's window. A window spanning several ledgers therefore
+// values all of its accumulated lot_b/bid_d deltas at end-of-window rates rather
+// than at each fill's own rates. The divergence from per-ledger ingestion is
+// bounded by the interest accruing between a fill and window close — relative
+// error at most borrow APR × (window duration / year), ~1e-5 for the default
+// 100-ledger (~8 min) window at 50% APR. It affects only the
+// interestEarned/interestPaid cost-basis display fields and applies once, to
+// windowed migration: live ingestion runs window=1, where the rates read here
+// are the fill's own.
 func (m *PositionModel) ApplyAuctionAdjustments(ctx context.Context, dbTx pgx.Tx, adjs []PositionAuctionAdjustment) error {
 	if len(adjs) == 0 {
 		return nil

--- a/internal/data/blend/positions.go
+++ b/internal/data/blend/positions.go
@@ -390,6 +390,16 @@ func (m *PositionModel) BatchApplyNetDeltas(ctx context.Context, dbTx pgx.Tx, de
 // UPDATE ... FROM applies only ONE matching source row per target row, so two
 // fills against the same position in one batch would otherwise silently drop
 // an adjustment. Auction deltas are purely additive, so summing is exact.
+//
+// Conversion happens after the GROUP BY, so a folded batch is floored once on
+// the summed delta rather than per fill. Flooring doesn't distribute over
+// addition, so n fills against one position overstate magnitude by at most
+// n-1 stroops (at b_rate 1.1, two fills of 5 give trunc(11.0) = 11, not
+// trunc(5.5) * 2 = 10). That is strictly smaller than the end-of-window rate
+// approximation quantified on ApplyAuctionAdjustments below, and affects the
+// same display-only cost-basis fields, so the cheaper single trunc is kept
+// deliberately. Moving trunc inside the subquery would restore per-fill
+// flooring if that ever matters.
 var applyAuctionAdjustmentsSQL = fmt.Sprintf(`
 	UPDATE blend_positions p SET
 		net_supplied = (p.net_supplied::numeric + trunc(u.lot_b * r.b_rate::numeric / %[1]s))::text,

--- a/internal/data/blend/positions_test.go
+++ b/internal/data/blend/positions_test.go
@@ -335,6 +335,21 @@ func TestPositionModel_BatchApplyNetDeltas(t *testing.T) {
 	t.Run("is a no-op when no deltas are staged", func(t *testing.T) {
 		require.NoError(t, m.BatchApplyNetDeltas(ctx, nil, nil))
 	})
+
+	t.Run("rejects duplicate (pool, user, asset) keys", func(t *testing.T) {
+		// UPDATE ... FROM would apply only one of the two source rows, and
+		// merging them here would be order-dependent because of ZeroBorrowed —
+		// the model demands pre-aggregated input instead.
+		userAddr := keypair.MustRandom().Address()
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+		defer func() { _ = tx.Rollback(ctx) }()
+		err = m.BatchApplyNetDeltas(ctx, tx, []blend.PositionNetDelta{
+			{Pool: poolAddr, User: userAddr, Asset: assetAddr, NetSuppliedDelta: "10", NetBorrowedDelta: "0", LedgerNumber: 5},
+			{Pool: poolAddr, User: userAddr, Asset: assetAddr, NetSuppliedDelta: "20", NetBorrowedDelta: "0", LedgerNumber: 5},
+		})
+		require.ErrorContains(t, err, "pre-aggregated")
+	})
 }
 
 func TestPositionModel_ApplyAuctionAdjustments(t *testing.T) {
@@ -364,6 +379,28 @@ func TestPositionModel_ApplyAuctionAdjustments(t *testing.T) {
 		// 1000 bid d-tokens * 1.05 d_rate = 1050 underlying added to net_borrowed.
 		assert.Equal(t, "1050.0000000000000000", row.NetBorrowed)
 		assert.Equal(t, int32(77), row.LastModifiedLedger)
+	})
+
+	t.Run("sums duplicate (pool, user, asset) adjustments before applying", func(t *testing.T) {
+		userAddr := keypair.MustRandom().Address()
+		insertPosition(t, ctx, pool, poolAddr, userAddr, 4, "0", "0", "0", "0", "0")
+
+		// Two fills against the same position in one batch: without the
+		// GROUP BY pre-aggregation, UPDATE ... FROM would apply only one.
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.ApplyAuctionAdjustments(ctx, tx, []blend.PositionAuctionAdjustment{
+				{Pool: poolAddr, User: userAddr, Asset: assetAddr, LotBTokensDelta: "1000", BidDTokensDelta: "1000", LedgerNumber: 77},
+				{Pool: poolAddr, User: userAddr, Asset: assetAddr, LotBTokensDelta: "500", BidDTokensDelta: "500", LedgerNumber: 78},
+			}))
+		})
+
+		row, ok := getPosition(t, ctx, pool, poolAddr, userAddr, 4)
+		require.True(t, ok)
+		// (1000 + 500) lot b-tokens * 1.1 b_rate = 1650 underlying.
+		assert.Equal(t, "1650.0000000000000000", row.NetSupplied)
+		// (1000 + 500) bid d-tokens * 1.05 d_rate = 1575 underlying.
+		assert.Equal(t, "1575.0000000000000000", row.NetBorrowed)
+		assert.Equal(t, int32(78), row.LastModifiedLedger, "ledger takes the MAX across the batch")
 	})
 
 	t.Run("is a no-op when no adjustments are staged", func(t *testing.T) {

--- a/internal/data/blend/positions_test.go
+++ b/internal/data/blend/positions_test.go
@@ -375,10 +375,38 @@ func TestPositionModel_ApplyAuctionAdjustments(t *testing.T) {
 		row, ok := getPosition(t, ctx, pool, poolAddr, userAddr, 4)
 		require.True(t, ok)
 		// 1000 lot b-tokens * 1.1 b_rate = 1100 underlying added to net_supplied.
-		assert.Equal(t, "1100.0000000000000000", row.NetSupplied)
+		assert.Equal(t, "1100", row.NetSupplied)
 		// 1000 bid d-tokens * 1.05 d_rate = 1050 underlying added to net_borrowed.
-		assert.Equal(t, "1050.0000000000000000", row.NetBorrowed)
+		assert.Equal(t, "1050", row.NetBorrowed)
 		assert.Equal(t, int32(77), row.LastModifiedLedger)
+	})
+
+	t.Run("floors the converted underlying toward zero (matching fixed_mul_floor)", func(t *testing.T) {
+		// A filler gains lot / owes bid (positive deltas); the liquidated user's
+		// deltas are negative. 333 * 1.1 = 366.3 and 333 * 1.05 = 349.65 — both
+		// have a fractional tail that must be dropped toward zero, so the negative
+		// (user) side lands on -366 / -349, NOT the -367 / -350 that floor would give.
+		fillerAddr := keypair.MustRandom().Address()
+		userAddr := keypair.MustRandom().Address()
+		insertPosition(t, ctx, pool, poolAddr, fillerAddr, 4, "0", "0", "0", "0", "0")
+		insertPosition(t, ctx, pool, poolAddr, userAddr, 4, "0", "0", "0", "0", "0")
+
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.ApplyAuctionAdjustments(ctx, tx, []blend.PositionAuctionAdjustment{
+				{Pool: poolAddr, User: fillerAddr, Asset: assetAddr, LotBTokensDelta: "333", BidDTokensDelta: "333", LedgerNumber: 90},
+				{Pool: poolAddr, User: userAddr, Asset: assetAddr, LotBTokensDelta: "-333", BidDTokensDelta: "-333", LedgerNumber: 90},
+			}))
+		})
+
+		filler, ok := getPosition(t, ctx, pool, poolAddr, fillerAddr, 4)
+		require.True(t, ok)
+		assert.Equal(t, "366", filler.NetSupplied, "trunc(366.3) = 366")
+		assert.Equal(t, "349", filler.NetBorrowed, "trunc(349.65) = 349")
+
+		user, ok := getPosition(t, ctx, pool, poolAddr, userAddr, 4)
+		require.True(t, ok)
+		assert.Equal(t, "-366", user.NetSupplied, "trunc(-366.3) = -366, not floor's -367")
+		assert.Equal(t, "-349", user.NetBorrowed, "trunc(-349.65) = -349, not floor's -350")
 	})
 
 	t.Run("sums duplicate (pool, user, asset) adjustments before applying", func(t *testing.T) {
@@ -397,9 +425,9 @@ func TestPositionModel_ApplyAuctionAdjustments(t *testing.T) {
 		row, ok := getPosition(t, ctx, pool, poolAddr, userAddr, 4)
 		require.True(t, ok)
 		// (1000 + 500) lot b-tokens * 1.1 b_rate = 1650 underlying.
-		assert.Equal(t, "1650.0000000000000000", row.NetSupplied)
+		assert.Equal(t, "1650", row.NetSupplied)
 		// (1000 + 500) bid d-tokens * 1.05 d_rate = 1575 underlying.
-		assert.Equal(t, "1575.0000000000000000", row.NetBorrowed)
+		assert.Equal(t, "1575", row.NetBorrowed)
 		assert.Equal(t, int32(78), row.LastModifiedLedger, "ledger takes the MAX across the batch")
 	})
 

--- a/internal/data/blend/positions_test.go
+++ b/internal/data/blend/positions_test.go
@@ -1,0 +1,405 @@
+// Unit tests for the Blend v2 PositionModel.
+// These tests exercise real SQL and require a PostgreSQL test database.
+// Uses an external test package to avoid an import cycle with internal/data.
+package blend_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/data/blend"
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+)
+
+func newPositionsFixture(t *testing.T) (context.Context, *pgxpool.Pool, *blend.PositionModel, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	dbt := dbtest.Open(t)
+	pool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+
+	m := &blend.PositionModel{
+		DB:      pool,
+		Metrics: metrics.NewMetrics(prometheus.NewRegistry()).DB,
+	}
+
+	cleanup := func() {
+		pool.Close()
+		dbt.Close()
+	}
+	return ctx, pool, m, cleanup
+}
+
+func runInTx(t *testing.T, ctx context.Context, pool *pgxpool.Pool, fn func(pgx.Tx)) {
+	t.Helper()
+	tx, err := pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+	fn(tx)
+	require.NoError(t, tx.Commit(ctx))
+}
+
+// insertPositionLedger is the fixed last_modified_ledger seeded by insertPosition.
+// Tests that need to assert a ledger bump use it as the "before" value.
+const insertPositionLedger = 1
+
+// insertPosition seeds a blend_positions row directly via raw SQL so tests can set up
+// fixtures (including net_supplied/net_borrowed) without going through the model.
+func insertPosition(
+	t *testing.T, ctx context.Context, pool *pgxpool.Pool,
+	poolAddr, userAddr string, reserveIndex int32,
+	supplyB, collateralB, liabilityD, netSupplied, netBorrowed string,
+) {
+	t.Helper()
+	_, err := pool.Exec(ctx, `
+		INSERT INTO blend_positions (
+			pool_contract_id, user_account_id, reserve_index,
+			supply_b_tokens, collateral_b_tokens, liability_d_tokens,
+			net_supplied, net_borrowed, last_modified_ledger
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+	`, types.AddressBytea(poolAddr), types.AddressBytea(userAddr), reserveIndex,
+		supplyB, collateralB, liabilityD, netSupplied, netBorrowed, insertPositionLedger)
+	require.NoError(t, err)
+}
+
+// insertReserve seeds a blend_reserves row with the given rates. Other NOT NULL
+// columns are filled with harmless zero/false defaults since the join-based
+// position methods only read pool_contract_id, asset_contract_id, reserve_index,
+// b_rate, and d_rate.
+func insertReserve(
+	t *testing.T, ctx context.Context, pool *pgxpool.Pool,
+	poolAddr, assetAddr string, reserveIndex int32, bRate, dRate string,
+) {
+	t.Helper()
+	_, err := pool.Exec(ctx, `
+		INSERT INTO blend_reserves (
+			pool_contract_id, reserve_index, asset_contract_id,
+			b_rate, d_rate, b_supply, d_supply, ir_mod, backstop_credit,
+			last_time, decimals, c_factor, l_factor, util, max_util,
+			r_base, r_one, r_two, r_three, reactivity, supply_cap, enabled,
+			last_modified_ledger
+		) VALUES (
+			$1, $2, $3,
+			$4, $5, '0', '0', '0', '0',
+			0, 7, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, '0', true,
+			0
+		)
+	`, types.AddressBytea(poolAddr), reserveIndex, types.AddressBytea(assetAddr), bRate, dRate)
+	require.NoError(t, err)
+}
+
+type positionRow struct {
+	SupplyB, CollateralB, LiabilityD string
+	NetSupplied, NetBorrowed         string
+	LastModifiedLedger               int32
+}
+
+func getPosition(t *testing.T, ctx context.Context, pool *pgxpool.Pool, poolAddr, userAddr string, reserveIndex int32) (positionRow, bool) {
+	t.Helper()
+	var row positionRow
+	err := pool.QueryRow(ctx, `
+		SELECT supply_b_tokens, collateral_b_tokens, liability_d_tokens, net_supplied, net_borrowed, last_modified_ledger
+		FROM blend_positions
+		WHERE pool_contract_id = $1 AND user_account_id = $2 AND reserve_index = $3
+	`, types.AddressBytea(poolAddr), types.AddressBytea(userAddr), reserveIndex).Scan(
+		&row.SupplyB, &row.CollateralB, &row.LiabilityD, &row.NetSupplied, &row.NetBorrowed, &row.LastModifiedLedger,
+	)
+	if err != nil {
+		return positionRow{}, false
+	}
+	return row, true
+}
+
+func TestPositionModel_BatchUpsertSnapshots(t *testing.T) {
+	ctx, pool, m, cleanup := newPositionsFixture(t)
+	defer cleanup()
+
+	poolAddr := keypair.MustRandom().Address()
+	userAddr := keypair.MustRandom().Address()
+
+	t.Run("inserts a fresh row", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsertSnapshots(ctx, tx, []blend.PositionSnapshot{{
+				Pool: poolAddr, User: userAddr, ReserveIndex: 0,
+				SupplyBTokens: "100", CollateralBTokens: "200", LiabilityDTokens: "50",
+				LedgerNumber: 10,
+			}}))
+		})
+
+		row, ok := getPosition(t, ctx, pool, poolAddr, userAddr, 0)
+		require.True(t, ok)
+		assert.Equal(t, "100", row.SupplyB)
+		assert.Equal(t, "200", row.CollateralB)
+		assert.Equal(t, "50", row.LiabilityD)
+		assert.Equal(t, "0", row.NetSupplied)
+		assert.Equal(t, "0", row.NetBorrowed)
+		assert.Equal(t, int32(10), row.LastModifiedLedger)
+	})
+
+	t.Run("re-upsert replaces token columns without touching net_supplied/net_borrowed", func(t *testing.T) {
+		userAddr := keypair.MustRandom().Address()
+		// Seed net_supplied/net_borrowed via a net-delta application first.
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsertSnapshots(ctx, tx, []blend.PositionSnapshot{{
+				Pool: poolAddr, User: userAddr, ReserveIndex: 1,
+				SupplyBTokens: "1", CollateralBTokens: "2", LiabilityDTokens: "3",
+				LedgerNumber: 5,
+			}}))
+		})
+		assetForUpsertNetTest := keypair.MustRandom().Address()
+		insertReserve(t, ctx, pool, poolAddr, assetForUpsertNetTest, 1, "1000000000000", "1000000000000")
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchApplyNetDeltas(ctx, tx, []blend.PositionNetDelta{{
+				Pool: poolAddr, User: userAddr, Asset: assetForUpsertNetTest,
+				NetSuppliedDelta: "777", NetBorrowedDelta: "888", LedgerNumber: 6,
+			}}))
+		})
+		row, ok := getPosition(t, ctx, pool, poolAddr, userAddr, 1)
+		require.True(t, ok)
+		require.Equal(t, "777", row.NetSupplied)
+		require.Equal(t, "888", row.NetBorrowed)
+
+		// Now re-upsert the token snapshot with new values.
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsertSnapshots(ctx, tx, []blend.PositionSnapshot{{
+				Pool: poolAddr, User: userAddr, ReserveIndex: 1,
+				SupplyBTokens: "999", CollateralBTokens: "888", LiabilityDTokens: "777",
+				LedgerNumber: 7,
+			}}))
+		})
+
+		row, ok = getPosition(t, ctx, pool, poolAddr, userAddr, 1)
+		require.True(t, ok)
+		assert.Equal(t, "999", row.SupplyB)
+		assert.Equal(t, "888", row.CollateralB)
+		assert.Equal(t, "777", row.LiabilityD)
+		assert.Equal(t, int32(7), row.LastModifiedLedger)
+		// net_supplied/net_borrowed must remain untouched by the snapshot upsert.
+		assert.Equal(t, "777", row.NetSupplied)
+		assert.Equal(t, "888", row.NetBorrowed)
+	})
+
+	t.Run("is a no-op when no rows are staged", func(t *testing.T) {
+		require.NoError(t, m.BatchUpsertSnapshots(ctx, nil, nil))
+	})
+}
+
+func TestPositionModel_ZeroAbsentReserves(t *testing.T) {
+	ctx, pool, m, cleanup := newPositionsFixture(t)
+	defer cleanup()
+
+	poolAddr := keypair.MustRandom().Address()
+
+	t.Run("zeroes only the absent index, leaving present ones untouched", func(t *testing.T) {
+		userAddr := keypair.MustRandom().Address()
+		insertPosition(t, ctx, pool, poolAddr, userAddr, 0, "10", "20", "30", "1", "2")
+		insertPosition(t, ctx, pool, poolAddr, userAddr, 1, "11", "21", "31", "3", "4")
+		insertPosition(t, ctx, pool, poolAddr, userAddr, 2, "12", "22", "32", "5", "6")
+
+		// A different user's rows must be untouched by this call.
+		otherUser := keypair.MustRandom().Address()
+		insertPosition(t, ctx, pool, poolAddr, otherUser, 1, "77", "78", "79", "1", "1")
+
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.ZeroAbsentReserves(ctx, tx, []blend.PositionPresence{{
+				Pool: poolAddr, User: userAddr, PresentIndexes: []int32{0, 2}, LedgerNumber: 99,
+			}}))
+		})
+
+		row0, ok := getPosition(t, ctx, pool, poolAddr, userAddr, 0)
+		require.True(t, ok)
+		assert.Equal(t, "10", row0.SupplyB, "present index 0 must be untouched")
+		assert.Equal(t, "20", row0.CollateralB)
+		assert.Equal(t, "30", row0.LiabilityD)
+		assert.Equal(t, int32(insertPositionLedger), row0.LastModifiedLedger)
+
+		row1, ok := getPosition(t, ctx, pool, poolAddr, userAddr, 1)
+		require.True(t, ok)
+		assert.Equal(t, "0", row1.SupplyB, "absent index 1 must be zeroed")
+		assert.Equal(t, "0", row1.CollateralB)
+		assert.Equal(t, "0", row1.LiabilityD)
+		assert.Equal(t, int32(99), row1.LastModifiedLedger)
+		// net columns are cost basis and must never be touched by zeroing.
+		assert.Equal(t, "3", row1.NetSupplied)
+		assert.Equal(t, "4", row1.NetBorrowed)
+
+		row2, ok := getPosition(t, ctx, pool, poolAddr, userAddr, 2)
+		require.True(t, ok)
+		assert.Equal(t, "12", row2.SupplyB, "present index 2 must be untouched")
+
+		otherRow, ok := getPosition(t, ctx, pool, poolAddr, otherUser, 1)
+		require.True(t, ok)
+		assert.Equal(t, "77", otherRow.SupplyB, "a different user's rows must be untouched")
+	})
+
+	t.Run("empty PresentIndexes zeroes every reserve for that user", func(t *testing.T) {
+		userAddr := keypair.MustRandom().Address()
+		insertPosition(t, ctx, pool, poolAddr, userAddr, 0, "10", "20", "30", "1", "2")
+		insertPosition(t, ctx, pool, poolAddr, userAddr, 1, "11", "21", "31", "3", "4")
+
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.ZeroAbsentReserves(ctx, tx, []blend.PositionPresence{{
+				Pool: poolAddr, User: userAddr, PresentIndexes: nil, LedgerNumber: 50,
+			}}))
+		})
+
+		row0, ok := getPosition(t, ctx, pool, poolAddr, userAddr, 0)
+		require.True(t, ok)
+		assert.Equal(t, "0", row0.SupplyB)
+		assert.Equal(t, "0", row0.CollateralB)
+		assert.Equal(t, "0", row0.LiabilityD)
+
+		row1, ok := getPosition(t, ctx, pool, poolAddr, userAddr, 1)
+		require.True(t, ok)
+		assert.Equal(t, "0", row1.SupplyB)
+	})
+
+	t.Run("is a no-op when no presences are staged", func(t *testing.T) {
+		require.NoError(t, m.ZeroAbsentReserves(ctx, nil, nil))
+	})
+}
+
+func TestPositionModel_BatchApplyNetDeltas(t *testing.T) {
+	ctx, pool, m, cleanup := newPositionsFixture(t)
+	defer cleanup()
+
+	poolAddr := keypair.MustRandom().Address()
+	assetAddr := keypair.MustRandom().Address()
+	insertReserve(t, ctx, pool, poolAddr, assetAddr, 3, "1100000000000", "1050000000000")
+
+	t.Run("adds server-side to existing net values", func(t *testing.T) {
+		userAddr := keypair.MustRandom().Address()
+		insertPosition(t, ctx, pool, poolAddr, userAddr, 3, "0", "0", "0", "1000", "500")
+
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchApplyNetDeltas(ctx, tx, []blend.PositionNetDelta{{
+				Pool: poolAddr, User: userAddr, Asset: assetAddr,
+				NetSuppliedDelta: "250", NetBorrowedDelta: "100", LedgerNumber: 42,
+			}}))
+		})
+
+		row, ok := getPosition(t, ctx, pool, poolAddr, userAddr, 3)
+		require.True(t, ok)
+		assert.Equal(t, "1250", row.NetSupplied)
+		assert.Equal(t, "600", row.NetBorrowed)
+		assert.Equal(t, int32(42), row.LastModifiedLedger)
+	})
+
+	t.Run("ZeroBorrowed replaces net_borrowed instead of adding", func(t *testing.T) {
+		userAddr := keypair.MustRandom().Address()
+		insertPosition(t, ctx, pool, poolAddr, userAddr, 3, "0", "0", "0", "1000", "9999999")
+
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchApplyNetDeltas(ctx, tx, []blend.PositionNetDelta{{
+				Pool: poolAddr, User: userAddr, Asset: assetAddr,
+				NetSuppliedDelta: "0", NetBorrowedDelta: "0", ZeroBorrowed: true, LedgerNumber: 43,
+			}}))
+		})
+
+		row, ok := getPosition(t, ctx, pool, poolAddr, userAddr, 3)
+		require.True(t, ok)
+		assert.Equal(t, "0", row.NetBorrowed, "bad-debt fold must replace, not add")
+	})
+
+	t.Run("unknown asset with no blend_reserves row changes nothing and errors nothing", func(t *testing.T) {
+		userAddr := keypair.MustRandom().Address()
+		insertPosition(t, ctx, pool, poolAddr, userAddr, 3, "0", "0", "0", "1000", "500")
+		unknownAsset := keypair.MustRandom().Address()
+
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchApplyNetDeltas(ctx, tx, []blend.PositionNetDelta{{
+				Pool: poolAddr, User: userAddr, Asset: unknownAsset,
+				NetSuppliedDelta: "250", NetBorrowedDelta: "100", LedgerNumber: 44,
+			}}))
+		})
+
+		row, ok := getPosition(t, ctx, pool, poolAddr, userAddr, 3)
+		require.True(t, ok)
+		assert.Equal(t, "1000", row.NetSupplied, "no matching reserve row: nothing should change")
+		assert.Equal(t, "500", row.NetBorrowed)
+		assert.Equal(t, int32(insertPositionLedger), row.LastModifiedLedger)
+	})
+
+	t.Run("is a no-op when no deltas are staged", func(t *testing.T) {
+		require.NoError(t, m.BatchApplyNetDeltas(ctx, nil, nil))
+	})
+}
+
+func TestPositionModel_ApplyAuctionAdjustments(t *testing.T) {
+	ctx, pool, m, cleanup := newPositionsFixture(t)
+	defer cleanup()
+
+	poolAddr := keypair.MustRandom().Address()
+	assetAddr := keypair.MustRandom().Address()
+	// b_rate = 1.1 (scaled by 1e12), d_rate = 1.05 (scaled by 1e12).
+	insertReserve(t, ctx, pool, poolAddr, assetAddr, 4, "1100000000000", "1050000000000")
+
+	t.Run("values protocol-token deltas at current rates", func(t *testing.T) {
+		userAddr := keypair.MustRandom().Address()
+		insertPosition(t, ctx, pool, poolAddr, userAddr, 4, "0", "0", "0", "0", "0")
+
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.ApplyAuctionAdjustments(ctx, tx, []blend.PositionAuctionAdjustment{{
+				Pool: poolAddr, User: userAddr, Asset: assetAddr,
+				LotBTokensDelta: "1000", BidDTokensDelta: "1000", LedgerNumber: 77,
+			}}))
+		})
+
+		row, ok := getPosition(t, ctx, pool, poolAddr, userAddr, 4)
+		require.True(t, ok)
+		// 1000 lot b-tokens * 1.1 b_rate = 1100 underlying added to net_supplied.
+		assert.Equal(t, "1100.0000000000000000", row.NetSupplied)
+		// 1000 bid d-tokens * 1.05 d_rate = 1050 underlying added to net_borrowed.
+		assert.Equal(t, "1050.0000000000000000", row.NetBorrowed)
+		assert.Equal(t, int32(77), row.LastModifiedLedger)
+	})
+
+	t.Run("is a no-op when no adjustments are staged", func(t *testing.T) {
+		require.NoError(t, m.ApplyAuctionAdjustments(ctx, nil, nil))
+	})
+}
+
+func TestPositionModel_DeleteByPoolUser(t *testing.T) {
+	ctx, pool, m, cleanup := newPositionsFixture(t)
+	defer cleanup()
+
+	poolA := keypair.MustRandom().Address()
+	poolB := keypair.MustRandom().Address()
+	userA := keypair.MustRandom().Address()
+	userB := keypair.MustRandom().Address()
+
+	insertPosition(t, ctx, pool, poolA, userA, 0, "1", "1", "1", "1", "1")
+	insertPosition(t, ctx, pool, poolA, userA, 1, "2", "2", "2", "2", "2")
+	insertPosition(t, ctx, pool, poolA, userB, 0, "3", "3", "3", "3", "3")
+	insertPosition(t, ctx, pool, poolB, userA, 0, "4", "4", "4", "4", "4")
+
+	runInTx(t, ctx, pool, func(tx pgx.Tx) {
+		require.NoError(t, m.DeleteByPoolUser(ctx, tx, []blend.PoolUserKey{{Pool: poolA, User: userA}}))
+	})
+
+	_, ok := getPosition(t, ctx, pool, poolA, userA, 0)
+	assert.False(t, ok, "(poolA, userA) reserve 0 should be deleted")
+	_, ok = getPosition(t, ctx, pool, poolA, userA, 1)
+	assert.False(t, ok, "(poolA, userA) reserve 1 should be deleted")
+
+	_, ok = getPosition(t, ctx, pool, poolA, userB, 0)
+	assert.True(t, ok, "a different user in the same pool must be untouched")
+	_, ok = getPosition(t, ctx, pool, poolB, userA, 0)
+	assert.True(t, ok, "the same user in a different pool must be untouched")
+
+	t.Run("is a no-op when no keys are staged", func(t *testing.T) {
+		require.NoError(t, m.DeleteByPoolUser(ctx, nil, nil))
+	})
+}

--- a/internal/data/blend/positions_test.go
+++ b/internal/data/blend/positions_test.go
@@ -431,6 +431,37 @@ func TestPositionModel_ApplyAuctionAdjustments(t *testing.T) {
 		assert.Equal(t, int32(78), row.LastModifiedLedger, "ledger takes the MAX across the batch")
 	})
 
+	t.Run("aggregates before flooring, so folded fills round once not per-fill", func(t *testing.T) {
+		// Documents the rounding order. Flooring doesn't distribute over
+		// addition: at b_rate 1.1, two fills of 5 give trunc(10 * 1.1) = 11 here,
+		// where per-fill flooring would give trunc(5.5) * 2 = 10. Same 1-stroop
+		// skew on the negative (liquidated user) side. If the conversion ever moves
+		// inside the GROUP BY, these expectations become 10 / 20 and -10 / -20.
+		fillerAddr := keypair.MustRandom().Address()
+		userAddr := keypair.MustRandom().Address()
+		insertPosition(t, ctx, pool, poolAddr, fillerAddr, 4, "0", "0", "0", "0", "0")
+		insertPosition(t, ctx, pool, poolAddr, userAddr, 4, "0", "0", "0", "0", "0")
+
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.ApplyAuctionAdjustments(ctx, tx, []blend.PositionAuctionAdjustment{
+				{Pool: poolAddr, User: fillerAddr, Asset: assetAddr, LotBTokensDelta: "5", BidDTokensDelta: "10", LedgerNumber: 91},
+				{Pool: poolAddr, User: fillerAddr, Asset: assetAddr, LotBTokensDelta: "5", BidDTokensDelta: "10", LedgerNumber: 92},
+				{Pool: poolAddr, User: userAddr, Asset: assetAddr, LotBTokensDelta: "-5", BidDTokensDelta: "-10", LedgerNumber: 91},
+				{Pool: poolAddr, User: userAddr, Asset: assetAddr, LotBTokensDelta: "-5", BidDTokensDelta: "-10", LedgerNumber: 92},
+			}))
+		})
+
+		filler, ok := getPosition(t, ctx, pool, poolAddr, fillerAddr, 4)
+		require.True(t, ok)
+		assert.Equal(t, "11", filler.NetSupplied, "trunc((5+5) * 1.1) = 11, not trunc(5.5) * 2 = 10")
+		assert.Equal(t, "21", filler.NetBorrowed, "trunc((10+10) * 1.05) = 21, not trunc(10.5) * 2 = 20")
+
+		user, ok := getPosition(t, ctx, pool, poolAddr, userAddr, 4)
+		require.True(t, ok)
+		assert.Equal(t, "-11", user.NetSupplied, "same skew, more negative")
+		assert.Equal(t, "-21", user.NetBorrowed)
+	})
+
 	t.Run("is a no-op when no adjustments are staged", func(t *testing.T) {
 		require.NoError(t, m.ApplyAuctionAdjustments(ctx, nil, nil))
 	})

--- a/internal/data/blend/reserves.go
+++ b/internal/data/blend/reserves.go
@@ -189,7 +189,7 @@ func (m *ReserveModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []Rese
 			reactivity           = EXCLUDED.reactivity,
 			supply_cap           = EXCLUDED.supply_cap,
 			enabled              = EXCLUDED.enabled,
-			last_modified_ledger = EXCLUDED.last_modified_ledger`
+			last_modified_ledger = GREATEST(blend_reserves.last_modified_ledger, EXCLUDED.last_modified_ledger)`
 	if _, err := dbTx.Exec(ctx, upsertQuery,
 		pools, indexes, assets,
 		bRates, dRates, bSupplies, dSupplies, irMods, backstopCredits, lastTimes,

--- a/internal/data/blend/reserves.go
+++ b/internal/data/blend/reserves.go
@@ -1,0 +1,292 @@
+// Per-pool reserve config/rate storage for Blend v2 (blend_reserves).
+package blend
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+	"github.com/stellar/wallet-backend/internal/utils"
+)
+
+// reservesTable is the metrics label for blend_reserves queries.
+const reservesTable = "blend_reserves"
+
+// Reserve is a full row of blend_reserves (ResConfig + ResData + the reserve's
+// asset/index identity), mirroring every column.
+type Reserve struct {
+	PoolContractID     types.AddressBytea
+	ReserveIndex       int32
+	AssetContractID    types.AddressBytea
+	BRate              string
+	DRate              string
+	BSupply            string
+	DSupply            string
+	IRMod              string
+	BackstopCredit     string
+	LastTime           int64
+	Decimals           int32
+	CFactor            int32
+	LFactor            int32
+	Util               int32
+	MaxUtil            int32
+	RBase              int32
+	ROne               int32
+	RTwo               int32
+	RThree             int32
+	Reactivity         int32
+	SupplyCap          string
+	Enabled            bool
+	LastModifiedLedger uint32
+}
+
+// ReserveDataUpdate carries only the ResData columns (live rates/accrual state
+// that change on every pool interaction), keyed by (Pool, Asset). It is
+// narrower than the full-row Reserve so per-interaction rate refreshes don't
+// need to know or preserve ResConfig (decimals/factors/caps), which only
+// changes on admin config updates.
+type ReserveDataUpdate struct {
+	Pool, Asset    string
+	BRate          string
+	DRate          string
+	IRMod          string
+	BSupply        string
+	DSupply        string
+	BackstopCredit string
+	LastTime       int64
+	LedgerNumber   uint32
+}
+
+// poolAssetKey identifies a single reserve by its (pool, asset) address pair.
+type poolAssetKey struct {
+	Pool, Asset string
+}
+
+// ReserveModelInterface exposes Blend v2 reserve storage operations.
+type ReserveModelInterface interface {
+	// BatchUpsert inserts or fully replaces reserve rows keyed by
+	// (pool_contract_id, reserve_index). Every column is overwritten — callers
+	// must supply the reserve's full current ResConfig+ResData together.
+	BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []Reserve) error
+	// BatchUpdateData updates only the ResData columns of existing rows, keyed
+	// by (pool_contract_id, asset_contract_id). Rows with no matching (pool,
+	// asset) are silently skipped (0 rows affected, no error). Each (pool, asset)
+	// key must be unique within a batch; duplicates are rejected with an error.
+	BatchUpdateData(ctx context.Context, dbTx pgx.Tx, rows []ReserveDataUpdate) error
+}
+
+// ReserveModel implements ReserveModelInterface against blend_reserves.
+type ReserveModel struct {
+	DB      *pgxpool.Pool
+	Metrics *metrics.DBMetrics
+}
+
+var _ ReserveModelInterface = (*ReserveModel)(nil)
+
+// BatchUpsert inserts or fully replaces blend_reserves rows. See ReserveModelInterface.
+func (m *ReserveModel) BatchUpsert(ctx context.Context, dbTx pgx.Tx, rows []Reserve) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	pools := make([][]byte, len(rows))
+	indexes := make([]int32, len(rows))
+	assets := make([][]byte, len(rows))
+	bRates := make([]string, len(rows))
+	dRates := make([]string, len(rows))
+	bSupplies := make([]string, len(rows))
+	dSupplies := make([]string, len(rows))
+	irMods := make([]string, len(rows))
+	backstopCredits := make([]string, len(rows))
+	lastTimes := make([]int64, len(rows))
+	decimals := make([]int32, len(rows))
+	cFactors := make([]int32, len(rows))
+	lFactors := make([]int32, len(rows))
+	targetUtils := make([]int32, len(rows))
+	maxUtils := make([]int32, len(rows))
+	rBases := make([]int32, len(rows))
+	rOnes := make([]int32, len(rows))
+	rTwos := make([]int32, len(rows))
+	rThrees := make([]int32, len(rows))
+	reactivities := make([]int32, len(rows))
+	supplyCaps := make([]string, len(rows))
+	enableds := make([]bool, len(rows))
+	ledgers := make([]int32, len(rows))
+	for i, r := range rows {
+		poolBytes, err := addressToBytes(string(r.PoolContractID))
+		if err != nil {
+			return fmt.Errorf("converting pool address for reserve upsert: %w", err)
+		}
+		assetBytes, err := addressToBytes(string(r.AssetContractID))
+		if err != nil {
+			return fmt.Errorf("converting asset address for reserve upsert: %w", err)
+		}
+		pools[i] = poolBytes
+		indexes[i] = r.ReserveIndex
+		assets[i] = assetBytes
+		bRates[i] = r.BRate
+		dRates[i] = r.DRate
+		bSupplies[i] = r.BSupply
+		dSupplies[i] = r.DSupply
+		irMods[i] = r.IRMod
+		backstopCredits[i] = r.BackstopCredit
+		lastTimes[i] = r.LastTime
+		decimals[i] = r.Decimals
+		cFactors[i] = r.CFactor
+		lFactors[i] = r.LFactor
+		targetUtils[i] = r.Util
+		maxUtils[i] = r.MaxUtil
+		rBases[i] = r.RBase
+		rOnes[i] = r.ROne
+		rTwos[i] = r.RTwo
+		rThrees[i] = r.RThree
+		reactivities[i] = r.Reactivity
+		supplyCaps[i] = r.SupplyCap
+		enableds[i] = r.Enabled
+		ledgers[i] = int32(r.LastModifiedLedger)
+	}
+
+	const upsertQuery = `
+		INSERT INTO blend_reserves (
+			pool_contract_id, reserve_index, asset_contract_id,
+			b_rate, d_rate, b_supply, d_supply, ir_mod, backstop_credit, last_time,
+			decimals, c_factor, l_factor, util, max_util,
+			r_base, r_one, r_two, r_three, reactivity, supply_cap, enabled,
+			last_modified_ledger
+		)
+		SELECT * FROM UNNEST(
+			$1::bytea[], $2::integer[], $3::bytea[],
+			$4::text[], $5::text[], $6::text[], $7::text[], $8::text[], $9::text[], $10::bigint[],
+			$11::integer[], $12::integer[], $13::integer[], $14::integer[], $15::integer[],
+			$16::integer[], $17::integer[], $18::integer[], $19::integer[], $20::integer[], $21::text[], $22::boolean[],
+			$23::integer[]
+		)
+		ON CONFLICT (pool_contract_id, reserve_index) DO UPDATE SET
+			asset_contract_id    = EXCLUDED.asset_contract_id,
+			b_rate               = EXCLUDED.b_rate,
+			d_rate               = EXCLUDED.d_rate,
+			b_supply             = EXCLUDED.b_supply,
+			d_supply             = EXCLUDED.d_supply,
+			ir_mod               = EXCLUDED.ir_mod,
+			backstop_credit      = EXCLUDED.backstop_credit,
+			last_time            = EXCLUDED.last_time,
+			decimals             = EXCLUDED.decimals,
+			c_factor             = EXCLUDED.c_factor,
+			l_factor             = EXCLUDED.l_factor,
+			util                 = EXCLUDED.util,
+			max_util             = EXCLUDED.max_util,
+			r_base               = EXCLUDED.r_base,
+			r_one                = EXCLUDED.r_one,
+			r_two                = EXCLUDED.r_two,
+			r_three              = EXCLUDED.r_three,
+			reactivity           = EXCLUDED.reactivity,
+			supply_cap           = EXCLUDED.supply_cap,
+			enabled              = EXCLUDED.enabled,
+			last_modified_ledger = EXCLUDED.last_modified_ledger`
+	if _, err := dbTx.Exec(ctx, upsertQuery,
+		pools, indexes, assets,
+		bRates, dRates, bSupplies, dSupplies, irMods, backstopCredits, lastTimes,
+		decimals, cFactors, lFactors, targetUtils, maxUtils,
+		rBases, rOnes, rTwos, rThrees, reactivities, supplyCaps, enableds,
+		ledgers,
+	); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", reservesTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("upserting blend reserves: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", reservesTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", reservesTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("BatchUpsert", reservesTable).Observe(float64(len(rows)))
+	return nil
+}
+
+// BatchUpdateData updates only the ResData columns of existing blend_reserves
+// rows, keyed by (pool_contract_id, asset_contract_id). See ReserveModelInterface.
+//
+// Each (Pool, Asset) key must appear at most once per batch: Postgres's
+// UPDATE ... FROM applies only ONE matching source row per target row, so a
+// duplicate key would silently pick an arbitrary update and drop the rest.
+// Duplicates can't be merged here either — the ResData columns are absolute
+// state, not deltas, so the winner depends on an ordering the batch doesn't
+// carry — so the caller must pre-aggregate per key and duplicates are
+// rejected with an error.
+func (m *ReserveModel) BatchUpdateData(ctx context.Context, dbTx pgx.Tx, rows []ReserveDataUpdate) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	pools := make([][]byte, len(rows))
+	assets := make([][]byte, len(rows))
+	bRates := make([]string, len(rows))
+	dRates := make([]string, len(rows))
+	irMods := make([]string, len(rows))
+	bSupplies := make([]string, len(rows))
+	dSupplies := make([]string, len(rows))
+	backstopCredits := make([]string, len(rows))
+	lastTimes := make([]int64, len(rows))
+	ledgers := make([]int32, len(rows))
+	seen := make(map[poolAssetKey]struct{}, len(rows))
+	for i, r := range rows {
+		poolBytes, err := addressToBytes(r.Pool)
+		if err != nil {
+			return fmt.Errorf("converting pool address for reserve data update: %w", err)
+		}
+		assetBytes, err := addressToBytes(r.Asset)
+		if err != nil {
+			return fmt.Errorf("converting asset address for reserve data update: %w", err)
+		}
+		key := poolAssetKey{Pool: r.Pool, Asset: r.Asset}
+		if _, dup := seen[key]; dup {
+			return fmt.Errorf("duplicate reserve data update for pool=%s asset=%s: rows must be pre-aggregated per key", r.Pool, r.Asset)
+		}
+		seen[key] = struct{}{}
+		pools[i] = poolBytes
+		assets[i] = assetBytes
+		bRates[i] = r.BRate
+		dRates[i] = r.DRate
+		irMods[i] = r.IRMod
+		bSupplies[i] = r.BSupply
+		dSupplies[i] = r.DSupply
+		backstopCredits[i] = r.BackstopCredit
+		lastTimes[i] = r.LastTime
+		ledgers[i] = int32(r.LedgerNumber)
+	}
+
+	const updateQuery = `
+		UPDATE blend_reserves r SET
+			b_rate               = u.b_rate,
+			d_rate               = u.d_rate,
+			ir_mod               = u.ir_mod,
+			b_supply             = u.b_supply,
+			d_supply             = u.d_supply,
+			backstop_credit      = u.backstop_credit,
+			last_time            = u.last_time,
+			last_modified_ledger = GREATEST(r.last_modified_ledger, u.ledger)
+		FROM UNNEST(
+			$1::bytea[], $2::bytea[], $3::text[], $4::text[], $5::text[],
+			$6::text[], $7::text[], $8::text[], $9::bigint[], $10::integer[]
+		) AS u(pool, asset, b_rate, d_rate, ir_mod, b_supply, d_supply, backstop_credit, last_time, ledger)
+		WHERE r.pool_contract_id = u.pool AND r.asset_contract_id = u.asset`
+	if _, err := dbTx.Exec(ctx, updateQuery,
+		pools, assets, bRates, dRates, irMods, bSupplies, dSupplies, backstopCredits, lastTimes, ledgers,
+	); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("BatchUpdateData", reservesTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("updating blend reserve data: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("BatchUpdateData", reservesTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("BatchUpdateData", reservesTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("BatchUpdateData", reservesTable).Observe(float64(len(rows)))
+	return nil
+}

--- a/internal/data/blend/reserves_test.go
+++ b/internal/data/blend/reserves_test.go
@@ -1,0 +1,248 @@
+// Unit tests for the Blend v2 ReserveModel.
+// These tests exercise real SQL and require a PostgreSQL test database.
+// Uses an external test package to avoid an import cycle with internal/data.
+package blend_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/data/blend"
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+)
+
+func newReservesFixture(t *testing.T) (context.Context, *pgxpool.Pool, *blend.ReserveModel, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	dbt := dbtest.Open(t)
+	pool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+
+	m := &blend.ReserveModel{
+		DB:      pool,
+		Metrics: metrics.NewMetrics(prometheus.NewRegistry()).DB,
+	}
+
+	cleanup := func() {
+		pool.Close()
+		dbt.Close()
+	}
+	return ctx, pool, m, cleanup
+}
+
+type reserveRow struct {
+	BRate, DRate, BSupply, DSupply, IRMod, BackstopCredit string
+	LastTime                                              int64
+	Decimals, CFactor, LFactor, Util, MaxUtil             int32
+	RBase, ROne, RTwo, RThree, Reactivity                 int32
+	SupplyCap                                             string
+	Enabled                                               bool
+	LastModifiedLedger                                    int32
+}
+
+func getReserve(t *testing.T, ctx context.Context, pool *pgxpool.Pool, poolAddr string, reserveIndex int32) (reserveRow, bool) {
+	t.Helper()
+	var row reserveRow
+	err := pool.QueryRow(ctx, `
+		SELECT b_rate, d_rate, b_supply, d_supply, ir_mod, backstop_credit, last_time,
+			decimals, c_factor, l_factor, util, max_util,
+			r_base, r_one, r_two, r_three, reactivity, supply_cap, enabled, last_modified_ledger
+		FROM blend_reserves WHERE pool_contract_id = $1 AND reserve_index = $2
+	`, types.AddressBytea(poolAddr), reserveIndex).Scan(
+		&row.BRate, &row.DRate, &row.BSupply, &row.DSupply, &row.IRMod, &row.BackstopCredit, &row.LastTime,
+		&row.Decimals, &row.CFactor, &row.LFactor, &row.Util, &row.MaxUtil,
+		&row.RBase, &row.ROne, &row.RTwo, &row.RThree, &row.Reactivity, &row.SupplyCap, &row.Enabled, &row.LastModifiedLedger,
+	)
+	if err != nil {
+		return reserveRow{}, false
+	}
+	return row, true
+}
+
+// fullReserve builds a fully-populated blend.Reserve row for use as a BatchUpsert fixture.
+func fullReserve(poolAddr, assetAddr string, index int32, ledger uint32) blend.Reserve {
+	return blend.Reserve{
+		PoolContractID:     types.AddressBytea(poolAddr),
+		ReserveIndex:       index,
+		AssetContractID:    types.AddressBytea(assetAddr),
+		BRate:              "1000000000000",
+		DRate:              "1000000000000",
+		BSupply:            "100",
+		DSupply:            "50",
+		IRMod:              "1000000000000",
+		BackstopCredit:     "0",
+		LastTime:           1000,
+		Decimals:           7,
+		CFactor:            900000,
+		LFactor:            900000,
+		Util:               500000,
+		MaxUtil:            950000,
+		RBase:              10000,
+		ROne:               20000,
+		RTwo:               30000,
+		RThree:             40000,
+		Reactivity:         1000,
+		SupplyCap:          "1000000",
+		Enabled:            true,
+		LastModifiedLedger: ledger,
+	}
+}
+
+func TestReserveModel_BatchUpsert(t *testing.T) {
+	ctx, pool, m, cleanup := newReservesFixture(t)
+	defer cleanup()
+
+	poolAddr := keypair.MustRandom().Address()
+	assetAddr := keypair.MustRandom().Address()
+
+	t.Run("inserts a fresh row with every column", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsert(ctx, tx, []blend.Reserve{fullReserve(poolAddr, assetAddr, 0, 10)}))
+		})
+
+		row, ok := getReserve(t, ctx, pool, poolAddr, 0)
+		require.True(t, ok)
+		assert.Equal(t, "1000000000000", row.BRate)
+		assert.Equal(t, "100", row.BSupply)
+		assert.Equal(t, int32(7), row.Decimals)
+		assert.Equal(t, int32(900000), row.CFactor)
+		assert.True(t, row.Enabled)
+		assert.Equal(t, int32(10), row.LastModifiedLedger)
+	})
+
+	t.Run("re-upsert replaces every column, including config", func(t *testing.T) {
+		r := fullReserve(poolAddr, assetAddr, 0, 11)
+		r.BRate = "2000000000000"
+		r.Decimals = 6
+		r.Enabled = false
+
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpsert(ctx, tx, []blend.Reserve{r}))
+		})
+
+		row, ok := getReserve(t, ctx, pool, poolAddr, 0)
+		require.True(t, ok)
+		assert.Equal(t, "2000000000000", row.BRate)
+		assert.Equal(t, int32(6), row.Decimals)
+		assert.False(t, row.Enabled)
+		assert.Equal(t, int32(11), row.LastModifiedLedger)
+	})
+
+	t.Run("is a no-op when no rows are staged", func(t *testing.T) {
+		require.NoError(t, m.BatchUpsert(ctx, nil, nil))
+	})
+}
+
+func TestReserveModel_BatchUpdateData(t *testing.T) {
+	ctx, pool, m, cleanup := newReservesFixture(t)
+	defer cleanup()
+
+	poolAddr := keypair.MustRandom().Address()
+	assetAddr := keypair.MustRandom().Address()
+	runInTx(t, ctx, pool, func(tx pgx.Tx) {
+		require.NoError(t, m.BatchUpsert(ctx, tx, []blend.Reserve{fullReserve(poolAddr, assetAddr, 2, 5)}))
+	})
+
+	t.Run("updates only the ResData columns, preserving config columns", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpdateData(ctx, tx, []blend.ReserveDataUpdate{{
+				Pool: poolAddr, Asset: assetAddr,
+				BRate: "3000000000000", DRate: "3100000000000", IRMod: "999",
+				BSupply: "555", DSupply: "444", BackstopCredit: "12",
+				LastTime: 2000, LedgerNumber: 20,
+			}}))
+		})
+
+		row, ok := getReserve(t, ctx, pool, poolAddr, 2)
+		require.True(t, ok)
+		assert.Equal(t, "3000000000000", row.BRate)
+		assert.Equal(t, "3100000000000", row.DRate)
+		assert.Equal(t, "999", row.IRMod)
+		assert.Equal(t, "555", row.BSupply)
+		assert.Equal(t, "444", row.DSupply)
+		assert.Equal(t, "12", row.BackstopCredit)
+		assert.Equal(t, int64(2000), row.LastTime)
+		assert.Equal(t, int32(20), row.LastModifiedLedger)
+		// Config columns must be untouched by a data-only update.
+		assert.Equal(t, int32(7), row.Decimals)
+		assert.Equal(t, int32(900000), row.CFactor)
+		assert.Equal(t, "1000000", row.SupplyCap)
+		assert.True(t, row.Enabled)
+	})
+
+	t.Run("last_modified_ledger never regresses (GREATEST)", func(t *testing.T) {
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpdateData(ctx, tx, []blend.ReserveDataUpdate{{
+				Pool: poolAddr, Asset: assetAddr,
+				BRate: "1", DRate: "1", IRMod: "1", BSupply: "1", DSupply: "1", BackstopCredit: "1",
+				LastTime: 1, LedgerNumber: 1, // older than the ledger 20 set above
+			}}))
+		})
+
+		row, ok := getReserve(t, ctx, pool, poolAddr, 2)
+		require.True(t, ok)
+		assert.Equal(t, int32(20), row.LastModifiedLedger, "ledger must not regress")
+		// Data columns are still overwritten unconditionally regardless of ledger ordering.
+		assert.Equal(t, "1", row.BRate)
+	})
+
+	t.Run("unknown (pool, asset) pair updates nothing and returns no error", func(t *testing.T) {
+		unknownAsset := keypair.MustRandom().Address()
+		runInTx(t, ctx, pool, func(tx pgx.Tx) {
+			require.NoError(t, m.BatchUpdateData(ctx, tx, []blend.ReserveDataUpdate{{
+				Pool: poolAddr, Asset: unknownAsset,
+				BRate: "999999", DRate: "1", IRMod: "1", BSupply: "1", DSupply: "1", BackstopCredit: "1",
+				LastTime: 1, LedgerNumber: 999,
+			}}))
+		})
+
+		// The existing reserve (index 2, keyed by assetAddr) must be untouched.
+		row, ok := getReserve(t, ctx, pool, poolAddr, 2)
+		require.True(t, ok)
+		assert.NotEqual(t, int32(999), row.LastModifiedLedger)
+		assert.NotEqual(t, "999999", row.BRate)
+	})
+
+	t.Run("rejects duplicate (pool, asset) keys", func(t *testing.T) {
+		// UPDATE ... FROM would apply only one of the two source rows, and the
+		// ResData columns are absolute state rather than deltas, so there is no
+		// order-free merge — the model demands pre-aggregated input instead.
+		before, ok := getReserve(t, ctx, pool, poolAddr, 2)
+		require.True(t, ok)
+
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+		defer func() { _ = tx.Rollback(ctx) }()
+		err = m.BatchUpdateData(ctx, tx, []blend.ReserveDataUpdate{{
+			Pool: poolAddr, Asset: assetAddr,
+			BRate: "10", DRate: "10", IRMod: "10", BSupply: "10", DSupply: "10", BackstopCredit: "10",
+			LastTime: 3000, LedgerNumber: 30,
+		}, {
+			Pool: poolAddr, Asset: assetAddr,
+			BRate: "20", DRate: "20", IRMod: "20", BSupply: "20", DSupply: "20", BackstopCredit: "20",
+			LastTime: 3001, LedgerNumber: 31,
+		}})
+		require.ErrorContains(t, err, "duplicate reserve data update")
+		require.ErrorContains(t, err, "pre-aggregated")
+
+		// The guard fires before any SQL runs, so the table is untouched.
+		after, ok := getReserve(t, ctx, pool, poolAddr, 2)
+		require.True(t, ok)
+		assert.Equal(t, before, after)
+	})
+
+	t.Run("is a no-op when no rows are staged", func(t *testing.T) {
+		require.NoError(t, m.BatchUpdateData(ctx, nil, nil))
+	})
+}

--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/stellar/wallet-backend/internal/data/blend"
 	"github.com/stellar/wallet-backend/internal/data/sep41"
 	"github.com/stellar/wallet-backend/internal/metrics"
 )
@@ -27,6 +28,7 @@ type Models struct {
 	Transactions         *TransactionModel
 	StateChanges         *StateChangeModel
 	SEP41                sep41.Models
+	Blend                blend.Models
 }
 
 func NewModels(pool *pgxpool.Pool, dbMetrics *metrics.DBMetrics) (*Models, error) {
@@ -52,5 +54,6 @@ func NewModels(pool *pgxpool.Pool, dbMetrics *metrics.DBMetrics) (*Models, error
 		Transactions:         &TransactionModel{DB: pool, Metrics: dbMetrics},
 		StateChanges:         &StateChangeModel{DB: pool, Metrics: dbMetrics},
 		SEP41:                sep41.NewModels(pool, dbMetrics),
+		Blend:                blend.NewModels(pool, dbMetrics),
 	}, nil
 }

--- a/internal/db/migrations/2026-07-08.0-blend_state_change_enums.sql
+++ b/internal/db/migrations/2026-07-08.0-blend_state_change_enums.sql
@@ -1,0 +1,49 @@
+-- +migrate Up
+
+-- Extend state_changes CHECK constraints with the Blend v2 categories and reasons.
+-- Categories name the on-chain object an account position changes against
+-- (category = object, reason = action, matching the core convention); the
+-- amount-bearing categories reuse the generic CREDIT/DEBIT/ADD/REMOVE/BURN
+-- reasons, so only Blend-specific verbs are added to the reason list.
+-- The base lists restate 2025-06-10.4-statechanges.sql exactly.
+-- NOT VALID skips a full hypertable scan; constraint changes propagate to chunks automatically.
+ALTER TABLE state_changes DROP CONSTRAINT state_changes_state_change_category_check;
+ALTER TABLE state_changes ADD CONSTRAINT state_changes_state_change_category_check CHECK (
+    state_change_category IN (
+        'BALANCE', 'ACCOUNT', 'SIGNER', 'SIGNATURE_THRESHOLD',
+        'DATA_ENTRY', 'HOME_DOMAIN', 'ALLOWANCE', 'FLAGS', 'TRUSTLINE',
+        'BALANCE_AUTHORIZATION',
+        'BLEND_SUPPLY', 'BLEND_COLLATERAL', 'BLEND_DEBT', 'BLEND_AUCTION',
+        'BLEND_EMISSIONS', 'BLEND_BACKSTOP_EMISSIONS', 'BLEND_BACKSTOP',
+        'BLEND_BACKSTOP_QUEUE'
+    )
+) NOT VALID;
+
+ALTER TABLE state_changes DROP CONSTRAINT state_changes_state_change_reason_check;
+ALTER TABLE state_changes ADD CONSTRAINT state_changes_state_change_reason_check CHECK (
+    state_change_reason IN (
+        'CREATE', 'MERGE', 'DEBIT', 'CREDIT', 'MINT', 'BURN',
+        'ADD', 'REMOVE', 'UPDATE', 'SET', 'CLEAR',
+        'BORROW', 'REPAY', 'FLASH_LOAN', 'BAD_DEBT', 'FILL', 'CLAIM'
+    )
+) NOT VALID;
+
+-- +migrate Down
+
+-- Requires no BLEND_* rows to exist (delete them first in dev).
+ALTER TABLE state_changes DROP CONSTRAINT state_changes_state_change_category_check;
+ALTER TABLE state_changes ADD CONSTRAINT state_changes_state_change_category_check CHECK (
+    state_change_category IN (
+        'BALANCE', 'ACCOUNT', 'SIGNER', 'SIGNATURE_THRESHOLD',
+        'DATA_ENTRY', 'HOME_DOMAIN', 'ALLOWANCE', 'FLAGS', 'TRUSTLINE',
+        'BALANCE_AUTHORIZATION'
+    )
+) NOT VALID;
+
+ALTER TABLE state_changes DROP CONSTRAINT state_changes_state_change_reason_check;
+ALTER TABLE state_changes ADD CONSTRAINT state_changes_state_change_reason_check CHECK (
+    state_change_reason IN (
+        'CREATE', 'MERGE', 'DEBIT', 'CREDIT', 'MINT', 'BURN',
+        'ADD', 'REMOVE', 'UPDATE', 'SET', 'CLEAR'
+    )
+) NOT VALID;

--- a/internal/db/migrations/2026-07-08.0-blend_state_change_enums.sql
+++ b/internal/db/migrations/2026-07-08.0-blend_state_change_enums.sql
@@ -7,7 +7,7 @@
 -- reasons, so only Blend-specific verbs are added to the reason list.
 -- The base lists restate 2025-06-10.4-statechanges.sql exactly.
 -- NOT VALID skips a full hypertable scan; constraint changes propagate to chunks automatically.
-ALTER TABLE state_changes DROP CONSTRAINT state_changes_state_change_category_check;
+ALTER TABLE state_changes DROP CONSTRAINT IF EXISTS state_changes_state_change_category_check;
 ALTER TABLE state_changes ADD CONSTRAINT state_changes_state_change_category_check CHECK (
     state_change_category IN (
         'BALANCE', 'ACCOUNT', 'SIGNER', 'SIGNATURE_THRESHOLD',
@@ -19,7 +19,7 @@ ALTER TABLE state_changes ADD CONSTRAINT state_changes_state_change_category_che
     )
 ) NOT VALID;
 
-ALTER TABLE state_changes DROP CONSTRAINT state_changes_state_change_reason_check;
+ALTER TABLE state_changes DROP CONSTRAINT IF EXISTS state_changes_state_change_reason_check;
 ALTER TABLE state_changes ADD CONSTRAINT state_changes_state_change_reason_check CHECK (
     state_change_reason IN (
         'CREATE', 'MERGE', 'DEBIT', 'CREDIT', 'MINT', 'BURN',
@@ -30,8 +30,31 @@ ALTER TABLE state_changes ADD CONSTRAINT state_changes_state_change_reason_check
 
 -- +migrate Down
 
--- Requires no BLEND_* rows to exist (delete them first in dev).
-ALTER TABLE state_changes DROP CONSTRAINT state_changes_state_change_category_check;
+-- Rollback requires no BLEND_* rows: the re-narrowed CHECKs below are NOT VALID
+-- (cheap, no hypertable scan), so they cannot reject pre-existing rows. Fail
+-- loudly here rather than leaving rows the restored constraints forbid. The
+-- EXISTS probes are served by the columnstore's bloom sparse indexes on
+-- state_change_category/state_change_reason, so conforming chunks are skipped
+-- without decompression.
+-- +migrate StatementBegin
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM state_changes
+    WHERE state_change_category IN (
+      'BLEND_SUPPLY', 'BLEND_COLLATERAL', 'BLEND_DEBT', 'BLEND_AUCTION',
+      'BLEND_EMISSIONS', 'BLEND_BACKSTOP_EMISSIONS', 'BLEND_BACKSTOP',
+      'BLEND_BACKSTOP_QUEUE')
+  ) OR EXISTS (
+    SELECT 1 FROM state_changes
+    WHERE state_change_reason IN ('BORROW', 'REPAY', 'FLASH_LOAN', 'BAD_DEBT', 'FILL', 'CLAIM')
+  ) THEN
+    RAISE EXCEPTION 'rollback requires no BLEND_* state_changes rows; delete them first';
+  END IF;
+END $$;
+-- +migrate StatementEnd
+
+ALTER TABLE state_changes DROP CONSTRAINT IF EXISTS state_changes_state_change_category_check;
 ALTER TABLE state_changes ADD CONSTRAINT state_changes_state_change_category_check CHECK (
     state_change_category IN (
         'BALANCE', 'ACCOUNT', 'SIGNER', 'SIGNATURE_THRESHOLD',
@@ -40,7 +63,7 @@ ALTER TABLE state_changes ADD CONSTRAINT state_changes_state_change_category_che
     )
 ) NOT VALID;
 
-ALTER TABLE state_changes DROP CONSTRAINT state_changes_state_change_reason_check;
+ALTER TABLE state_changes DROP CONSTRAINT IF EXISTS state_changes_state_change_reason_check;
 ALTER TABLE state_changes ADD CONSTRAINT state_changes_state_change_reason_check CHECK (
     state_change_reason IN (
         'CREATE', 'MERGE', 'DEBIT', 'CREDIT', 'MINT', 'BURN',

--- a/internal/db/migrations/2026-07-08.1-blend_pools.sql
+++ b/internal/db/migrations/2026-07-08.1-blend_pools.sql
@@ -9,6 +9,8 @@ CREATE TABLE blend_pools (
     status               INTEGER,           -- 0..6 (Admin_Active..Setup)
     max_positions        INTEGER,
     min_collateral       TEXT,
+    admin                BYTEA,              -- pool admin (instance "Admin" key); owned vs standard-pool trust signal
+    in_reward_zone       BOOLEAN NOT NULL DEFAULT FALSE,  -- member of the backstop's RZ list (earns BLND emissions)
     last_modified_ledger INTEGER NOT NULL DEFAULT 0
 ) WITH (
     fillfactor = 90,

--- a/internal/db/migrations/2026-07-08.1-blend_pools.sql
+++ b/internal/db/migrations/2026-07-08.1-blend_pools.sql
@@ -1,0 +1,24 @@
+-- +migrate Up
+
+-- pool-level config + metadata (from PoolConfig instance storage + pool name)
+CREATE TABLE blend_pools (
+    pool_contract_id     BYTEA PRIMARY KEY,
+    name                 TEXT,               -- "Fixed Pool v2" (also enriched onto protocol_contracts.name)
+    oracle_contract_id   BYTEA,             -- SEP-40 oracle for this pool
+    backstop_rate        INTEGER,           -- bstop_rate / take rate
+    status               INTEGER,           -- 0..6 (Admin_Active..Setup)
+    max_positions        INTEGER,
+    min_collateral       TEXT,
+    last_modified_ledger INTEGER NOT NULL DEFAULT 0
+) WITH (
+    fillfactor = 90,
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 50,
+    autovacuum_analyze_scale_factor = 0.01,
+    autovacuum_analyze_threshold = 50,
+    autovacuum_vacuum_cost_delay = 0
+);
+
+-- +migrate Down
+
+DROP TABLE IF EXISTS blend_pools;

--- a/internal/db/migrations/2026-07-08.2-blend_positions.sql
+++ b/internal/db/migrations/2026-07-08.2-blend_positions.sql
@@ -1,0 +1,33 @@
+-- +migrate Up
+
+-- current lending positions (one row per pool/user/reserve)
+-- one Positions(user) entry fans out to N rows: persist is a full replace per
+-- (pool, user) — upsert present reserve indexes, ZERO rows whose index is absent from
+-- the maps (full exit removes the map key while the entry persists; zeroed rows keep
+-- cost basis for lifetime earned). Entry removal deletes the rows.
+CREATE TABLE blend_positions (
+    pool_contract_id     BYTEA NOT NULL,
+    user_account_id      BYTEA NOT NULL,
+    reserve_index        INTEGER NOT NULL,
+    -- current holdings: absolute snapshots from the Positions entry (last-write-wins)
+    supply_b_tokens      TEXT NOT NULL DEFAULT '0',   -- non-collateral supply
+    collateral_b_tokens  TEXT NOT NULL DEFAULT '0',
+    liability_d_tokens   TEXT NOT NULL DEFAULT '0',
+    -- cost basis for "earned to date": cumulative underlying, event-folded (additive)
+    net_supplied         TEXT NOT NULL DEFAULT '0',   -- Σ(supply+collateral deposits) − Σ(withdrawals)
+    net_borrowed         TEXT NOT NULL DEFAULT '0',   -- Σ(borrows) − Σ(repays)
+    last_modified_ledger INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (pool_contract_id, user_account_id, reserve_index)
+) WITH (
+    fillfactor = 90,
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 50,
+    autovacuum_analyze_scale_factor = 0.01,
+    autovacuum_analyze_threshold = 50,
+    autovacuum_vacuum_cost_delay = 0
+);
+CREATE INDEX idx_blend_positions_user ON blend_positions (user_account_id);
+
+-- +migrate Down
+
+DROP TABLE IF EXISTS blend_positions;

--- a/internal/db/migrations/2026-07-08.3-blend_reserves.sql
+++ b/internal/db/migrations/2026-07-08.3-blend_reserves.sql
@@ -1,0 +1,50 @@
+-- +migrate Up
+
+-- per-pool reserve config + live rates (ResData + ResConfig + ResList)
+CREATE TABLE blend_reserves (
+    pool_contract_id     BYTEA NOT NULL,
+    reserve_index        INTEGER NOT NULL,
+    asset_contract_id    BYTEA NOT NULL,      -- reserve asset (token/SAC C-address)
+    b_rate               TEXT NOT NULL,
+    d_rate               TEXT NOT NULL,
+    b_supply             TEXT NOT NULL,
+    d_supply             TEXT NOT NULL,
+    ir_mod               TEXT NOT NULL,
+    backstop_credit      TEXT NOT NULL,
+    last_time            BIGINT NOT NULL,
+    decimals             INTEGER NOT NULL,
+    c_factor             INTEGER NOT NULL,
+    l_factor             INTEGER NOT NULL,
+    util                 INTEGER NOT NULL,    -- target util
+    max_util             INTEGER NOT NULL,
+    r_base               INTEGER NOT NULL,
+    r_one                INTEGER NOT NULL,
+    r_two                INTEGER NOT NULL,
+    r_three              INTEGER NOT NULL,
+    reactivity           INTEGER NOT NULL,
+    supply_cap           TEXT NOT NULL,
+    enabled              BOOLEAN NOT NULL,
+    last_modified_ledger INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (pool_contract_id, reserve_index),
+    -- One reserve slot per (pool, asset): the fold SQL resolves reserve_index by
+    -- joining on this pair (BatchApplyNetDeltas, ApplyAuctionAdjustments,
+    -- BatchUpdateData), and UPDATE ... FROM silently applies an arbitrary source
+    -- row if the join ever matched twice. The backing unique index also serves
+    -- those joins.
+    UNIQUE (pool_contract_id, asset_contract_id)
+) WITH (
+    -- Reserve 20% free space per page so PostgreSQL can do HOT (Heap-Only Tuple) updates.
+    -- Unlike the per-user position tables, every reserve of an active pool is rewritten on
+    -- each interaction with it (b_rate, d_rate, the supplies and last_time all accrue on every
+    -- supply, borrow, repay and withdraw), so this table needs the full 20% reserve to sustain
+    -- HOT updates. None of those accruing columns are indexed.
+    fillfactor = 80,
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 50,
+    autovacuum_analyze_scale_factor = 0.01,
+    autovacuum_analyze_threshold = 50,
+    autovacuum_vacuum_cost_delay = 0
+);
+-- +migrate Down
+
+DROP TABLE IF EXISTS blend_reserves;

--- a/internal/db/migrations/2026-07-08.4-blend_backstop_positions.sql
+++ b/internal/db/migrations/2026-07-08.4-blend_backstop_positions.sql
@@ -16,6 +16,9 @@ CREATE TABLE blend_backstop_positions (
     autovacuum_analyze_threshold = 50,
     autovacuum_vacuum_cost_delay = 0
 );
+-- BackstopPositionModel.GetByAccount filters on user_account_id alone (the 2nd PK
+-- column), so the PK cannot serve it — index the per-account read path.
+CREATE INDEX idx_blend_backstop_positions_user ON blend_backstop_positions (user_account_id);
 
 -- +migrate Down
 

--- a/internal/db/migrations/2026-07-08.4-blend_backstop_positions.sql
+++ b/internal/db/migrations/2026-07-08.4-blend_backstop_positions.sql
@@ -1,0 +1,22 @@
+-- +migrate Up
+
+-- user backstop positions (UserBalance(pool,user))
+CREATE TABLE blend_backstop_positions (
+    pool_contract_id     BYTEA NOT NULL,
+    user_account_id      BYTEA NOT NULL,
+    shares               TEXT NOT NULL DEFAULT '0',
+    q4w                  JSONB,               -- [{amount, expiration}] queued withdrawals
+    last_modified_ledger INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (pool_contract_id, user_account_id)
+) WITH (
+    fillfactor = 90,
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 50,
+    autovacuum_analyze_scale_factor = 0.01,
+    autovacuum_analyze_threshold = 50,
+    autovacuum_vacuum_cost_delay = 0
+);
+
+-- +migrate Down
+
+DROP TABLE IF EXISTS blend_backstop_positions;

--- a/internal/db/migrations/2026-07-08.5-blend_backstop_pools.sql
+++ b/internal/db/migrations/2026-07-08.5-blend_backstop_pools.sql
@@ -1,0 +1,27 @@
+-- +migrate Up
+
+-- pool-level backstop totals (PoolBalance(pool) on the backstop contract) — for "Backstop $X"
+CREATE TABLE blend_backstop_pools (
+    pool_contract_id     BYTEA PRIMARY KEY,
+    shares               TEXT NOT NULL DEFAULT '0',
+    tokens               TEXT NOT NULL DEFAULT '0',   -- backstop-LP (BLND-USDC) token amount
+    q4w                  TEXT NOT NULL DEFAULT '0',
+    -- backstop emission accrual for this pool (BEmisData(pool); exact field layout:
+    -- confirm at impl)
+    emis_eps             BIGINT,
+    emis_index           TEXT,
+    emis_expiration      BIGINT,
+    emis_last_time       BIGINT,
+    last_modified_ledger INTEGER NOT NULL DEFAULT 0
+) WITH (
+    fillfactor = 90,
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 50,
+    autovacuum_analyze_scale_factor = 0.01,
+    autovacuum_analyze_threshold = 50,
+    autovacuum_vacuum_cost_delay = 0
+);
+
+-- +migrate Down
+
+DROP TABLE IF EXISTS blend_backstop_pools;

--- a/internal/db/migrations/2026-07-08.6-blend_reserve_emissions.sql
+++ b/internal/db/migrations/2026-07-08.6-blend_reserve_emissions.sql
@@ -1,0 +1,29 @@
+-- +migrate Up
+
+-- reserve-level emission config/accrual (EmisData(reserve_token_id) entries on each
+-- pool) — the eps source for emissions/net APY
+CREATE TABLE blend_reserve_emissions (
+    pool_contract_id     BYTEA NOT NULL,
+    reserve_token_id     INTEGER NOT NULL,    -- reserve_index*2 (dToken) / +1 (bToken)
+    eps                  BIGINT NOT NULL,
+    emission_index       TEXT NOT NULL,
+    expiration           BIGINT NOT NULL,
+    last_time            BIGINT NOT NULL,
+    last_modified_ledger INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (pool_contract_id, reserve_token_id)
+) WITH (
+    -- Reserve 20% free space per page so PostgreSQL can do HOT (Heap-Only Tuple) updates.
+    -- A row exists only for a reserve token that has emissions configured, and every such row
+    -- re-accrues (emission_index, last_time) on each interaction with its reserve, so nearly the
+    -- whole table turns over on every active ledger. Only the PK columns are indexed.
+    fillfactor = 80,
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 50,
+    autovacuum_analyze_scale_factor = 0.01,
+    autovacuum_analyze_threshold = 50,
+    autovacuum_vacuum_cost_delay = 0
+);
+
+-- +migrate Down
+
+DROP TABLE IF EXISTS blend_reserve_emissions;

--- a/internal/db/migrations/2026-07-08.7-blend_emissions.sql
+++ b/internal/db/migrations/2026-07-08.7-blend_emissions.sql
@@ -21,6 +21,10 @@ CREATE TABLE blend_emissions (
     autovacuum_analyze_threshold = 50,
     autovacuum_vacuum_cost_delay = 0
 );
+-- EmissionModel.GetByAccount filters on user_account_id alone (the 2nd PK column,
+-- behind source_contract_id), so the PK cannot serve it — index the per-account
+-- read path.
+CREATE INDEX idx_blend_emissions_user ON blend_emissions (user_account_id);
 
 -- +migrate Down
 

--- a/internal/db/migrations/2026-07-08.7-blend_emissions.sql
+++ b/internal/db/migrations/2026-07-08.7-blend_emissions.sql
@@ -1,0 +1,27 @@
+-- +migrate Up
+
+-- Backstop user emissions (UEmisData(pool, user)) are stored with
+-- source_contract_id = the POOL contract and token_id = -1, so per-pool
+-- backstop streams stay distinct; reserve-emission rows use token_id >= 0
+-- (reserve_index*2, +1 for bToken).
+-- raw user emission accrual (reserve emissions on pool, backstop emissions on backstop)
+CREATE TABLE blend_emissions (
+    source_contract_id   BYTEA NOT NULL,      -- pool (reserve emis) or backstop
+    user_account_id      BYTEA NOT NULL,
+    token_id             INTEGER NOT NULL,    -- reserve_token_id (reserve_index*2 (+1 for bToken)) / backstop id
+    emission_index       TEXT NOT NULL,       -- user's last-accrued index
+    accrued              TEXT NOT NULL,
+    last_modified_ledger INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (source_contract_id, user_account_id, token_id)
+) WITH (
+    fillfactor = 90,
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 50,
+    autovacuum_analyze_scale_factor = 0.01,
+    autovacuum_analyze_threshold = 50,
+    autovacuum_vacuum_cost_delay = 0
+);
+
+-- +migrate Down
+
+DROP TABLE IF EXISTS blend_emissions;

--- a/internal/db/migrations/2026-07-08.8-blend_oracle_prices.sql
+++ b/internal/db/migrations/2026-07-08.8-blend_oracle_prices.sql
@@ -1,0 +1,27 @@
+-- +migrate Up
+
+-- current-only price snapshot (NOT historical) — fed by the SEP-40 lastprice task
+CREATE TABLE blend_oracle_prices (
+    oracle_contract_id   BYTEA NOT NULL,
+    asset_contract_id    BYTEA NOT NULL,      -- pools query SEP-40 with Asset::Stellar(address)
+    price                TEXT NOT NULL,       -- fixed-point at price_decimals
+    price_decimals       INTEGER NOT NULL,
+    price_timestamp      BIGINT NOT NULL,     -- oracle-reported timestamp
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (oracle_contract_id, asset_contract_id)
+) WITH (
+    -- Reserve 20% free space per page so PostgreSQL can do HOT (Heap-Only Tuple) updates.
+    -- This table is a current-only snapshot rather than a history: every row is overwritten on
+    -- each SEP-40 lastprice refresh, so all rows are hot. The rewritten columns (price,
+    -- price_decimals, price_timestamp, updated_at) are all non-indexed.
+    fillfactor = 80,
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 50,
+    autovacuum_analyze_scale_factor = 0.01,
+    autovacuum_analyze_threshold = 50,
+    autovacuum_vacuum_cost_delay = 0
+);
+
+-- +migrate Down
+
+DROP TABLE IF EXISTS blend_oracle_prices;

--- a/internal/db/migrations/2026-07-08.9-blend_claimed.sql
+++ b/internal/db/migrations/2026-07-08.9-blend_claimed.sql
@@ -1,0 +1,43 @@
+-- +migrate Up
+
+-- Lifetime pool-reserve BLND claimed per (pool, user), accumulated additively from
+-- pool `claim` events during current-state indexing.
+CREATE TABLE blend_pool_claimed (
+    pool_contract_id     BYTEA NOT NULL,
+    user_account_id      BYTEA NOT NULL,
+    claimed_blnd         TEXT NOT NULL DEFAULT '0',   -- Σ claimed BLND (underlying, 7 decimals)
+    last_modified_ledger INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (pool_contract_id, user_account_id)
+) WITH (
+    fillfactor = 90,
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 50,
+    autovacuum_analyze_scale_factor = 0.01,
+    autovacuum_analyze_threshold = 50,
+    autovacuum_vacuum_cost_delay = 0
+);
+-- The resolver reads by account; user is not the primary-key prefix.
+CREATE INDEX idx_blend_pool_claimed_user ON blend_pool_claimed (user_account_id);
+
+-- Lifetime backstop-emission claims in Comet LP tokens, account-wide. A backstop
+-- `claim` auto-compounds the claimed BLND into LP across every pool the caller
+-- claimed from and emits a single aggregate amount carrying NO pool address, so
+-- this total can only be keyed by user, not by pool.
+CREATE TABLE blend_backstop_claimed (
+    user_account_id      BYTEA NOT NULL,
+    claimed_lp           TEXT NOT NULL DEFAULT '0',   -- Σ claimed Comet LP (7 decimals)
+    last_modified_ledger INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (user_account_id)
+) WITH (
+    fillfactor = 90,
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 50,
+    autovacuum_analyze_scale_factor = 0.01,
+    autovacuum_analyze_threshold = 50,
+    autovacuum_vacuum_cost_delay = 0
+);
+
+-- +migrate Down
+
+DROP TABLE IF EXISTS blend_backstop_claimed;
+DROP TABLE IF EXISTS blend_pool_claimed;

--- a/internal/db/migrations/2026-07-16.0-blend_auctions.sql
+++ b/internal/db/migrations/2026-07-16.0-blend_auctions.sql
@@ -1,0 +1,29 @@
+-- +migrate Up
+
+-- Active auctions (Auction(user, auction_type) TEMPORARY entries on pools). A row
+-- exists while the auction is open; entry deletion (fill/cancel) deletes the row.
+-- TTL eviction is not surfaced to the indexer, so a never-filled auction's row can
+-- outlive the entry's ~45d TTL — readers should treat a very old start_block as stale.
+CREATE TABLE blend_auctions (
+    pool_contract_id     BYTEA NOT NULL,
+    user_account_id      BYTEA NOT NULL,     -- auction owner: liquidated user; the backstop for bad-debt/interest
+    auction_type         INTEGER NOT NULL,   -- 0 user liquidation, 1 bad debt, 2 interest
+    bid                  JSONB NOT NULL,     -- {asset C-address: amount string} the filler pays
+    lot                  JSONB NOT NULL,     -- {asset C-address: amount string} the filler receives
+    start_block          INTEGER NOT NULL,   -- AuctionData.block: start ledger anchoring Dutch-auction scaling
+    last_modified_ledger INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (pool_contract_id, user_account_id, auction_type)
+) WITH (
+    fillfactor = 90,
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 50,
+    autovacuum_analyze_scale_factor = 0.01,
+    autovacuum_analyze_threshold = 50,
+    autovacuum_vacuum_cost_delay = 0
+);
+-- account-first lookup ("is this account being liquidated anywhere")
+CREATE INDEX idx_blend_auctions_user ON blend_auctions (user_account_id);
+
+-- +migrate Down
+
+DROP TABLE IF EXISTS blend_auctions;

--- a/internal/db/migrations/protocols/002_blend.sql
+++ b/internal/db/migrations/protocols/002_blend.sql
@@ -1,0 +1,3 @@
+-- Idempotent BLEND protocol registration. Executed by internal/db/migrations/protocols/main.go,
+-- which runs the file verbatim on every protocol-setup invocation.
+INSERT INTO protocols (id) VALUES ('BLEND') ON CONFLICT (id) DO NOTHING;

--- a/internal/indexer/types/types.go
+++ b/internal/indexer/types/types.go
@@ -504,6 +504,18 @@ const (
 	StateChangeCategoryFlags                StateChangeCategory = "FLAGS"
 	StateChangeCategoryTrustline            StateChangeCategory = "TRUSTLINE"
 	StateChangeCategoryBalanceAuthorization StateChangeCategory = "BALANCE_AUTHORIZATION"
+
+	// Blend v2 lending categories. Each names the on-chain object an account
+	// position changes against, mirroring the core convention (category =
+	// object, reason = action).
+	StateChangeCategoryBlendSupply            StateChangeCategory = "BLEND_SUPPLY"
+	StateChangeCategoryBlendCollateral        StateChangeCategory = "BLEND_COLLATERAL"
+	StateChangeCategoryBlendDebt              StateChangeCategory = "BLEND_DEBT"
+	StateChangeCategoryBlendAuction           StateChangeCategory = "BLEND_AUCTION"
+	StateChangeCategoryBlendEmissions         StateChangeCategory = "BLEND_EMISSIONS"
+	StateChangeCategoryBlendBackstopEmissions StateChangeCategory = "BLEND_BACKSTOP_EMISSIONS"
+	StateChangeCategoryBlendBackstop          StateChangeCategory = "BLEND_BACKSTOP"
+	StateChangeCategoryBlendBackstopQueue     StateChangeCategory = "BLEND_BACKSTOP_QUEUE"
 )
 
 type StateChangeReason string
@@ -520,6 +532,16 @@ const (
 	StateChangeReasonUpdate StateChangeReason = "UPDATE"
 	StateChangeReasonSet    StateChangeReason = "SET"
 	StateChangeReasonClear  StateChangeReason = "CLEAR"
+
+	// Blend v2 lending reasons. Amount-bearing positions reuse CREDIT/DEBIT
+	// (and the queue ADD/REMOVE, defaulted debt BURN); the verbs below cover
+	// actions with no generic equivalent.
+	StateChangeReasonBorrow    StateChangeReason = "BORROW"
+	StateChangeReasonRepay     StateChangeReason = "REPAY"
+	StateChangeReasonFlashLoan StateChangeReason = "FLASH_LOAN"
+	StateChangeReasonBadDebt   StateChangeReason = "BAD_DEBT"
+	StateChangeReasonFill      StateChangeReason = "FILL"
+	StateChangeReasonClaim     StateChangeReason = "CLAIM"
 )
 
 // Flag bitmask constants for encoding/decoding authorization flags.

--- a/internal/serve/graphql/resolvers/utils.go
+++ b/internal/serve/graphql/resolvers/utils.go
@@ -208,6 +208,7 @@ func convertStateChangeTypes(stateChange types.StateChange) (generated.BaseState
 			return &types.BalanceAuthorizationChangeModel{StateChange: stateChange}, nil
 		default: // invalid reason for BALANCE_AUTHORIZATION; falls through to the error below
 		}
+	default: // category with no GraphQL representation yet (BLEND_*); falls through to the error below
 	}
 	return nil, fmt.Errorf("state change (toID=%d, opID=%d, stateChangeID=%d) has no GraphQL type for (category=%s, reason=%s)",
 		stateChange.ToID, stateChange.OperationID, stateChange.StateChangeID, stateChange.StateChangeCategory, stateChange.StateChangeReason)


### PR DESCRIPTION
### Blend v2 schema + data models

Second of 5 stacked PRs adding Blend Capital v2 lending support (stacked on #657). This PR adds the database schema and the Go **writer** layer that Blend ingestion populates. The GraphQL readers that expose this data land in #661.

### Migrations

`state_changes` CHECK constraints gain the Blend v2 values under the schema-wide convention that **category names the on-chain object and reason names the action**: eight categories (`BLEND_SUPPLY`, `BLEND_COLLATERAL`, `BLEND_DEBT`, `BLEND_AUCTION`, `BLEND_EMISSIONS`, `BLEND_BACKSTOP_EMISSIONS`, `BLEND_BACKSTOP`, `BLEND_BACKSTOP_QUEUE`). Amount-bearing categories reuse the generic `CREDIT`/`DEBIT`/`ADD`/`REMOVE`/`BURN` verbs; only `BORROW`, `REPAY`, `FLASH_LOAN`, `BAD_DEBT`, `FILL`, and `CLAIM` are added. The constraints restate the tightened base lists exactly and are recreated `NOT VALID` so no hypertable rewrite is needed. The rollback enforces its no-BLEND-rows precondition with a fail-loud guard (a `DO` block probing both the category and reason lists — served by the columnstore's bloom sparse indexes — since `NOT VALID` re-narrowed CHECKs cannot reject pre-existing rows), and all constraint drops are `IF EXISTS` so both directions are re-runnable.

11 new current-state tables — plain mutable tables, **not** hypertables, because they hold UPSERT-heavy snapshots of live on-chain state (same rationale as `sep41_balances`). Storage parameters follow the current conventions: `fillfactor = 80` only where essentially every row turns over per active ledger (`blend_reserves`, `blend_reserve_emissions`, `blend_oracle_prices`, each with an in-file justification), `fillfactor = 90` elsewhere, and no `autovacuum_vacuum_cost_limit` (cost_delay = 0 already exempts these tables from cross-worker balancing):

| Table | Holds |
|---|---|
| `blend_pools` | per pool: oracle, status, backstop rate, max positions, min collateral, admin, reward-zone flag, name |
| `blend_positions` | per pool/user/reserve: supplied / collateral / borrowed balances + net-supplied / net-borrowed cost basis |
| `blend_reserves` | per pool/reserve: b/d rates & supplies, backstop credit, interest-rate-curve config, collateral/liability factors |
| `blend_backstop_positions` | per pool/user: backstop shares + queued-for-withdrawal (Q4W) entries |
| `blend_backstop_pools` | per pool: total backstop shares / tokens / q4w + emission state |
| `blend_reserve_emissions` | per pool/reserve-token: emission rate, index, expiration |
| `blend_emissions` | per user: reserve and backstop emission accrual |
| `blend_oracle_prices` | per oracle/asset: latest price snapshot |
| `blend_pool_claimed` / `blend_backstop_claimed` | lifetime claimed BLND (per pool/user) / Comet LP (per user) |
| `blend_auctions` | active Dutch auctions per pool/user/type (bid, lot, start block) |

Every user-keyed table is indexed on `user_account_id` for the per-account "my positions" read path. `blend_reserves` additionally enforces `UNIQUE (pool_contract_id, asset_contract_id)` — the fold SQL resolves `reserve_index` by joining on that pair, and `UPDATE ... FROM` would silently apply an arbitrary source row if it ever matched twice; the backing unique index also serves those joins. Also registers the `BLEND` protocol.

### Go data layer (`internal/data/blend`, writer surface only)

- **`PositionModel`** — snapshot upserts (last-write-wins), zeroing of exited reserves (rows kept so lifetime-earned survives a full exit), additive net-delta cost-basis folds (asset → reserve resolved via `blend_reserves`), bad-debt reset, and auction adjustments that convert protocol tokens to underlying at current rates (floored to match the contract; conversion happens once on the batch-summed delta, so folded fills round once, not per fill — pinned by test, skew ≤ n−1 stroops, below the documented rate-staleness bound).
- **`PoolModel`** (partial upsert — a NULL field never clobbers known config; plus an absolute reward-zone set), **`ReserveModel`** (full-row upserts plus a ResData-only partial update, both rejecting duplicate (pool, asset) keys per batch — `UPDATE ... FROM` would silently pick one arbitrary source row), **`BackstopPositionModel`** / **`BackstopPoolModel`**, **`Emission`** / **`ReserveEmission`** models, **`PoolClaimed`** / **`BackstopClaimed`** (additive lifetime totals), and **`AuctionModel`**.
- Wired as `data.Models.Blend`; adds the 8 Blend category + 6 reason Go constants (the locked cross-PR contract).
- All models are covered by dbtest.

### Notes for reviewers

- Backstop user-emission rows share `blend_emissions` with reserve emissions, distinguished by `token_id = -1` (backstop) vs `>= 0` (reserve token); backstop rows carry the pool as `source_contract_id`.
- Lifetime-claimed totals aren't stored on-chain (a claim zeroes on-chain accrual), so they're folded additively from claim events during ingestion.
- **Known limitation:** the backstop's backfill-emissions gate (`BACKFILL_STATUS` / `BACKFILL_EMISSIONS`) is not captured — during that transitional state accrued backstop BLND isn't yet claimable, so a user's claimable-BLND figure can be overstated in that window. Deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



