### PR TITLE
ci: push images via ecr-push helper instead of docker push

### DIFF
--- a/.github/workflows/build-cnpg-timescaledb.yml
+++ b/.github/workflows/build-cnpg-timescaledb.yml
@@ -69,4 +69,4 @@ jobs:
             --build-arg PG_MAJOR="${PG_MAJOR}" \
             --build-arg TSDB_VERSION="${TSDB_VERSION}" \
             -t "${TAG}" .
-          docker push "${TAG}"
+          ecr-push "${TAG}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,4 +51,4 @@ jobs:
           TAG: ${{ steps.ecr-login.outputs.ecr-registry }}/${{ steps.target.outputs.namespace }}/wallet-backend:${{ github.sha }}
         run: |
           make docker-build
-          make docker-push
+          ecr-push "$TAG"


### PR DESCRIPTION
### What

Switches the push step in `build.yml` and `build-cnpg-timescaledb.yml` from plain `docker push` to the `ecr-push` helper that `stellar/actions/sdf-ecr-login@main` installs onto `PATH`.

### Why

The prd dispatches added in #674 fail at the push step:

```
denied: User: arn:aws:sts::746476062914:assumed-role/github-actions-ecr-push/ecr-push-<run>-1
is not authorized to perform: ecr:InitiateLayerUpload on resource:
arn:aws:ecr:us-east-1:746476062914:repository/prd/wallet-backend
```

(same for `prd/cnpg-timescaledb` — runs [30826813834](https://github.com/stellar/wallet-backend/actions/runs/30826813834), [30826834157](https://github.com/stellar/wallet-backend/actions/runs/30826834157)).

The `github-actions-ecr-push` role's push permissions are gated on the target ECR repository carrying a `Repository=<github org/repo>` resource tag. `ecr-push` handles exactly that before pushing: it creates a missing repo (only under `dev/`, `stg/`, `prd/`) with the tag, or adds the tag to an existing repo that lacks it. `prd/wallet-backend` exists without the tag; `prd/cnpg-timescaledb` doesn't exist yet — the first run self-heals both, which also removes the "create `prd/cnpg-timescaledb` in ECR first" prerequisite noted in #674.

This is the same pattern gesserit uses: [build-and-push.yml](https://github.com/stellar/gesserit/blob/main/.github/workflows/build-and-push.yml#L33).

### Notes

- `publish-prerelease.yml` still pushes to stg via `make docker-push`; that path works today (stg repos already carry the tag). Can be switched to `ecr-push` as a consistency follow-up.
- `promote-release.yml` retags to `prd/wallet-backend` via `docker buildx imagetools create`; once the first `ecr-push` run stamps the `Repository` tag on that repo, its access is covered too.
