### PR TITLE
feat(blend): periodic SEP-40 oracle price snapshot with Comet BLND/LP leg

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -35,6 +35,8 @@ func (c *ingestCmd) Command() *cobra.Command {
 		utils.IngestServerPortOption(&cfg.ServerPort),
 		utils.AdminPortOption(&cfg.AdminPort),
 		utils.GetLedgersLimitOption(&cfg.GetLedgersLimit),
+		utils.BlendPriceIntervalOption(&cfg.BlendPriceInterval),
+		utils.BlendBackstopLPContractIDOption(&cfg.BlendBackstopLPContractID),
 		{
 			Name:        "ingestion-mode",
 			Usage:       "What mode to run ingestion in - live or backfill",

--- a/cmd/utils/custom_set_value_test.go
+++ b/cmd/utils/custom_set_value_test.go
@@ -296,3 +296,38 @@ func TestSetConfigOptionDuration(t *testing.T) {
 		})
 	}
 }
+
+func TestBlendPriceIntervalOption(t *testing.T) {
+	opts := struct{ d time.Duration }{}
+	co := BlendPriceIntervalOption(&opts.d)
+
+	testCases := []customSetterTestCase[time.Duration]{
+		{
+			name:            "returns an error if the duration is negative",
+			args:            []string{"--blend-price-interval=-1s"},
+			wantErrContains: "blend-price-interval must not be negative",
+		},
+		{
+			name:            "returns an error if a negative duration comes through the ENV var",
+			envValue:        "-30s",
+			wantErrContains: "blend-price-interval must not be negative",
+		},
+		{
+			name:       "zero disables the task and is accepted",
+			args:       []string{"--blend-price-interval", "0s"},
+			wantResult: 0,
+		},
+		{
+			name:       "a positive interval is accepted",
+			args:       []string{"--blend-price-interval", "90s"},
+			wantResult: 90 * time.Second,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts.d = 0
+			customSetterTester(t, tc, *co)
+		})
+	}
+}

--- a/cmd/utils/global_options.go
+++ b/cmd/utils/global_options.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"go/types"
 	"time"
 
@@ -154,16 +155,25 @@ func NetworkOption(configKey *string) *config.ConfigOption {
 }
 
 // BlendPriceIntervalOption returns the config option for the wait between Blend v2 oracle
-// price snapshot passes. Setting it to 0 disables the snapshot task entirely.
+// price snapshot passes. Setting it to 0 disables the snapshot task entirely; negative
+// values are rejected at startup so a typo can't silently disable price updates.
 func BlendPriceIntervalOption(configKey *time.Duration) *config.ConfigOption {
 	return &config.ConfigOption{
-		Name:           "blend-price-interval",
-		Usage:          `Interval between Blend v2 oracle price snapshot passes (Go duration string, e.g. "60s"). 0 disables the snapshot task.`,
-		OptType:        types.String,
-		CustomSetValue: SetConfigOptionDuration,
-		ConfigKey:      configKey,
-		FlagDefault:    "60s",
-		Required:       false,
+		Name:    "blend-price-interval",
+		Usage:   `Interval between Blend v2 oracle price snapshot passes (Go duration string, e.g. "60s"). 0 disables the snapshot task.`,
+		OptType: types.String,
+		CustomSetValue: func(co *config.ConfigOption) error {
+			if err := SetConfigOptionDuration(co); err != nil {
+				return err
+			}
+			if d := *co.ConfigKey.(*time.Duration); d < 0 {
+				return fmt.Errorf("%s must not be negative (0 disables the task), got %s", co.Name, d)
+			}
+			return nil
+		},
+		ConfigKey:   configKey,
+		FlagDefault: "60s",
+		Required:    false,
 	}
 }
 

--- a/cmd/utils/global_options.go
+++ b/cmd/utils/global_options.go
@@ -153,6 +153,34 @@ func NetworkOption(configKey *string) *config.ConfigOption {
 	}
 }
 
+// BlendPriceIntervalOption returns the config option for the wait between Blend v2 oracle
+// price snapshot passes. Setting it to 0 disables the snapshot task entirely.
+func BlendPriceIntervalOption(configKey *time.Duration) *config.ConfigOption {
+	return &config.ConfigOption{
+		Name:           "blend-price-interval",
+		Usage:          `Interval between Blend v2 oracle price snapshot passes (Go duration string, e.g. "60s"). 0 disables the snapshot task.`,
+		OptType:        types.String,
+		CustomSetValue: SetConfigOptionDuration,
+		ConfigKey:      configKey,
+		FlagDefault:    "60s",
+		Required:       false,
+	}
+}
+
+// BlendBackstopLPContractIDOption returns the config option for the Blend v2 backstop's
+// Comet BLND:USDC weighted pool. Its C-address enables the price snapshot task's BLND/LP-share
+// derived-pricing leg; leaving it empty disables that leg.
+func BlendBackstopLPContractIDOption(configKey *string) *config.ConfigOption {
+	return &config.ConfigOption{
+		Name:        "blend-backstop-lp-contract-id",
+		Usage:       "C-address of the Blend v2 backstop's Comet BLND:USDC weighted pool, enabling the BLND/LP-share price leg. Empty disables it.",
+		OptType:     types.String,
+		ConfigKey:   configKey,
+		FlagDefault: "",
+		Required:    false,
+	}
+}
+
 func GraphQLComplexityLimitOption(configKey *int) *config.ConfigOption {
 	return &config.ConfigOption{
 		Name:        "graphql-complexity-limit",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -175,6 +175,8 @@ services:
       TRACKER_DSN: ${TRACKER_DSN}
       STELLAR_ENVIRONMENT: ${STELLAR_ENVIRONMENT:-development}
       # ADMIN_PORT: 9094  # Optional: Port for pprof endpoints at /debug/pprof. WARNING: Do NOT expose publicly!
+      # BLEND_PRICE_INTERVAL: 60s  # Optional: interval between Blend v2 oracle price snapshot passes. 0 disables it.
+      # BLEND_BACKSTOP_LP_CONTRACT_ID: ""  # Optional: Comet BLND:USDC LP C-address enabling the BLND/LP price leg.
 
   ingest-mainnet:
     container_name: ingest-mainnet
@@ -217,6 +219,8 @@ services:
       TRACKER_DSN: ${TRACKER_DSN}
       STELLAR_ENVIRONMENT: ${STELLAR_ENVIRONMENT:-development}
       # ADMIN_PORT: 9095  # Optional: Port for pprof endpoints at /debug/pprof. WARNING: Do NOT expose publicly!
+      # BLEND_PRICE_INTERVAL: 60s  # Optional: interval between Blend v2 oracle price snapshot passes. 0 disables it.
+      # BLEND_BACKSTOP_LP_CONTRACT_ID: ""  # Optional: Comet BLND:USDC LP C-address enabling the BLND/LP price leg.
 volumes:
   postgres-db:
     driver: local

--- a/internal/data/blend/models.go
+++ b/internal/data/blend/models.go
@@ -19,7 +19,7 @@ type Models struct {
 	PoolClaimed       *PoolClaimedModel
 	BackstopClaimed   *BackstopClaimedModel
 	Auctions          *AuctionModel
-	// OraclePrices *OraclePriceModel is added in PR4 alongside oracle_prices.go.
+	OraclePrices      *OraclePriceModel
 }
 
 // NewModels constructs the Blend Models aggregate wired to the given pool/metrics.
@@ -35,5 +35,6 @@ func NewModels(pool *pgxpool.Pool, dbMetrics *metrics.DBMetrics) Models {
 		PoolClaimed:       &PoolClaimedModel{DB: pool, Metrics: dbMetrics},
 		BackstopClaimed:   &BackstopClaimedModel{DB: pool, Metrics: dbMetrics},
 		Auctions:          &AuctionModel{DB: pool, Metrics: dbMetrics},
+		OraclePrices:      &OraclePriceModel{DB: pool, Metrics: dbMetrics},
 	}
 }

--- a/internal/data/blend/oracle_prices.go
+++ b/internal/data/blend/oracle_prices.go
@@ -1,0 +1,151 @@
+// Oracle price snapshot storage for Blend v2 (blend_oracle_prices).
+package blend
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+	"github.com/stellar/wallet-backend/internal/utils"
+)
+
+// oraclePricesTable is the metrics label for blend_oracle_prices queries.
+const oraclePricesTable = "blend_oracle_prices"
+
+// PriceTarget identifies one (oracle, asset) pair that some pool's reserve
+// prices against — the input list the SEP-40 lastprice snapshot task queries
+// on each tick.
+type PriceTarget struct {
+	OracleContractID types.AddressBytea
+	AssetContractID  types.AddressBytea
+}
+
+// OraclePrice is a full row of blend_oracle_prices: the current-only (not
+// historical) latest known SEP-40 price for one (oracle, asset) pair.
+type OraclePrice struct {
+	OracleContractID types.AddressBytea
+	AssetContractID  types.AddressBytea
+	Price            string // raw i128 fixed-point value at PriceDecimals
+	PriceDecimals    int32
+	PriceTimestamp   int64 // oracle-reported timestamp
+	// UpdatedAt is populated when scanning an existing row. BatchUpsert ignores
+	// it on write and always sets updated_at to NOW() itself.
+	UpdatedAt time.Time
+}
+
+// OraclePriceModelInterface exposes Blend v2 oracle price snapshot storage
+// operations.
+//
+// Unlike sibling Blend models, both methods here operate directly on the
+// pgxpool rather than a caller-supplied pgx.Tx: the price snapshot task runs
+// on its own schedule, independent of ledger ingestion, so there is no
+// enclosing ingest transaction for it to join.
+type OraclePriceModelInterface interface {
+	// GetPriceTargets returns the deduplicated set of (oracle, asset) pairs
+	// that some pool's reserve prices against — every blend_reserves row
+	// joined to its pool's oracle. Pools with no oracle wired yet (NULL
+	// oracle_contract_id) are excluded.
+	GetPriceTargets(ctx context.Context) ([]PriceTarget, error)
+	// BatchUpsert inserts or fully replaces price rows keyed by
+	// (oracle_contract_id, asset_contract_id). updated_at is always set to
+	// NOW(), whether the row is freshly inserted or replaced.
+	BatchUpsert(ctx context.Context, rows []OraclePrice) error
+}
+
+// OraclePriceModel implements OraclePriceModelInterface against blend_oracle_prices.
+type OraclePriceModel struct {
+	DB      *pgxpool.Pool
+	Metrics *metrics.DBMetrics
+}
+
+var _ OraclePriceModelInterface = (*OraclePriceModel)(nil)
+
+// GetPriceTargets returns the deduplicated (oracle, asset) pairs derived from
+// blend_reserves joined to their pool's oracle. See OraclePriceModelInterface.
+func (m *OraclePriceModel) GetPriceTargets(ctx context.Context) ([]PriceTarget, error) {
+	start := time.Now()
+
+	const query = `
+		SELECT DISTINCT p.oracle_contract_id, r.asset_contract_id
+		FROM blend_pools p
+		JOIN blend_reserves r ON r.pool_contract_id = p.pool_contract_id
+		WHERE p.oracle_contract_id IS NOT NULL
+		ORDER BY p.oracle_contract_id, r.asset_contract_id`
+	rows, err := m.DB.Query(ctx, query)
+	if err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("GetPriceTargets", oraclePricesTable, utils.GetDBErrorType(err)).Inc()
+		return nil, fmt.Errorf("querying blend oracle price targets: %w", err)
+	}
+	defer rows.Close()
+
+	var targets []PriceTarget
+	for rows.Next() {
+		var t PriceTarget
+		if err := rows.Scan(&t.OracleContractID, &t.AssetContractID); err != nil {
+			m.Metrics.QueryErrors.WithLabelValues("GetPriceTargets", oraclePricesTable, utils.GetDBErrorType(err)).Inc()
+			return nil, fmt.Errorf("scanning blend oracle price target row: %w", err)
+		}
+		targets = append(targets, t)
+	}
+	if err := rows.Err(); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("GetPriceTargets", oraclePricesTable, utils.GetDBErrorType(err)).Inc()
+		return nil, fmt.Errorf("iterating blend oracle price target rows: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("GetPriceTargets", oraclePricesTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("GetPriceTargets", oraclePricesTable).Inc()
+	return targets, nil
+}
+
+// BatchUpsert inserts or fully replaces blend_oracle_prices rows. See OraclePriceModelInterface.
+func (m *OraclePriceModel) BatchUpsert(ctx context.Context, rows []OraclePrice) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+
+	oracles := make([][]byte, len(rows))
+	assets := make([][]byte, len(rows))
+	prices := make([]string, len(rows))
+	decimals := make([]int32, len(rows))
+	timestamps := make([]int64, len(rows))
+	for i, r := range rows {
+		oracleBytes, err := addressToBytes(string(r.OracleContractID))
+		if err != nil {
+			return fmt.Errorf("converting oracle address for price upsert: %w", err)
+		}
+		assetBytes, err := addressToBytes(string(r.AssetContractID))
+		if err != nil {
+			return fmt.Errorf("converting asset address for price upsert: %w", err)
+		}
+		oracles[i] = oracleBytes
+		assets[i] = assetBytes
+		prices[i] = r.Price
+		decimals[i] = r.PriceDecimals
+		timestamps[i] = r.PriceTimestamp
+	}
+
+	const upsertQuery = `
+		INSERT INTO blend_oracle_prices (oracle_contract_id, asset_contract_id, price, price_decimals, price_timestamp, updated_at)
+		SELECT u.*, NOW() FROM UNNEST($1::bytea[], $2::bytea[], $3::text[], $4::integer[], $5::bigint[])
+			AS u(oracle_contract_id, asset_contract_id, price, price_decimals, price_timestamp)
+		ON CONFLICT (oracle_contract_id, asset_contract_id) DO UPDATE SET
+			price = EXCLUDED.price, price_decimals = EXCLUDED.price_decimals,
+			price_timestamp = EXCLUDED.price_timestamp, updated_at = NOW()`
+	if _, err := m.DB.Exec(ctx, upsertQuery, oracles, assets, prices, decimals, timestamps); err != nil {
+		m.Metrics.QueryErrors.WithLabelValues("BatchUpsert", oraclePricesTable, utils.GetDBErrorType(err)).Inc()
+		return fmt.Errorf("upserting blend oracle prices: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	m.Metrics.QueryDuration.WithLabelValues("BatchUpsert", oraclePricesTable).Observe(duration)
+	m.Metrics.QueriesTotal.WithLabelValues("BatchUpsert", oraclePricesTable).Inc()
+	m.Metrics.BatchSize.WithLabelValues("BatchUpsert", oraclePricesTable).Observe(float64(len(rows)))
+	return nil
+}

--- a/internal/data/blend/oracle_prices_test.go
+++ b/internal/data/blend/oracle_prices_test.go
@@ -1,0 +1,173 @@
+// Unit tests for the Blend v2 OraclePriceModel.
+// These tests exercise real SQL and require a PostgreSQL test database.
+// Uses an external test package to avoid an import cycle with internal/data.
+package blend_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/data/blend"
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+)
+
+func newOraclePricesFixture(t *testing.T) (context.Context, *pgxpool.Pool, *blend.OraclePriceModel, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	dbt := dbtest.Open(t)
+	pool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+
+	m := &blend.OraclePriceModel{
+		DB:      pool,
+		Metrics: metrics.NewMetrics(prometheus.NewRegistry()).DB,
+	}
+
+	cleanup := func() {
+		pool.Close()
+		dbt.Close()
+	}
+	return ctx, pool, m, cleanup
+}
+
+// insertPool seeds a blend_pools row directly via raw SQL. An empty oracleAddr
+// stores oracle_contract_id as SQL NULL.
+func insertPool(t *testing.T, ctx context.Context, pool *pgxpool.Pool, poolAddr, oracleAddr string) {
+	t.Helper()
+	var oracle any
+	if oracleAddr != "" {
+		oracle = types.AddressBytea(oracleAddr)
+	}
+	_, err := pool.Exec(ctx, `
+		INSERT INTO blend_pools (pool_contract_id, oracle_contract_id, last_modified_ledger)
+		VALUES ($1, $2, 1)
+	`, types.AddressBytea(poolAddr), oracle)
+	require.NoError(t, err)
+}
+
+type oraclePriceRow struct {
+	Price          string
+	PriceDecimals  int32
+	PriceTimestamp int64
+	UpdatedAt      time.Time
+}
+
+func getOraclePrice(t *testing.T, ctx context.Context, pool *pgxpool.Pool, oracleAddr, assetAddr string) (oraclePriceRow, bool) {
+	t.Helper()
+	var row oraclePriceRow
+	err := pool.QueryRow(ctx, `
+		SELECT price, price_decimals, price_timestamp, updated_at
+		FROM blend_oracle_prices WHERE oracle_contract_id = $1 AND asset_contract_id = $2
+	`, types.AddressBytea(oracleAddr), types.AddressBytea(assetAddr)).Scan(
+		&row.Price, &row.PriceDecimals, &row.PriceTimestamp, &row.UpdatedAt,
+	)
+	if err != nil {
+		return oraclePriceRow{}, false
+	}
+	return row, true
+}
+
+func TestGetPriceTargets(t *testing.T) {
+	ctx, pool, m, cleanup := newOraclePricesFixture(t)
+	defer cleanup()
+
+	oracle1 := keypair.MustRandom().Address()
+	oracle2 := keypair.MustRandom().Address()
+	poolA := keypair.MustRandom().Address()
+	poolB := keypair.MustRandom().Address()
+	poolC := keypair.MustRandom().Address()
+	poolNoOracle := keypair.MustRandom().Address()
+	assetX := keypair.MustRandom().Address()
+	assetY := keypair.MustRandom().Address()
+	assetZ := keypair.MustRandom().Address()
+	assetExcluded := keypair.MustRandom().Address()
+
+	// poolA and poolB share oracle1.
+	insertPool(t, ctx, pool, poolA, oracle1)
+	insertPool(t, ctx, pool, poolB, oracle1)
+	// poolC has its own oracle.
+	insertPool(t, ctx, pool, poolC, oracle2)
+	// poolNoOracle has no oracle wired yet; its reserves must be excluded.
+	insertPool(t, ctx, pool, poolNoOracle, "")
+
+	insertReserve(t, ctx, pool, poolA, assetX, 0, "1", "1")
+	insertReserve(t, ctx, pool, poolB, assetX, 0, "1", "1") // same asset via a different pool -> dedup
+	insertReserve(t, ctx, pool, poolB, assetY, 1, "1", "1")
+	insertReserve(t, ctx, pool, poolC, assetZ, 0, "1", "1")
+	insertReserve(t, ctx, pool, poolNoOracle, assetExcluded, 0, "1", "1")
+
+	targets, err := m.GetPriceTargets(ctx)
+	require.NoError(t, err)
+
+	want := []blend.PriceTarget{
+		{OracleContractID: types.AddressBytea(oracle1), AssetContractID: types.AddressBytea(assetX)},
+		{OracleContractID: types.AddressBytea(oracle1), AssetContractID: types.AddressBytea(assetY)},
+		{OracleContractID: types.AddressBytea(oracle2), AssetContractID: types.AddressBytea(assetZ)},
+	}
+	assert.ElementsMatch(t, want, targets)
+}
+
+func TestOraclePriceBatchUpsert(t *testing.T) {
+	ctx, pool, m, cleanup := newOraclePricesFixture(t)
+	defer cleanup()
+
+	oracleAddr := keypair.MustRandom().Address()
+	assetA := keypair.MustRandom().Address()
+	assetB := keypair.MustRandom().Address()
+
+	require.NoError(t, m.BatchUpsert(ctx, []blend.OraclePrice{
+		{
+			OracleContractID: types.AddressBytea(oracleAddr), AssetContractID: types.AddressBytea(assetA),
+			Price: "100000000", PriceDecimals: 7, PriceTimestamp: 1000,
+		},
+		{
+			OracleContractID: types.AddressBytea(oracleAddr), AssetContractID: types.AddressBytea(assetB),
+			Price: "200000000", PriceDecimals: 7, PriceTimestamp: 1000,
+		},
+	}))
+
+	rowA, ok := getOraclePrice(t, ctx, pool, oracleAddr, assetA)
+	require.True(t, ok)
+	assert.Equal(t, "100000000", rowA.Price)
+	assert.Equal(t, int64(1000), rowA.PriceTimestamp)
+
+	rowB, ok := getOraclePrice(t, ctx, pool, oracleAddr, assetB)
+	require.True(t, ok)
+	assert.Equal(t, "200000000", rowB.Price)
+
+	// Ensure NOW() is measurably different on the re-upsert below.
+	time.Sleep(10 * time.Millisecond)
+
+	require.NoError(t, m.BatchUpsert(ctx, []blend.OraclePrice{
+		{
+			OracleContractID: types.AddressBytea(oracleAddr), AssetContractID: types.AddressBytea(assetA),
+			Price: "150000000", PriceDecimals: 7, PriceTimestamp: 2000,
+		},
+	}))
+
+	rowA2, ok := getOraclePrice(t, ctx, pool, oracleAddr, assetA)
+	require.True(t, ok)
+	assert.Equal(t, "150000000", rowA2.Price, "re-upserted row's price must change")
+	assert.Equal(t, int64(2000), rowA2.PriceTimestamp, "re-upserted row's timestamp must change")
+	assert.True(t, rowA2.UpdatedAt.After(rowA.UpdatedAt), "updated_at must advance on re-upsert")
+
+	rowB2, ok := getOraclePrice(t, ctx, pool, oracleAddr, assetB)
+	require.True(t, ok)
+	assert.Equal(t, "200000000", rowB2.Price, "untouched row's price must not change")
+	assert.Equal(t, rowB.UpdatedAt, rowB2.UpdatedAt, "untouched row's updated_at must not change")
+
+	t.Run("is a no-op when no rows are staged", func(t *testing.T) {
+		require.NoError(t, m.BatchUpsert(ctx, nil))
+	})
+}

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -212,8 +212,9 @@ func setupDeps(ctx context.Context, cfg Configs) (services.IngestService, func()
 		return nil, nil, fmt.Errorf("instantiating contract metadata service: %w", err)
 	}
 
-	// Start the Blend v2 oracle price snapshot task. Live-only: backfill replays historical
+	// The Blend v2 oracle price snapshot task. Live-only: backfill replays historical
 	// ledgers and has no use for a periodic wall-clock snapshot of current prices.
+	var postLockTasks []func(context.Context)
 	if cfg.IngestionMode == services.IngestionModeLive && cfg.BlendPriceInterval > 0 {
 		blendPrices, err := blend.NewPriceSnapshotService(blend.PriceSnapshotConfig{
 			OraclePrices:         models.Blend.OraclePrices,
@@ -225,7 +226,9 @@ func setupDeps(ctx context.Context, cfg Configs) (services.IngestService, func()
 		if err != nil {
 			return nil, nil, fmt.Errorf("instantiating blend price snapshot service: %w", err)
 		}
-		go blendPrices.Run(ctx)
+		// Started by the ingest service only after it acquires the live
+		// advisory lock — a lock-losing instance must not snapshot prices.
+		postLockTasks = append(postLockTasks, blendPrices.Run)
 	}
 
 	// Build a single ProtocolDeps to pass through both the validator and
@@ -327,6 +330,7 @@ func setupDeps(ctx context.Context, cfg Configs) (services.IngestService, func()
 		ProtocolValidators:        protocolValidators,
 		WasmSpecExtractor:         wasmExtractor,
 		ContractMetadataService:   contractMetadataService,
+		PostLockTasks:             postLockTasks,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("instantiating ingest service: %w", err)

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -221,6 +221,7 @@ func setupDeps(ctx context.Context, cfg Configs) (services.IngestService, func()
 			Metadata:             contractMetadataService,
 			Interval:             cfg.BlendPriceInterval,
 			BackstopLPContractID: cfg.BlendBackstopLPContractID,
+			RPC:                  rpcService,
 			Metrics:              m.BlendPrices,
 		})
 		if err != nil {

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stellar/wallet-backend/internal/metrics"
 	httphandler "github.com/stellar/wallet-backend/internal/serve/httphandler"
 	"github.com/stellar/wallet-backend/internal/services"
-	_ "github.com/stellar/wallet-backend/internal/services/blend" // registers BLEND validator + processor via init()
+	"github.com/stellar/wallet-backend/internal/services/blend"   // also registers BLEND validator + processor via init()
 	_ "github.com/stellar/wallet-backend/internal/services/sep41" // registers SEP-41 validator + processor via init()
 )
 
@@ -97,6 +97,12 @@ type Configs struct {
 	DBMinConns        int
 	DBMaxConnLifetime time.Duration
 	DBMaxConnIdleTime time.Duration
+	// BlendPriceInterval is the wait between Blend v2 oracle price snapshot passes.
+	// 0 disables the snapshot task. Only takes effect in live ingestion mode.
+	BlendPriceInterval time.Duration
+	// BlendBackstopLPContractID is the Blend v2 backstop's Comet BLND:USDC weighted pool
+	// C-address, enabling the price snapshot task's BLND/LP-share derived-pricing leg.
+	BlendBackstopLPContractID string
 }
 
 func (c Configs) BuildPoolConfig() db.PoolConfig {
@@ -204,6 +210,22 @@ func setupDeps(ctx context.Context, cfg Configs) (services.IngestService, func()
 	contractMetadataService, err := services.NewContractMetadataService(rpcService, models.Contract, contractMetadataPool)
 	if err != nil {
 		return nil, nil, fmt.Errorf("instantiating contract metadata service: %w", err)
+	}
+
+	// Start the Blend v2 oracle price snapshot task. Live-only: backfill replays historical
+	// ledgers and has no use for a periodic wall-clock snapshot of current prices.
+	if cfg.IngestionMode == services.IngestionModeLive && cfg.BlendPriceInterval > 0 {
+		blendPrices, err := blend.NewPriceSnapshotService(blend.PriceSnapshotConfig{
+			OraclePrices:         models.Blend.OraclePrices,
+			Metadata:             contractMetadataService,
+			Interval:             cfg.BlendPriceInterval,
+			BackstopLPContractID: cfg.BlendBackstopLPContractID,
+			Metrics:              m.BlendPrices,
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("instantiating blend price snapshot service: %w", err)
+		}
+		go blendPrices.Run(ctx)
 	}
 
 	// Build a single ProtocolDeps to pass through both the validator and

--- a/internal/metrics/blend.go
+++ b/internal/metrics/blend.go
@@ -11,11 +11,11 @@ type BlendPriceMetrics struct {
 	// (target discovery + every oracle/Comet fetch + the final batch upsert).
 	// PromQL: histogram_quantile(0.99, rate(wallet_blend_price_snapshot_duration_seconds_bucket[$__rate_interval]))
 	SnapshotDuration prometheus.Histogram
-	// FetchesTotal counts per-(oracle,asset) lastprice fetch outcomes (and the
-	// Comet leg's single derived-valuation outcome), labeled by result:
-	// success, error, none (SEP-40 Option::None — no price recorded yet),
-	// stale (oracle-reported timestamp older than the pool contract's 24h
-	// rejection window), or invalid (price ≤ 0).
+	// FetchesTotal counts per-(oracle,asset) lastprice fetch outcomes (plus
+	// the Comet leg: one success per derived row, one error per failed
+	// attempt), labeled by result: success, error, none (SEP-40 Option::None
+	// — no price recorded yet), stale (oracle-reported timestamp older than
+	// the pool contract's 24h rejection window), or invalid (price ≤ 0).
 	// PromQL: rate(wallet_blend_price_fetches_total{result="error"}[$__rate_interval])
 	FetchesTotal *prometheus.CounterVec
 	// PricesTracked is the row count written by the most recent snapshot pass.

--- a/internal/metrics/blend.go
+++ b/internal/metrics/blend.go
@@ -1,0 +1,42 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// BlendPriceMetrics holds Prometheus collectors for the Blend v2 oracle price
+// snapshot service. Unlike Migration/Ingestion, this runs on its own ticker
+// independent of ledger ingestion (see services/blend.PriceSnapshotService),
+// so it carries no ledger-sequence-shaped metrics of its own.
+type BlendPriceMetrics struct {
+	// SnapshotDuration observes one full SnapshotOnce pass's wall time
+	// (target discovery + every oracle/Comet fetch + the final batch upsert).
+	// PromQL: histogram_quantile(0.99, rate(wallet_blend_price_snapshot_duration_seconds_bucket[$__rate_interval]))
+	SnapshotDuration prometheus.Histogram
+	// FetchesTotal counts per-(oracle,asset) lastprice fetch outcomes (and the
+	// Comet leg's single derived-valuation outcome), labeled by result:
+	// success, error, or none (SEP-40 Option::None — no price recorded yet).
+	// PromQL: rate(wallet_blend_price_fetches_total{result="error"}[$__rate_interval])
+	FetchesTotal *prometheus.CounterVec
+	// PricesTracked is the row count written by the most recent snapshot pass.
+	// PromQL: wallet_blend_prices_tracked
+	PricesTracked prometheus.Gauge
+}
+
+func newBlendPriceMetrics(reg prometheus.Registerer) *BlendPriceMetrics {
+	m := &BlendPriceMetrics{
+		SnapshotDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "wallet_blend_price_snapshot_duration_seconds",
+			Help:    "Duration of a full Blend v2 oracle price snapshot pass.",
+			Buckets: prometheus.DefBuckets,
+		}),
+		FetchesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "wallet_blend_price_fetches_total",
+			Help: "Blend v2 oracle price fetch outcomes, labeled by result (success, error, none).",
+		}, []string{"result"}),
+		PricesTracked: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "wallet_blend_prices_tracked",
+			Help: "Number of (oracle, asset) price rows written by the most recent Blend v2 snapshot pass.",
+		}),
+	}
+	reg.MustRegister(m.SnapshotDuration, m.FetchesTotal, m.PricesTracked)
+	return m
+}

--- a/internal/metrics/blend.go
+++ b/internal/metrics/blend.go
@@ -13,12 +13,22 @@ type BlendPriceMetrics struct {
 	SnapshotDuration prometheus.Histogram
 	// FetchesTotal counts per-(oracle,asset) lastprice fetch outcomes (and the
 	// Comet leg's single derived-valuation outcome), labeled by result:
-	// success, error, or none (SEP-40 Option::None — no price recorded yet).
+	// success, error, none (SEP-40 Option::None — no price recorded yet),
+	// stale (oracle-reported timestamp older than the pool contract's 24h
+	// rejection window), or invalid (price ≤ 0).
 	// PromQL: rate(wallet_blend_price_fetches_total{result="error"}[$__rate_interval])
 	FetchesTotal *prometheus.CounterVec
 	// PricesTracked is the row count written by the most recent snapshot pass.
 	// PromQL: wallet_blend_prices_tracked
 	PricesTracked prometheus.Gauge
+	// OldestPriceAge is the age in seconds of the oldest oracle-reported price
+	// observed by the most recent snapshot pass that decoded any price,
+	// including prices skipped as stale — a dead oracle shows up as this gauge
+	// growing without bound. A pass that decoded no price leaves the gauge
+	// untouched rather than reporting 0, which would read as "all prices
+	// current"; those passes are visible in FetchesTotal{result="error"}.
+	// PromQL: wallet_blend_price_oldest_age_seconds
+	OldestPriceAge prometheus.Gauge
 }
 
 func newBlendPriceMetrics(reg prometheus.Registerer) *BlendPriceMetrics {
@@ -30,13 +40,17 @@ func newBlendPriceMetrics(reg prometheus.Registerer) *BlendPriceMetrics {
 		}),
 		FetchesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "wallet_blend_price_fetches_total",
-			Help: "Blend v2 oracle price fetch outcomes, labeled by result (success, error, none).",
+			Help: "Blend v2 oracle price fetch outcomes, labeled by result (success, error, none, stale, invalid).",
 		}, []string{"result"}),
 		PricesTracked: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "wallet_blend_prices_tracked",
 			Help: "Number of (oracle, asset) price rows written by the most recent Blend v2 snapshot pass.",
 		}),
