### PR TITLE
feat(wbclient): typed Blend v2 client methods (pools, pool, account positions)

### DIFF
--- a/pkg/wbclient/blend_client_test.go
+++ b/pkg/wbclient/blend_client_test.go
@@ -1,0 +1,273 @@
+package wbclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/pkg/wbclient/types"
+)
+
+func TestGetBlendPools(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("decodes pools including enum status and null-heavy rows", func(t *testing.T) {
+		srv := graphqlServer(t, `{
+			"blendPools": [
+				{
+					"address": "CPOOLAAA",
+					"name": "Fixed Pool V2",
+					"status": "ACTIVE",
+					"oracleContractId": "CORACLE",
+					"backstopRate": 4750000,
+					"maxPositions": 8,
+					"suppliedUsd": 2100000.5,
+					"borrowedUsd": 900000.25,
+					"backstopUsd": 130000.0,
+					"interestApy": 0.043,
+					"netApy": 0.047,
+					"admin": "GADMIN",
+					"inRewardZone": true,
+					"reserves": [{
+						"assetContractId": "CUSDC",
+						"tokenName": "USD Coin",
+						"tokenSymbol": "USDC",
+						"tokenDecimals": 7,
+						"enabled": true,
+						"utilization": 0.62,
+						"supplyApy": 0.043,
+						"borrowApy": 0.061,
+						"emissionsSupplyApr": 0.008,
+						"emissionsBorrowApr": 0,
+						"suppliedTokens": "15000000000000",
+						"borrowedTokens": "9300000000000",
+						"suppliedUsd": 1500000.0,
+						"borrowedUsd": 930000.0,
+						"cFactor": 9000000,
+						"lFactor": 9500000,
+						"priceUsd": 1.0
+					}]
+				},
+				{
+					"address": "CPOOLBBB",
+					"name": null,
+					"status": null,
+					"oracleContractId": null,
+					"backstopRate": null,
+					"maxPositions": null,
+					"suppliedUsd": null,
+					"borrowedUsd": null,
+					"backstopUsd": null,
+					"interestApy": null,
+					"netApy": null,
+					"admin": null,
+					"inRewardZone": false,
+					"reserves": []
+				}
+			]
+		}`)
+		defer srv.Close()
+
+		c := NewClient(srv.URL, nil)
+		pools, err := c.GetBlendPools(ctx)
+		require.NoError(t, err)
+		require.Len(t, pools, 2)
+
+		active := pools[0]
+		require.NotNil(t, active.Status)
+		assert.Equal(t, types.BlendPoolStatusActive, *active.Status)
+		assert.True(t, active.Status.AcceptsSupply())
+		assert.True(t, active.Status.AcceptsBorrow())
+		assert.True(t, active.InRewardZone)
+		require.Len(t, active.Reserves, 1)
+		assert.Equal(t, "15000000000000", active.Reserves[0].SuppliedTokens)
+		require.NotNil(t, active.Reserves[0].CFactor)
+		assert.EqualValues(t, 9000000, *active.Reserves[0].CFactor)
+
+		// Not-yet-ingested pool: nullable fields decode to nil, never zero.
+		pending := pools[1]
+		assert.Nil(t, pending.Status)
+		assert.Nil(t, pending.SuppliedUsd)
+		assert.Nil(t, pending.Name)
+		assert.NotNil(t, pending.Reserves)
+	})
+
+	t.Run("returns empty non-nil slice when there are no pools", func(t *testing.T) {
+		srv := graphqlServer(t, `{"blendPools": []}`)
+		defer srv.Close()
+
+		c := NewClient(srv.URL, nil)
+		pools, err := c.GetBlendPools(ctx)
+		require.NoError(t, err)
+		assert.NotNil(t, pools)
+		assert.Empty(t, pools)
+	})
+}
+
+func TestGetBlendPool(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns nil without error for an unknown pool", func(t *testing.T) {
+		srv := graphqlServer(t, `{"blendPool": null}`)
+		defer srv.Close()
+
+		c := NewClient(srv.URL, nil)
+		pool, err := c.GetBlendPool(ctx, "CUNKNOWN")
+		require.NoError(t, err)
+		assert.Nil(t, pool)
+	})
+
+	t.Run("sends the pool address variable", func(t *testing.T) {
+		type gqlReq struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+
+		var received gqlReq
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			err := json.NewDecoder(r.Body).Decode(&received)
+			require.NoError(t, err)
+			w.Header().Set("Content-Type", "application/json")
+			_, err = w.Write([]byte(`{"data":{"blendPool": null}}`))
+			require.NoError(t, err)
+		}))
+		defer srv.Close()
+
+		c := NewClient(srv.URL, nil)
+		_, err := c.GetBlendPool(ctx, "CPOOLAAA")
+		require.NoError(t, err)
+
+		assert.Contains(t, received.Query, "blendPool(address: $address)")
+		assert.Equal(t, "CPOOLAAA", received.Variables["address"])
+	})
+}
+
+func TestGetAccountBlendPositions(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns ErrAccountNotFound when accountByAddress is null", func(t *testing.T) {
+		srv := graphqlServer(t, `{"accountByAddress": null}`)
+		defer srv.Close()
+
+		c := NewClient(srv.URL, nil)
+		positions, err := c.GetAccountBlendPositions(ctx, "GABC")
+		assert.Nil(t, positions)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrAccountNotFound), "expected ErrAccountNotFound, got %v", err)
+	})
+
+	t.Run("decodes a full positions tree", func(t *testing.T) {
+		srv := graphqlServer(t, `{
+			"accountByAddress": {
+				"blendPositions": {
+					"pools": [{
+						"poolAddress": "CPOOLAAA",
+						"poolName": "Fixed Pool V2",
+						"usdValue": 77876.27,
+						"suppliedUsd": 674117.02,
+						"borrowedUsd": 596240.75,
+						"netApy": -0.029,
+						"claimedBlnd": "12345",
+						"reserves": [{
+							"assetContractId": "CUSDC",
+							"tokenName": "USD Coin",
+							"tokenSymbol": "USDC",
+							"tokenDecimals": 7,
+							"suppliedTokens": "1000000000",
+							"collateralTokens": "5563385856000",
+							"borrowedTokens": "4953691474632",
+							"suppliedUsd": 556438.59,
+							"borrowedUsd": 495221.33,
+							"supplyApy": 0.0741,
+							"borrowApy": 0.1151,
+							"emissionsSupplyApr": 0.002,
+							"emissionsBorrowApr": 0.001,
+							"interestEarned": "6843215",
+							"interestPaid": "1234567",
+							"emissionsEarnedBlnd": "999",
+							"emissionsEarnedUsd": 0.53,
+							"priceUsd": 1.0
+						}]
+					}],
+					"backstop": [{
+						"poolAddress": "CPOOLAAA",
+						"poolName": "Fixed Pool V2",
+						"shares": "1000000",
+						"lpTokens": "1100000",
+						"usdValue": 52.5,
+						"q4w": [{"amount": "5000", "expiration": 1760000000, "lpTokens": "5500", "usdValue": 0.26}],
+						"emissionsEarnedBlnd": "42",
+						"emissionsEarnedUsd": 0.001
+					}],
+					"backstopClaimedLp": "777",
+					"activeAuctions": [{
+						"poolAddress": "CPOOLAAA",
+						"poolName": "Fixed Pool V2",
+						"auctionType": "USER_LIQUIDATION",
+						"bid": [{"assetContractId": "CUSDC", "amount": "100"}],
+						"lot": [{"assetContractId": "CXLM", "amount": "200"}],
+						"startBlock": 63400000
+					}]
+				}
+			}
+		}`)
+		defer srv.Close()
+
+		c := NewClient(srv.URL, nil)
+		positions, err := c.GetAccountBlendPositions(ctx, "GABC")
+		require.NoError(t, err)
+		require.NotNil(t, positions)
+
+		require.Len(t, positions.Pools, 1)
+		pool := positions.Pools[0]
+		require.NotNil(t, pool.NetApy)
+		assert.InDelta(t, -0.029, *pool.NetApy, 1e-9)
+		require.Len(t, pool.Reserves, 1)
+		reserve := pool.Reserves[0]
+		assert.Equal(t, "5563385856000", reserve.CollateralTokens)
+		assert.Equal(t, "6843215", reserve.InterestEarned)
+		require.NotNil(t, reserve.EmissionsSupplyApr)
+		assert.InDelta(t, 0.002, *reserve.EmissionsSupplyApr, 1e-9)
+		require.NotNil(t, reserve.EmissionsBorrowApr)
+		assert.InDelta(t, 0.001, *reserve.EmissionsBorrowApr, 1e-9)
+
+		require.Len(t, positions.Backstop, 1)
+		require.Len(t, positions.Backstop[0].Q4w, 1)
+		assert.EqualValues(t, 1760000000, positions.Backstop[0].Q4w[0].Expiration)
+		assert.Equal(t, "777", positions.BackstopClaimedLp)
+
+		require.Len(t, positions.ActiveAuctions, 1)
+		assert.Equal(t, types.BlendAuctionTypeUserLiquidation, positions.ActiveAuctions[0].AuctionType)
+	})
+
+	t.Run("sends the account address variable", func(t *testing.T) {
+		type gqlReq struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+
+		var received gqlReq
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			err := json.NewDecoder(r.Body).Decode(&received)
+			require.NoError(t, err)
+			w.Header().Set("Content-Type", "application/json")
+			_, err = w.Write([]byte(`{"data":{"accountByAddress": null}}`))
+			require.NoError(t, err)
+		}))
+		defer srv.Close()
+
+		c := NewClient(srv.URL, nil)
+		_, err := c.GetAccountBlendPositions(ctx, "GABC")
+		require.ErrorIs(t, err, ErrAccountNotFound)
+
+		assert.Contains(t, received.Query, "accountByAddress(address: $address)")
+		assert.Contains(t, received.Query, "blendPositions")
+		assert.Equal(t, "GABC", received.Variables["address"])
+	})
+}

