### PR TITLE
fix(graphql): derive account existence (is_funded) from native balance

### DIFF
--- a/internal/serve/graphql/resolvers/queries.resolvers.go
+++ b/internal/serve/graphql/resolvers/queries.resolvers.go
@@ -69,6 +69,14 @@ func (r *queryResolver) Transactions(ctx context.Context, first *int32, after *s
 }
 
 // AccountByAddress is the resolver for the accountByAddress field.
+//
+// For a classic (G...) address the account exists on-chain only if it has a
+// native_balances row: that row is written when the account ledger entry is created
+// and removed when the account is merged. Returning null (rather than a synthesized
+// Account) when the row is absent lets callers distinguish an existing account from a
+// never-created, merged, or contract-token-only address — the nullable accountByAddress
+// field is the account-existence signal. Contract (C...) addresses are not classic
+// accounts, so the existence gate does not apply to them.
 func (r *queryResolver) AccountByAddress(ctx context.Context, address string) (*types.Account, error) {
 	if !utils.IsValidStellarAddress(address) {
 		return nil, &gqlerror.Error{
@@ -77,6 +85,15 @@ func (r *queryResolver) AccountByAddress(ctx context.Context, address string) (*
 				"code":    "INVALID_ADDRESS",
 				"address": address,
 			},
+		}
+	}
+	if !utils.IsContractAddress(address) {
+		nb, err := r.balanceReader.GetNativeBalance(ctx, address)
+		if err != nil {
+			return nil, fmt.Errorf("checking account existence for %s: %w", address, err)
+		}
+		if nb == nil {
+			return nil, nil
 		}
 	}
 	return &types.Account{StellarAddress: types.AddressBytea(address)}, nil

--- a/internal/serve/graphql/resolvers/queries_resolvers_test.go
+++ b/internal/serve/graphql/resolvers/queries_resolvers_test.go
@@ -6,12 +6,14 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/toid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
 	"github.com/stellar/wallet-backend/internal/data"
+	sep41data "github.com/stellar/wallet-backend/internal/data/sep41"
 	"github.com/stellar/wallet-backend/internal/metrics"
 )
 
@@ -227,25 +229,54 @@ func TestQueryResolver_Transactions(t *testing.T) {
 }
 
 func TestQueryResolver_Account(t *testing.T) {
-	resolver := &queryResolver{&Resolver{}}
+	m := metrics.NewMetrics(prometheus.NewRegistry())
+	reader := NewBalanceReader(
+		&data.TrustlineBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
+		&data.NativeBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
+		&data.SACBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
+		&data.LiquidityPoolBalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
+		&sep41data.BalanceModel{DB: testDBConnectionPool, Metrics: m.DB},
+		&sep41data.AllowanceModel{DB: testDBConnectionPool, Metrics: m.DB},
+	)
+	resolver := &queryResolver{&Resolver{balanceReader: reader}}
 
-	t.Run("success", func(t *testing.T) {
-		acc, err := resolver.AccountByAddress(testCtx, sharedTestAccountAddress)
+	t.Run("funded classic account returns account", func(t *testing.T) {
+		// A native_balances row is the "classic account exists" signal.
+		fundedAddr := keypair.MustRandom().Address()
+		execTestDB(t, `INSERT INTO native_balances (account_id, balance, last_modified_ledger) VALUES ($1, $2, $3)`,
+			mustAddressBytes(t, fundedAddr), int64(10_000_000), int64(1000))
+		t.Cleanup(func() {
+			execTestDB(t, `DELETE FROM native_balances WHERE account_id = $1`, mustAddressBytes(t, fundedAddr))
+		})
+
+		acc, err := resolver.AccountByAddress(testCtx, fundedAddr)
 		require.NoError(t, err)
-		assert.Equal(t, sharedTestAccountAddress, string(acc.StellarAddress))
+		require.NotNil(t, acc)
+		assert.Equal(t, fundedAddr, string(acc.StellarAddress))
 	})
 
-	t.Run("any valid address returns account", func(t *testing.T) {
+	t.Run("classic address with no native balance returns nil", func(t *testing.T) {
+		// No classic account (no native_balances row) -> null. Covers never-funded,
+		// merged, and contract-token-only holders; the resolver keys only off the native row.
 		acc, err := resolver.AccountByAddress(testCtx, sharedNonExistentAccountAddress)
 		require.NoError(t, err)
-		assert.NotNil(t, acc)
-		assert.Equal(t, sharedNonExistentAccountAddress, string(acc.StellarAddress))
+		assert.Nil(t, acc)
 	})
 
-	t.Run("empty address", func(t *testing.T) {
+	t.Run("contract address returns account without native lookup", func(t *testing.T) {
+		acc, err := resolver.AccountByAddress(testCtx, MainnetNativeContractAddress)
+		require.NoError(t, err)
+		require.NotNil(t, acc)
+		assert.Equal(t, MainnetNativeContractAddress, string(acc.StellarAddress))
+	})
+
+	t.Run("empty address returns INVALID_ADDRESS", func(t *testing.T) {
 		acc, err := resolver.AccountByAddress(testCtx, "")
 		require.Error(t, err)
 		assert.Nil(t, acc)
+		var gqlErr *gqlerror.Error
+		require.ErrorAs(t, err, &gqlErr)
+		assert.Equal(t, "INVALID_ADDRESS", gqlErr.Extensions["code"])
 	})
 }
 


### PR DESCRIPTION
## Problem

`accountByAddress` (GraphQL) returned a non-null `Account` for **any** syntactically valid address, with no existence check. freighter-backend-v2 derives `is_funded` from whether this query returns null (`ErrAccountNotFound`), so v2 reported **`is_funded=true` for every valid address** — never-created, merged, and contract-token-only accounts alike. Most damaging: a freshly generated, never-funded account (the case Freighter's "fund your account" UX depends on) reports funded.

This surfaced in the dev freighter balance validator as a cluster of `is_funded` mismatches (v1=false, v2=true), all on addresses with no classic account.

## Fix

Gate existence on the `native_balances` row. That row is created when the account is created and **deleted on merge** (`token_ingestion.go`, `native_balances.go`), and every funded Stellar account holds ≥ base reserve — so its presence is a faithful "the classic account exists" signal, identical to Horizon/v1's definition of `isFunded`.

`AccountByAddress` now returns `nil, nil` (→ `accountByAddress: null` → v2 `is_funded=false` + empty balances) for a **G-address with no native row**. Contract (`C...`) addresses are not classic accounts and skip the gate. No freighter-backend-v2 change is needed — its `ErrAccountNotFound` branch already sets `is_funded=false` with empty balances.

## Semantics ("Match v1")

- Never-funded / merged / contract-token-only G-addresses → `is_funded=false`, no balances. Matches v1 exactly (v1 can't even simulate `balance()` for an unfunded account, so it returns `{}`).
- **No merge-time cascade deletion of other balances (deliberate):** trustlines/LP shares are account subentries and are already removed before a merge can occur (`AccountMerge` requires `numSubEntries == 0`); SAC/SEP-41 are Soroban contract-data that survive a merge and are legitimately still held. The null gate hides them for display without destroying data.

## Testing

- Updated `TestQueryResolver_Account`: funded G-address → account; G-address with no native row → nil (covers never-funded / merged / contract-token-only); C-address → account (gate skipped); invalid → `INVALID_ADDRESS`.
- `make check` (golangci-lint 0 issues; vet/shadow/deadcode/gql-validate clean) and the resolvers package `go test -race` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