+		OldestPriceAge: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "wallet_blend_price_oldest_age_seconds",
+			Help: "Age in seconds of the oldest oracle-reported price observed by the most recent Blend v2 snapshot pass that decoded any price, including prices skipped as stale.",
+		}),
 	}
-	reg.MustRegister(m.SnapshotDuration, m.FetchesTotal, m.PricesTracked)
+	reg.MustRegister(m.SnapshotDuration, m.FetchesTotal, m.PricesTracked, m.OldestPriceAge)
 	return m
 }

--- a/internal/metrics/blend_test.go
+++ b/internal/metrics/blend_test.go
@@ -1,0 +1,47 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlendPriceMetrics_Registration(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := newBlendPriceMetrics(reg)
+
+	require.NotNil(t, m.SnapshotDuration)
+	require.NotNil(t, m.FetchesTotal)
+	require.NotNil(t, m.PricesTracked)
+}
+
+func TestBlendPriceMetrics_Record(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := newBlendPriceMetrics(reg)
+
+	m.SnapshotDuration.Observe(0.25)
+	m.FetchesTotal.WithLabelValues("success").Inc()
+	m.FetchesTotal.WithLabelValues("success").Inc()
+	m.FetchesTotal.WithLabelValues("error").Inc()
+	m.FetchesTotal.WithLabelValues("none").Inc()
+	m.PricesTracked.Set(2)
+
+	assert.Equal(t, 2.0, testutil.ToFloat64(m.FetchesTotal.WithLabelValues("success")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.FetchesTotal.WithLabelValues("error")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.FetchesTotal.WithLabelValues("none")))
+	assert.Equal(t, 2.0, testutil.ToFloat64(m.PricesTracked))
+}
+
+func TestBlendPriceMetrics_Lint(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := newBlendPriceMetrics(reg)
+
+	for _, c := range []prometheus.Collector{m.SnapshotDuration, m.FetchesTotal, m.PricesTracked} {
+		problems, err := testutil.CollectAndLint(c)
+		require.NoError(t, err)
+		assert.Empty(t, problems)
+	}
+}