--- a/pkg/wbclient/client.go
+++ b/pkg/wbclient/client.go
@@ -690,3 +690,63 @@ func (c *Client) logHTTPError(ctx context.Context, resp *http.Response) error {
 
 	return nil
 }
+
+type BlendPoolsData struct {
+	BlendPools []types.BlendPool `json:"blendPools"`
+}
+
+type BlendPoolData struct {
+	BlendPool *types.BlendPool `json:"blendPool"`
+}
+
+type AccountBlendPositionsData struct {
+	AccountByAddress *struct {
+		BlendPositions types.BlendAccountPositions `json:"blendPositions"`
+	} `json:"accountByAddress"`
+}
+
+// GetBlendPools fetches the pool-wide Blend v2 catalog (every pool, with
+// reserves), independent of any account. Always returns a non-nil slice on
+// success.
+func (c *Client) GetBlendPools(ctx context.Context) ([]types.BlendPool, error) {
+	data, err := executeGraphQL[BlendPoolsData](c, ctx, buildBlendPoolsQuery(), nil)
+	if err != nil {
+		return nil, err
+	}
+	if data.BlendPools == nil {
+		return []types.BlendPool{}, nil
+	}
+	return data.BlendPools, nil
+}
+
+// GetBlendPool fetches one Blend pool by its contract address. Returns
+// (nil, nil) when the pool is unknown to the indexer.
+func (c *Client) GetBlendPool(ctx context.Context, address string) (*types.BlendPool, error) {
+	variables := map[string]interface{}{
+		"address": address,
+	}
+
+	data, err := executeGraphQL[BlendPoolData](c, ctx, buildBlendPoolQuery(), variables)
+	if err != nil {
+		return nil, err
+	}
+	return data.BlendPool, nil
+}
+
+// GetAccountBlendPositions fetches an account's Blend v2 positions across
+// every pool it has touched. Returns ErrAccountNotFound when the account is
+// unknown to the indexer, matching the other account-scoped methods.
+func (c *Client) GetAccountBlendPositions(ctx context.Context, address string) (*types.BlendAccountPositions, error) {
+	variables := map[string]interface{}{
+		"address": address,
+	}
+
+	data, err := executeGraphQL[AccountBlendPositionsData](c, ctx, buildAccountBlendPositionsQuery(), variables)
+	if err != nil {
+		return nil, err
+	}
+	if data.AccountByAddress == nil {
+		return nil, ErrAccountNotFound
+	}
+	return &data.AccountByAddress.BlendPositions, nil
+}

--- a/pkg/wbclient/queries.go
+++ b/pkg/wbclient/queries.go
@@ -452,3 +452,143 @@ func buildFieldList(fields []string, defaultFields string) string {
 
 	return strings.Join(fields, "\n\t\t\t\t")
 }
+
+// blendReserveFields is the full BlendReserve selection (pool-wide catalog row).
+const blendReserveFields = `
+	assetContractId
+	tokenName
+	tokenSymbol
+	tokenDecimals
+	enabled
+	utilization
+	supplyApy
+	borrowApy
+	emissionsSupplyApr
+	emissionsBorrowApr
+	suppliedTokens
+	borrowedTokens
+	suppliedUsd
+	borrowedUsd
+	cFactor
+	lFactor
+	priceUsd
+`
+
+// blendPoolFields is the full BlendPool selection, reserves included.
+const blendPoolFields = `
+	address
+	name
+	status
+	oracleContractId
+	backstopRate
+	maxPositions
+	suppliedUsd
+	borrowedUsd
+	backstopUsd
+	interestApy
+	netApy
+	admin
+	inRewardZone
+	reserves {
+		%s
+	}
+`
+
+// blendAccountPositionsFields is the full BlendAccountPositions selection.
+const blendAccountPositionsFields = `
+	pools {
+		poolAddress
+		poolName
+		usdValue
+		suppliedUsd
+		borrowedUsd
+		netApy
+		claimedBlnd
+		reserves {
+			assetContractId
+			tokenName
+			tokenSymbol
+			tokenDecimals
+			suppliedTokens
+			collateralTokens
+			borrowedTokens
+			suppliedUsd
+			borrowedUsd
+			supplyApy
+			borrowApy
+			emissionsSupplyApr
+			emissionsBorrowApr
+			interestEarned
+			interestPaid
+			emissionsEarnedBlnd
+			emissionsEarnedUsd
+			priceUsd
+		}
+	}
+	backstop {
+		poolAddress
+		poolName
+		shares
+		lpTokens
+		usdValue
+		q4w {
+			amount
+			expiration
+			lpTokens
+			usdValue
+		}
+		emissionsEarnedBlnd
+		emissionsEarnedUsd
+	}
+	backstopClaimedLp
+	activeAuctions {
+		poolAddress
+		poolName
+		auctionType
+		bid {
+			assetContractId
+			amount
+		}
+		lot {
+			assetContractId
+			amount
+		}
+		startBlock
+	}
+`
+
+// buildBlendPoolsQuery builds the GraphQL query for the pool-wide Blend catalog
+func buildBlendPoolsQuery() string {
+	return fmt.Sprintf(`
+		query BlendPools {
+			blendPools {
+				%s
+			}
+		}
+	`, fmt.Sprintf(blendPoolFields, blendReserveFields))
+}
+
+// buildBlendPoolQuery builds the GraphQL query for one Blend pool by address
+func buildBlendPoolQuery() string {
+	return fmt.Sprintf(`
+		query BlendPool($address: String!) {
+			blendPool(address: $address) {
+				%s
+			}
+		}
+	`, fmt.Sprintf(blendPoolFields, blendReserveFields))
+}
+
+// buildAccountBlendPositionsQuery builds the GraphQL query for an account's
+// Blend positions
+func buildAccountBlendPositionsQuery() string {
+	return fmt.Sprintf(`
+		query AccountBlendPositions($address: String!) {
+			accountByAddress(address: $address) {
+				blendPositions {
+					%s
+				}
+			}
+		}
+	`, blendAccountPositionsFields)
+}