--- a/internal/metrics/blend_test.go
+++ b/internal/metrics/blend_test.go
@@ -16,6 +16,7 @@ func TestBlendPriceMetrics_Registration(t *testing.T) {
 	require.NotNil(t, m.SnapshotDuration)
 	require.NotNil(t, m.FetchesTotal)
 	require.NotNil(t, m.PricesTracked)
+	require.NotNil(t, m.OldestPriceAge)
 }
 
 func TestBlendPriceMetrics_Record(t *testing.T) {
@@ -28,18 +29,20 @@ func TestBlendPriceMetrics_Record(t *testing.T) {
 	m.FetchesTotal.WithLabelValues("error").Inc()
 	m.FetchesTotal.WithLabelValues("none").Inc()
 	m.PricesTracked.Set(2)
+	m.OldestPriceAge.Set(90000)
 
 	assert.Equal(t, 2.0, testutil.ToFloat64(m.FetchesTotal.WithLabelValues("success")))
 	assert.Equal(t, 1.0, testutil.ToFloat64(m.FetchesTotal.WithLabelValues("error")))
 	assert.Equal(t, 1.0, testutil.ToFloat64(m.FetchesTotal.WithLabelValues("none")))
 	assert.Equal(t, 2.0, testutil.ToFloat64(m.PricesTracked))
+	assert.Equal(t, 90000.0, testutil.ToFloat64(m.OldestPriceAge))
 }
 
 func TestBlendPriceMetrics_Lint(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	m := newBlendPriceMetrics(reg)
 
-	for _, c := range []prometheus.Collector{m.SnapshotDuration, m.FetchesTotal, m.PricesTracked} {
+	for _, c := range []prometheus.Collector{m.SnapshotDuration, m.FetchesTotal, m.PricesTracked, m.OldestPriceAge} {
 		problems, err := testutil.CollectAndLint(c)
 		require.NoError(t, err)
 		assert.Empty(t, problems)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -9,15 +9,16 @@ import (
 
 // Metrics holds all Prometheus collectors for the wallet-backend service.
 type Metrics struct {
-	DB         *DBMetrics
-	RPC        *RPCMetrics
-	Ingestion  *IngestionMetrics
-	HTTP       *HTTPMetrics
-	GraphQL    *GraphQLMetrics
-	Auth       *AuthMetrics
-	Migration  *MigrationMetrics
-	Dataloader *DataloaderMetrics
-	registry   *prometheus.Registry
+	DB          *DBMetrics
+	RPC         *RPCMetrics
+	Ingestion   *IngestionMetrics
+	HTTP        *HTTPMetrics
+	GraphQL     *GraphQLMetrics
+	Auth        *AuthMetrics
+	Migration   *MigrationMetrics
+	Dataloader  *DataloaderMetrics
+	BlendPrices *BlendPriceMetrics
+	registry    *prometheus.Registry
 }
 
 // NewMetrics creates a new Metrics instance with all sub-struct collectors registered.
@@ -29,15 +30,16 @@ func NewMetrics(reg *prometheus.Registry) *Metrics {
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 	)
 	return &Metrics{
-		DB:         newDBMetrics(reg),
-		RPC:        newRPCMetrics(reg),
-		Ingestion:  newIngestionMetrics(reg),
-		HTTP:       newHTTPMetrics(reg),
-		GraphQL:    NewGraphQLMetrics(reg),
-		Auth:       newAuthMetrics(reg),
-		Migration:  newMigrationMetrics(reg),
-		Dataloader: newDataloaderMetrics(reg),
-		registry:   reg,
+		DB:          newDBMetrics(reg),
+		RPC:         newRPCMetrics(reg),
+		Ingestion:   newIngestionMetrics(reg),
+		HTTP:        newHTTPMetrics(reg),
+		GraphQL:     NewGraphQLMetrics(reg),
+		Auth:        newAuthMetrics(reg),
+		Migration:   newMigrationMetrics(reg),
+		Dataloader:  newDataloaderMetrics(reg),
+		BlendPrices: newBlendPriceMetrics(reg),
+		registry:    reg,
 	}
 }
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -22,6 +22,7 @@ func TestNewMetrics(t *testing.T) {
 	require.NotNil(t, m.Auth)
 	require.NotNil(t, m.Migration)
 	require.NotNil(t, m.Dataloader)
+	require.NotNil(t, m.BlendPrices)
 
 	assert.Same(t, reg, m.Registry())
 }

--- a/internal/services/blend/comet.go
+++ b/internal/services/blend/comet.go
@@ -1,0 +1,244 @@
+// Package blend — comet.go derives the BLND/USD spot price and the Comet
+// backstop-deposit LP token's USD price from a Comet weighted pool's raw
+// on-chain state. The Blend v2 backstop's deposit token is a Comet BLND:USDC
+// weighted LP (mainnet
+// CAS3FL6TLZKDGGSISDBWGGPXT3NRR4DYTZD7YOD3HMYO6LTJUVGRVEAM, testnet
+// CA5UTUUPHYL5K22UBRUVC37EARZUGYOSGK3IKIXG2JLCC5ZZLI4BDWDM, wasm hash
+// 8abc28913035c07411ed5d134e6bfeab4723d97ddd4d1a22a0605d35c94d1a36 — pinned
+// 2026-07-08); no on-chain oracle prices it directly, so the price snapshot
+// task derives it from the pool's own balances/weights instead.
+//
+// Verification (2026-07-08): `stellar contract info interface --contract-id
+// CAS3FL6TLZKDGGSISDBWGGPXT3NRR4DYTZD7YOD3HMYO6LTJUVGRVEAM --rpc-url
+// https://mainnet.sorobanrpc.com --network-passphrase "Public Global Stellar
+// Network ; September 2015"` (stellar-cli 27.0.0) against the live mainnet
+// contract, cross-checked against CometDEX/comet-contracts-v1 (GitHub,
+// contracts/src/c_pool/comet.rs and contracts/src/c_consts.rs) confirms:
+//
+//   - get_tokens(env: Env) -> Vec<Address>            — no-arg
+//   - get_balance(env: Env, token: Address) -> i128    — 1-arg
+//   - get_normalized_weight(env: Env, token: Address) -> i128 — 1-arg;
+//     comet.rs's own doc comment: "Get the weight of the token in decimal
+//     form with 7 decimals". c_consts.rs defines `STROOP: i128 = 10^7` as
+//     Comet's fixed-point scale, confirming the weight scalar is 7 decimals
+//     — the same scale Comet uses for balances and get_total_supply (the LP
+//     token's total shares), and the scale this file's own inputs/outputs use.
+//   - get_total_supply(env: Env) -> i128                — no-arg
+//
+// services.ContractMetadataService.FetchSingleField already accepts
+// variadic xdr.ScVal arguments, so the two 1-arg getters need no plumbing
+// changes — fetchCometState calls them directly with a single Address
+// argument built by contractAddressScVal (scval.go).
+package blend
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/stellar/wallet-backend/internal/services"
+)
+
+// cometPriceDecimals is the fixed-point precision cometValuation's outputs
+// use — 7 decimals, matching Comet's own STROOP scale (see package doc) so
+// callers can treat blndPrice/lpPrice the same way they treat any other
+// on-chain 7-decimal amount (i128String's raw-integer-string convention,
+// also used by blend_oracle_prices.Price).
+const cometPriceDecimals = 7
+
+// cometTokenCount is the number of legs a Comet BLND:USDC weighted pool
+// has. fetchCometState errors on any other count rather than guessing which
+// tokens to treat as BLND/USDC.
+const cometTokenCount = 2
+
+// cometState is a Comet weighted pool's raw on-chain balances, weights, and
+// LP total supply, already split into BLND and USDC legs. All fields are
+// 7-decimal fixed-point big.Ints (Comet's STROOP scale) — the same shape
+// cometValuation consumes.
+type cometState struct {
+	BLNDBalance *big.Int
+	USDCBalance *big.Int
+	BLNDWeight  *big.Int
+	USDCWeight  *big.Int
+	LPSupply    *big.Int
+}
+
+// cometValuation derives the BLND spot price (denominated in USDC, taken as
+// USD by convention — this pool has no on-chain USDC/USD leg of its own) and
+// the Comet LP token's USD price from a weighted two-token Comet pool's raw
+// balances/weights/supply.
+//
+// Spot price (Balancer-style weighted pool; see comet-contracts-v1's
+// calc_spot_price, and the identical formula in the Balancer V1 whitepaper):
+// for legs with balances B and normalized weights W,
+// spot_price(quote, base) = (B_quote/W_quote) / (B_base/W_base). Here the
+// quote leg is USDC and the base leg is BLND, so:
+//
+//	blndPrice = (usdcBal/usdcWeight) / (blndBal/blndWeight)
+//
+// LP token USD price is the pool's total USD value divided by lpSupply,
+// where pool value = blndBal*blndPrice + usdcBal (USDC contributes at its
+// own balance since USDC ≡ $1). This NAV-per-share definition holds for any
+// weight split — it does not depend on blndWeight/usdcWeight directly, only
+// through blndPrice.
+//
+// Inputs are 7-decimal fixed-point big.Ints (Comet's STROOP scale); outputs
+// are 7-decimal fixed-point decimal strings (e.g. "2000000" for 0.2, not
+// "0.2000000" — see i128String). All arithmetic is done with big.Rat to
+// avoid intermediate overflow/precision loss, matching real-world Comet
+// balances that run into the trillions of raw units.
+//
+// Returns an error — never a panic — for a nil, zero, or negative balance,
+// weight, or lpSupply: valuing a pool with no liquidity, no weight, or no
+// outstanding shares is meaningless, not just numerically undefined.
+func cometValuation(blndBal, usdcBal, blndWeight, usdcWeight, lpSupply *big.Int) (blndPrice, lpPrice string, err error) {
+	inputs := []struct {
+		name string
+		val  *big.Int
+	}{
+		{"blndBal", blndBal},
+		{"usdcBal", usdcBal},
+		{"blndWeight", blndWeight},
+		{"usdcWeight", usdcWeight},
+		{"lpSupply", lpSupply},
+	}
+	for _, in := range inputs {
+		if in.val == nil {
+			return "", "", fmt.Errorf("blend: cometValuation: %s is nil", in.name)
+		}
+		if in.val.Sign() <= 0 {
+			return "", "", fmt.Errorf("blend: cometValuation: %s must be positive, got %s", in.name, in.val)
+		}
+	}
+
+	// blndPriceRat = (usdcBal/usdcWeight) / (blndBal/blndWeight)
+	//              = (usdcBal * blndWeight) / (usdcWeight * blndBal)
+	num := new(big.Int).Mul(usdcBal, blndWeight)
+	den := new(big.Int).Mul(usdcWeight, blndBal)
+	blndPriceRat := new(big.Rat).SetFrac(num, den)
+
+	blndValue := new(big.Rat).Mul(new(big.Rat).SetInt(blndBal), blndPriceRat)
+	poolValue := new(big.Rat).Add(blndValue, new(big.Rat).SetInt(usdcBal))
+	lpPriceRat := new(big.Rat).Quo(poolValue, new(big.Rat).SetInt(lpSupply))
+
+	return ratToFixedString(blndPriceRat, cometPriceDecimals), ratToFixedString(lpPriceRat, cometPriceDecimals), nil
+}
+
+// ratToFixedString converts r into a base-10 fixed-point integer string at
+// decimals digits of precision — e.g. 0.2 at 7 decimals renders as
+// "2000000", the same "raw integer, no decimal point" convention i128String
+// and blend_oracle_prices.Price use elsewhere in this codebase. Rounds to
+// the nearest representable value, with exact halves rounding away from
+// zero.
+func ratToFixedString(r *big.Rat, decimals int) string {
+	scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(decimals)), nil)
+	scaled := new(big.Rat).Mul(r, new(big.Rat).SetInt(scale))
+
+	// big.Rat always normalizes with a positive denominator, so num's sign
+	// is scaled's sign and QuoRem (truncating/T-division) leaves rem with
+	// that same sign.
+	num := scaled.Num()
+	den := scaled.Denom()
+	q, rem := new(big.Int).QuoRem(num, den, new(big.Int))
+
+	twiceRem := new(big.Int).Lsh(new(big.Int).Abs(rem), 1)
+	if twiceRem.Cmp(den) >= 0 {
+		if num.Sign() < 0 {
+			q.Sub(q, big.NewInt(1))
+		} else {
+			q.Add(q, big.NewInt(1))
+		}
+	}
+	return q.String()
+}
+
+// fetchCometState calls the Comet getters (get_tokens, get_balance,
+// get_normalized_weight, get_total_supply — see package doc for verified
+// signatures) via metadata against the Comet pool at cometID, and splits the
+// two legs into BLND and USDC by weight: the higher-weighted leg is BLND
+// (the pinned Comet pool is an 80/20 BLND:USDC split), regardless of which
+// index get_tokens() happens to return it at. Any RPC failure, unexpected
+// return shape, token count other than 2, or a tie between the two weights
+// (which would make the BLND/USDC split ambiguous) is reported as an error.
+func fetchCometState(ctx context.Context, metadata services.ContractMetadataService, cometID string) (*cometState, error) {
+	if metadata == nil {
+		return nil, fmt.Errorf("blend: fetchCometState: nil ContractMetadataService")
+	}
+
+	tokensVal, err := metadata.FetchSingleField(ctx, cometID, "get_tokens")
+	if err != nil {
+		return nil, fmt.Errorf("blend: fetchCometState: fetching get_tokens: %w", err)
+	}
+	tokenVals, ok := vecVal(tokensVal)
+	if !ok {
+		return nil, fmt.Errorf("blend: fetchCometState: get_tokens: expected Vec, got %v", tokensVal.Type)
+	}
+	if len(tokenVals) != cometTokenCount {
+		return nil, fmt.Errorf("blend: fetchCometState: expected %d tokens in Comet pool %s, got %d", cometTokenCount, cometID, len(tokenVals))
+	}
+
+	tokens := make([]string, cometTokenCount)
+	for i, tv := range tokenVals {
+		addr, ok := addrString(tv)
+		if !ok {
+			return nil, fmt.Errorf("blend: fetchCometState: get_tokens[%d]: expected Address, got %v", i, tv.Type)
+		}
+		tokens[i] = addr
+	}
+
+	balances := make([]*big.Int, cometTokenCount)
+	weights := make([]*big.Int, cometTokenCount)
+	for i, tok := range tokens {
+		argVal, err := contractAddressScVal(tok)
+		if err != nil {
+			return nil, fmt.Errorf("blend: fetchCometState: encoding token %s argument: %w", tok, err)
+		}
+
+		balVal, err := metadata.FetchSingleField(ctx, cometID, "get_balance", argVal)
+		if err != nil {
+			return nil, fmt.Errorf("blend: fetchCometState: fetching get_balance(%s): %w", tok, err)
+		}
+		balParts, ok := balVal.GetI128()
+		if !ok {
+			return nil, fmt.Errorf("blend: fetchCometState: get_balance(%s): expected i128, got %v", tok, balVal.Type)
+		}
+		balances[i] = i128ToBigInt(balParts)
+
+		weightVal, err := metadata.FetchSingleField(ctx, cometID, "get_normalized_weight", argVal)
+		if err != nil {
+			return nil, fmt.Errorf("blend: fetchCometState: fetching get_normalized_weight(%s): %w", tok, err)
+		}
+		weightParts, ok := weightVal.GetI128()
+		if !ok {
+			return nil, fmt.Errorf("blend: fetchCometState: get_normalized_weight(%s): expected i128, got %v", tok, weightVal.Type)
+		}
+		weights[i] = i128ToBigInt(weightParts)
+	}
+
+	supplyVal, err := metadata.FetchSingleField(ctx, cometID, "get_total_supply")
+	if err != nil {
+		return nil, fmt.Errorf("blend: fetchCometState: fetching get_total_supply: %w", err)
+	}
+	supplyParts, ok := supplyVal.GetI128()
+	if !ok {
+		return nil, fmt.Errorf("blend: fetchCometState: get_total_supply: expected i128, got %v", supplyVal.Type)
+	}
+	lpSupply := i128ToBigInt(supplyParts)
+
+	blndIdx := 0
+	switch weights[0].Cmp(weights[1]) {
+	case 0:
+		return nil, fmt.Errorf("blend: fetchCometState: cannot identify BLND leg: both tokens have equal weight %s", weights[0])
+	case -1:
+		blndIdx = 1
+	}
+	usdcIdx := 1 - blndIdx
+
+	return &cometState{
+		BLNDBalance: balances[blndIdx],
+		USDCBalance: balances[usdcIdx],
+		BLNDWeight:  weights[blndIdx],
+		USDCWeight:  weights[usdcIdx],
+		LPSupply:    lpSupply,
+	}, nil
+}

--- a/internal/services/blend/comet.go
+++ b/internal/services/blend/comet.go
@@ -52,10 +52,14 @@ const cometPriceDecimals = 7
 const cometTokenCount = 2
 
 // cometState is a Comet weighted pool's raw on-chain balances, weights, and
-// LP total supply, already split into BLND and USDC legs. All fields are
-// 7-decimal fixed-point big.Ints (Comet's STROOP scale) — the same shape
-// cometValuation consumes.
+// LP total supply, already split into BLND and USDC legs. Balance/weight/
+// supply fields are 7-decimal fixed-point big.Ints (Comet's STROOP scale) —
+// the same shape cometValuation consumes. BLNDAddress is the strkey
+// C-address of the BLND leg's token contract (get_tokens()[blndIdx]) — the
+// price snapshot task (prices.go) needs it to key the derived BLND price row
+// by the real BLND token address rather than the Comet pool's own address.
 type cometState struct {
+	BLNDAddress string
 	BLNDBalance *big.Int
 	USDCBalance *big.Int
 	BLNDWeight  *big.Int
@@ -235,6 +239,7 @@ func fetchCometState(ctx context.Context, metadata services.ContractMetadataServ
 	usdcIdx := 1 - blndIdx
 
 	return &cometState{
+		BLNDAddress: tokens[blndIdx],
 		BLNDBalance: balances[blndIdx],
 		USDCBalance: balances[usdcIdx],
 		BLNDWeight:  weights[blndIdx],

--- a/internal/services/blend/comet.go
+++ b/internal/services/blend/comet.go
@@ -3,38 +3,46 @@
 // on-chain state. The Blend v2 backstop's deposit token is a Comet BLND:USDC
 // weighted LP (mainnet
 // CAS3FL6TLZKDGGSISDBWGGPXT3NRR4DYTZD7YOD3HMYO6LTJUVGRVEAM, testnet
-// CA5UTUUPHYL5K22UBRUVC37EARZUGYOSGK3IKIXG2JLCC5ZZLI4BDWDM, wasm hash
-// 8abc28913035c07411ed5d134e6bfeab4723d97ddd4d1a22a0605d35c94d1a36 — pinned
-// 2026-07-08); no on-chain oracle prices it directly, so the price snapshot
-// task derives it from the pool's own balances/weights instead.
+// CA5UTUUPHYL5K22UBRUVC37EARZUGYOSGK3IKIXG2JLCC5ZZLI4BDWDM); no on-chain
+// oracle prices it directly, so the price snapshot task derives it from the
+// pool's own balances/weights instead.
 //
-// Verification (2026-07-08): `stellar contract info interface --contract-id
-// CAS3FL6TLZKDGGSISDBWGGPXT3NRR4DYTZD7YOD3HMYO6LTJUVGRVEAM --rpc-url
-// https://mainnet.sorobanrpc.com --network-passphrase "Public Global Stellar
-// Network ; September 2015"` (stellar-cli 27.0.0) against the live mainnet
-// contract, cross-checked against CometDEX/comet-contracts-v1 (GitHub,
-// contracts/src/c_pool/comet.rs and contracts/src/c_consts.rs) confirms:
+// The pool state is read straight from the contract's ledger entries rather
+// than by simulating its getter functions: everything the valuation needs
+// lives in two persistent ContractData entries (CometDEX/comet-contracts-v1,
+// contracts/src/c_pool/storage_types.rs `DataKey` and metadata.rs accessors):
 //
-//   - get_tokens(env: Env) -> Vec<Address>            — no-arg
-//   - get_balance(env: Env, token: Address) -> i128    — 1-arg
-//   - get_normalized_weight(env: Env, token: Address) -> i128 — 1-arg;
-//     comet.rs's own doc comment: "Get the weight of the token in decimal
-//     form with 7 decimals". c_consts.rs defines `STROOP: i128 = 10^7` as
-//     Comet's fixed-point scale, confirming the weight scalar is 7 decimals
-//     — the same scale Comet uses for balances and get_total_supply (the LP
-//     token's total shares), and the scale this file's own inputs/outputs use.
-//   - get_total_supply(env: Env) -> i128                — no-arg
+//   - DataKey::AllRecordData — Map<Address, Record{balance, weight, scalar,
+//     index}>, the same fields get_balance/get_normalized_weight return
+//   - DataKey::TotalShares — i128, what get_total_supply returns
 //
-// services.ContractMetadataService.FetchSingleField already accepts
-// variadic xdr.ScVal arguments, so the two 1-arg getters need no plumbing
-// changes — fetchCometState calls them directly with a single Address
-// argument built by contractAddressScVal (scval.go).
+// One getLedgerEntries request returns both entries plus the contract
+// instance from a single RPC snapshot (the response carries one
+// latestLedger), so the read is atomic by construction — a Comet transaction
+// can never interleave with it — where per-getter simulations would each
+// execute against whatever ledger is latest at that moment. The instance
+// entry's executable WASM hash is asserted against cometWasmHash before any
+// storage is decoded: the deployed contract has no upgrade entrypoint (its
+// layout cannot change at this address), so a mismatch means the configured
+// address is not the pinned Comet pool.
+//
+// Verification (2026-07-22): the key encodings (unit enum variants as
+// single-element ScvVec[Symbol]), the Record field shapes, both legs'
+// 7-decimal scalars, and the instance WASM hash were all confirmed against
+// the live mainnet pool via getLedgerEntries — a bare-Symbol key encoding
+// returns no entry. Comet's own doc comment on get_normalized_weight
+// ("decimal form with 7 decimals") and c_consts.rs `STROOP: i128 = 10^7`
+// pin the weight scale; init.rs asserts total_weight == STROOP.
 package blend
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"math/big"
+
+	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/wallet-backend/internal/services"
 )
@@ -51,13 +59,20 @@ const cometPriceDecimals = 7
 // tokens to treat as BLND/USDC.
 const cometTokenCount = 2
 
+// cometWasmHash is the executable WASM hash of the deployed Comet pool
+// contract (identical on mainnet and testnet; pinned 2026-07-08, re-confirmed
+// live 2026-07-22). fetchCometState refuses to decode storage whose contract
+// instance reports any other hash — the storage layout this file relies on
+// is defined by exactly this code.
+const cometWasmHash = "8abc28913035c07411ed5d134e6bfeab4723d97ddd4d1a22a0605d35c94d1a36"
+
 // cometState is a Comet weighted pool's raw on-chain balances, weights, and
 // LP total supply, already split into BLND and USDC legs. Balance/weight/
 // supply fields are 7-decimal fixed-point big.Ints (Comet's STROOP scale) —
 // the same shape cometValuation consumes. BLNDAddress is the strkey
-// C-address of the BLND leg's token contract (get_tokens()[blndIdx]) — the
-// price snapshot task (prices.go) needs it to key the derived BLND price row
-// by the real BLND token address rather than the Comet pool's own address.
+// C-address of the BLND leg's token contract — the price snapshot task
+// (prices.go) needs it to key the derived BLND price row by the real BLND
+// token address rather than the Comet pool's own address.
 type cometState struct {
 	BLNDAddress string
 	BLNDBalance *big.Int
@@ -174,67 +189,183 @@ func ratToFixedString(r *big.Rat, decimals int) string {
 	return ratToScaled(r, decimals).String()
 }
 
-// fetchCometState calls the Comet getters (get_tokens, get_balance,
-// get_normalized_weight, get_total_supply — see package doc for verified
-// signatures) via metadata against the Comet pool at cometID, and splits the
-// two legs into BLND and USDC by weight: the higher-weighted leg is BLND
-// (the pinned Comet pool is an 80/20 BLND:USDC split), regardless of which
-// index get_tokens() happens to return it at. The mutable numeric state is
-// read twice and must match (see the consistency comment inline). Any RPC
-// failure, unexpected return shape, token count other than 2, a mismatch
-// between the two consistency reads, or a tie between the two weights (which
-// would make the BLND/USDC split ambiguous) is reported as an error.
-func fetchCometState(ctx context.Context, metadata services.ContractMetadataService, cometID string) (*cometState, error) {
-	if metadata == nil {
-		return nil, fmt.Errorf("blend: fetchCometState: nil ContractMetadataService")
+// cometUnitKeyScVal builds the ScVal encoding of a Comet DataKey unit enum
+// variant as it appears in ContractData ledger-entry keys: a single-element
+// ScVec holding the variant-name Symbol (verified live — see package doc).
+func cometUnitKeyScVal(variant string) xdr.ScVal {
+	sym := xdr.ScSymbol(variant)
+	vec := &xdr.ScVec{{Type: xdr.ScValTypeScvSymbol, Sym: &sym}}
+	return xdr.ScVal{Type: xdr.ScValTypeScvVec, Vec: &vec}
+}
+
+// cometLedgerKey builds the base64-encoded LedgerKey for one of the Comet
+// pool's persistent ContractData entries at cometID.
+func cometLedgerKey(cometID string, key xdr.ScVal) (string, error) {
+	addrVal, err := contractAddressScVal(cometID)
+	if err != nil {
+		return "", fmt.Errorf("blend: encoding comet pool address: %w", err)
+	}
+	lk := xdr.LedgerKey{
+		Type: xdr.LedgerEntryTypeContractData,
+		ContractData: &xdr.LedgerKeyContractData{
+			Contract:   *addrVal.Address,
+			Key:        key,
+			Durability: xdr.ContractDataDurabilityPersistent,
+		},
+	}
+	b64, err := lk.MarshalBinaryBase64()
+	if err != nil {
+		return "", fmt.Errorf("blend: marshaling comet ledger key: %w", err)
+	}
+	return b64, nil
+}
+
+// recordI128Field pulls one named i128 field out of a decoded Comet Record
+// struct (an ScMap keyed by field-name Symbols — see mapGet).
+func recordI128Field(record *xdr.ScMap, token, field string) (*big.Int, error) {
+	fieldVal, found := mapGet(record, field)
+	if !found {
+		return nil, fmt.Errorf("blend: fetchCometState: record for %s: missing %q field", token, field)
+	}
+	parts, ok := fieldVal.GetI128()
+	if !ok {
+		return nil, fmt.Errorf("blend: fetchCometState: record for %s: %q is not an i128 (got %v)", token, field, fieldVal.Type)
+	}
+	return i128ToBigInt(parts), nil
+}
+
+// decodeContractDataVal unmarshals one getLedgerEntries result's base64 XDR
+// payload and returns the ContractData entry's value ScVal.
+func decodeContractDataVal(dataXDR string) (xdr.ScVal, error) {
+	raw, err := base64.StdEncoding.DecodeString(dataXDR)
+	if err != nil {
+		return xdr.ScVal{}, fmt.Errorf("decoding entry base64: %w", err)
+	}
+	var data xdr.LedgerEntryData
+	if err := data.UnmarshalBinary(raw); err != nil {
+		return xdr.ScVal{}, fmt.Errorf("unmarshaling entry XDR: %w", err)
+	}
+	if data.Type != xdr.LedgerEntryTypeContractData || data.ContractData == nil {
+		return xdr.ScVal{}, fmt.Errorf("expected ContractData entry, got %v", data.Type)
+	}
+	return data.ContractData.Val, nil
+}
+
+// fetchCometState reads the Comet pool's state at cometID — token balances,
+// normalized weights, and LP total supply — from its ContractData ledger
+// entries in a single getLedgerEntries call (atomic; see package doc), after
+// asserting the contract instance's WASM hash matches cometWasmHash. The two
+// legs are split into BLND and USDC by weight: the higher-weighted leg is
+// BLND (the pinned Comet pool is an 80/20 BLND:USDC split). Any RPC failure,
+// missing entry, WASM hash mismatch, unexpected shape, token count other
+// than 2, differing token scalars (the valuation's raw-balance ratio assumes
+// both legs share decimals), or a tie between the two weights (which would
+// make the BLND/USDC split ambiguous) is reported as an error.
+func fetchCometState(ctx context.Context, rpc services.RPCService, cometID string) (*cometState, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("blend: fetchCometState: context error: %w", err)
+	}
+	if rpc == nil {
+		return nil, fmt.Errorf("blend: fetchCometState: nil RPCService")
 	}
 
-	tokensVal, err := metadata.FetchSingleField(ctx, cometID, "get_tokens")
+	instanceKey, err := cometLedgerKey(cometID, xdr.ScVal{Type: xdr.ScValTypeScvLedgerKeyContractInstance})
 	if err != nil {
-		return nil, fmt.Errorf("blend: fetchCometState: fetching get_tokens: %w", err)
+		return nil, fmt.Errorf("blend: fetchCometState: %w", err)
 	}
-	tokenVals, ok := vecVal(tokensVal)
+	recordKey, err := cometLedgerKey(cometID, cometUnitKeyScVal("AllRecordData"))
+	if err != nil {
+		return nil, fmt.Errorf("blend: fetchCometState: %w", err)
+	}
+	sharesKey, err := cometLedgerKey(cometID, cometUnitKeyScVal("TotalShares"))
+	if err != nil {
+		return nil, fmt.Errorf("blend: fetchCometState: %w", err)
+	}
+
+	result, err := rpc.GetLedgerEntries([]string{instanceKey, recordKey, sharesKey})
+	if err != nil {
+		return nil, fmt.Errorf("blend: fetchCometState: fetching ledger entries: %w", err)
+	}
+	byKey := make(map[string]string, len(result.Entries))
+	for _, entry := range result.Entries {
+		byKey[entry.KeyXDR] = entry.DataXDR
+	}
+	vals := make(map[string]xdr.ScVal, 3)
+	for name, key := range map[string]string{"instance": instanceKey, "AllRecordData": recordKey, "TotalShares": sharesKey} {
+		dataXDR, found := byKey[key]
+		if !found {
+			return nil, fmt.Errorf("blend: fetchCometState: pool %s: %s entry not found on chain", cometID, name)
+		}
+		val, err := decodeContractDataVal(dataXDR)
+		if err != nil {
+			return nil, fmt.Errorf("blend: fetchCometState: pool %s: %s entry: %w", cometID, name, err)
+		}
+		vals[name] = val
+	}
+
+	instance, ok := vals["instance"].GetInstance()
 	if !ok {
-		return nil, fmt.Errorf("blend: fetchCometState: get_tokens: expected Vec, got %v", tokensVal.Type)
+		return nil, fmt.Errorf("blend: fetchCometState: pool %s: instance entry is not a ContractInstance (got %v)", cometID, vals["instance"].Type)
 	}
-	if len(tokenVals) != cometTokenCount {
-		return nil, fmt.Errorf("blend: fetchCometState: expected %d tokens in Comet pool %s, got %d", cometTokenCount, cometID, len(tokenVals))
+	wasmHash, ok := instance.Executable.GetWasmHash()
+	if !ok {
+		return nil, fmt.Errorf("blend: fetchCometState: pool %s: contract executable is not WASM (got %v)", cometID, instance.Executable.Type)
+	}
+	if gotHash := hex.EncodeToString(wasmHash[:]); gotHash != cometWasmHash {
+		return nil, fmt.Errorf("blend: fetchCometState: pool %s: WASM hash %s does not match the pinned Comet hash %s — refusing to decode its storage", cometID, gotHash, cometWasmHash)
+	}
+
+	recordMap, ok := vals["AllRecordData"].GetMap()
+	if !ok {
+		return nil, fmt.Errorf("blend: fetchCometState: pool %s: AllRecordData is not a Map (got %v)", cometID, vals["AllRecordData"].Type)
+	}
+	if recordMap == nil || len(*recordMap) != cometTokenCount {
+		got := 0
+		if recordMap != nil {
+			got = len(*recordMap)
+		}
+		return nil, fmt.Errorf("blend: fetchCometState: expected %d tokens in Comet pool %s, got %d", cometTokenCount, cometID, got)
 	}
 
 	tokens := make([]string, cometTokenCount)
-	for i, tv := range tokenVals {
-		addr, ok := addrString(tv)
+	balances := make([]*big.Int, cometTokenCount)
+	weights := make([]*big.Int, cometTokenCount)
+	scalars := make([]*big.Int, cometTokenCount)
+	for i, entry := range *recordMap {
+		addr, ok := addrString(entry.Key)
 		if !ok {
-			return nil, fmt.Errorf("blend: fetchCometState: get_tokens[%d]: expected Address, got %v", i, tv.Type)
+			return nil, fmt.Errorf("blend: fetchCometState: AllRecordData key[%d]: expected Address, got %v", i, entry.Key.Type)
 		}
 		tokens[i] = addr
+
+		record, ok := entry.Val.GetMap()
+		if !ok {
+			return nil, fmt.Errorf("blend: fetchCometState: record for %s: expected Map, got %v", addr, entry.Val.Type)
+		}
+		if balances[i], err = recordI128Field(record, addr, "balance"); err != nil {
+			return nil, err
+		}
+		if weights[i], err = recordI128Field(record, addr, "weight"); err != nil {
+			return nil, err
+		}
+		if scalars[i], err = recordI128Field(record, addr, "scalar"); err != nil {
+			return nil, err
+		}
+	}
+	if scalars[0].Cmp(scalars[1]) != 0 {
+		return nil, fmt.Errorf("blend: fetchCometState: pool %s: token scalars differ (%s vs %s) — the valuation's raw-balance ratio requires both legs to share decimals", cometID, scalars[0], scalars[1])
 	}
 
-	// Each getter call is its own latest-ledger RPC simulation, so a Comet
-	// transaction (swap, join, exit) landing between calls would mix pre- and
-	// post-trade values into a pool state that never existed on-chain. Soroban
-	// allows only one contract invocation per simulated transaction, so the
-	// getters cannot be batched into a single consistent read; instead the
-	// numeric state is read twice and both readings must agree. Any pool
-	// mutation changes at least one balance or the LP supply, so agreement
-	// means both readings observed the same state. A mismatch errors out —
-	// the snapshot task's next pass retries.
-	first, err := readCometNumericState(ctx, metadata, cometID, tokens)
-	if err != nil {
-		return nil, err
+	sharesParts, ok := vals["TotalShares"].GetI128()
+	if !ok {
+		return nil, fmt.Errorf("blend: fetchCometState: TotalShares: expected i128, got %v", vals["TotalShares"].Type)
 	}
-	second, err := readCometNumericState(ctx, metadata, cometID, tokens)
-	if err != nil {
-		return nil, err
-	}
-	if !first.equal(second) {
-		return nil, fmt.Errorf("blend: fetchCometState: pool %s state changed between consistency reads", cometID)
-	}
+	lpSupply := i128ToBigInt(sharesParts)
 
 	blndIdx := 0
-	switch first.weights[0].Cmp(first.weights[1]) {
+	switch weights[0].Cmp(weights[1]) {
 	case 0:
-		return nil, fmt.Errorf("blend: fetchCometState: cannot identify BLND leg: both tokens have equal weight %s", first.weights[0])
+		return nil, fmt.Errorf("blend: fetchCometState: cannot identify BLND leg: both tokens have equal weight %s", weights[0])
 	case -1:
 		blndIdx = 1
 	}
@@ -242,78 +373,10 @@ func fetchCometState(ctx context.Context, metadata services.ContractMetadataServ
 
 	return &cometState{
 		BLNDAddress: tokens[blndIdx],
-		BLNDBalance: first.balances[blndIdx],
-		USDCBalance: first.balances[usdcIdx],
-		BLNDWeight:  first.weights[blndIdx],
-		USDCWeight:  first.weights[usdcIdx],
-		LPSupply:    first.lpSupply,
+		BLNDBalance: balances[blndIdx],
+		USDCBalance: balances[usdcIdx],
+		BLNDWeight:  weights[blndIdx],
+		USDCWeight:  weights[usdcIdx],
+		LPSupply:    lpSupply,
 	}, nil
-}
-
-// cometNumericReading is one read of a Comet pool's mutable numeric state:
-// per-token balances and normalized weights (parallel to the token list it
-// was read with), and the LP token total supply.
-type cometNumericReading struct {
-	balances []*big.Int
-	weights  []*big.Int
-	lpSupply *big.Int
-}
-
-// equal reports whether two readings observed identical pool state. Both
-// readings must come from the same token list.
-func (r *cometNumericReading) equal(o *cometNumericReading) bool {
-	for i := range r.balances {
-		if r.balances[i].Cmp(o.balances[i]) != 0 || r.weights[i].Cmp(o.weights[i]) != 0 {
-			return false
-		}
-	}
-	return r.lpSupply.Cmp(o.lpSupply) == 0
-}
-
-// readCometNumericState performs one read of the Comet pool's numeric getters
-// — get_balance and get_normalized_weight per token, plus get_total_supply —
-// see fetchCometState for the double-read consistency contract built on it.
-func readCometNumericState(ctx context.Context, metadata services.ContractMetadataService, cometID string, tokens []string) (*cometNumericReading, error) {
-	reading := &cometNumericReading{
-		balances: make([]*big.Int, len(tokens)),
-		weights:  make([]*big.Int, len(tokens)),
-	}
-	for i, tok := range tokens {
-		argVal, err := contractAddressScVal(tok)
-		if err != nil {
-			return nil, fmt.Errorf("blend: fetchCometState: encoding token %s argument: %w", tok, err)
-		}
-
-		balVal, err := metadata.FetchSingleField(ctx, cometID, "get_balance", argVal)
-		if err != nil {
-			return nil, fmt.Errorf("blend: fetchCometState: fetching get_balance(%s): %w", tok, err)
-		}
-		balParts, ok := balVal.GetI128()
-		if !ok {
-			return nil, fmt.Errorf("blend: fetchCometState: get_balance(%s): expected i128, got %v", tok, balVal.Type)
-		}
-		reading.balances[i] = i128ToBigInt(balParts)
-
-		weightVal, err := metadata.FetchSingleField(ctx, cometID, "get_normalized_weight", argVal)
-		if err != nil {
-			return nil, fmt.Errorf("blend: fetchCometState: fetching get_normalized_weight(%s): %w", tok, err)
-		}
-		weightParts, ok := weightVal.GetI128()
-		if !ok {
-			return nil, fmt.Errorf("blend: fetchCometState: get_normalized_weight(%s): expected i128, got %v", tok, weightVal.Type)
-		}
-		reading.weights[i] = i128ToBigInt(weightParts)
-	}
-
-	supplyVal, err := metadata.FetchSingleField(ctx, cometID, "get_total_supply")
-	if err != nil {
-		return nil, fmt.Errorf("blend: fetchCometState: fetching get_total_supply: %w", err)
-	}
-	supplyParts, ok := supplyVal.GetI128()
-	if !ok {
-		return nil, fmt.Errorf("blend: fetchCometState: get_total_supply: expected i128, got %v", supplyVal.Type)
-	}
-	reading.lpSupply = i128ToBigInt(supplyParts)
-
-	return reading, nil
 }

--- a/internal/services/blend/comet.go
+++ b/internal/services/blend/comet.go
@@ -125,16 +125,26 @@ func cometValuation(blndBal, usdcBal, blndWeight, usdcWeight, lpSupply *big.Int)
 	poolValue := new(big.Rat).Add(blndValue, new(big.Rat).SetInt(usdcBal))
 	lpPriceRat := new(big.Rat).Quo(poolValue, new(big.Rat).SetInt(lpSupply))
 
-	return ratToFixedString(blndPriceRat, cometPriceDecimals), ratToFixedString(lpPriceRat, cometPriceDecimals), nil
+	// Both rationals are strictly positive (every input is), but one below half
+	// of a single 7-decimal unit scales down to a zero quotient. A zero price
+	// violates the snapshot invariant that non-positive prices are never
+	// persisted (snapshotOracle skips them as invalid), so reject it on the
+	// scaled integers — before formatting — rather than let downstream
+	// valuation report $0 for a live asset.
+	blndScaled := ratToScaled(blndPriceRat, cometPriceDecimals)
+	lpScaled := ratToScaled(lpPriceRat, cometPriceDecimals)
+	if blndScaled.Sign() <= 0 || lpScaled.Sign() <= 0 {
+		return "", "", fmt.Errorf("blend: cometValuation: price rounds to zero at %d decimals (blnd=%s, lp=%s)", cometPriceDecimals, blndScaled, lpScaled)
+	}
+	return blndScaled.String(), lpScaled.String(), nil
 }
 
-// ratToFixedString converts r into a base-10 fixed-point integer string at
-// decimals digits of precision — e.g. 0.2 at 7 decimals renders as
-// "2000000", the same "raw integer, no decimal point" convention i128String
-// and blend_oracle_prices.Price use elsewhere in this codebase. Rounds to
-// the nearest representable value, with exact halves rounding away from
-// zero.
-func ratToFixedString(r *big.Rat, decimals int) string {
+// ratToScaled converts r into a fixed-point integer at decimals digits of
+// precision — e.g. 0.2 at 7 decimals becomes 2000000. Rounds to the nearest
+// representable value, with exact halves rounding away from zero. Callers
+// that must distinguish "rounded down to zero" from a genuinely zero value
+// check the returned integer's sign; ratToFixedString formats it.
+func ratToScaled(r *big.Rat, decimals int) *big.Int {
 	scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(decimals)), nil)
 	scaled := new(big.Rat).Mul(r, new(big.Rat).SetInt(scale))
 
@@ -153,7 +163,15 @@ func ratToFixedString(r *big.Rat, decimals int) string {
 			q.Add(q, big.NewInt(1))
 		}
 	}
-	return q.String()
+	return q
+}
+
+// ratToFixedString renders ratToScaled's result as a base-10 integer string —
+// the same "raw integer, no decimal point" convention i128String and
+// blend_oracle_prices.Price use elsewhere in this codebase (0.2 at 7 decimals
+// is "2000000", not "0.2000000").
+func ratToFixedString(r *big.Rat, decimals int) string {
+	return ratToScaled(r, decimals).String()
 }
 
 // fetchCometState calls the Comet getters (get_tokens, get_balance,
@@ -161,9 +179,11 @@ func ratToFixedString(r *big.Rat, decimals int) string {
 // signatures) via metadata against the Comet pool at cometID, and splits the
 // two legs into BLND and USDC by weight: the higher-weighted leg is BLND
 // (the pinned Comet pool is an 80/20 BLND:USDC split), regardless of which
-// index get_tokens() happens to return it at. Any RPC failure, unexpected
-// return shape, token count other than 2, or a tie between the two weights
-// (which would make the BLND/USDC split ambiguous) is reported as an error.
+// index get_tokens() happens to return it at. The mutable numeric state is
+// read twice and must match (see the consistency comment inline). Any RPC
+// failure, unexpected return shape, token count other than 2, a mismatch
+// between the two consistency reads, or a tie between the two weights (which
+// would make the BLND/USDC split ambiguous) is reported as an error.
 func fetchCometState(ctx context.Context, metadata services.ContractMetadataService, cometID string) (*cometState, error) {
 	if metadata == nil {
 		return nil, fmt.Errorf("blend: fetchCometState: nil ContractMetadataService")
@@ -190,8 +210,74 @@ func fetchCometState(ctx context.Context, metadata services.ContractMetadataServ
 		tokens[i] = addr
 	}
 
-	balances := make([]*big.Int, cometTokenCount)
-	weights := make([]*big.Int, cometTokenCount)
+	// Each getter call is its own latest-ledger RPC simulation, so a Comet
+	// transaction (swap, join, exit) landing between calls would mix pre- and
+	// post-trade values into a pool state that never existed on-chain. Soroban
+	// allows only one contract invocation per simulated transaction, so the
+	// getters cannot be batched into a single consistent read; instead the
+	// numeric state is read twice and both readings must agree. Any pool
+	// mutation changes at least one balance or the LP supply, so agreement
+	// means both readings observed the same state. A mismatch errors out —
+	// the snapshot task's next pass retries.
+	first, err := readCometNumericState(ctx, metadata, cometID, tokens)
+	if err != nil {
+		return nil, err
+	}
+	second, err := readCometNumericState(ctx, metadata, cometID, tokens)
+	if err != nil {
+		return nil, err
+	}
+	if !first.equal(second) {
+		return nil, fmt.Errorf("blend: fetchCometState: pool %s state changed between consistency reads", cometID)
+	}
+
+	blndIdx := 0
+	switch first.weights[0].Cmp(first.weights[1]) {
+	case 0:
+		return nil, fmt.Errorf("blend: fetchCometState: cannot identify BLND leg: both tokens have equal weight %s", first.weights[0])
+	case -1:
+		blndIdx = 1
+	}
+	usdcIdx := 1 - blndIdx
+
+	return &cometState{
+		BLNDAddress: tokens[blndIdx],
+		BLNDBalance: first.balances[blndIdx],
+		USDCBalance: first.balances[usdcIdx],
+		BLNDWeight:  first.weights[blndIdx],
+		USDCWeight:  first.weights[usdcIdx],
+		LPSupply:    first.lpSupply,
+	}, nil
+}
+
+// cometNumericReading is one read of a Comet pool's mutable numeric state:
+// per-token balances and normalized weights (parallel to the token list it
+// was read with), and the LP token total supply.
+type cometNumericReading struct {
+	balances []*big.Int
+	weights  []*big.Int
+	lpSupply *big.Int
+}
+
+// equal reports whether two readings observed identical pool state. Both
+// readings must come from the same token list.
+func (r *cometNumericReading) equal(o *cometNumericReading) bool {
+	for i := range r.balances {
+		if r.balances[i].Cmp(o.balances[i]) != 0 || r.weights[i].Cmp(o.weights[i]) != 0 {
+			return false
+		}
+	}
+	return r.lpSupply.Cmp(o.lpSupply) == 0
+}
+
+// readCometNumericState performs one read of the Comet pool's numeric getters
+// — get_balance and get_normalized_weight per token, plus get_total_supply —
+// see fetchCometState for the double-read consistency contract built on it.
+func readCometNumericState(ctx context.Context, metadata services.ContractMetadataService, cometID string, tokens []string) (*cometNumericReading, error) {
+	reading := &cometNumericReading{
+		balances: make([]*big.Int, len(tokens)),
+		weights:  make([]*big.Int, len(tokens)),
+	}
 	for i, tok := range tokens {
 		argVal, err := contractAddressScVal(tok)
 		if err != nil {
@@ -206,7 +292,7 @@ func fetchCometState(ctx context.Context, metadata services.ContractMetadataServ
 		if !ok {
 			return nil, fmt.Errorf("blend: fetchCometState: get_balance(%s): expected i128, got %v", tok, balVal.Type)
 		}
-		balances[i] = i128ToBigInt(balParts)
+		reading.balances[i] = i128ToBigInt(balParts)
 
 		weightVal, err := metadata.FetchSingleField(ctx, cometID, "get_normalized_weight", argVal)
 		if err != nil {
@@ -216,7 +302,7 @@ func fetchCometState(ctx context.Context, metadata services.ContractMetadataServ
 		if !ok {
 			return nil, fmt.Errorf("blend: fetchCometState: get_normalized_weight(%s): expected i128, got %v", tok, weightVal.Type)
 		}
-		weights[i] = i128ToBigInt(weightParts)
+		reading.weights[i] = i128ToBigInt(weightParts)
 	}
 
 	supplyVal, err := metadata.FetchSingleField(ctx, cometID, "get_total_supply")
@@ -227,23 +313,7 @@ func fetchCometState(ctx context.Context, metadata services.ContractMetadataServ
 	if !ok {
 		return nil, fmt.Errorf("blend: fetchCometState: get_total_supply: expected i128, got %v", supplyVal.Type)
 	}
-	lpSupply := i128ToBigInt(supplyParts)
+	reading.lpSupply = i128ToBigInt(supplyParts)
 
-	blndIdx := 0
-	switch weights[0].Cmp(weights[1]) {
-	case 0:
-		return nil, fmt.Errorf("blend: fetchCometState: cannot identify BLND leg: both tokens have equal weight %s", weights[0])
-	case -1:
-		blndIdx = 1
-	}
-	usdcIdx := 1 - blndIdx
-
-	return &cometState{
-		BLNDAddress: tokens[blndIdx],
-		BLNDBalance: balances[blndIdx],
-		USDCBalance: balances[usdcIdx],
-		BLNDWeight:  weights[blndIdx],
-		USDCWeight:  weights[usdcIdx],
-		LPSupply:    lpSupply,
-	}, nil
+	return reading, nil
 }

--- a/internal/services/blend/comet_test.go
+++ b/internal/services/blend/comet_test.go
@@ -1,0 +1,301 @@
+package blend
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/stellar/go-stellar-sdk/xdr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/services"
+)
+
+// bigFromStroop scales a float amount into a 7-decimal ("STROOP") fixed-point
+// big.Int, matching how Comet balances, get_normalized_weight, and
+// get_total_supply are all denominated on-chain (see comet.go's verification
+// note). Test-only: real callers get their big.Ints from i128ToBigInt.
+func bigFromStroop(amount float64) *big.Int {
+	scaled := new(big.Rat).Mul(new(big.Rat).SetFloat64(amount), new(big.Rat).SetInt64(1e7))
+	// amount is always an exact multiple of 1e-7 in these tests, so this is exact.
+	return new(big.Int).Quo(scaled.Num(), scaled.Denom())
+}
+
+func TestRatToFixedString(t *testing.T) {
+	t.Run("exact integer", func(t *testing.T) {
+		assert.Equal(t, "10000000", ratToFixedString(big.NewRat(1, 1), 7))
+	})
+
+	t.Run("rounds down below half", func(t *testing.T) {
+		// 1/3 at 0 decimals = 0.333... -> 0
+		assert.Equal(t, "0", ratToFixedString(big.NewRat(1, 3), 0))
+	})
+
+	t.Run("rounds up at exactly half, away from zero", func(t *testing.T) {
+		assert.Equal(t, "1", ratToFixedString(big.NewRat(1, 2), 0))
+		assert.Equal(t, "-1", ratToFixedString(big.NewRat(-1, 2), 0))
+	})
+
+	t.Run("rounds up above half", func(t *testing.T) {
+		// 2/3 at 0 decimals = 0.666... -> 1
+		assert.Equal(t, "1", ratToFixedString(big.NewRat(2, 3), 0))
+	})
+
+	t.Run("zero", func(t *testing.T) {
+		assert.Equal(t, "0", ratToFixedString(big.NewRat(0, 1), 7))
+	})
+}
+
+// TestCometValuation is pure math — no mocks. Expected values were
+// cross-checked with exact rational arithmetic (Python's fractions module)
+// independently of the Go implementation.
+func TestCometValuation(t *testing.T) {
+	t.Run("canonical 80/20 pool", func(t *testing.T) {
+		// blndBal=4,000,000, usdcBal=200,000, weights 0.8/0.2, lpSupply=1,000,000.
+		// blndPrice = (200k/0.2)/(4M/0.8) = 1,000,000/5,000,000 = 0.2 USD.
+		// lpPrice = (4M*0.2 + 200k)/1M = (800k+200k)/1M = 1.0 USD.
+		blndPrice, lpPrice, err := cometValuation(
+			bigFromStroop(4_000_000), bigFromStroop(200_000),
+			bigFromStroop(0.8), bigFromStroop(0.2),
+			bigFromStroop(1_000_000),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "2000000", blndPrice)
+		assert.Equal(t, "10000000", lpPrice)
+	})
+
+	t.Run("uneven supply, non-terminating spot price", func(t *testing.T) {
+		// blndBal=3,000,000, usdcBal=100,000, weights 0.8/0.2, lpSupply=700,000.
+		// blndPrice = (100k*0.8)/(0.2*3M) = 80,000/600,000 = 2/15 = 0.1333333...
+		// -> rounds to 1333333 at 7 decimals.
+		// poolValue = 3M*(2/15) + 100k = 400,000 + 100,000 = 500,000.
+		// lpPrice = 500,000/700,000 = 5/7 = 0.7142857142... -> rounds to 7142857.
+		blndPrice, lpPrice, err := cometValuation(
+			bigFromStroop(3_000_000), bigFromStroop(100_000),
+			bigFromStroop(0.8), bigFromStroop(0.2),
+			bigFromStroop(700_000),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "1333333", blndPrice)
+		assert.Equal(t, "7142857", lpPrice)
+	})
+
+	t.Run("tiny balances still round correctly", func(t *testing.T) {
+		// Smallest possible non-zero 7-decimal amounts (raw i128 == 3, 7, 5).
+		blndBal := big.NewInt(3)
+		usdcBal := big.NewInt(7)
+		blndWeight := bigFromStroop(0.8)
+		usdcWeight := bigFromStroop(0.2)
+		lpSupply := big.NewInt(5)
+
+		// blndPrice = (7/0.2)/(3/0.8) = (7*0.8)/(0.2*3) = 5.6/0.6 = 28/3 = 9.3333... -> 93333333.
+		// poolValue = 3*(28/3) + 7 = 28+7 = 35 (raw). lpPrice = 35/5 = 7.0 -> 70000000.
+		blndPrice, lpPrice, err := cometValuation(blndBal, usdcBal, blndWeight, usdcWeight, lpSupply)
+		require.NoError(t, err)
+		assert.Equal(t, "93333333", blndPrice)
+		assert.Equal(t, "70000000", lpPrice)
+	})
+
+	t.Run("rejects nil and non-positive inputs without dividing by zero", func(t *testing.T) {
+		one := bigFromStroop(1)
+		zero := big.NewInt(0)
+		neg := big.NewInt(-1)
+
+		cases := map[string]struct {
+			blndBal, usdcBal, blndWeight, usdcWeight, lpSupply *big.Int
+		}{
+			"nil blndBal":       {nil, one, one, one, one},
+			"nil usdcBal":       {one, nil, one, one, one},
+			"nil blndWeight":    {one, one, nil, one, one},
+			"nil usdcWeight":    {one, one, one, nil, one},
+			"nil lpSupply":      {one, one, one, one, nil},
+			"zero blndBal":      {zero, one, one, one, one},
+			"zero usdcBal":      {one, zero, one, one, one},
+			"zero blndWeight":   {one, one, zero, one, one},
+			"zero usdcWeight":   {one, one, one, zero, one},
+			"zero lpSupply":     {one, one, one, one, zero},
+			"negative blndBal":  {neg, one, one, one, one},
+			"negative lpSupply": {one, one, one, one, neg},
+		}
+
+		for name, c := range cases {
+			t.Run(name, func(t *testing.T) {
+				_, _, err := cometValuation(c.blndBal, c.usdcBal, c.blndWeight, c.usdcWeight, c.lpSupply)
+				assert.Error(t, err)
+			})
+		}
+	})
+}
+
+// TestFetchCometState mocks services.ContractMetadataService — no real RPC.
+func TestFetchCometState(t *testing.T) {
+	ctx := context.Background()
+	// cometID (mainnet) / cometIDTestnet exercise fetchCometState against two
+	// distinct pool addresses — the price snapshot task (a later change) will
+	// call it once per network, so the tests deliberately don't hardcode a
+	// single address throughout.
+	const (
+		cometID        = "CAS3FL6TLZKDGGSISDBWGGPXT3NRR4DYTZD7YOD3HMYO6LTJUVGRVEAM"
+		cometIDTestnet = "CA5UTUUPHYL5K22UBRUVC37EARZUGYOSGK3IKIXG2JLCC5ZZLI4BDWDM"
+	)
+
+	// setupHappyMock wires up get_tokens/get_balance/get_normalized_weight/
+	// get_total_supply against the pool at poolID so the token at index
+	// blndIdx is BLND (weight 0.8) and the other is USDC (weight 0.2),
+	// proving fetchCometState identifies BLND by weight rather than by
+	// get_tokens() position.
+	setupHappyMock := func(t *testing.T, poolID string, blndIdx int) *services.ContractMetadataServiceMock {
+		t.Helper()
+		tokenA := randomContractAddr(t)
+		tokenB := randomContractAddr(t)
+		tokens := []string{tokenA, tokenB}
+		blndAddr, usdcAddr := tokens[blndIdx], tokens[1-blndIdx]
+
+		m := services.NewContractMetadataServiceMock(t)
+		m.On("FetchSingleField", mock.Anything, poolID, "get_tokens", []xdr.ScVal(nil)).
+			Return(vecScVal(contractAddrScVal(t, tokenA), contractAddrScVal(t, tokenB)), nil).Once()
+
+		blndArg, err := contractAddressScVal(blndAddr)
+		require.NoError(t, err)
+		usdcArg, err := contractAddressScVal(usdcAddr)
+		require.NoError(t, err)
+
+		m.On("FetchSingleField", mock.Anything, poolID, "get_balance", []xdr.ScVal{blndArg}).
+			Return(i128ScVal(40_000_000_000_000), nil).Once() // 4,000,000.0000000
+		m.On("FetchSingleField", mock.Anything, poolID, "get_balance", []xdr.ScVal{usdcArg}).
+			Return(i128ScVal(2_000_000_000_000), nil).Once() // 200,000.0000000
+		m.On("FetchSingleField", mock.Anything, poolID, "get_normalized_weight", []xdr.ScVal{blndArg}).
+			Return(i128ScVal(8_000_000), nil).Once() // 0.8
+		m.On("FetchSingleField", mock.Anything, poolID, "get_normalized_weight", []xdr.ScVal{usdcArg}).
+			Return(i128ScVal(2_000_000), nil).Once() // 0.2
+		m.On("FetchSingleField", mock.Anything, poolID, "get_total_supply", []xdr.ScVal(nil)).
+			Return(i128ScVal(10_000_000_000_000), nil).Once() // 1,000,000.0000000
+
+		return m
+	}
+
+	t.Run("identifies BLND leg by weight when it is get_tokens()[0]", func(t *testing.T) {
+		m := setupHappyMock(t, cometID, 0)
+
+		state, err := fetchCometState(ctx, m, cometID)
+		require.NoError(t, err)
+		require.NotNil(t, state)
+		assert.Equal(t, big.NewInt(40_000_000_000_000), state.BLNDBalance)
+		assert.Equal(t, big.NewInt(2_000_000_000_000), state.USDCBalance)
+		assert.Equal(t, big.NewInt(8_000_000), state.BLNDWeight)
+		assert.Equal(t, big.NewInt(2_000_000), state.USDCWeight)
+		assert.Equal(t, big.NewInt(10_000_000_000_000), state.LPSupply)
+	})
+
+	t.Run("identifies BLND leg by weight when it is get_tokens()[1], against a different pool address", func(t *testing.T) {
+		m := setupHappyMock(t, cometIDTestnet, 1)
+
+		state, err := fetchCometState(ctx, m, cometIDTestnet)
+		require.NoError(t, err)
+		require.NotNil(t, state)
+		assert.Equal(t, big.NewInt(40_000_000_000_000), state.BLNDBalance)
+		assert.Equal(t, big.NewInt(2_000_000_000_000), state.USDCBalance)
+	})
+
+	t.Run("nil metadata service degrades with error", func(t *testing.T) {
+		_, err := fetchCometState(ctx, nil, cometID)
+		assert.Error(t, err)
+	})
+
+	t.Run("get_tokens RPC error propagates", func(t *testing.T) {
+		m := services.NewContractMetadataServiceMock(t)
+		m.On("FetchSingleField", mock.Anything, cometID, "get_tokens", []xdr.ScVal(nil)).
+			Return(xdr.ScVal{}, assert.AnError).Once()
+
+		_, err := fetchCometState(ctx, m, cometID)
+		assert.Error(t, err)
+	})
+
+	t.Run("get_tokens wrong shape errors", func(t *testing.T) {
+		m := services.NewContractMetadataServiceMock(t)
+		m.On("FetchSingleField", mock.Anything, cometID, "get_tokens", []xdr.ScVal(nil)).
+			Return(u32ScVal(1), nil).Once()
+
+		_, err := fetchCometState(ctx, m, cometID)
+		assert.Error(t, err)
+	})
+
+	t.Run("get_tokens wrong count errors", func(t *testing.T) {
+		m := services.NewContractMetadataServiceMock(t)
+		m.On("FetchSingleField", mock.Anything, cometID, "get_tokens", []xdr.ScVal(nil)).
+			Return(vecScVal(contractAddrScVal(t, randomContractAddr(t))), nil).Once()
+
+		_, err := fetchCometState(ctx, m, cometID)
+		assert.Error(t, err)
+	})
+
+	t.Run("get_balance RPC error propagates", func(t *testing.T) {
+		tokenA := randomContractAddr(t)
+		tokenB := randomContractAddr(t)
+
+		m := services.NewContractMetadataServiceMock(t)
+		m.On("FetchSingleField", mock.Anything, cometID, "get_tokens", []xdr.ScVal(nil)).
+			Return(vecScVal(contractAddrScVal(t, tokenA), contractAddrScVal(t, tokenB)), nil).Once()
+		m.On("FetchSingleField", mock.Anything, cometID, "get_balance", mock.Anything).
+			Return(xdr.ScVal{}, assert.AnError).Once()
+
+		_, err := fetchCometState(ctx, m, cometID)
+		assert.Error(t, err)
+	})
+
+	t.Run("get_normalized_weight wrong type errors", func(t *testing.T) {
+		tokenA := randomContractAddr(t)
+		tokenB := randomContractAddr(t)
+
+		m := services.NewContractMetadataServiceMock(t)
+		m.On("FetchSingleField", mock.Anything, cometID, "get_tokens", []xdr.ScVal(nil)).
+			Return(vecScVal(contractAddrScVal(t, tokenA), contractAddrScVal(t, tokenB)), nil).Once()
+		m.On("FetchSingleField", mock.Anything, cometID, "get_balance", mock.Anything).
+			Return(i128ScVal(1), nil)
+		m.On("FetchSingleField", mock.Anything, cometID, "get_normalized_weight", mock.Anything).
+			Return(u32ScVal(1), nil).Once()
+
+		_, err := fetchCometState(ctx, m, cometID)
+		assert.Error(t, err)
+	})
+
+	t.Run("get_total_supply RPC error propagates", func(t *testing.T) {
+		tokenA := randomContractAddr(t)
+		tokenB := randomContractAddr(t)
+
+		m := services.NewContractMetadataServiceMock(t)
+		m.On("FetchSingleField", mock.Anything, cometID, "get_tokens", []xdr.ScVal(nil)).
+			Return(vecScVal(contractAddrScVal(t, tokenA), contractAddrScVal(t, tokenB)), nil).Once()
+		m.On("FetchSingleField", mock.Anything, cometID, "get_balance", mock.Anything).
+			Return(i128ScVal(1), nil)
+		m.On("FetchSingleField", mock.Anything, cometID, "get_normalized_weight", mock.Anything).
+			Return(i128ScVal(8_000_000), nil).Once().
+			On("FetchSingleField", mock.Anything, cometID, "get_normalized_weight", mock.Anything).
+			Return(i128ScVal(2_000_000), nil).Once()
+		m.On("FetchSingleField", mock.Anything, cometID, "get_total_supply", []xdr.ScVal(nil)).
+			Return(xdr.ScVal{}, assert.AnError).Once()
+
+		_, err := fetchCometState(ctx, m, cometID)
+		assert.Error(t, err)
+	})
+
+	t.Run("equal weights are ambiguous and error", func(t *testing.T) {
+		tokenA := randomContractAddr(t)
+		tokenB := randomContractAddr(t)
+
+		m := services.NewContractMetadataServiceMock(t)
+		m.On("FetchSingleField", mock.Anything, cometID, "get_tokens", []xdr.ScVal(nil)).
+			Return(vecScVal(contractAddrScVal(t, tokenA), contractAddrScVal(t, tokenB)), nil).Once()
+		m.On("FetchSingleField", mock.Anything, cometID, "get_balance", mock.Anything).
+			Return(i128ScVal(1), nil)
+		m.On("FetchSingleField", mock.Anything, cometID, "get_normalized_weight", mock.Anything).
+			Return(i128ScVal(5_000_000), nil)
+		m.On("FetchSingleField", mock.Anything, cometID, "get_total_supply", []xdr.ScVal(nil)).
+			Return(i128ScVal(1), nil)
+
+		_, err := fetchCometState(ctx, m, cometID)
+		assert.Error(t, err)
+	})
+}

--- a/internal/services/blend/comet_test.go
+++ b/internal/services/blend/comet_test.go
@@ -2,6 +2,8 @@ package blend
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/hex"
 	"math/big"
 	"testing"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stellar/wallet-backend/internal/entities"
 	"github.com/stellar/wallet-backend/internal/services"
 )
 
@@ -138,61 +141,129 @@ func TestCometValuation(t *testing.T) {
 	})
 }
 
-// TestFetchCometState mocks services.ContractMetadataService — no real RPC.
+// cometEntryResult builds one entities.LedgerEntryResult for the Comet pool
+// at poolID whose ContractData key/value are key/val — the shape
+// fetchCometState decodes out of a getLedgerEntries response.
+func cometEntryResult(t *testing.T, poolID string, key, val xdr.ScVal) entities.LedgerEntryResult {
+	t.Helper()
+	keyB64, err := cometLedgerKey(poolID, key)
+	require.NoError(t, err)
+
+	addrVal, err := contractAddressScVal(poolID)
+	require.NoError(t, err)
+	data := xdr.LedgerEntryData{
+		Type: xdr.LedgerEntryTypeContractData,
+		ContractData: &xdr.ContractDataEntry{
+			Contract:   *addrVal.Address,
+			Key:        key,
+			Durability: xdr.ContractDataDurabilityPersistent,
+			Val:        val,
+		},
+	}
+	raw, err := data.MarshalBinary()
+	require.NoError(t, err)
+	return entities.LedgerEntryResult{KeyXDR: keyB64, DataXDR: base64.StdEncoding.EncodeToString(raw)}
+}
+
+// cometInstanceVal builds the ScvContractInstance value for a WASM contract
+// whose executable hash is wasmHashHex.
+func cometInstanceVal(t *testing.T, wasmHashHex string) xdr.ScVal {
+	t.Helper()
+	raw, err := hex.DecodeString(wasmHashHex)
+	require.NoError(t, err)
+	var hash xdr.Hash
+	copy(hash[:], raw)
+	return xdr.ScVal{
+		Type: xdr.ScValTypeScvContractInstance,
+		Instance: &xdr.ScContractInstance{
+			Executable: xdr.ContractExecutable{
+				Type:     xdr.ContractExecutableTypeContractExecutableWasm,
+				WasmHash: &hash,
+			},
+		},
+	}
+}
+
+// cometRecordVal builds one Comet Record struct value ({balance, index,
+// scalar, weight} keyed by field-name Symbols, matching the live entry dump
+// in comet.go's verification note).
+func cometRecordVal(t *testing.T, balance *big.Int, weight *big.Int, scalar int64, index uint32) xdr.ScVal {
+	t.Helper()
+	v := xdr.ScVal{Type: xdr.ScValTypeScvMap}
+	m := mapScVal(
+		xdr.ScMapEntry{Key: symScVal("balance"), Val: i128ScVal(balance.Int64())},
+		xdr.ScMapEntry{Key: symScVal("index"), Val: u32ScVal(index)},
+		xdr.ScMapEntry{Key: symScVal("scalar"), Val: i128ScVal(scalar)},
+		xdr.ScMapEntry{Key: symScVal("weight"), Val: i128ScVal(weight.Int64())},
+	)
+	v.Map = &m
+	return v
+}
+
+// cometRecordMapVal builds the AllRecordData Map<Address, Record> value for
+// the given token records, in the order supplied.
+func cometRecordMapVal(t *testing.T, tokens []string, records []xdr.ScVal) xdr.ScVal {
+	t.Helper()
+	entries := make([]xdr.ScMapEntry, len(tokens))
+	for i := range tokens {
+		entries[i] = xdr.ScMapEntry{Key: contractAddrScVal(t, tokens[i]), Val: records[i]}
+	}
+	v := xdr.ScVal{Type: xdr.ScValTypeScvMap}
+	m := mapScVal(entries...)
+	v.Map = &m
+	return v
+}
+
+// TestFetchCometState mocks services.RPCService — no real RPC. The happy
+// mocks mirror the live mainnet entry dump recorded in comet.go: an 80/20
+// BLND:USDC record map, a TotalShares i128, and a contract instance pinned
+// to cometWasmHash.
 func TestFetchCometState(t *testing.T) {
 	ctx := context.Background()
 	// cometID (mainnet) / cometIDTestnet exercise fetchCometState against two
-	// distinct pool addresses — the price snapshot task (a later change) will
-	// call it once per network, so the tests deliberately don't hardcode a
-	// single address throughout.
+	// distinct pool addresses — the price snapshot task calls it with whatever
+	// pool the deployment configures, so the tests deliberately don't
+	// hardcode a single address throughout.
 	const (
 		cometID        = "CAS3FL6TLZKDGGSISDBWGGPXT3NRR4DYTZD7YOD3HMYO6LTJUVGRVEAM"
 		cometIDTestnet = "CA5UTUUPHYL5K22UBRUVC37EARZUGYOSGK3IKIXG2JLCC5ZZLI4BDWDM"
 	)
+	const sevenDecScalar = 100_000_000_000 // 10^(18-7), both legs 7-decimals
 
-	// setupHappyMock wires up get_tokens/get_balance/get_normalized_weight/
-	// get_total_supply against the pool at poolID so the token at index
-	// blndIdx is BLND (weight 0.8) and the other is USDC (weight 0.2),
-	// proving fetchCometState identifies BLND by weight rather than by
-	// get_tokens() position.
-	setupHappyMock := func(t *testing.T, poolID string, blndIdx int) *services.ContractMetadataServiceMock {
+	// happyEntries wires up the three ledger entries for the pool at poolID so
+	// the token at index blndIdx is BLND (weight 0.8) and the other is USDC
+	// (weight 0.2), proving fetchCometState identifies BLND by weight rather
+	// than by record-map position.
+	happyEntries := func(t *testing.T, poolID string, blndIdx int) ([]string, []entities.LedgerEntryResult) {
 		t.Helper()
-		tokenA := randomContractAddr(t)
-		tokenB := randomContractAddr(t)
-		tokens := []string{tokenA, tokenB}
-		blndAddr, usdcAddr := tokens[blndIdx], tokens[1-blndIdx]
+		tokens := []string{randomContractAddr(t), randomContractAddr(t)}
+		records := make([]xdr.ScVal, 2)
+		records[blndIdx] = cometRecordVal(t, big.NewInt(40_000_000_000_000), big.NewInt(8_000_000), sevenDecScalar, uint32(blndIdx))    // 4,000,000.0 BLND, weight 0.8
+		records[1-blndIdx] = cometRecordVal(t, big.NewInt(2_000_000_000_000), big.NewInt(2_000_000), sevenDecScalar, uint32(1-blndIdx)) // 200,000.0 USDC, weight 0.2
 
-		m := services.NewContractMetadataServiceMock(t)
-		m.On("FetchSingleField", mock.Anything, poolID, "get_tokens", []xdr.ScVal(nil)).
-			Return(vecScVal(contractAddrScVal(t, tokenA), contractAddrScVal(t, tokenB)), nil).Once()
+		return tokens, []entities.LedgerEntryResult{
+			cometEntryResult(t, poolID, xdr.ScVal{Type: xdr.ScValTypeScvLedgerKeyContractInstance}, cometInstanceVal(t, cometWasmHash)),
+			cometEntryResult(t, poolID, cometUnitKeyScVal("AllRecordData"), cometRecordMapVal(t, tokens, records)),
+			cometEntryResult(t, poolID, cometUnitKeyScVal("TotalShares"), i128ScVal(10_000_000_000_000)), // 1,000,000.0 shares
+		}
+	}
 
-		blndArg, err := contractAddressScVal(blndAddr)
-		require.NoError(t, err)
-		usdcArg, err := contractAddressScVal(usdcAddr)
-		require.NoError(t, err)
-
-		// Each numeric getter is fetched twice: fetchCometState's torn-read
-		// guard requires two agreeing consistency reads.
-		m.On("FetchSingleField", mock.Anything, poolID, "get_balance", []xdr.ScVal{blndArg}).
-			Return(i128ScVal(40_000_000_000_000), nil).Times(2) // 4,000,000.0000000
-		m.On("FetchSingleField", mock.Anything, poolID, "get_balance", []xdr.ScVal{usdcArg}).
-			Return(i128ScVal(2_000_000_000_000), nil).Times(2) // 200,000.0000000
-		m.On("FetchSingleField", mock.Anything, poolID, "get_normalized_weight", []xdr.ScVal{blndArg}).
-			Return(i128ScVal(8_000_000), nil).Times(2) // 0.8
-		m.On("FetchSingleField", mock.Anything, poolID, "get_normalized_weight", []xdr.ScVal{usdcArg}).
-			Return(i128ScVal(2_000_000), nil).Times(2) // 0.2
-		m.On("FetchSingleField", mock.Anything, poolID, "get_total_supply", []xdr.ScVal(nil)).
-			Return(i128ScVal(10_000_000_000_000), nil).Times(2) // 1,000,000.0000000
-
+	mockRPC := func(t *testing.T, entries []entities.LedgerEntryResult, err error) *services.RPCServiceMock {
+		t.Helper()
+		m := services.NewRPCServiceMock(t)
+		m.On("GetLedgerEntries", mock.MatchedBy(func(keys []string) bool { return len(keys) == 3 })).
+			Return(entities.RPCGetLedgerEntriesResult{LatestLedger: 1, Entries: entries}, err).Once()
 		return m
 	}
 
-	t.Run("identifies BLND leg by weight when it is get_tokens()[0]", func(t *testing.T) {
-		m := setupHappyMock(t, cometID, 0)
+	t.Run("identifies BLND leg by weight when it is the first record", func(t *testing.T) {
+		tokens, entries := happyEntries(t, cometID, 0)
+		m := mockRPC(t, entries, nil)
 
 		state, err := fetchCometState(ctx, m, cometID)
 		require.NoError(t, err)
 		require.NotNil(t, state)
+		assert.Equal(t, tokens[0], state.BLNDAddress)
 		assert.Equal(t, big.NewInt(40_000_000_000_000), state.BLNDBalance)
 		assert.Equal(t, big.NewInt(2_000_000_000_000), state.USDCBalance)
 		assert.Equal(t, big.NewInt(8_000_000), state.BLNDWeight)
@@ -200,141 +271,110 @@ func TestFetchCometState(t *testing.T) {
 		assert.Equal(t, big.NewInt(10_000_000_000_000), state.LPSupply)
 	})
 
-	t.Run("identifies BLND leg by weight when it is get_tokens()[1], against a different pool address", func(t *testing.T) {
-		m := setupHappyMock(t, cometIDTestnet, 1)
+	t.Run("identifies BLND leg by weight when it is the second record, against a different pool address", func(t *testing.T) {
+		tokens, entries := happyEntries(t, cometIDTestnet, 1)
+		m := mockRPC(t, entries, nil)
 
 		state, err := fetchCometState(ctx, m, cometIDTestnet)
 		require.NoError(t, err)
 		require.NotNil(t, state)
+		assert.Equal(t, tokens[1], state.BLNDAddress)
 		assert.Equal(t, big.NewInt(40_000_000_000_000), state.BLNDBalance)
 		assert.Equal(t, big.NewInt(2_000_000_000_000), state.USDCBalance)
 	})
 
-	t.Run("nil metadata service degrades with error", func(t *testing.T) {
+	t.Run("nil RPC service degrades with error", func(t *testing.T) {
 		_, err := fetchCometState(ctx, nil, cometID)
 		assert.Error(t, err)
 	})
 
-	t.Run("get_tokens RPC error propagates", func(t *testing.T) {
-		m := services.NewContractMetadataServiceMock(t)
-		m.On("FetchSingleField", mock.Anything, cometID, "get_tokens", []xdr.ScVal(nil)).
-			Return(xdr.ScVal{}, assert.AnError).Once()
+	t.Run("RPC error propagates", func(t *testing.T) {
+		m := mockRPC(t, nil, assert.AnError)
 
 		_, err := fetchCometState(ctx, m, cometID)
 		assert.Error(t, err)
 	})
 
-	t.Run("get_tokens wrong shape errors", func(t *testing.T) {
-		m := services.NewContractMetadataServiceMock(t)
-		m.On("FetchSingleField", mock.Anything, cometID, "get_tokens", []xdr.ScVal(nil)).
-			Return(u32ScVal(1), nil).Once()
+	t.Run("missing entry errors", func(t *testing.T) {
+		_, entries := happyEntries(t, cometID, 0)
+		m := mockRPC(t, entries[:2], nil) // TotalShares absent
 
 		_, err := fetchCometState(ctx, m, cometID)
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, "TotalShares entry not found")
 	})
 
-	t.Run("get_tokens wrong count errors", func(t *testing.T) {
-		m := services.NewContractMetadataServiceMock(t)
-		m.On("FetchSingleField", mock.Anything, cometID, "get_tokens", []xdr.ScVal(nil)).
-			Return(vecScVal(contractAddrScVal(t, randomContractAddr(t))), nil).Once()
+	t.Run("WASM hash mismatch refuses to decode", func(t *testing.T) {
+		_, entries := happyEntries(t, cometID, 0)
+		otherHash := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		entries[0] = cometEntryResult(t, cometID, xdr.ScVal{Type: xdr.ScValTypeScvLedgerKeyContractInstance}, cometInstanceVal(t, otherHash))
+		m := mockRPC(t, entries, nil)
 
 		_, err := fetchCometState(ctx, m, cometID)
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, "does not match the pinned Comet hash")
 	})
 
-	t.Run("get_balance RPC error propagates", func(t *testing.T) {
-		tokenA := randomContractAddr(t)
-		tokenB := randomContractAddr(t)
-
-		m := services.NewContractMetadataServiceMock(t)
-		m.On("FetchSingleField", mock.Anything, cometID, "get_tokens", []xdr.ScVal(nil)).
-			Return(vecScVal(contractAddrScVal(t, tokenA), contractAddrScVal(t, tokenB)), nil).Once()
-		m.On("FetchSingleField", mock.Anything, cometID, "get_balance", mock.Anything).
-			Return(xdr.ScVal{}, assert.AnError).Once()
+	t.Run("wrong token count errors", func(t *testing.T) {
+		_, entries := happyEntries(t, cometID, 0)
+		oneToken := []string{randomContractAddr(t)}
+		oneRecord := []xdr.ScVal{cometRecordVal(t, big.NewInt(1), big.NewInt(10_000_000), sevenDecScalar, 0)}
+		entries[1] = cometEntryResult(t, cometID, cometUnitKeyScVal("AllRecordData"), cometRecordMapVal(t, oneToken, oneRecord))
+		m := mockRPC(t, entries, nil)
 
 		_, err := fetchCometState(ctx, m, cometID)
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, "expected 2 tokens")
 	})
 
-	t.Run("get_normalized_weight wrong type errors", func(t *testing.T) {
-		tokenA := randomContractAddr(t)
-		tokenB := randomContractAddr(t)
-
-		m := services.NewContractMetadataServiceMock(t)
-		m.On("FetchSingleField", mock.Anything, cometID, "get_tokens", []xdr.ScVal(nil)).
-			Return(vecScVal(contractAddrScVal(t, tokenA), contractAddrScVal(t, tokenB)), nil).Once()
-		m.On("FetchSingleField", mock.Anything, cometID, "get_balance", mock.Anything).
-			Return(i128ScVal(1), nil)
-		m.On("FetchSingleField", mock.Anything, cometID, "get_normalized_weight", mock.Anything).
-			Return(u32ScVal(1), nil).Once()
+	t.Run("differing token scalars error", func(t *testing.T) {
+		_, entries := happyEntries(t, cometID, 0)
+		tokens := []string{randomContractAddr(t), randomContractAddr(t)}
+		records := []xdr.ScVal{
+			cometRecordVal(t, big.NewInt(1000), big.NewInt(8_000_000), sevenDecScalar, 0),
+			cometRecordVal(t, big.NewInt(1000), big.NewInt(2_000_000), 1_000_000_000_000, 1), // 6-decimal token
+		}
+		entries[1] = cometEntryResult(t, cometID, cometUnitKeyScVal("AllRecordData"), cometRecordMapVal(t, tokens, records))
+		m := mockRPC(t, entries, nil)
 
 		_, err := fetchCometState(ctx, m, cometID)
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, "token scalars differ")
 	})
 
-	t.Run("get_total_supply RPC error propagates", func(t *testing.T) {
-		tokenA := randomContractAddr(t)
-		tokenB := randomContractAddr(t)
-
-		m := services.NewContractMetadataServiceMock(t)
-		m.On("FetchSingleField", mock.Anything, cometID, "get_tokens", []xdr.ScVal(nil)).
-			Return(vecScVal(contractAddrScVal(t, tokenA), contractAddrScVal(t, tokenB)), nil).Once()
-		m.On("FetchSingleField", mock.Anything, cometID, "get_balance", mock.Anything).
-			Return(i128ScVal(1), nil)
-		m.On("FetchSingleField", mock.Anything, cometID, "get_normalized_weight", mock.Anything).
-			Return(i128ScVal(8_000_000), nil).Once().
-			On("FetchSingleField", mock.Anything, cometID, "get_normalized_weight", mock.Anything).
-			Return(i128ScVal(2_000_000), nil).Once()
-		m.On("FetchSingleField", mock.Anything, cometID, "get_total_supply", []xdr.ScVal(nil)).
-			Return(xdr.ScVal{}, assert.AnError).Once()
+	t.Run("record missing a field errors", func(t *testing.T) {
+		_, entries := happyEntries(t, cometID, 0)
+		tokens := []string{randomContractAddr(t), randomContractAddr(t)}
+		noWeight := xdr.ScVal{Type: xdr.ScValTypeScvMap}
+		nm := mapScVal(
+			xdr.ScMapEntry{Key: symScVal("balance"), Val: i128ScVal(1000)},
+			xdr.ScMapEntry{Key: symScVal("scalar"), Val: i128ScVal(sevenDecScalar)},
+		)
+		noWeight.Map = &nm
+		records := []xdr.ScVal{noWeight, cometRecordVal(t, big.NewInt(1000), big.NewInt(2_000_000), sevenDecScalar, 1)}
+		entries[1] = cometEntryResult(t, cometID, cometUnitKeyScVal("AllRecordData"), cometRecordMapVal(t, tokens, records))
+		m := mockRPC(t, entries, nil)
 
 		_, err := fetchCometState(ctx, m, cometID)
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, `missing "weight" field`)
 	})
 
-	t.Run("state changed between consistency reads errors", func(t *testing.T) {
-		tokenA := randomContractAddr(t)
-		tokenB := randomContractAddr(t)
-		blndArg, err := contractAddressScVal(tokenA)
-		require.NoError(t, err)
+	t.Run("TotalShares wrong type errors", func(t *testing.T) {
+		_, entries := happyEntries(t, cometID, 0)
+		entries[2] = cometEntryResult(t, cometID, cometUnitKeyScVal("TotalShares"), u32ScVal(1))
+		m := mockRPC(t, entries, nil)
 
-		m := services.NewContractMetadataServiceMock(t)
-		m.On("FetchSingleField", mock.Anything, cometID, "get_tokens", []xdr.ScVal(nil)).
-			Return(vecScVal(contractAddrScVal(t, tokenA), contractAddrScVal(t, tokenB)), nil).Once()
-		// tokenA's balance moves between the two consistency reads — a swap
-		// landing mid-read — while everything else stays put.
-		m.On("FetchSingleField", mock.Anything, cometID, "get_balance", []xdr.ScVal{blndArg}).
-			Return(i128ScVal(40_000_000_000_000), nil).Once().
-			On("FetchSingleField", mock.Anything, cometID, "get_balance", []xdr.ScVal{blndArg}).
-			Return(i128ScVal(41_000_000_000_000), nil).Once()
-		m.On("FetchSingleField", mock.Anything, cometID, "get_balance", mock.Anything).
-			Return(i128ScVal(2_000_000_000_000), nil)
-		m.On("FetchSingleField", mock.Anything, cometID, "get_normalized_weight", []xdr.ScVal{blndArg}).
-			Return(i128ScVal(8_000_000), nil)
-		m.On("FetchSingleField", mock.Anything, cometID, "get_normalized_weight", mock.Anything).
-			Return(i128ScVal(2_000_000), nil)
-		m.On("FetchSingleField", mock.Anything, cometID, "get_total_supply", []xdr.ScVal(nil)).
-			Return(i128ScVal(10_000_000_000_000), nil)
-
-		_, err = fetchCometState(ctx, m, cometID)
-		assert.ErrorContains(t, err, "state changed between consistency reads")
+		_, err := fetchCometState(ctx, m, cometID)
+		assert.ErrorContains(t, err, "TotalShares: expected i128")
 	})
 
 	t.Run("equal weights are ambiguous and error", func(t *testing.T) {
-		tokenA := randomContractAddr(t)
-		tokenB := randomContractAddr(t)
-
-		m := services.NewContractMetadataServiceMock(t)
-		m.On("FetchSingleField", mock.Anything, cometID, "get_tokens", []xdr.ScVal(nil)).
-			Return(vecScVal(contractAddrScVal(t, tokenA), contractAddrScVal(t, tokenB)), nil).Once()
-		m.On("FetchSingleField", mock.Anything, cometID, "get_balance", mock.Anything).
-			Return(i128ScVal(1), nil)
-		m.On("FetchSingleField", mock.Anything, cometID, "get_normalized_weight", mock.Anything).
-			Return(i128ScVal(5_000_000), nil)
-		m.On("FetchSingleField", mock.Anything, cometID, "get_total_supply", []xdr.ScVal(nil)).
-			Return(i128ScVal(1), nil)
+		_, entries := happyEntries(t, cometID, 0)
+		tokens := []string{randomContractAddr(t), randomContractAddr(t)}
+		records := []xdr.ScVal{
+			cometRecordVal(t, big.NewInt(1000), big.NewInt(5_000_000), sevenDecScalar, 0),
+			cometRecordVal(t, big.NewInt(1000), big.NewInt(5_000_000), sevenDecScalar, 1),
+		}
+		entries[1] = cometEntryResult(t, cometID, cometUnitKeyScVal("AllRecordData"), cometRecordMapVal(t, tokens, records))
+		m := mockRPC(t, entries, nil)
 
 		_, err := fetchCometState(ctx, m, cometID)
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, "cannot identify BLND leg")
 	})
 }

--- a/internal/services/blend/comet_test.go
+++ b/internal/services/blend/comet_test.go
@@ -98,6 +98,15 @@ func TestCometValuation(t *testing.T) {
 		assert.Equal(t, "70000000", lpPrice)
 	})
 
+	t.Run("rejects a positive price that rounds to zero", func(t *testing.T) {
+		// usdcBal=1 raw unit vs blndBal=10^20 raw units at equal weights puts
+		// the BLND spot at 10^-20 — far below half of one 7-decimal unit, so
+		// it would round to "0", which the snapshot invariant forbids.
+		huge := new(big.Int).Exp(big.NewInt(10), big.NewInt(20), nil)
+		_, _, err := cometValuation(huge, big.NewInt(1), big.NewInt(5_000_000), big.NewInt(5_000_000), huge)
+		assert.ErrorContains(t, err, "rounds to zero")
+	})
+
 	t.Run("rejects nil and non-positive inputs without dividing by zero", func(t *testing.T) {
 		one := bigFromStroop(1)
 		zero := big.NewInt(0)
@@ -162,16 +171,18 @@ func TestFetchCometState(t *testing.T) {
 		usdcArg, err := contractAddressScVal(usdcAddr)
 		require.NoError(t, err)
 
+		// Each numeric getter is fetched twice: fetchCometState's torn-read
+		// guard requires two agreeing consistency reads.
 		m.On("FetchSingleField", mock.Anything, poolID, "get_balance", []xdr.ScVal{blndArg}).
-			Return(i128ScVal(40_000_000_000_000), nil).Once() // 4,000,000.0000000
+			Return(i128ScVal(40_000_000_000_000), nil).Times(2) // 4,000,000.0000000
 		m.On("FetchSingleField", mock.Anything, poolID, "get_balance", []xdr.ScVal{usdcArg}).
-			Return(i128ScVal(2_000_000_000_000), nil).Once() // 200,000.0000000
+			Return(i128ScVal(2_000_000_000_000), nil).Times(2) // 200,000.0000000
 		m.On("FetchSingleField", mock.Anything, poolID, "get_normalized_weight", []xdr.ScVal{blndArg}).
-			Return(i128ScVal(8_000_000), nil).Once() // 0.8
+			Return(i128ScVal(8_000_000), nil).Times(2) // 0.8
 		m.On("FetchSingleField", mock.Anything, poolID, "get_normalized_weight", []xdr.ScVal{usdcArg}).
-			Return(i128ScVal(2_000_000), nil).Once() // 0.2
+			Return(i128ScVal(2_000_000), nil).Times(2) // 0.2
 		m.On("FetchSingleField", mock.Anything, poolID, "get_total_supply", []xdr.ScVal(nil)).
-			Return(i128ScVal(10_000_000_000_000), nil).Once() // 1,000,000.0000000
+			Return(i128ScVal(10_000_000_000_000), nil).Times(2) // 1,000,000.0000000
 
 		return m
 	}
@@ -279,6 +290,34 @@ func TestFetchCometState(t *testing.T) {
 
 		_, err := fetchCometState(ctx, m, cometID)
 		assert.Error(t, err)
+	})
+
+	t.Run("state changed between consistency reads errors", func(t *testing.T) {
+		tokenA := randomContractAddr(t)
+		tokenB := randomContractAddr(t)
+		blndArg, err := contractAddressScVal(tokenA)
+		require.NoError(t, err)
+
+		m := services.NewContractMetadataServiceMock(t)
+		m.On("FetchSingleField", mock.Anything, cometID, "get_tokens", []xdr.ScVal(nil)).
+			Return(vecScVal(contractAddrScVal(t, tokenA), contractAddrScVal(t, tokenB)), nil).Once()
+		// tokenA's balance moves between the two consistency reads — a swap
+		// landing mid-read — while everything else stays put.
+		m.On("FetchSingleField", mock.Anything, cometID, "get_balance", []xdr.ScVal{blndArg}).
+			Return(i128ScVal(40_000_000_000_000), nil).Once().
+			On("FetchSingleField", mock.Anything, cometID, "get_balance", []xdr.ScVal{blndArg}).
+			Return(i128ScVal(41_000_000_000_000), nil).Once()
+		m.On("FetchSingleField", mock.Anything, cometID, "get_balance", mock.Anything).
+			Return(i128ScVal(2_000_000_000_000), nil)
+		m.On("FetchSingleField", mock.Anything, cometID, "get_normalized_weight", []xdr.ScVal{blndArg}).
+			Return(i128ScVal(8_000_000), nil)
+		m.On("FetchSingleField", mock.Anything, cometID, "get_normalized_weight", mock.Anything).
+			Return(i128ScVal(2_000_000), nil)
+		m.On("FetchSingleField", mock.Anything, cometID, "get_total_supply", []xdr.ScVal(nil)).
+			Return(i128ScVal(10_000_000_000_000), nil)
+
+		_, err = fetchCometState(ctx, m, cometID)
+		assert.ErrorContains(t, err, "state changed between consistency reads")
 	})
 
 	t.Run("equal weights are ambiguous and error", func(t *testing.T) {

--- a/internal/services/blend/prices.go
+++ b/internal/services/blend/prices.go
@@ -1,0 +1,267 @@
+// Package blend — prices.go implements the periodic SEP-40 oracle price
+// snapshot task: on a fixed interval, it discovers every (oracle, asset) pair
+// some tracked pool's reserve prices against (blenddata.OraclePriceModel.
+// GetPriceTargets), fetches each oracle's decimals() once and every target's
+// lastprice(asset) (scval.go's buildSep40StellarAsset/decodePriceData), and
+// optionally derives the Blend v2 backstop's Comet BLND:USDC LP deposit
+// token's BLND and LP-share USD prices from the pool's own on-chain state
+// (comet.go) — no on-chain oracle prices a Comet LP token directly. Every row
+// from one pass is written in a single blenddata.OraclePriceModel.BatchUpsert
+// call.
+//
+// Comet leg row convention (locked cross-PR contract — PR5 reads these rows):
+// both rows are stored under oracle_contract_id = the Comet pool's own
+// C-address (a schema convenience key, not a claim the pool implements
+// SEP-40). The LP-share row is self-priced: asset_contract_id ==
+// oracle_contract_id. The BLND row's asset_contract_id is the real BLND
+// token address (cometState.BLNDAddress). Both are recorded at Comet's
+// 7-decimal STROOP scale (cometPriceDecimals) with PriceTimestamp set to the
+// snapshot's own wall-clock time (unix seconds), since the Comet getters
+// carry no oracle-reported timestamp of their own.
+//
+// A failure fetching one oracle's decimals or any of its lastprice targets
+// is isolated to that oracle: it never aborts the rest of the pass. All such
+// failures (and a Comet leg failure, when configured) are joined with
+// errors.Join and returned to the caller for logging; SnapshotOnce still
+// upserts whatever rows the pass did manage to collect.
+package blend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/stellar/go-stellar-sdk/support/log"
+
+	blenddata "github.com/stellar/wallet-backend/internal/data/blend"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+	"github.com/stellar/wallet-backend/internal/services"
+)
+
+// PriceSnapshotConfig configures a PriceSnapshotService.
+type PriceSnapshotConfig struct {
+	// OraclePrices is the blend_oracle_prices data access layer: GetPriceTargets
+	// discovers what to fetch, BatchUpsert persists what was fetched.
+	OraclePrices *blenddata.OraclePriceModel
+	// Metadata performs the RPC simulation calls (decimals, lastprice, and the
+	// Comet getters) against contracts.
+	Metadata services.ContractMetadataService
+	// Interval is the wait between the end of one snapshot pass and the start
+	// of the next.
+	Interval time.Duration
+	// BackstopLPContractID is the Comet BLND:USDC weighted pool backing the
+	// Blend v2 backstop's deposit token, as a strkey C-address. Empty disables
+	// the BLND/LP-share derived-pricing leg entirely.
+	BackstopLPContractID string
+	// Metrics receives per-pass duration, per-fetch outcome, and tracked-row-
+	// count observations.
+	Metrics *metrics.BlendPriceMetrics
+}
+
+// PriceSnapshotService periodically snapshots SEP-40 oracle prices — and,
+// when configured, the Comet backstop LP/BLND leg — into blend_oracle_prices.
+// See the package doc for the persistence and error-isolation contract.
+type PriceSnapshotService struct {
+	oraclePrices *blenddata.OraclePriceModel
+	metadata     services.ContractMetadataService
+	interval     time.Duration
+	cometID      string
+	metrics      *metrics.BlendPriceMetrics
+}
+
+// NewPriceSnapshotService validates cfg and constructs a PriceSnapshotService.
+// BackstopLPContractID is the only optional field.
+func NewPriceSnapshotService(cfg PriceSnapshotConfig) (*PriceSnapshotService, error) {
+	if cfg.OraclePrices == nil {
+		return nil, fmt.Errorf("blend: PriceSnapshotConfig.OraclePrices is required")
+	}
+	if cfg.Metadata == nil {
+		return nil, fmt.Errorf("blend: PriceSnapshotConfig.Metadata is required")
+	}
+	if cfg.Interval <= 0 {
+		return nil, fmt.Errorf("blend: PriceSnapshotConfig.Interval must be positive, got %s", cfg.Interval)
+	}
+	if cfg.Metrics == nil {
+		return nil, fmt.Errorf("blend: PriceSnapshotConfig.Metrics is required")
+	}
+	return &PriceSnapshotService{
+		oraclePrices: cfg.OraclePrices,
+		metadata:     cfg.Metadata,
+		interval:     cfg.Interval,
+		cometID:      cfg.BackstopLPContractID,
+		metrics:      cfg.Metrics,
+	}, nil
+}
+
+// Run snapshots once immediately, then every s.interval until ctx is
+// cancelled. A failed pass is logged, never fatal — the next tick tries
+// again. Mirrors protocol_migrate.go's refreshTargetTip ticker-loop shape.
+func (s *PriceSnapshotService) Run(ctx context.Context) {
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		if err := s.SnapshotOnce(ctx); err != nil {
+			log.Ctx(ctx).Warnf("blend: price snapshot pass failed: %v", err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// SnapshotOnce runs a single price-snapshot pass: discover targets, fetch
+// every oracle's prices (isolating per-oracle failures), optionally derive
+// the Comet leg, and upsert everything collected in one BatchUpsert call.
+// Returns an errors.Join of every isolated failure (nil if there were none);
+// a non-nil error does not mean no rows were written.
+func (s *PriceSnapshotService) SnapshotOnce(ctx context.Context) error {
+	start := time.Now()
+	defer func() {
+		s.metrics.SnapshotDuration.Observe(time.Since(start).Seconds())
+	}()
+
+	targets, err := s.oraclePrices.GetPriceTargets(ctx)
+	if err != nil {
+		return fmt.Errorf("blend: price snapshot: fetching price targets: %w", err)
+	}
+
+	byOracle := make(map[string][]blenddata.PriceTarget)
+	for _, target := range targets {
+		oracle := string(target.OracleContractID)
+		byOracle[oracle] = append(byOracle[oracle], target)
+	}
+
+	var rows []blenddata.OraclePrice
+	var errs []error
+	for oracle, oracleTargets := range byOracle {
+		oracleRows, oracleErr := s.snapshotOracle(ctx, oracle, oracleTargets)
+		if oracleErr != nil {
+			errs = append(errs, fmt.Errorf("blend: price snapshot: oracle %s: %w", oracle, oracleErr))
+		}
+		rows = append(rows, oracleRows...)
+	}
+
+	if s.cometID != "" {
+		cometRows, cometErr := s.snapshotComet(ctx)
+		if cometErr != nil {
+			s.metrics.FetchesTotal.WithLabelValues("error").Inc()
+			errs = append(errs, fmt.Errorf("blend: price snapshot: comet leg: %w", cometErr))
+		} else {
+			s.metrics.FetchesTotal.WithLabelValues("success").Add(float64(len(cometRows)))
+			rows = append(rows, cometRows...)
+		}
+	}
+
+	s.metrics.PricesTracked.Set(float64(len(rows)))
+
+	if len(rows) > 0 {
+		if upsertErr := s.oraclePrices.BatchUpsert(ctx, rows); upsertErr != nil {
+			errs = append(errs, fmt.Errorf("blend: price snapshot: persisting %d rows: %w", len(rows), upsertErr))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// snapshotOracle fetches decimals() once for oracle, then lastprice(asset)
+// for each of targets, skipping (not erroring on) a SEP-40 Option::None
+// response. A decimals() failure aborts this oracle's whole batch — every
+// target's price is meaningless without it — but is isolated to this oracle
+// by the caller. A single target's lastprice failure is isolated to that
+// target: the rest of this oracle's targets are still attempted.
+func (s *PriceSnapshotService) snapshotOracle(ctx context.Context, oracle string, targets []blenddata.PriceTarget) ([]blenddata.OraclePrice, error) {
+	decimalsVal, err := s.metadata.FetchSingleField(ctx, oracle, "decimals")
+	if err != nil {
+		s.metrics.FetchesTotal.WithLabelValues("error").Inc()
+		return nil, fmt.Errorf("fetching decimals: %w", err)
+	}
+	decimals, ok := u32Val(decimalsVal)
+	if !ok {
+		s.metrics.FetchesTotal.WithLabelValues("error").Inc()
+		return nil, fmt.Errorf("decimals: expected u32, got %v", decimalsVal.Type)
+	}
+
+	rows := make([]blenddata.OraclePrice, 0, len(targets))
+	var errs []error
+	for _, target := range targets {
+		assetArg, buildErr := buildSep40StellarAsset(string(target.AssetContractID))
+		if buildErr != nil {
+			s.metrics.FetchesTotal.WithLabelValues("error").Inc()
+			errs = append(errs, fmt.Errorf("asset %s: building lastprice argument: %w", target.AssetContractID, buildErr))
+			continue
+		}
+
+		priceVal, fetchErr := s.metadata.FetchSingleField(ctx, oracle, "lastprice", assetArg)
+		if fetchErr != nil {
+			s.metrics.FetchesTotal.WithLabelValues("error").Inc()
+			errs = append(errs, fmt.Errorf("asset %s: fetching lastprice: %w", target.AssetContractID, fetchErr))
+			continue
+		}
+
+		priceData, decodeErr := decodePriceData(priceVal)
+		if decodeErr != nil {
+			s.metrics.FetchesTotal.WithLabelValues("error").Inc()
+			errs = append(errs, fmt.Errorf("asset %s: decoding lastprice: %w", target.AssetContractID, decodeErr))
+			continue
+		}
+		if priceData == nil {
+			s.metrics.FetchesTotal.WithLabelValues("none").Inc()
+			continue
+		}
+
+		s.metrics.FetchesTotal.WithLabelValues("success").Inc()
+		rows = append(rows, blenddata.OraclePrice{
+			OracleContractID: target.OracleContractID,
+			AssetContractID:  target.AssetContractID,
+			Price:            priceData.Price.String(),
+			PriceDecimals:    int32(decimals),
+			PriceTimestamp:   int64(priceData.Timestamp),
+		})
+	}
+
+	return rows, errors.Join(errs...)
+}
+
+// snapshotComet derives the BLND and Comet LP-share USD prices from the
+// configured backstop Comet pool's raw on-chain state (fetchCometState,
+// cometValuation) and returns their blend_oracle_prices rows. See the
+// package doc for the row-key convention.
+func (s *PriceSnapshotService) snapshotComet(ctx context.Context) ([]blenddata.OraclePrice, error) {
+	state, err := fetchCometState(ctx, s.metadata, s.cometID)
+	if err != nil {
+		return nil, fmt.Errorf("fetching comet state: %w", err)
+	}
+
+	blndPrice, lpPrice, err := cometValuation(state.BLNDBalance, state.USDCBalance, state.BLNDWeight, state.USDCWeight, state.LPSupply)
+	if err != nil {
+		return nil, fmt.Errorf("valuing comet pool: %w", err)
+	}
+
+	now := time.Now().Unix()
+	cometAddr := types.AddressBytea(s.cometID)
+	return []blenddata.OraclePrice{
+		{
+			OracleContractID: cometAddr,
+			AssetContractID:  types.AddressBytea(state.BLNDAddress),
+			Price:            blndPrice,
+			PriceDecimals:    cometPriceDecimals,
+			PriceTimestamp:   now,
+		},
+		{
+			// The LP share is self-priced: this row's asset is the Comet pool
+			// itself, matching the locked cross-PR row-key convention.
+			OracleContractID: cometAddr,
+			AssetContractID:  cometAddr,
+			Price:            lpPrice,
+			PriceDecimals:    cometPriceDecimals,
+			PriceTimestamp:   now,
+		},
+	}, nil
+}

--- a/internal/services/blend/prices.go
+++ b/internal/services/blend/prices.go
@@ -95,24 +95,25 @@ func NewPriceSnapshotService(cfg PriceSnapshotConfig) (*PriceSnapshotService, er
 	}, nil
 }
 
-// Run snapshots once immediately, then every s.interval until ctx is
-// cancelled. A failed pass is logged, never fatal — the next tick tries
-// again. Mirrors protocol_migrate.go's refreshTargetTip ticker-loop shape.
+// Run snapshots once immediately, then repeatedly until ctx is cancelled,
+// waiting s.interval AFTER each pass completes (end-to-start delay). A
+// ticker would queue a tick while a slow pass runs — many oracle targets
+// plus RPC retries can exceed the interval — and the next pass would then
+// start immediately, hammering RPC/DB back-to-back. A failed pass is
+// logged, never fatal — the next pass tries again.
 func (s *PriceSnapshotService) Run(ctx context.Context) {
-	ticker := time.NewTicker(s.interval)
-	defer ticker.Stop()
+	timer := time.NewTimer(0) // fires immediately: the first pass runs at startup
+	defer timer.Stop()
 	for {
-		if ctx.Err() != nil {
+		select {
+		case <-ctx.Done():
 			return
+		case <-timer.C:
 		}
 		if err := s.SnapshotOnce(ctx); err != nil {
 			log.Ctx(ctx).Warnf("blend: price snapshot pass failed: %v", err)
 		}
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-		}
+		timer.Reset(s.interval)
 	}
 }
 

--- a/internal/services/blend/prices.go
+++ b/internal/services/blend/prices.go
@@ -16,8 +16,8 @@
 // oracle_contract_id. The BLND row's asset_contract_id is the real BLND
 // token address (cometState.BLNDAddress). Both are recorded at Comet's
 // 7-decimal STROOP scale (cometPriceDecimals) with PriceTimestamp set to the
-// snapshot's own wall-clock time (unix seconds), since the Comet getters
-// carry no oracle-reported timestamp of their own.
+// snapshot's own wall-clock time (unix seconds), since the Comet pool state
+// carries no oracle-reported timestamp of its own.
 //
 // A price the pool contract itself would reject is never persisted: an
 // oracle-reported timestamp older than maxPriceAge is skipped as "stale" and
@@ -56,8 +56,8 @@ type PriceSnapshotConfig struct {
 	// OraclePrices is the blend_oracle_prices data access layer: GetPriceTargets
 	// discovers what to fetch, BatchUpsert persists what was fetched.
 	OraclePrices *blenddata.OraclePriceModel
-	// Metadata performs the RPC simulation calls (decimals, lastprice, and the
-	// Comet getters) against contracts.
+	// Metadata performs the SEP-40 RPC simulation calls (decimals, lastprice)
+	// against oracle contracts.
 	Metadata services.ContractMetadataService
 	// Interval is the wait between the end of one snapshot pass and the start
 	// of the next.
@@ -66,6 +66,9 @@ type PriceSnapshotConfig struct {
 	// Blend v2 backstop's deposit token, as a strkey C-address. Empty disables
 	// the BLND/LP-share derived-pricing leg entirely.
 	BackstopLPContractID string
+	// RPC reads the Comet pool's ContractData ledger entries (fetchCometState).
+	// Required only when BackstopLPContractID is set.
+	RPC services.RPCService
 	// Metrics receives per-pass duration, per-fetch outcome, and tracked-row-
 	// count observations.
 	Metrics *metrics.BlendPriceMetrics
@@ -79,11 +82,12 @@ type PriceSnapshotService struct {
 	metadata     services.ContractMetadataService
 	interval     time.Duration
 	cometID      string
+	rpc          services.RPCService
 	metrics      *metrics.BlendPriceMetrics
 }
 
 // NewPriceSnapshotService validates cfg and constructs a PriceSnapshotService.
-// BackstopLPContractID is the only optional field.
+// BackstopLPContractID is optional; RPC is required alongside it.
 func NewPriceSnapshotService(cfg PriceSnapshotConfig) (*PriceSnapshotService, error) {
 	if cfg.OraclePrices == nil {
 		return nil, fmt.Errorf("blend: PriceSnapshotConfig.OraclePrices is required")
@@ -94,6 +98,9 @@ func NewPriceSnapshotService(cfg PriceSnapshotConfig) (*PriceSnapshotService, er
 	if cfg.Interval <= 0 {
 		return nil, fmt.Errorf("blend: PriceSnapshotConfig.Interval must be positive, got %s", cfg.Interval)
 	}
+	if cfg.BackstopLPContractID != "" && cfg.RPC == nil {
+		return nil, fmt.Errorf("blend: PriceSnapshotConfig.RPC is required when BackstopLPContractID is set")
+	}
 	if cfg.Metrics == nil {
 		return nil, fmt.Errorf("blend: PriceSnapshotConfig.Metrics is required")
 	}
@@ -102,6 +109,7 @@ func NewPriceSnapshotService(cfg PriceSnapshotConfig) (*PriceSnapshotService, er
 		metadata:     cfg.Metadata,
 		interval:     cfg.Interval,
 		cometID:      cfg.BackstopLPContractID,
+		rpc:          cfg.RPC,
 		metrics:      cfg.Metrics,
 	}, nil
 }
@@ -287,7 +295,7 @@ func (s *PriceSnapshotService) snapshotOracle(ctx context.Context, oracle string
 // cometValuation) and returns their blend_oracle_prices rows. See the
 // package doc for the row-key convention.
 func (s *PriceSnapshotService) snapshotComet(ctx context.Context) ([]blenddata.OraclePrice, error) {
-	state, err := fetchCometState(ctx, s.metadata, s.cometID)
+	state, err := fetchCometState(ctx, s.rpc, s.cometID)
 	if err != nil {
 		return nil, fmt.Errorf("fetching comet state: %w", err)
 	}

--- a/internal/services/blend/prices.go
+++ b/internal/services/blend/prices.go
@@ -19,6 +19,11 @@
 // snapshot's own wall-clock time (unix seconds), since the Comet getters
 // carry no oracle-reported timestamp of their own.
 //
+// A price the pool contract itself would reject is never persisted: an
+// oracle-reported timestamp older than maxPriceAge is skipped as "stale" and
+// a price ≤ 0 as "invalid" (both observable via the fetch-outcome counter,
+// staleness additionally via the oldest-price-age gauge).
+//
 // A failure fetching one oracle's decimals or any of its lastprice targets
 // is isolated to that oracle: it never aborts the rest of the pass. All such
 // failures (and a Comet leg failure, when configured) are joined with
@@ -39,6 +44,12 @@ import (
 	"github.com/stellar/wallet-backend/internal/metrics"
 	"github.com/stellar/wallet-backend/internal/services"
 )
+
+// maxPriceAge is how old an oracle-reported price may be and still be
+// persisted. It mirrors the Blend v2 pool contract's own rejection window:
+// pool.rs::load_price panics on prices older than 24h (and on prices ≤ 0),
+// so a price past this age could never be used by the pool it prices for.
+const maxPriceAge = 24 * time.Hour
 
 // PriceSnapshotConfig configures a PriceSnapshotService.
 type PriceSnapshotConfig struct {
@@ -139,14 +150,37 @@ func (s *PriceSnapshotService) SnapshotOnce(ctx context.Context) error {
 		byOracle[oracle] = append(byOracle[oracle], target)
 	}
 
+	now := time.Now().Unix()
 	var rows []blenddata.OraclePrice
 	var errs []error
+	var oldestAge int64
+	var decodedAnyPrice bool
 	for oracle, oracleTargets := range byOracle {
-		oracleRows, oracleErr := s.snapshotOracle(ctx, oracle, oracleTargets)
+		oracleRows, oracleOldestAge, oracleErr := s.snapshotOracle(ctx, oracle, oracleTargets, now)
 		if oracleErr != nil {
 			errs = append(errs, fmt.Errorf("blend: price snapshot: oracle %s: %w", oracle, oracleErr))
 		}
+		// A decoded positive price either yields a row or, when skipped as
+		// stale, pushes the oldest age past zero — so this disjunction is
+		// exactly "this oracle reported at least one usable-looking price".
+		if len(oracleRows) > 0 || oracleOldestAge > 0 {
+			decodedAnyPrice = true
+		}
+		if oracleOldestAge > oldestAge {
+			oldestAge = oracleOldestAge
+		}
 		rows = append(rows, oracleRows...)
+	}
+	// The gauge measures SEP-40 lastprice staleness only — the Comet leg's
+	// prices are derived from ledger entries and carry the snapshot's own
+	// clock, so they say nothing about oracle freshness and are not counted
+	// here. A pass that decoded no oracle price at all (every fetch failed,
+	// or there were no targets) has nothing to report: writing 0 would read
+	// as "every price is current", inverting the signal. Skipping the write
+	// keeps the last real reading, which Prometheus then shows ageing, while
+	// FetchesTotal{result="error"} carries the failure.
+	if decodedAnyPrice {
+		s.metrics.OldestPriceAge.Set(float64(oldestAge))
 	}
 
 	if s.cometID != "" {
@@ -173,24 +207,29 @@ func (s *PriceSnapshotService) SnapshotOnce(ctx context.Context) error {
 
 // snapshotOracle fetches decimals() once for oracle, then lastprice(asset)
 // for each of targets, skipping (not erroring on) a SEP-40 Option::None
-// response. A decimals() failure aborts this oracle's whole batch — every
-// target's price is meaningless without it — but is isolated to this oracle
-// by the caller. A single target's lastprice failure is isolated to that
-// target: the rest of this oracle's targets are still attempted.
-func (s *PriceSnapshotService) snapshotOracle(ctx context.Context, oracle string, targets []blenddata.PriceTarget) ([]blenddata.OraclePrice, error) {
+// response, a price the pool contract would reject as stale (older than
+// maxPriceAge against now) or invalid (≤ 0). A decimals() failure aborts
+// this oracle's whole batch — every target's price is meaningless without
+// it — but is isolated to this oracle by the caller. A single target's
+// lastprice failure is isolated to that target: the rest of this oracle's
+// targets are still attempted. The second return value is the age in
+// seconds of the oldest price decoded (including skipped-as-stale ones —
+// that growth is the dead-oracle signal the gauge exists for).
+func (s *PriceSnapshotService) snapshotOracle(ctx context.Context, oracle string, targets []blenddata.PriceTarget, now int64) ([]blenddata.OraclePrice, int64, error) {
 	decimalsVal, err := s.metadata.FetchSingleField(ctx, oracle, "decimals")
 	if err != nil {
 		s.metrics.FetchesTotal.WithLabelValues("error").Inc()
-		return nil, fmt.Errorf("fetching decimals: %w", err)
+		return nil, 0, fmt.Errorf("fetching decimals: %w", err)
 	}
 	decimals, ok := u32Val(decimalsVal)
 	if !ok {
 		s.metrics.FetchesTotal.WithLabelValues("error").Inc()
-		return nil, fmt.Errorf("decimals: expected u32, got %v", decimalsVal.Type)
+		return nil, 0, fmt.Errorf("decimals: expected u32, got %v", decimalsVal.Type)
 	}
 
 	rows := make([]blenddata.OraclePrice, 0, len(targets))
 	var errs []error
+	var oldestAge int64
 	for _, target := range targets {
 		assetArg, buildErr := buildSep40StellarAsset(string(target.AssetContractID))
 		if buildErr != nil {
@@ -216,6 +255,17 @@ func (s *PriceSnapshotService) snapshotOracle(ctx context.Context, oracle string
 			s.metrics.FetchesTotal.WithLabelValues("none").Inc()
 			continue
 		}
+		if priceData.Price.Sign() <= 0 {
+			s.metrics.FetchesTotal.WithLabelValues("invalid").Inc()
+			continue
+		}
+		if age := now - int64(priceData.Timestamp); age > oldestAge {
+			oldestAge = age
+		}
+		if int64(priceData.Timestamp) < now-int64(maxPriceAge/time.Second) {
+			s.metrics.FetchesTotal.WithLabelValues("stale").Inc()
+			continue
+		}
 
 		s.metrics.FetchesTotal.WithLabelValues("success").Inc()
 		rows = append(rows, blenddata.OraclePrice{
@@ -227,7 +277,7 @@ func (s *PriceSnapshotService) snapshotOracle(ctx context.Context, oracle string
 		})
 	}
 
-	return rows, errors.Join(errs...)
+	return rows, oldestAge, errors.Join(errs...)
 }
 
 // snapshotComet derives the BLND and Comet LP-share USD prices from the

--- a/internal/services/blend/prices.go
+++ b/internal/services/blend/prices.go
@@ -194,13 +194,14 @@ func (s *PriceSnapshotService) SnapshotOnce(ctx context.Context) error {
 		}
 	}
 
-	s.metrics.PricesTracked.Set(float64(len(rows)))
-
+	written := len(rows)
 	if len(rows) > 0 {
 		if upsertErr := s.oraclePrices.BatchUpsert(ctx, rows); upsertErr != nil {
 			errs = append(errs, fmt.Errorf("blend: price snapshot: persisting %d rows: %w", len(rows), upsertErr))
+			written = 0
 		}
 	}
+	s.metrics.PricesTracked.Set(float64(written))
 
 	return errors.Join(errs...)
 }
@@ -213,8 +214,9 @@ func (s *PriceSnapshotService) SnapshotOnce(ctx context.Context) error {
 // it — but is isolated to this oracle by the caller. A single target's
 // lastprice failure is isolated to that target: the rest of this oracle's
 // targets are still attempted. The second return value is the age in
-// seconds of the oldest price decoded (including skipped-as-stale ones —
-// that growth is the dead-oracle signal the gauge exists for).
+// seconds of the oldest positive price decoded (including skipped-as-stale
+// ones — that growth is the dead-oracle signal the gauge exists for;
+// invalid ≤ 0 prices are excluded, their timestamps mean nothing).
 func (s *PriceSnapshotService) snapshotOracle(ctx context.Context, oracle string, targets []blenddata.PriceTarget, now int64) ([]blenddata.OraclePrice, int64, error) {
 	decimalsVal, err := s.metadata.FetchSingleField(ctx, oracle, "decimals")
 	if err != nil {

--- a/internal/services/blend/prices_test.go
+++ b/internal/services/blend/prices_test.go
@@ -1,0 +1,363 @@
+// Unit tests for PriceSnapshotService. These exercise the real
+// blenddata.OraclePriceModel against a PostgreSQL test database (dbtest,
+// mirroring internal/data/blend/oracle_prices_test.go's fixture usage) and a
+// mocked services.ContractMetadataService — no real RPC.
+package blend
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stellar/go-stellar-sdk/xdr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	blenddata "github.com/stellar/wallet-backend/internal/data/blend"
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+	"github.com/stellar/wallet-backend/internal/services"
+)
+
+// newPriceSnapshotFixture opens an isolated test database (migrations
+// applied) and wraps it in a real OraclePriceModel, mirroring
+// internal/data/blend/oracle_prices_test.go's newOraclePricesFixture.
+func newPriceSnapshotFixture(t *testing.T) (context.Context, *pgxpool.Pool, *blenddata.OraclePriceModel, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	dbt := dbtest.Open(t)
+	pool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+
+	m := &blenddata.OraclePriceModel{
+		DB:      pool,
+		Metrics: metrics.NewMetrics(prometheus.NewRegistry()).DB,
+	}
+
+	cleanup := func() {
+		pool.Close()
+		dbt.Close()
+	}
+	return ctx, pool, m, cleanup
+}
+
+// insertBlendPool seeds a blend_pools row wiring poolAddr to oracleAddr, the
+// minimum blend_pools shape GetPriceTargets' join needs.
+func insertBlendPool(t *testing.T, ctx context.Context, pool *pgxpool.Pool, poolAddr, oracleAddr string) {
+	t.Helper()
+	_, err := pool.Exec(ctx, `
+		INSERT INTO blend_pools (pool_contract_id, oracle_contract_id, last_modified_ledger)
+		VALUES ($1, $2, 1)
+	`, types.AddressBytea(poolAddr), types.AddressBytea(oracleAddr))
+	require.NoError(t, err)
+}
+
+// insertBlendReserve seeds a blend_reserves row for (poolAddr, assetAddr).
+// Only pool_contract_id/reserve_index/asset_contract_id matter to
+// GetPriceTargets; other NOT NULL columns get harmless defaults.
+func insertBlendReserve(t *testing.T, ctx context.Context, pool *pgxpool.Pool, poolAddr, assetAddr string, reserveIndex int32) {
+	t.Helper()
+	_, err := pool.Exec(ctx, `
+		INSERT INTO blend_reserves (
+			pool_contract_id, reserve_index, asset_contract_id,
+			b_rate, d_rate, b_supply, d_supply, ir_mod, backstop_credit,
+			last_time, decimals, c_factor, l_factor, util, max_util,
+			r_base, r_one, r_two, r_three, reactivity, supply_cap, enabled,
+			last_modified_ledger
+		) VALUES (
+			$1, $2, $3,
+			'1', '1', '0', '0', '0', '0',
+			0, 7, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, '0', true,
+			0
+		)
+	`, types.AddressBytea(poolAddr), reserveIndex, types.AddressBytea(assetAddr))
+	require.NoError(t, err)
+}
+
+// getOraclePriceRow reads back one blend_oracle_prices row, if present.
+func getOraclePriceRow(t *testing.T, ctx context.Context, pool *pgxpool.Pool, oracleAddr, assetAddr string) (blenddata.OraclePrice, bool) {
+	t.Helper()
+	var row blenddata.OraclePrice
+	err := pool.QueryRow(ctx, `
+		SELECT price, price_decimals, price_timestamp
+		FROM blend_oracle_prices WHERE oracle_contract_id = $1 AND asset_contract_id = $2
+	`, types.AddressBytea(oracleAddr), types.AddressBytea(assetAddr)).Scan(
+		&row.Price, &row.PriceDecimals, &row.PriceTimestamp,
+	)
+	if err != nil {
+		return blenddata.OraclePrice{}, false
+	}
+	return row, true
+}
+
+func countOraclePriceRows(t *testing.T, ctx context.Context, pool *pgxpool.Pool) int {
+	t.Helper()
+	var n int
+	require.NoError(t, pool.QueryRow(ctx, `SELECT COUNT(*) FROM blend_oracle_prices`).Scan(&n))
+	return n
+}
+
+// priceDataScVal builds the Some(PriceData) ScVal a SEP-40 lastprice(asset)
+// call returns: an ScMap with field-name Symbol keys "price"/"timestamp",
+// mirroring TestDecodePriceData's fixtures in scval_test.go.
+func priceDataScVal(price int64, timestamp uint64) xdr.ScVal {
+	v := xdr.ScVal{Type: xdr.ScValTypeScvMap}
+	m := mapScVal(
+		xdr.ScMapEntry{Key: symScVal("price"), Val: i128ScVal(price)},
+		xdr.ScMapEntry{Key: symScVal("timestamp"), Val: u64ScVal(timestamp)},
+	)
+	v.Map = &m
+	return v
+}
+
+func newTestSnapshotService(t *testing.T, oraclePrices *blenddata.OraclePriceModel, meta services.ContractMetadataService, cometID string, bpm *metrics.BlendPriceMetrics) *PriceSnapshotService {
+	t.Helper()
+	svc, err := NewPriceSnapshotService(PriceSnapshotConfig{
+		OraclePrices:         oraclePrices,
+		Metadata:             meta,
+		Interval:             time.Minute,
+		BackstopLPContractID: cometID,
+		Metrics:              bpm,
+	})
+	require.NoError(t, err)
+	return svc
+}
+
+func TestNewPriceSnapshotService_Validation(t *testing.T) {
+	_, _, oraclePrices, cleanup := newPriceSnapshotFixture(t)
+	defer cleanup()
+	meta := services.NewContractMetadataServiceMock(t)
+	bpm := metrics.NewMetrics(prometheus.NewRegistry()).BlendPrices
+
+	t.Run("requires OraclePrices", func(t *testing.T) {
+		_, err := NewPriceSnapshotService(PriceSnapshotConfig{Metadata: meta, Interval: time.Minute, Metrics: bpm})
+		assert.Error(t, err)
+	})
+	t.Run("requires Metadata", func(t *testing.T) {
+		_, err := NewPriceSnapshotService(PriceSnapshotConfig{OraclePrices: oraclePrices, Interval: time.Minute, Metrics: bpm})
+		assert.Error(t, err)
+	})
+	t.Run("requires a positive Interval", func(t *testing.T) {
+		_, err := NewPriceSnapshotService(PriceSnapshotConfig{OraclePrices: oraclePrices, Metadata: meta, Metrics: bpm})
+		assert.Error(t, err)
+	})
+	t.Run("requires Metrics", func(t *testing.T) {
+		_, err := NewPriceSnapshotService(PriceSnapshotConfig{OraclePrices: oraclePrices, Metadata: meta, Interval: time.Minute})
+		assert.Error(t, err)
+	})
+	t.Run("BackstopLPContractID is optional", func(t *testing.T) {
+		svc, err := NewPriceSnapshotService(PriceSnapshotConfig{OraclePrices: oraclePrices, Metadata: meta, Interval: time.Minute, Metrics: bpm})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+	})
+}
+
+// TestSnapshotOnce_ReserveAssets covers the common path: two oracles, one
+// backing two pool reserves' assets and the other backing one, each fetched
+// and persisted correctly.
+func TestSnapshotOnce_ReserveAssets(t *testing.T) {
+	ctx, pool, oraclePrices, cleanup := newPriceSnapshotFixture(t)
+	defer cleanup()
+
+	oracle1 := randomContractAddr(t)
+	oracle2 := randomContractAddr(t)
+	poolA := randomContractAddr(t)
+	poolB := randomContractAddr(t)
+	assetX := randomContractAddr(t)
+	assetY := randomContractAddr(t)
+	assetZ := randomContractAddr(t)
+
+	insertBlendPool(t, ctx, pool, poolA, oracle1)
+	insertBlendReserve(t, ctx, pool, poolA, assetX, 0)
+	insertBlendReserve(t, ctx, pool, poolA, assetY, 1)
+	insertBlendPool(t, ctx, pool, poolB, oracle2)
+	insertBlendReserve(t, ctx, pool, poolB, assetZ, 0)
+
+	assetXArg, err := buildSep40StellarAsset(assetX)
+	require.NoError(t, err)
+	assetYArg, err := buildSep40StellarAsset(assetY)
+	require.NoError(t, err)
+	assetZArg, err := buildSep40StellarAsset(assetZ)
+	require.NoError(t, err)
+
+	meta := services.NewContractMetadataServiceMock(t)
+	meta.On("FetchSingleField", mock.Anything, oracle1, "decimals", []xdr.ScVal(nil)).
+		Return(u32ScVal(7), nil).Once()
+	meta.On("FetchSingleField", mock.Anything, oracle1, "lastprice", []xdr.ScVal{assetXArg}).
+		Return(priceDataScVal(100_000_000, 1_700_000_000), nil).Once()
+	meta.On("FetchSingleField", mock.Anything, oracle1, "lastprice", []xdr.ScVal{assetYArg}).
+		Return(priceDataScVal(200_000_000, 1_700_000_001), nil).Once()
+	meta.On("FetchSingleField", mock.Anything, oracle2, "decimals", []xdr.ScVal(nil)).
+		Return(u32ScVal(14), nil).Once()
+	meta.On("FetchSingleField", mock.Anything, oracle2, "lastprice", []xdr.ScVal{assetZArg}).
+		Return(priceDataScVal(300_000_000, 1_700_000_002), nil).Once()
+
+	bpm := metrics.NewMetrics(prometheus.NewRegistry()).BlendPrices
+	svc := newTestSnapshotService(t, oraclePrices, meta, "", bpm)
+
+	require.NoError(t, svc.SnapshotOnce(ctx))
+
+	rowX, ok := getOraclePriceRow(t, ctx, pool, oracle1, assetX)
+	require.True(t, ok)
+	assert.Equal(t, "100000000", rowX.Price)
+	assert.Equal(t, int32(7), rowX.PriceDecimals)
+	assert.Equal(t, int64(1_700_000_000), rowX.PriceTimestamp)
+
+	rowY, ok := getOraclePriceRow(t, ctx, pool, oracle1, assetY)
+	require.True(t, ok)
+	assert.Equal(t, "200000000", rowY.Price)
+	assert.Equal(t, int32(7), rowY.PriceDecimals)
+
+	rowZ, ok := getOraclePriceRow(t, ctx, pool, oracle2, assetZ)
+	require.True(t, ok)
+	assert.Equal(t, "300000000", rowZ.Price)
+	assert.Equal(t, int32(14), rowZ.PriceDecimals)
+
+	assert.Equal(t, 3, countOraclePriceRows(t, ctx, pool))
+	assert.Equal(t, 3.0, testutil.ToFloat64(bpm.FetchesTotal.WithLabelValues("success")))
+	assert.Equal(t, 3.0, testutil.ToFloat64(bpm.PricesTracked))
+}
+
+// TestSnapshotOnce_NonePriceSkipped covers a SEP-40 Option::None response
+// (ScvVoid): no row is written, no error is raised, and the "none" fetch
+// outcome is counted.
+func TestSnapshotOnce_NonePriceSkipped(t *testing.T) {
+	ctx, pool, oraclePrices, cleanup := newPriceSnapshotFixture(t)
+	defer cleanup()
+
+	oracle := randomContractAddr(t)
+	poolA := randomContractAddr(t)
+	asset := randomContractAddr(t)
+	insertBlendPool(t, ctx, pool, poolA, oracle)
+	insertBlendReserve(t, ctx, pool, poolA, asset, 0)
+
+	assetArg, err := buildSep40StellarAsset(asset)
+	require.NoError(t, err)
+
+	meta := services.NewContractMetadataServiceMock(t)
+	meta.On("FetchSingleField", mock.Anything, oracle, "decimals", []xdr.ScVal(nil)).
+		Return(u32ScVal(7), nil).Once()
+	meta.On("FetchSingleField", mock.Anything, oracle, "lastprice", []xdr.ScVal{assetArg}).
+		Return(voidScVal(), nil).Once()
+
+	bpm := metrics.NewMetrics(prometheus.NewRegistry()).BlendPrices
+	svc := newTestSnapshotService(t, oraclePrices, meta, "", bpm)
+
+	require.NoError(t, svc.SnapshotOnce(ctx))
+
+	_, ok := getOraclePriceRow(t, ctx, pool, oracle, asset)
+	assert.False(t, ok, "no row should be written for a None price")
+	assert.Equal(t, 0, countOraclePriceRows(t, ctx, pool))
+	assert.Equal(t, 1.0, testutil.ToFloat64(bpm.FetchesTotal.WithLabelValues("none")))
+	assert.Equal(t, 0.0, testutil.ToFloat64(bpm.PricesTracked))
+}
+
+// TestSnapshotOnce_OracleErrorIsolated covers one oracle's failure not
+// preventing another oracle's rows from being persisted.
+func TestSnapshotOnce_OracleErrorIsolated(t *testing.T) {
+	ctx, pool, oraclePrices, cleanup := newPriceSnapshotFixture(t)
+	defer cleanup()
+
+	oracleBad := randomContractAddr(t)
+	oracleGood := randomContractAddr(t)
+	poolBad := randomContractAddr(t)
+	poolGood := randomContractAddr(t)
+	assetBad := randomContractAddr(t)
+	assetGood := randomContractAddr(t)
+
+	insertBlendPool(t, ctx, pool, poolBad, oracleBad)
+	insertBlendReserve(t, ctx, pool, poolBad, assetBad, 0)
+	insertBlendPool(t, ctx, pool, poolGood, oracleGood)
+	insertBlendReserve(t, ctx, pool, poolGood, assetGood, 0)
+
+	assetGoodArg, err := buildSep40StellarAsset(assetGood)
+	require.NoError(t, err)
+
+	meta := services.NewContractMetadataServiceMock(t)
+	meta.On("FetchSingleField", mock.Anything, oracleBad, "decimals", []xdr.ScVal(nil)).
+		Return(xdr.ScVal{}, assert.AnError).Once()
+	meta.On("FetchSingleField", mock.Anything, oracleGood, "decimals", []xdr.ScVal(nil)).
+		Return(u32ScVal(7), nil).Once()
+	meta.On("FetchSingleField", mock.Anything, oracleGood, "lastprice", []xdr.ScVal{assetGoodArg}).
+		Return(priceDataScVal(500_000_000, 1_700_000_000), nil).Once()
+
+	bpm := metrics.NewMetrics(prometheus.NewRegistry()).BlendPrices
+	svc := newTestSnapshotService(t, oraclePrices, meta, "", bpm)
+
+	err = svc.SnapshotOnce(ctx)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, oracleBad)
+
+	_, ok := getOraclePriceRow(t, ctx, pool, oracleBad, assetBad)
+	assert.False(t, ok, "the failing oracle's target must not have a row")
+
+	rowGood, ok := getOraclePriceRow(t, ctx, pool, oracleGood, assetGood)
+	require.True(t, ok, "the healthy oracle's row must still persist")
+	assert.Equal(t, "500000000", rowGood.Price)
+
+	assert.Equal(t, 1, countOraclePriceRows(t, ctx, pool))
+}
+
+// TestSnapshotOnce_CometLeg covers the optional BLND/LP-share derived-pricing
+// leg: when BackstopLPContractID is configured, fetchCometState's getters are
+// called and two rows are written under oracle_contract_id = the Comet pool
+// address — the BLND row keyed by the real BLND token address, the LP-share
+// row self-priced (asset_contract_id == oracle_contract_id).
+func TestSnapshotOnce_CometLeg(t *testing.T) {
+	ctx, pool, oraclePrices, cleanup := newPriceSnapshotFixture(t)
+	defer cleanup()
+
+	cometID := randomContractAddr(t)
+	blndAddr := randomContractAddr(t)
+	usdcAddr := randomContractAddr(t)
+
+	blndArg, err := contractAddressScVal(blndAddr)
+	require.NoError(t, err)
+	usdcArg, err := contractAddressScVal(usdcAddr)
+	require.NoError(t, err)
+
+	meta := services.NewContractMetadataServiceMock(t)
+	meta.On("FetchSingleField", mock.Anything, cometID, "get_tokens", []xdr.ScVal(nil)).
+		Return(vecScVal(contractAddrScVal(t, blndAddr), contractAddrScVal(t, usdcAddr)), nil).Once()
+	meta.On("FetchSingleField", mock.Anything, cometID, "get_balance", []xdr.ScVal{blndArg}).
+		Return(i128ScVal(40_000_000_000_000), nil).Once() // 4,000,000.0000000
+	meta.On("FetchSingleField", mock.Anything, cometID, "get_balance", []xdr.ScVal{usdcArg}).
+		Return(i128ScVal(2_000_000_000_000), nil).Once() // 200,000.0000000
+	meta.On("FetchSingleField", mock.Anything, cometID, "get_normalized_weight", []xdr.ScVal{blndArg}).
+		Return(i128ScVal(8_000_000), nil).Once() // 0.8
+	meta.On("FetchSingleField", mock.Anything, cometID, "get_normalized_weight", []xdr.ScVal{usdcArg}).
+		Return(i128ScVal(2_000_000), nil).Once() // 0.2
+	meta.On("FetchSingleField", mock.Anything, cometID, "get_total_supply", []xdr.ScVal(nil)).
+		Return(i128ScVal(10_000_000_000_000), nil).Once() // 1,000,000.0000000
+
+	bpm := metrics.NewMetrics(prometheus.NewRegistry()).BlendPrices
+	svc := newTestSnapshotService(t, oraclePrices, meta, cometID, bpm)
+
+	require.NoError(t, svc.SnapshotOnce(ctx))
+
+	blndRow, ok := getOraclePriceRow(t, ctx, pool, cometID, blndAddr)
+	require.True(t, ok, "expected a BLND leg row keyed by the BLND token address")
+	assert.Equal(t, "2000000", blndRow.Price)
+	assert.Equal(t, int32(7), blndRow.PriceDecimals)
+
+	lpRow, ok := getOraclePriceRow(t, ctx, pool, cometID, cometID)
+	require.True(t, ok, "expected a self-priced LP-share row")
+	assert.Equal(t, "10000000", lpRow.Price)
+	assert.Equal(t, int32(7), lpRow.PriceDecimals)
+
+	assert.Equal(t, 2, countOraclePriceRows(t, ctx, pool))
+	assert.Equal(t, 2.0, testutil.ToFloat64(bpm.FetchesTotal.WithLabelValues("success")))
+	assert.Equal(t, 2.0, testutil.ToFloat64(bpm.PricesTracked))
+
+	now := time.Now().Unix()
+	assert.InDelta(t, now, blndRow.PriceTimestamp, 5, "BLND row timestamp should be ~now, not an oracle-reported one")
+	assert.InDelta(t, now, lpRow.PriceTimestamp, 5, "LP row timestamp should be ~now, not an oracle-reported one")
+}

--- a/internal/services/blend/prices_test.go
+++ b/internal/services/blend/prices_test.go
@@ -234,6 +234,45 @@ func TestSnapshotOnce_ReserveAssets(t *testing.T) {
 		"oldest-price-age gauge should reflect the oldest oracle-reported timestamp")
 }
 
+// TestSnapshotOnce_UpsertFailureZeroesPricesTracked covers a BatchUpsert
+// failure: the pass reports the error, and the prices-tracked gauge reads 0 —
+// it counts rows actually written, not rows collected.
+func TestSnapshotOnce_UpsertFailureZeroesPricesTracked(t *testing.T) {
+	ctx, pool, oraclePrices, cleanup := newPriceSnapshotFixture(t)
+	defer cleanup()
+
+	oracle := randomContractAddr(t)
+	poolA := randomContractAddr(t)
+	asset := randomContractAddr(t)
+	insertBlendPool(t, ctx, pool, poolA, oracle)
+	insertBlendReserve(t, ctx, pool, poolA, asset, 0)
+
+	assetArg, err := buildSep40StellarAsset(asset)
+	require.NoError(t, err)
+
+	meta := services.NewContractMetadataServiceMock(t)
+	meta.On("FetchSingleField", mock.Anything, oracle, "decimals", []xdr.ScVal(nil)).
+		Return(u32ScVal(7), nil).Once()
+	meta.On("FetchSingleField", mock.Anything, oracle, "lastprice", []xdr.ScVal{assetArg}).
+		Return(priceDataScVal(100_000_000, uint64(time.Now().Unix())), nil).Once()
+
+	// Sabotage the upsert target after target discovery's tables are seeded:
+	// GetPriceTargets reads blend_pools/blend_reserves and still succeeds.
+	_, err = pool.Exec(ctx, `DROP TABLE blend_oracle_prices`)
+	require.NoError(t, err)
+
+	bpm := metrics.NewMetrics(prometheus.NewRegistry()).BlendPrices
+	svc := newTestSnapshotService(t, oraclePrices, meta, "", bpm)
+
+	err = svc.SnapshotOnce(ctx)
+	require.ErrorContains(t, err, "persisting 1 rows")
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(bpm.FetchesTotal.WithLabelValues("success")),
+		"the fetch itself succeeded — only persistence failed")
+	assert.Equal(t, 0.0, testutil.ToFloat64(bpm.PricesTracked),
+		"nothing was written, so the gauge must not report collected rows")
+}
+
 // TestSnapshotOnce_NonePriceSkipped covers a SEP-40 Option::None response
 // (ScvVoid): no row is written, no error is raised, and the "none" fetch
 // outcome is counted.

--- a/internal/services/blend/prices_test.go
+++ b/internal/services/blend/prices_test.go
@@ -1,11 +1,12 @@
 // Unit tests for PriceSnapshotService. These exercise the real
 // blenddata.OraclePriceModel against a PostgreSQL test database (dbtest,
-// mirroring internal/data/blend/oracle_prices_test.go's fixture usage) and a
-// mocked services.ContractMetadataService — no real RPC.
+// mirroring internal/data/blend/oracle_prices_test.go's fixture usage) and
+// mocked services.ContractMetadataService/RPCService — no real RPC.
 package blend
 
 import (
 	"context"
+	"math/big"
 	"testing"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	blenddata "github.com/stellar/wallet-backend/internal/data/blend"
 	"github.com/stellar/wallet-backend/internal/db"
 	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/entities"
 	"github.com/stellar/wallet-backend/internal/indexer/types"
 	"github.com/stellar/wallet-backend/internal/metrics"
 	"github.com/stellar/wallet-backend/internal/services"
@@ -118,13 +120,14 @@ func priceDataScVal(price int64, timestamp uint64) xdr.ScVal {
 	return v
 }
 
-func newTestSnapshotService(t *testing.T, oraclePrices *blenddata.OraclePriceModel, meta services.ContractMetadataService, cometID string, bpm *metrics.BlendPriceMetrics) *PriceSnapshotService {
+func newTestSnapshotService(t *testing.T, oraclePrices *blenddata.OraclePriceModel, meta services.ContractMetadataService, cometID string, rpc services.RPCService, bpm *metrics.BlendPriceMetrics) *PriceSnapshotService {
 	t.Helper()
 	svc, err := NewPriceSnapshotService(PriceSnapshotConfig{
 		OraclePrices:         oraclePrices,
 		Metadata:             meta,
 		Interval:             time.Minute,
 		BackstopLPContractID: cometID,
+		RPC:                  rpc,
 		Metrics:              bpm,
 	})
 	require.NoError(t, err)
@@ -157,6 +160,10 @@ func TestNewPriceSnapshotService_Validation(t *testing.T) {
 		svc, err := NewPriceSnapshotService(PriceSnapshotConfig{OraclePrices: oraclePrices, Metadata: meta, Interval: time.Minute, Metrics: bpm})
 		require.NoError(t, err)
 		require.NotNil(t, svc)
+	})
+	t.Run("requires RPC when BackstopLPContractID is set", func(t *testing.T) {
+		_, err := NewPriceSnapshotService(PriceSnapshotConfig{OraclePrices: oraclePrices, Metadata: meta, Interval: time.Minute, BackstopLPContractID: randomContractAddr(t), Metrics: bpm})
+		assert.ErrorContains(t, err, "RPC is required")
 	})
 }
 
@@ -207,7 +214,7 @@ func TestSnapshotOnce_ReserveAssets(t *testing.T) {
 		Return(priceDataScVal(300_000_000, tsZ), nil).Once()
 
 	bpm := metrics.NewMetrics(prometheus.NewRegistry()).BlendPrices
-	svc := newTestSnapshotService(t, oraclePrices, meta, "", bpm)
+	svc := newTestSnapshotService(t, oraclePrices, meta, "", nil, bpm)
 
 	require.NoError(t, svc.SnapshotOnce(ctx))
 
@@ -262,7 +269,7 @@ func TestSnapshotOnce_UpsertFailureZeroesPricesTracked(t *testing.T) {
 	require.NoError(t, err)
 
 	bpm := metrics.NewMetrics(prometheus.NewRegistry()).BlendPrices
-	svc := newTestSnapshotService(t, oraclePrices, meta, "", bpm)
+	svc := newTestSnapshotService(t, oraclePrices, meta, "", nil, bpm)
 
 	err = svc.SnapshotOnce(ctx)
 	require.ErrorContains(t, err, "persisting 1 rows")
@@ -296,7 +303,7 @@ func TestSnapshotOnce_NonePriceSkipped(t *testing.T) {
 		Return(voidScVal(), nil).Once()
 
 	bpm := metrics.NewMetrics(prometheus.NewRegistry()).BlendPrices
-	svc := newTestSnapshotService(t, oraclePrices, meta, "", bpm)
+	svc := newTestSnapshotService(t, oraclePrices, meta, "", nil, bpm)
 
 	require.NoError(t, svc.SnapshotOnce(ctx))
 
@@ -339,7 +346,7 @@ func TestSnapshotOnce_StalePriceSkipped(t *testing.T) {
 		Return(priceDataScVal(200_000_000, uint64(time.Now().Unix()-staleAge)), nil).Once()
 
 	bpm := metrics.NewMetrics(prometheus.NewRegistry()).BlendPrices
-	svc := newTestSnapshotService(t, oraclePrices, meta, "", bpm)
+	svc := newTestSnapshotService(t, oraclePrices, meta, "", nil, bpm)
 
 	require.NoError(t, svc.SnapshotOnce(ctx))
 
@@ -427,7 +434,7 @@ func TestSnapshotOnce_NonPositivePriceSkipped(t *testing.T) {
 		Return(priceDataScVal(-5, uint64(time.Now().Unix())), nil).Once()
 
 	bpm := metrics.NewMetrics(prometheus.NewRegistry()).BlendPrices
-	svc := newTestSnapshotService(t, oraclePrices, meta, "", bpm)
+	svc := newTestSnapshotService(t, oraclePrices, meta, "", nil, bpm)
 
 	require.NoError(t, svc.SnapshotOnce(ctx))
 
@@ -466,7 +473,7 @@ func TestSnapshotOnce_OracleErrorIsolated(t *testing.T) {
 		Return(priceDataScVal(500_000_000, uint64(time.Now().Unix())), nil).Once()
 
 	bpm := metrics.NewMetrics(prometheus.NewRegistry()).BlendPrices
-	svc := newTestSnapshotService(t, oraclePrices, meta, "", bpm)
+	svc := newTestSnapshotService(t, oraclePrices, meta, "", nil, bpm)
 
 	err = svc.SnapshotOnce(ctx)
 	require.Error(t, err)
@@ -483,8 +490,8 @@ func TestSnapshotOnce_OracleErrorIsolated(t *testing.T) {
 }
 
 // TestSnapshotOnce_CometLeg covers the optional BLND/LP-share derived-pricing
-// leg: when BackstopLPContractID is configured, fetchCometState's getters are
-// called and two rows are written under oracle_contract_id = the Comet pool
+// leg: when BackstopLPContractID is configured, fetchCometState reads the
+// pool's ledger entries and two rows are written under oracle_contract_id = the Comet pool
 // address — the BLND row keyed by the real BLND token address, the LP-share
 // row self-priced (asset_contract_id == oracle_contract_id).
 func TestSnapshotOnce_CometLeg(t *testing.T) {
@@ -495,29 +502,26 @@ func TestSnapshotOnce_CometLeg(t *testing.T) {
 	blndAddr := randomContractAddr(t)
 	usdcAddr := randomContractAddr(t)
 
-	blndArg, err := contractAddressScVal(blndAddr)
-	require.NoError(t, err)
-	usdcArg, err := contractAddressScVal(usdcAddr)
-	require.NoError(t, err)
-
+	// One atomic getLedgerEntries read serves the whole Comet leg: the
+	// instance (WASM hash check), the AllRecordData record map, and
+	// TotalShares — mirroring the live mainnet entry dump in comet.go.
 	meta := services.NewContractMetadataServiceMock(t)
-	meta.On("FetchSingleField", mock.Anything, cometID, "get_tokens", []xdr.ScVal(nil)).
-		Return(vecScVal(contractAddrScVal(t, blndAddr), contractAddrScVal(t, usdcAddr)), nil).Once()
-	// The numeric getters are each fetched twice: fetchCometState's torn-read
-	// guard requires two agreeing consistency reads.
-	meta.On("FetchSingleField", mock.Anything, cometID, "get_balance", []xdr.ScVal{blndArg}).
-		Return(i128ScVal(40_000_000_000_000), nil).Times(2) // 4,000,000.0000000
-	meta.On("FetchSingleField", mock.Anything, cometID, "get_balance", []xdr.ScVal{usdcArg}).
-		Return(i128ScVal(2_000_000_000_000), nil).Times(2) // 200,000.0000000
-	meta.On("FetchSingleField", mock.Anything, cometID, "get_normalized_weight", []xdr.ScVal{blndArg}).
-		Return(i128ScVal(8_000_000), nil).Times(2) // 0.8
-	meta.On("FetchSingleField", mock.Anything, cometID, "get_normalized_weight", []xdr.ScVal{usdcArg}).
-		Return(i128ScVal(2_000_000), nil).Times(2) // 0.2
-	meta.On("FetchSingleField", mock.Anything, cometID, "get_total_supply", []xdr.ScVal(nil)).
-		Return(i128ScVal(10_000_000_000_000), nil).Times(2) // 1,000,000.0000000
+	entries := []entities.LedgerEntryResult{
+		cometEntryResult(t, cometID, xdr.ScVal{Type: xdr.ScValTypeScvLedgerKeyContractInstance}, cometInstanceVal(t, cometWasmHash)),
+		cometEntryResult(t, cometID, cometUnitKeyScVal("AllRecordData"), cometRecordMapVal(t,
+			[]string{blndAddr, usdcAddr},
+			[]xdr.ScVal{
+				cometRecordVal(t, big.NewInt(40_000_000_000_000), big.NewInt(8_000_000), 100_000_000_000, 0), // 4,000,000.0 BLND, weight 0.8
+				cometRecordVal(t, big.NewInt(2_000_000_000_000), big.NewInt(2_000_000), 100_000_000_000, 1),  // 200,000.0 USDC, weight 0.2
+			})),
+		cometEntryResult(t, cometID, cometUnitKeyScVal("TotalShares"), i128ScVal(10_000_000_000_000)), // 1,000,000.0 shares
+	}
+	rpc := services.NewRPCServiceMock(t)
+	rpc.On("GetLedgerEntries", mock.MatchedBy(func(keys []string) bool { return len(keys) == 3 })).
+		Return(entities.RPCGetLedgerEntriesResult{LatestLedger: 1, Entries: entries}, nil).Once()
 
 	bpm := metrics.NewMetrics(prometheus.NewRegistry()).BlendPrices
-	svc := newTestSnapshotService(t, oraclePrices, meta, cometID, bpm)
+	svc := newTestSnapshotService(t, oraclePrices, meta, cometID, rpc, bpm)
 
 	require.NoError(t, svc.SnapshotOnce(ctx))
 

--- a/internal/services/blend/prices_test.go
+++ b/internal/services/blend/prices_test.go
@@ -188,17 +188,23 @@ func TestSnapshotOnce_ReserveAssets(t *testing.T) {
 	assetZArg, err := buildSep40StellarAsset(assetZ)
 	require.NoError(t, err)
 
+	// Oracle-reported timestamps must be recent: SnapshotOnce skips prices
+	// older than maxPriceAge against the wall clock.
+	tsX := uint64(time.Now().Unix() - 60)
+	tsY := tsX + 1
+	tsZ := tsX + 2
+
 	meta := services.NewContractMetadataServiceMock(t)
 	meta.On("FetchSingleField", mock.Anything, oracle1, "decimals", []xdr.ScVal(nil)).
 		Return(u32ScVal(7), nil).Once()
 	meta.On("FetchSingleField", mock.Anything, oracle1, "lastprice", []xdr.ScVal{assetXArg}).
-		Return(priceDataScVal(100_000_000, 1_700_000_000), nil).Once()
+		Return(priceDataScVal(100_000_000, tsX), nil).Once()
 	meta.On("FetchSingleField", mock.Anything, oracle1, "lastprice", []xdr.ScVal{assetYArg}).
-		Return(priceDataScVal(200_000_000, 1_700_000_001), nil).Once()
+		Return(priceDataScVal(200_000_000, tsY), nil).Once()
 	meta.On("FetchSingleField", mock.Anything, oracle2, "decimals", []xdr.ScVal(nil)).
 		Return(u32ScVal(14), nil).Once()
 	meta.On("FetchSingleField", mock.Anything, oracle2, "lastprice", []xdr.ScVal{assetZArg}).
-		Return(priceDataScVal(300_000_000, 1_700_000_002), nil).Once()
+		Return(priceDataScVal(300_000_000, tsZ), nil).Once()
 
 	bpm := metrics.NewMetrics(prometheus.NewRegistry()).BlendPrices
 	svc := newTestSnapshotService(t, oraclePrices, meta, "", bpm)
@@ -209,7 +215,7 @@ func TestSnapshotOnce_ReserveAssets(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "100000000", rowX.Price)
 	assert.Equal(t, int32(7), rowX.PriceDecimals)
-	assert.Equal(t, int64(1_700_000_000), rowX.PriceTimestamp)
+	assert.Equal(t, int64(tsX), rowX.PriceTimestamp)
 
 	rowY, ok := getOraclePriceRow(t, ctx, pool, oracle1, assetY)
 	require.True(t, ok)
@@ -224,6 +230,8 @@ func TestSnapshotOnce_ReserveAssets(t *testing.T) {
 	assert.Equal(t, 3, countOraclePriceRows(t, ctx, pool))
 	assert.Equal(t, 3.0, testutil.ToFloat64(bpm.FetchesTotal.WithLabelValues("success")))
 	assert.Equal(t, 3.0, testutil.ToFloat64(bpm.PricesTracked))
+	assert.InDelta(t, 60, testutil.ToFloat64(bpm.OldestPriceAge), 5,
+		"oldest-price-age gauge should reflect the oldest oracle-reported timestamp")
 }
 
 // TestSnapshotOnce_NonePriceSkipped covers a SEP-40 Option::None response
@@ -260,6 +268,135 @@ func TestSnapshotOnce_NonePriceSkipped(t *testing.T) {
 	assert.Equal(t, 0.0, testutil.ToFloat64(bpm.PricesTracked))
 }
 
+// TestSnapshotOnce_StalePriceSkipped covers the staleness guard: a price
+// whose oracle-reported timestamp is older than maxPriceAge is not persisted
+// (the pool contract would reject it anyway), counted as a "stale" fetch
+// outcome, and still drives the oldest-price-age gauge so a dead oracle is
+// observable.
+func TestSnapshotOnce_StalePriceSkipped(t *testing.T) {
+	ctx, pool, oraclePrices, cleanup := newPriceSnapshotFixture(t)
+	defer cleanup()
+
+	oracle := randomContractAddr(t)
+	poolA := randomContractAddr(t)
+	assetFresh := randomContractAddr(t)
+	assetStale := randomContractAddr(t)
+	insertBlendPool(t, ctx, pool, poolA, oracle)
+	insertBlendReserve(t, ctx, pool, poolA, assetFresh, 0)
+	insertBlendReserve(t, ctx, pool, poolA, assetStale, 1)
+
+	assetFreshArg, err := buildSep40StellarAsset(assetFresh)
+	require.NoError(t, err)
+	assetStaleArg, err := buildSep40StellarAsset(assetStale)
+	require.NoError(t, err)
+
+	staleAge := int64(25 * 60 * 60) // 25h, just past the 24h maxPriceAge
+	meta := services.NewContractMetadataServiceMock(t)
+	meta.On("FetchSingleField", mock.Anything, oracle, "decimals", []xdr.ScVal(nil)).
+		Return(u32ScVal(7), nil).Once()
+	meta.On("FetchSingleField", mock.Anything, oracle, "lastprice", []xdr.ScVal{assetFreshArg}).
+		Return(priceDataScVal(100_000_000, uint64(time.Now().Unix())), nil).Once()
+	meta.On("FetchSingleField", mock.Anything, oracle, "lastprice", []xdr.ScVal{assetStaleArg}).
+		Return(priceDataScVal(200_000_000, uint64(time.Now().Unix()-staleAge)), nil).Once()
+
+	bpm := metrics.NewMetrics(prometheus.NewRegistry()).BlendPrices
+	svc := newTestSnapshotService(t, oraclePrices, meta, "", bpm)
+
+	require.NoError(t, svc.SnapshotOnce(ctx))
+
+	_, ok := getOraclePriceRow(t, ctx, pool, oracle, assetFresh)
+	assert.True(t, ok, "the fresh price must persist")
+	_, ok = getOraclePriceRow(t, ctx, pool, oracle, assetStale)
+	assert.False(t, ok, "the stale price must not persist")
+	assert.Equal(t, 1, countOraclePriceRows(t, ctx, pool))
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(bpm.FetchesTotal.WithLabelValues("success")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(bpm.FetchesTotal.WithLabelValues("stale")))
+	assert.InDelta(t, staleAge, testutil.ToFloat64(bpm.OldestPriceAge), 5,
+		"the gauge must include skipped-as-stale prices — that's the dead-oracle signal")
+}
+
+// TestSnapshotOnce_NoDecodedPriceKeepsOldestAgeGauge covers the oldest-price-
+// age gauge's write guard: a pass that decodes no oracle price at all — every
+// fetch failed, or there was nothing to fetch — publishes no value, so the
+// last real reading stands. Writing 0 there would read as "every price is
+// current", the exact inverse of the staleness signal the gauge exists for.
+func TestSnapshotOnce_NoDecodedPriceKeepsOldestAgeGauge(t *testing.T) {
+	ctx, pool, oraclePrices, cleanup := newPriceSnapshotFixture(t)
+	defer cleanup()
+
+	oracle := randomContractAddr(t)
+	poolA := randomContractAddr(t)
+	asset := randomContractAddr(t)
+	insertBlendPool(t, ctx, pool, poolA, oracle)
+	insertBlendReserve(t, ctx, pool, poolA, asset, 0)
+
+	meta := services.NewContractMetadataServiceMock(t)
+	meta.On("FetchSingleField", mock.Anything, oracle, "decimals", []xdr.ScVal(nil)).
+		Return(xdr.ScVal{}, assert.AnError).Once()
+
+	bpm := metrics.NewMetrics(prometheus.NewRegistry()).BlendPrices
+	// Stand in for an earlier pass's reading, which must survive both passes
+	// below.
+	const priorAge = 4242.0
+	bpm.OldestPriceAge.Set(priorAge)
+
+	svc := newTestSnapshotService(t, oraclePrices, meta, "", nil, bpm)
+
+	require.Error(t, svc.SnapshotOnce(ctx), "the failing decimals fetch must surface")
+	assert.Equal(t, 1.0, testutil.ToFloat64(bpm.FetchesTotal.WithLabelValues("error")),
+		"the failure signal belongs on the fetch counter, not the age gauge")
+	assert.Equal(t, priorAge, testutil.ToFloat64(bpm.OldestPriceAge),
+		"a pass whose every fetch failed must leave the gauge alone")
+
+	// Same guard with no targets at all: nothing is fetched, so there is
+	// still nothing to say about staleness.
+	_, err := pool.Exec(ctx, `DELETE FROM blend_reserves`)
+	require.NoError(t, err)
+
+	require.NoError(t, svc.SnapshotOnce(ctx))
+	assert.Equal(t, priorAge, testutil.ToFloat64(bpm.OldestPriceAge),
+		"a pass with no price targets must leave the gauge alone")
+}
+
+// TestSnapshotOnce_NonPositivePriceSkipped covers the validity guard: a zero
+// or negative price is never persisted (the pool contract rejects it) and is
+// counted as an "invalid" fetch outcome, without erroring the pass.
+func TestSnapshotOnce_NonPositivePriceSkipped(t *testing.T) {
+	ctx, pool, oraclePrices, cleanup := newPriceSnapshotFixture(t)
+	defer cleanup()
+
+	oracle := randomContractAddr(t)
+	poolA := randomContractAddr(t)
+	assetZero := randomContractAddr(t)
+	assetNegative := randomContractAddr(t)
+	insertBlendPool(t, ctx, pool, poolA, oracle)
+	insertBlendReserve(t, ctx, pool, poolA, assetZero, 0)
+	insertBlendReserve(t, ctx, pool, poolA, assetNegative, 1)
+
+	assetZeroArg, err := buildSep40StellarAsset(assetZero)
+	require.NoError(t, err)
+	assetNegativeArg, err := buildSep40StellarAsset(assetNegative)
+	require.NoError(t, err)
+
+	meta := services.NewContractMetadataServiceMock(t)
+	meta.On("FetchSingleField", mock.Anything, oracle, "decimals", []xdr.ScVal(nil)).
+		Return(u32ScVal(7), nil).Once()
+	meta.On("FetchSingleField", mock.Anything, oracle, "lastprice", []xdr.ScVal{assetZeroArg}).
+		Return(priceDataScVal(0, uint64(time.Now().Unix())), nil).Once()
+	meta.On("FetchSingleField", mock.Anything, oracle, "lastprice", []xdr.ScVal{assetNegativeArg}).
+		Return(priceDataScVal(-5, uint64(time.Now().Unix())), nil).Once()
+
+	bpm := metrics.NewMetrics(prometheus.NewRegistry()).BlendPrices
+	svc := newTestSnapshotService(t, oraclePrices, meta, "", bpm)
+
+	require.NoError(t, svc.SnapshotOnce(ctx))
+
+	assert.Equal(t, 0, countOraclePriceRows(t, ctx, pool))
+	assert.Equal(t, 2.0, testutil.ToFloat64(bpm.FetchesTotal.WithLabelValues("invalid")))
+	assert.Equal(t, 0.0, testutil.ToFloat64(bpm.PricesTracked))
+}
+
 // TestSnapshotOnce_OracleErrorIsolated covers one oracle's failure not
 // preventing another oracle's rows from being persisted.
 func TestSnapshotOnce_OracleErrorIsolated(t *testing.T) {
@@ -287,7 +424,7 @@ func TestSnapshotOnce_OracleErrorIsolated(t *testing.T) {
 	meta.On("FetchSingleField", mock.Anything, oracleGood, "decimals", []xdr.ScVal(nil)).
 		Return(u32ScVal(7), nil).Once()
 	meta.On("FetchSingleField", mock.Anything, oracleGood, "lastprice", []xdr.ScVal{assetGoodArg}).
-		Return(priceDataScVal(500_000_000, 1_700_000_000), nil).Once()
+		Return(priceDataScVal(500_000_000, uint64(time.Now().Unix())), nil).Once()
 
 	bpm := metrics.NewMetrics(prometheus.NewRegistry()).BlendPrices
 	svc := newTestSnapshotService(t, oraclePrices, meta, "", bpm)

--- a/internal/services/blend/prices_test.go
+++ b/internal/services/blend/prices_test.go
@@ -503,16 +503,18 @@ func TestSnapshotOnce_CometLeg(t *testing.T) {
 	meta := services.NewContractMetadataServiceMock(t)
 	meta.On("FetchSingleField", mock.Anything, cometID, "get_tokens", []xdr.ScVal(nil)).
 		Return(vecScVal(contractAddrScVal(t, blndAddr), contractAddrScVal(t, usdcAddr)), nil).Once()
+	// The numeric getters are each fetched twice: fetchCometState's torn-read
+	// guard requires two agreeing consistency reads.
 	meta.On("FetchSingleField", mock.Anything, cometID, "get_balance", []xdr.ScVal{blndArg}).
-		Return(i128ScVal(40_000_000_000_000), nil).Once() // 4,000,000.0000000
+		Return(i128ScVal(40_000_000_000_000), nil).Times(2) // 4,000,000.0000000
 	meta.On("FetchSingleField", mock.Anything, cometID, "get_balance", []xdr.ScVal{usdcArg}).
-		Return(i128ScVal(2_000_000_000_000), nil).Once() // 200,000.0000000
+		Return(i128ScVal(2_000_000_000_000), nil).Times(2) // 200,000.0000000
 	meta.On("FetchSingleField", mock.Anything, cometID, "get_normalized_weight", []xdr.ScVal{blndArg}).
-		Return(i128ScVal(8_000_000), nil).Once() // 0.8
+		Return(i128ScVal(8_000_000), nil).Times(2) // 0.8
 	meta.On("FetchSingleField", mock.Anything, cometID, "get_normalized_weight", []xdr.ScVal{usdcArg}).
-		Return(i128ScVal(2_000_000), nil).Once() // 0.2
+		Return(i128ScVal(2_000_000), nil).Times(2) // 0.2
 	meta.On("FetchSingleField", mock.Anything, cometID, "get_total_supply", []xdr.ScVal(nil)).
-		Return(i128ScVal(10_000_000_000_000), nil).Once() // 1,000,000.0000000
+		Return(i128ScVal(10_000_000_000_000), nil).Times(2) // 1,000,000.0000000
 
 	bpm := metrics.NewMetrics(prometheus.NewRegistry()).BlendPrices
 	svc := newTestSnapshotService(t, oraclePrices, meta, cometID, bpm)

--- a/internal/services/blend/scval.go
+++ b/internal/services/blend/scval.go
@@ -12,8 +12,10 @@
 package blend
 
 import (
+	"fmt"
 	"math/big"
 
+	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
 
@@ -42,11 +44,19 @@ func i128String(v xdr.ScVal) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	// value = Hi * 2^64 + Lo, where Hi is signed and Lo is unsigned.
+	return i128ToBigInt(parts).String(), true
+}
+
+// i128ToBigInt converts an XDR Int128Parts — Hi the signed high 64 bits, Lo
+// the unsigned low 64 bits — into the equivalent signed big.Int:
+// value = Hi*2^64 + Lo. Unlike i128String, this returns the big.Int itself
+// so a caller (decodePriceData) can do further arithmetic on the value
+// rather than just display it.
+func i128ToBigInt(parts xdr.Int128Parts) *big.Int {
 	bi := big.NewInt(int64(parts.Hi))
 	bi.Lsh(bi, 64)
 	bi.Add(bi, new(big.Int).SetUint64(uint64(parts.Lo)))
-	return bi.String(), true
+	return bi
 }
 
 // addrString decodes an ScVal holding an Address into its strkey-encoded
@@ -160,4 +170,101 @@ func mapAddrI128(v xdr.ScVal) (map[string]string, bool) {
 		out[k] = val
 	}
 	return out, true
+}
+
+// contractIDLen is the raw byte length of a strkey-decoded contract address
+// (a 32-byte sha256 hash), matching xdr.ContractId's array size.
+const contractIDLen = 32
+
+// buildSep40StellarAsset builds the SEP-40 `Asset::Stellar(Address)`
+// argument ScVal for a lastprice(asset) call against a SEP-40-compatible
+// oracle (e.g. Reflector), given the strkey C-address of the priced Stellar
+// Asset Contract. A Soroban SDK #[contracttype] tuple-variant enum
+// serializes as a 2-element ScVec — the variant's Symbol name followed by
+// its single payload value — the same convention decodeVecKeyEntry already
+// relies on for Blend's own persistent storage keys.
+//
+// Verified against SEP-40 (stellar-protocol ecosystem/sep-0040.md):
+// `enum Asset { Stellar(Address), Other(Symbol) }`,
+// `fn lastprice(asset: Asset) -> Option<PriceData>`. Live-confirmed by
+// dumping `stellar contract info interface` against the deployed Reflector
+// external-CEX/DEX oracle (mainnet
+// CAFJZQWSED6YAWZU3GWRTOCNPPCGBN32L7QV43XX5LZLFTK6JLN34DLN), which shows
+// the identical Rust shapes, and by simulating
+// lastprice(Asset::Stellar(<XLM SAC>)) against the Reflector Stellar-DEX
+// oracle (mainnet CALI2BYU2JE6WVRUFYTS6MSBNEHGJ35P4AVCZYF3B6QOE3QKOB2PLE6M),
+// which round-tripped to a real Some(PriceData{...}) response. See
+// TestBuildSep40StellarAsset for the full verification note.
+func buildSep40StellarAsset(contractAddress string) (xdr.ScVal, error) {
+	raw, err := strkey.Decode(strkey.VersionByteContract, contractAddress)
+	if err != nil {
+		return xdr.ScVal{}, fmt.Errorf("blend: decoding SEP-40 asset contract address %q: %w", contractAddress, err)
+	}
+	if len(raw) != contractIDLen {
+		return xdr.ScVal{}, fmt.Errorf("blend: SEP-40 asset contract address %q decoded to %d bytes, want %d", contractAddress, len(raw), contractIDLen)
+	}
+	var cid xdr.ContractId
+	copy(cid[:], raw)
+
+	sym := xdr.ScSymbol("Stellar")
+	vec := &xdr.ScVec{
+		{Type: xdr.ScValTypeScvSymbol, Sym: &sym},
+		{
+			Type: xdr.ScValTypeScvAddress,
+			Address: &xdr.ScAddress{
+				Type:       xdr.ScAddressTypeScAddressTypeContract,
+				ContractId: &cid,
+			},
+		},
+	}
+	return xdr.ScVal{Type: xdr.ScValTypeScvVec, Vec: &vec}, nil
+}
+
+// PriceData is the decoded form of a SEP-40 `PriceData` struct: the raw
+// on-chain i128 price (scaled by the oracle's own decimals(), which the
+// caller must fetch separately — this package does no rescaling) and the
+// Unix-seconds timestamp the price was recorded at.
+type PriceData struct {
+	Price     *big.Int
+	Timestamp uint64
+}
+
+// decodePriceData decodes a SEP-40 lastprice(asset) return value — an
+// Option<PriceData> — into a *PriceData. ScvVoid (Rust's None, meaning the
+// oracle has no price for the asset) decodes to (nil, nil), the same
+// no-error/no-value convention DecodeEntry's optional fields use elsewhere
+// in this package. A populated PriceData is a #[contracttype] struct, so it
+// serializes as an ScMap keyed by field-name Symbols (see mapGet). Any other
+// top-level shape, or a present-but-malformed/missing field, is reported as
+// an error rather than silently treated as "no price" — a caller must not
+// mistake a decode failure for a legitimate absent price.
+func decodePriceData(val xdr.ScVal) (*PriceData, error) {
+	if val.Type == xdr.ScValTypeScvVoid {
+		return nil, nil
+	}
+
+	m, ok := val.GetMap()
+	if !ok {
+		return nil, fmt.Errorf("blend: PriceData: expected ScMap or ScvVoid, got %v", val.Type)
+	}
+
+	priceVal, ok := mapGet(m, "price")
+	if !ok {
+		return nil, fmt.Errorf("blend: PriceData: missing %q field", "price")
+	}
+	parts, ok := priceVal.GetI128()
+	if !ok {
+		return nil, fmt.Errorf("blend: PriceData: %q field is not an i128 (got %v)", "price", priceVal.Type)
+	}
+
+	tsVal, ok := mapGet(m, "timestamp")
+	if !ok {
+		return nil, fmt.Errorf("blend: PriceData: missing %q field", "timestamp")
+	}
+	ts, ok := u64Val(tsVal)
+	if !ok {
+		return nil, fmt.Errorf("blend: PriceData: %q field is not a u64 (got %v)", "timestamp", tsVal.Type)
+	}
+
+	return &PriceData{Price: i128ToBigInt(parts), Timestamp: ts}, nil
 }

--- a/internal/services/blend/scval.go
+++ b/internal/services/blend/scval.go
@@ -176,6 +176,31 @@ func mapAddrI128(v xdr.ScVal) (map[string]string, bool) {
 // (a 32-byte sha256 hash), matching xdr.ContractId's array size.
 const contractIDLen = 32
 
+// contractAddressScVal builds the bare ScVal encoding of a contract C-address
+// as a Soroban `Address` value — the shape any `token: Address` (or similar)
+// function parameter expects, e.g. Comet's get_balance(token)/
+// get_normalized_weight(token) (see comet.go). buildSep40StellarAsset wraps
+// this same encoding inside a 2-element ScVec for the SEP-40
+// Asset::Stellar(Address) enum payload.
+func contractAddressScVal(contractAddress string) (xdr.ScVal, error) {
+	raw, err := strkey.Decode(strkey.VersionByteContract, contractAddress)
+	if err != nil {
+		return xdr.ScVal{}, fmt.Errorf("blend: decoding contract address %q: %w", contractAddress, err)
+	}
+	if len(raw) != contractIDLen {
+		return xdr.ScVal{}, fmt.Errorf("blend: contract address %q decoded to %d bytes, want %d", contractAddress, len(raw), contractIDLen)
+	}
+	var cid xdr.ContractId
+	copy(cid[:], raw)
+	return xdr.ScVal{
+		Type: xdr.ScValTypeScvAddress,
+		Address: &xdr.ScAddress{
+			Type:       xdr.ScAddressTypeScAddressTypeContract,
+			ContractId: &cid,
+		},
+	}, nil
+}
+
 // buildSep40StellarAsset builds the SEP-40 `Asset::Stellar(Address)`
 // argument ScVal for a lastprice(asset) call against a SEP-40-compatible
 // oracle (e.g. Reflector), given the strkey C-address of the priced Stellar
@@ -196,26 +221,15 @@ const contractIDLen = 32
 // which round-tripped to a real Some(PriceData{...}) response. See
 // TestBuildSep40StellarAsset for the full verification note.
 func buildSep40StellarAsset(contractAddress string) (xdr.ScVal, error) {
-	raw, err := strkey.Decode(strkey.VersionByteContract, contractAddress)
+	addrVal, err := contractAddressScVal(contractAddress)
 	if err != nil {
-		return xdr.ScVal{}, fmt.Errorf("blend: decoding SEP-40 asset contract address %q: %w", contractAddress, err)
+		return xdr.ScVal{}, fmt.Errorf("blend: building SEP-40 Asset::Stellar(%q): %w", contractAddress, err)
 	}
-	if len(raw) != contractIDLen {
-		return xdr.ScVal{}, fmt.Errorf("blend: SEP-40 asset contract address %q decoded to %d bytes, want %d", contractAddress, len(raw), contractIDLen)
-	}
-	var cid xdr.ContractId
-	copy(cid[:], raw)
 
 	sym := xdr.ScSymbol("Stellar")
 	vec := &xdr.ScVec{
 		{Type: xdr.ScValTypeScvSymbol, Sym: &sym},
-		{
-			Type: xdr.ScValTypeScvAddress,
-			Address: &xdr.ScAddress{
-				Type:       xdr.ScAddressTypeScAddressTypeContract,
-				ContractId: &cid,
-			},
-		},
+		addrVal,
 	}
 	return xdr.ScVal{Type: xdr.ScValTypeScvVec, Vec: &vec}, nil
 }

--- a/internal/services/blend/scval_test.go
+++ b/internal/services/blend/scval_test.go
@@ -1,6 +1,8 @@
 package blend
 
 import (
+	"math"
+	"math/big"
 	"testing"
 
 	"github.com/stellar/go-stellar-sdk/strkey"
@@ -140,5 +142,180 @@ func TestU32Val(t *testing.T) {
 	t.Run("returns false for a non-u32 value", func(t *testing.T) {
 		_, ok := u32Val(i128ScVal(1))
 		assert.False(t, ok)
+	})
+}
+
+// TestBuildSep40StellarAsset verification note ----------------------------
+//
+// SEP-40 (stellar-protocol ecosystem/sep-0040.md, fetched 2026-07-08) defines:
+//
+//	#[contracttype]
+//	enum Asset { Stellar(Address), Other(Symbol) }
+//	fn lastprice(env: Env, asset: Asset) -> Option<PriceData>;
+//	#[contracttype]
+//	pub struct PriceData { price: i128, timestamp: u64 }
+//
+// The tuple-variant enum's 2-element-ScVec([Symbol, payload]) encoding
+// matches this package's existing decodeVecKeyEntry convention for Blend's
+// own persistent storage keys.
+//
+// Live-confirmed on 2026-07-08 against real mainnet contracts (stellar-cli
+// 27.0.0, rpc-url https://mainnet.sorobanrpc.com):
+//   - `stellar contract info interface` against the deployed Reflector
+//     "external CEXs & DEXs" oracle
+//     (CAFJZQWSED6YAWZU3GWRTOCNPPCGBN32L7QV43XX5LZLFTK6JLN34DLN) dumped:
+//     `pub enum Asset { Stellar(soroban_sdk::Address), Other(soroban_sdk::Symbol) }`,
+//     `pub struct PriceData { pub price: i128, pub timestamp: u64 }`,
+//     `fn lastprice(env: soroban_sdk::Env, asset: Asset) -> Option<PriceData>;`
+//     — an exact match for the SEP-40 shapes above.
+//   - A live simulation of lastprice(Asset::Stellar(<XLM SAC
+//     CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA>)) against the
+//     Reflector "Stellar Mainnet DEX" oracle
+//     (CALI2BYU2JE6WVRUFYTS6MSBNEHGJ35P4AVCZYF3B6QOE3QKOB2PLE6M) round-tripped
+//     to a real `Some(PriceData{price, timestamp})` response, proving the
+//     Asset::Stellar(Address) argument encoding this test asserts is what a
+//     production oracle actually expects.
+func TestBuildSep40StellarAsset(t *testing.T) {
+	const contractAddr = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
+
+	t.Run("encodes Asset::Stellar(Address) as a 2-elem ScVec", func(t *testing.T) {
+		got, err := buildSep40StellarAsset(contractAddr)
+		require.NoError(t, err)
+
+		wantVec := &xdr.ScVec{
+			symScVal("Stellar"),
+			contractAddrScVal(t, contractAddr),
+		}
+		want := xdr.ScVal{Type: xdr.ScValTypeScvVec, Vec: &wantVec}
+
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("returns an error for a malformed address", func(t *testing.T) {
+		_, err := buildSep40StellarAsset("not-a-strkey-address")
+		assert.Error(t, err)
+	})
+
+	t.Run("returns an error for a well-formed but non-contract strkey address", func(t *testing.T) {
+		// A valid G... (account) strkey decodes cleanly but fails the
+		// VersionByteContract check inside strkey.Decode.
+		_, err := buildSep40StellarAsset("GCYNTH5HDQRNIQ3BSSYPWFO5AHH5ERVZ32C37QRXT6TXK3OJFFOIVXDE")
+		assert.Error(t, err)
+	})
+}
+
+func TestDecodePriceData(t *testing.T) {
+	t.Run("decodes Some(PriceData)", func(t *testing.T) {
+		// Field-name Symbols in alphabetical order, matching how a Soroban
+		// SDK #[contracttype] struct actually serializes.
+		v := xdr.ScVal{Type: xdr.ScValTypeScvMap}
+		m := mapScVal(
+			xdr.ScMapEntry{Key: symScVal("price"), Val: i128ScVal(1_000_000)},
+			xdr.ScMapEntry{Key: symScVal("timestamp"), Val: u64ScVal(1_700_000_000)},
+		)
+		v.Map = &m
+
+		pd, err := decodePriceData(v)
+		require.NoError(t, err)
+		require.NotNil(t, pd)
+		assert.Equal(t, big.NewInt(1_000_000), pd.Price)
+		assert.Equal(t, uint64(1_700_000_000), pd.Timestamp)
+	})
+
+	t.Run("decodes None (ScvVoid) to (nil, nil)", func(t *testing.T) {
+		pd, err := decodePriceData(voidScVal())
+		require.NoError(t, err)
+		assert.Nil(t, pd)
+	})
+
+	t.Run("returns an error for a value that is neither a map nor void", func(t *testing.T) {
+		_, err := decodePriceData(u32ScVal(1))
+		assert.Error(t, err)
+	})
+
+	t.Run("returns an error when the price field is missing", func(t *testing.T) {
+		v := xdr.ScVal{Type: xdr.ScValTypeScvMap}
+		m := mapScVal(
+			xdr.ScMapEntry{Key: symScVal("timestamp"), Val: u64ScVal(1_700_000_000)},
+		)
+		v.Map = &m
+
+		_, err := decodePriceData(v)
+		assert.Error(t, err)
+	})
+
+	t.Run("returns an error when the timestamp field is missing", func(t *testing.T) {
+		v := xdr.ScVal{Type: xdr.ScValTypeScvMap}
+		m := mapScVal(
+			xdr.ScMapEntry{Key: symScVal("price"), Val: i128ScVal(1_000_000)},
+		)
+		v.Map = &m
+
+		_, err := decodePriceData(v)
+		assert.Error(t, err)
+	})
+
+	t.Run("returns an error when timestamp is not a u64", func(t *testing.T) {
+		v := xdr.ScVal{Type: xdr.ScValTypeScvMap}
+		m := mapScVal(
+			xdr.ScMapEntry{Key: symScVal("price"), Val: i128ScVal(1_000_000)},
+			xdr.ScMapEntry{Key: symScVal("timestamp"), Val: i128ScVal(1_700_000_000)},
+		)
+		v.Map = &m
+
+		_, err := decodePriceData(v)
+		assert.Error(t, err)
+	})
+
+	t.Run("returns an error when price is not an i128", func(t *testing.T) {
+		v := xdr.ScVal{Type: xdr.ScValTypeScvMap}
+		m := mapScVal(
+			xdr.ScMapEntry{Key: symScVal("price"), Val: u32ScVal(1)},
+			xdr.ScMapEntry{Key: symScVal("timestamp"), Val: u64ScVal(1_700_000_000)},
+		)
+		v.Map = &m
+
+		_, err := decodePriceData(v)
+		assert.Error(t, err)
+	})
+}
+
+func TestI128ToBigInt(t *testing.T) {
+	t.Run("decodes zero", func(t *testing.T) {
+		got := i128ToBigInt(xdr.Int128Parts{Hi: 0, Lo: 0})
+		assert.Equal(t, big.NewInt(0), got)
+	})
+
+	t.Run("decodes a small positive value", func(t *testing.T) {
+		got := i128ToBigInt(xdr.Int128Parts{Hi: 0, Lo: 42})
+		assert.Equal(t, big.NewInt(42), got)
+	})
+
+	t.Run("decodes a value greater than 2^64 (Hi > 0)", func(t *testing.T) {
+		got := i128ToBigInt(xdr.Int128Parts{Hi: 1, Lo: 0})
+		want, ok := new(big.Int).SetString("18446744073709551616", 10) // 2^64
+		require.True(t, ok)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("decodes -1 (Hi=-1, Lo=MaxUint64 two's-complement encoding)", func(t *testing.T) {
+		got := i128ToBigInt(xdr.Int128Parts{Hi: -1, Lo: xdr.Uint64(math.MaxUint64)})
+		assert.Equal(t, big.NewInt(-1), got)
+	})
+
+	t.Run("decodes a negative value with Hi < -1", func(t *testing.T) {
+		got := i128ToBigInt(xdr.Int128Parts{Hi: -2, Lo: 0})
+		want, ok := new(big.Int).SetString("-36893488147419103232", 10) // -2 * 2^64
+		require.True(t, ok)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("round-trips against independently computed big.Int arithmetic", func(t *testing.T) {
+		parts := xdr.Int128Parts{Hi: 5, Lo: 12345}
+		got := i128ToBigInt(parts)
+
+		want := new(big.Int).Lsh(big.NewInt(int64(parts.Hi)), 64)
+		want.Add(want, new(big.Int).SetUint64(uint64(parts.Lo)))
+		assert.Equal(t, want, got)
 	})
 }

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -74,6 +74,12 @@ type IngestServiceConfig struct {
 	// === Live Mode Dependencies ===
 	TokenIngestionService TokenIngestionService
 	CheckpointService     CheckpointService
+	// PostLockTasks are long-lived background tasks started only after live
+	// ingestion acquires its advisory lock, so an instance that loses the
+	// lock never runs them (e.g. the Blend price snapshot task, which would
+	// otherwise duplicate RPC load and writes). Each runs in its own
+	// goroutine for the life of the ingestion context.
+	PostLockTasks []func(context.Context)
 
 	// === Protocol Processors ===
 	ProtocolProcessors []ProtocolProcessor // nil means no protocol state production
@@ -132,6 +138,7 @@ type ingestService struct {
 	isPermanentFetchError     func(error) bool
 	tokenIngestionService     TokenIngestionService
 	checkpointService         CheckpointService
+	postLockTasks             []func(context.Context)
 	appMetrics                *metrics.Metrics
 	networkPassphrase         string
 	getLedgersLimit           int
@@ -202,6 +209,7 @@ func NewIngestService(cfg IngestServiceConfig) (*ingestService, error) {
 		isPermanentFetchError:     cfg.IsPermanentFetchError,
 		tokenIngestionService:     cfg.TokenIngestionService,
 		checkpointService:         cfg.CheckpointService,
+		postLockTasks:             cfg.PostLockTasks,
 		appMetrics:                cfg.Metrics,
 		networkPassphrase:         cfg.NetworkPassphrase,
 		getLedgersLimit:           cfg.GetLedgersLimit,

--- a/internal/services/ingest_live.go
+++ b/internal/services/ingest_live.go
@@ -372,6 +372,13 @@ func (m *ingestService) startLiveIngestion(ctx context.Context) error {
 		return fmt.Errorf("snapshotting protocol cursors: %w", err)
 	}
 
+	// Background tasks gated on the advisory lock: an instance that failed to
+	// acquire it must never run them, or a crash-looping/standby pod would
+	// duplicate their RPC load and writes.
+	for _, task := range m.postLockTasks {
+		go task(ctx)
+	}
+
 	// Get latest ingested ledger to determine DB state
 	latestIngestedLedger, err := m.models.IngestStore.Get(ctx, data.LatestLedgerCursorName)
 	if err != nil {


### PR DESCRIPTION
### Blend oracle price snapshot task

Fourth of 5 stacked PRs adding Blend Capital v2 lending support (stacked on #659).

Adds a periodic price snapshot task under `ingest` (live mode only) that keeps `blend_oracle_prices` fresh for PR5's USD valuation. Each pass: discover targets → fetch prices → one `BatchUpsert`.

**SEP-40 leg** — for every `(oracle, asset)` pair derived from `blend_pools × blend_reserves`:
- `decimals()` once per oracle, `lastprice(Asset::Stellar(asset))` per target, via RPC simulation.
- Skipped, never persisted: `Option::None`, prices ≤ 0 (`invalid`), oracle timestamps older than 24h (`stale`) — the same prices `pool.rs::load_price` itself rejects. Write-side half of the staleness guard; #661 adds the read side.
- Per-oracle failures are isolated (`errors.Join`) — one bad oracle never aborts the pass.

**Comet leg** (optional) — BLND spot + backstop LP price derived from the Comet BLND:USDC pool, since no oracle prices the LP token:
- Reads pool state from its ContractData entries (`AllRecordData`, `TotalShares`) in **one `getLedgerEntries` call** — atomic, no getter simulations.
- Refuses to decode unless the instance WASM hash equals the pinned `8abc2891…` (contract has no upgrade entrypoint) and both legs' `scalar` fields match (equal decimals).
- `blndPrice = (usdcBal/usdcWeight)/(blndBal/blndWeight)` (Balancer spot, fee-less); `lpPrice` = pool NAV / LP supply; USDC ≡ $1. Prices rounding to `"0"` at 7 decimals are rejected.
- Row convention (PR5 reads this): both rows under `oracle_contract_id = <Comet address>`; LP row self-priced (`asset == oracle`); BLND row keyed by the real BLND token address.

**Scheduling & metrics**
- Immediate pass at startup, then a full interval *after* each pass ends — an overrunning pass never triggers a back-to-back one.
- Metrics: pass duration histogram; fetch counter (`success|error|none|stale|invalid`); prices-tracked gauge (rows actually written — 0 on upsert failure); oldest-price-age gauge (includes skipped-as-stale prices, so a dead oracle that still serves old timestamps grows it unboundedly).

**Config**
| Var | Default | Meaning |
|---|---|---|
| `BLEND_PRICE_INTERVAL` | `60s` | `0` disables; negative rejected at startup |
| `BLEND_BACKSTOP_LP_CONTRACT_ID` | empty | Comet pool C-address; empty disables the Comet leg |

**Verification** — all confirmed against live mainnet: SEP-40 `Asset::Stellar` encoding (spec + Reflector interface + `lastprice` simulation round-trip), Comet entry keys/shapes/scalars/WASM hash (`getLedgerEntries` dump), and the spot-price formula vs comet-contracts-v1 source (`c_math.rs::calc_spot_price`, `c_consts.rs`, `init.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