--- a/pkg/wbclient/types/blend.go
+++ b/pkg/wbclient/types/blend.go
@@ -1,0 +1,195 @@
+package types
+
+// Blend v2 client types, mirroring internal/serve/graphql/schema/blend.graphqls.
+// Conventions carried over from the schema:
+//   - USD/APY values are nullable Float: null means "uncomputable" (a missing
+//     or >24h-stale oracle price); a genuinely zero balance is 0, not null.
+//   - On-chain token amounts are non-null String at full precision.
+//   - tokenName/tokenSymbol/tokenDecimals come from the contract_tokens
+//     metadata registry and are nullable.
+
+// BlendPoolStatus is a pool's operational status. ADMIN_ACTIVE/ACTIVE/
+// ADMIN_ON_ICE/ON_ICE accept supply (deposits); ADMIN_ACTIVE/ACTIVE also
+// allow borrowing; ADMIN_FROZEN/FROZEN/SETUP reject both.
+type BlendPoolStatus string
+
+const (
+	BlendPoolStatusAdminActive BlendPoolStatus = "ADMIN_ACTIVE"
+	BlendPoolStatusActive      BlendPoolStatus = "ACTIVE"
+	BlendPoolStatusAdminOnIce  BlendPoolStatus = "ADMIN_ON_ICE"
+	BlendPoolStatusOnIce       BlendPoolStatus = "ON_ICE"
+	BlendPoolStatusAdminFrozen BlendPoolStatus = "ADMIN_FROZEN"
+	BlendPoolStatusFrozen      BlendPoolStatus = "FROZEN"
+	BlendPoolStatusSetup       BlendPoolStatus = "SETUP"
+)
+
+// AcceptsSupply reports whether a pool in this status accepts deposits.
+func (s BlendPoolStatus) AcceptsSupply() bool {
+	switch s {
+	case BlendPoolStatusAdminActive, BlendPoolStatusActive, BlendPoolStatusAdminOnIce, BlendPoolStatusOnIce:
+		return true
+	}
+	return false
+}
+
+// AcceptsBorrow reports whether a pool in this status allows borrowing.
+func (s BlendPoolStatus) AcceptsBorrow() bool {
+	return s == BlendPoolStatusAdminActive || s == BlendPoolStatusActive
+}
+
+// BlendAuctionType distinguishes the three Blend v2 Dutch auction kinds.
+type BlendAuctionType string
+
+const (
+	BlendAuctionTypeUserLiquidation BlendAuctionType = "USER_LIQUIDATION"
+	BlendAuctionTypeBadDebt         BlendAuctionType = "BAD_DEBT"
+	BlendAuctionTypeInterest        BlendAuctionType = "INTEREST"
+)
+
+// BlendAccountPositions aggregates one account's Blend v2 exposure across
+// every pool it has touched. BackstopClaimedLp is lifetime backstop-emission
+// claims in Comet LP tokens, account-wide (backstop claim events carry no
+// pool address).
+type BlendAccountPositions struct {
+	Pools             []BlendPoolPosition     `json:"pools"`
+	Backstop          []BlendBackstopPosition `json:"backstop"`
+	BackstopClaimedLp string                  `json:"backstopClaimedLp"`
+	ActiveAuctions    []BlendAuction          `json:"activeAuctions"`
+}
+
+// BlendPoolPosition rolls up an account's reserve positions within one pool.
+// UsdValue is supplied minus borrowed. NetApy nets supply earnings against
+// borrow interest over TOTAL SUPPLIED USD (the blend-sdk-js convention the
+// Blend UI shows); 0 for a debt-only position, null when any contributing
+// reserve is missing a fresh oracle price.
+type BlendPoolPosition struct {
+	PoolAddress string                 `json:"poolAddress"`
+	PoolName    *string                `json:"poolName"`
+	UsdValue    *float64               `json:"usdValue"`
+	SuppliedUsd *float64               `json:"suppliedUsd"`
+	BorrowedUsd *float64               `json:"borrowedUsd"`
+	NetApy      *float64               `json:"netApy"`
+	ClaimedBlnd string                 `json:"claimedBlnd"`
+	Reserves    []BlendReservePosition `json:"reserves"`
+}
+
+// BlendReservePosition is an account's position in one reserve of a pool.
+// Token amounts are underlying-asset amounts at rates projected to now.
+// InterestEarned/InterestPaid are lifetime, token-denominated (raw integers
+// at TokenDecimals; multiply by PriceUsd for USD), and survive a full exit.
+// EmissionsEarnedBlnd is claimable (uncollected) BLND across the reserve's
+// emission streams. EmissionsSupplyApr/EmissionsBorrowApr are the reserve's
+// pool-wide per-side emission-stream APRs (0 = no active stream, null =
+// stream active but unpriceable).
+type BlendReservePosition struct {
+	AssetContractID     string   `json:"assetContractId"`
+	TokenName           *string  `json:"tokenName"`
+	TokenSymbol         *string  `json:"tokenSymbol"`
+	TokenDecimals       *int32   `json:"tokenDecimals"`
+	SuppliedTokens      string   `json:"suppliedTokens"`
+	CollateralTokens    string   `json:"collateralTokens"`
+	BorrowedTokens      string   `json:"borrowedTokens"`
+	SuppliedUsd         *float64 `json:"suppliedUsd"`
+	BorrowedUsd         *float64 `json:"borrowedUsd"`
+	SupplyApy           *float64 `json:"supplyApy"`
+	BorrowApy           *float64 `json:"borrowApy"`
+	EmissionsSupplyApr  *float64 `json:"emissionsSupplyApr"`
+	EmissionsBorrowApr  *float64 `json:"emissionsBorrowApr"`
+	InterestEarned      string   `json:"interestEarned"`
+	InterestPaid        string   `json:"interestPaid"`
+	EmissionsEarnedBlnd string   `json:"emissionsEarnedBlnd"`
+	EmissionsEarnedUsd  *float64 `json:"emissionsEarnedUsd"`
+	PriceUsd            *float64 `json:"priceUsd"`
+}
+
+// BlendBackstopPosition is an account's backstop deposit in one pool. Shares
+// is the ACTIVE (non-queued) share balance; LpTokens/UsdValue value the
+// whole deposit including queued-for-withdrawal shares (queued shares keep
+// earning pool interest and remain slashable until withdrawn).
+type BlendBackstopPosition struct {
+	PoolAddress         string     `json:"poolAddress"`
+	PoolName            *string    `json:"poolName"`
+	Shares              string     `json:"shares"`
+	LpTokens            string     `json:"lpTokens"`
+	UsdValue            *float64   `json:"usdValue"`
+	Q4w                 []BlendQ4W `json:"q4w"`
+	EmissionsEarnedBlnd string     `json:"emissionsEarnedBlnd"`
+	EmissionsEarnedUsd  *float64   `json:"emissionsEarnedUsd"`
+}
+
+// BlendQ4W is one queued backstop withdrawal, unlocking at Expiration (unix
+// seconds). Amount is in backstop shares.
+type BlendQ4W struct {
+	Amount     string   `json:"amount"`
+	Expiration int64    `json:"expiration"`
+	LpTokens   string   `json:"lpTokens"`
+	UsdValue   *float64 `json:"usdValue"`
+}
+
+// BlendAuction is one active Dutch auction on a Blend v2 pool. Bid/Lot
+// amounts are raw protocol-token decimal strings, not USD.
+type BlendAuction struct {
+	PoolAddress string               `json:"poolAddress"`
+	PoolName    *string              `json:"poolName"`
+	AuctionType BlendAuctionType     `json:"auctionType"`
+	Bid         []BlendAuctionAmount `json:"bid"`
+	Lot         []BlendAuctionAmount `json:"lot"`
+	StartBlock  int32                `json:"startBlock"`
+}
+
+// BlendAuctionAmount is one asset's raw protocol-token amount within an
+// auction's bid or lot.
+type BlendAuctionAmount struct {
+	AssetContractID string `json:"assetContractId"`
+	Amount          string `json:"amount"`
+}
+
+// BlendPool is a pool-wide catalog view of one Blend v2 pool, independent of
+// any account. SuppliedUsd/BorrowedUsd are strict-null: a missing price on
+// any reserve makes the pool-wide total uncomputable. InterestApy is the
+// supplied-USD-weighted supply rate (interest only); NetApy additionally
+// folds in each reserve's supply-side BLND emissions — a supply-side yield,
+// not netted against the pool's borrow side.
+type BlendPool struct {
+	Address          string           `json:"address"`
+	Name             *string          `json:"name"`
+	Status           *BlendPoolStatus `json:"status"`
+	OracleContractID *string          `json:"oracleContractId"`
+	// BackstopRate is the share of borrower interest routed to the pool's
+	// backstop, as 7-decimal fixed point (4750000 = 47.5%).
+	BackstopRate *int32         `json:"backstopRate"`
+	MaxPositions *int32         `json:"maxPositions"`
+	SuppliedUsd  *float64       `json:"suppliedUsd"`
+	BorrowedUsd  *float64       `json:"borrowedUsd"`
+	BackstopUsd  *float64       `json:"backstopUsd"`
+	InterestApy  *float64       `json:"interestApy"`
+	NetApy       *float64       `json:"netApy"`
+	Reserves     []BlendReserve `json:"reserves"`
+	Admin        *string        `json:"admin"`
+	// InRewardZone reports whether the pool is in the backstop's reward zone
+	// and therefore receives BLND emissions.
+	InRewardZone bool `json:"inRewardZone"`
+}
+
+// BlendReserve is a pool-wide reserve catalog row: rates, totals, and risk
+// parameters as of now, no per-account data. CFactor/LFactor are 7-decimal
+// fixed point (9000000 = 0.9).
+type BlendReserve struct {
+	AssetContractID    string   `json:"assetContractId"`
+	TokenName          *string  `json:"tokenName"`
+	TokenSymbol        *string  `json:"tokenSymbol"`
+	TokenDecimals      *int32   `json:"tokenDecimals"`
+	Enabled            bool     `json:"enabled"`
+	Utilization        *float64 `json:"utilization"`
+	SupplyApy          *float64 `json:"supplyApy"`
+	BorrowApy          *float64 `json:"borrowApy"`
+	EmissionsSupplyApr *float64 `json:"emissionsSupplyApr"`
+	EmissionsBorrowApr *float64 `json:"emissionsBorrowApr"`
+	SuppliedTokens     string   `json:"suppliedTokens"`
+	BorrowedTokens     string   `json:"borrowedTokens"`
+	SuppliedUsd        *float64 `json:"suppliedUsd"`
+	BorrowedUsd        *float64 `json:"borrowedUsd"`
+	CFactor            *int32   `json:"cFactor"`
+	LFactor            *int32   `json:"lFactor"`
+	PriceUsd           *float64 `json:"priceUsd"`
+}

--- a/pkg/wbclient/types/blend.go
+++ b/pkg/wbclient/types/blend.go
@@ -28,6 +28,8 @@ func (s BlendPoolStatus) AcceptsSupply() bool {
 	switch s {
 	case BlendPoolStatusAdminActive, BlendPoolStatusActive, BlendPoolStatusAdminOnIce, BlendPoolStatusOnIce:
 		return true
+	case BlendPoolStatusAdminFrozen, BlendPoolStatusFrozen, BlendPoolStatusSetup:
+		return false
 	}
 	return false
 }


### PR DESCRIPTION
### What
Adds typed Blend v2 methods to `pkg/wbclient`: `GetBlendPools(ctx)`, `GetBlendPool(ctx, address)`, and `GetAccountBlendPositions(ctx, address)`, with client types in `pkg/wbclient/types/blend.go` mirroring `blend.graphqls` (pools, reserves, account positions, backstop, auctions; status/auction enums with helpers like `Status.AcceptsSupply()`). 

All three methods go through the existing `executeGraphQL`, so auth and error  handling are unchanged. Conventions follow the existing account-scoped methods: `ErrAccountNotFound` for unknown accounts, `(nil, nil)` for an unknown pool, nullable floats for USD/APY, token amounts as strings.

### Why

freighter-backend-v2 consumes the Blend API (#661 stack) and was hand-writing these GraphQL queries and decode types on its side.

### Known limitations

- Field lists are verified against `blend.graphqls` on this branch and unit-tested against fake servers, but not yet exercised against a live instance

### Issue that this PR addresses

https://github.com/stellar/freighter-backend-v2/pull/140#issuecomment-5051508715

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [ ] This is not a breaking change.
- [ ] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
