### PR TITLE
Add streaming-loadtest ledger backend for apply-load replay

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -85,11 +85,11 @@ func (c *ingestCmd) Command() *cobra.Command {
 		},
 		{
 			Name:        "archive-url",
-			Usage:       "Archive URL for history archives",
+			Usage:       "Archive URL for history archives. Required for every backend except 'streaming-loadtest', which runs without a history archive.",
 			OptType:     types.String,
 			ConfigKey:   &cfg.ArchiveURL,
 			FlagDefault: "https://history.stellar.org/prd/core-testnet/core_testnet_001/",
-			Required:    true,
+			Required:    false,
 		},
 		{
 			Name:        "checkpoint-frequency",
@@ -101,11 +101,29 @@ func (c *ingestCmd) Command() *cobra.Command {
 		},
 		{
 			Name:        "ledger-backend-type",
-			Usage:       "Type of ledger backend to use for fetching ledgers. Options: 'rpc' or 'datastore' (default)",
+			Usage:       "Type of ledger backend to use for fetching ledgers. Options: 'rpc', 'datastore' (default), or 'streaming-loadtest' (dev-only; reads apply-load ledger meta from named pipes)",
 			OptType:     types.String,
 			ConfigKey:   &ledgerBackendType,
 			FlagDefault: string(ingest.LedgerBackendTypeDatastore),
 			Required:    false,
+		},
+		{
+			Name:           "loadtest-meta-pipe-paths",
+			Usage:          "Dev-only. Comma-separated named pipe (FIFO) paths carrying apply-load ledger meta, one per apply-load process. Required when ledger-backend-type is 'streaming-loadtest', ignored otherwise.",
+			OptType:        types.String,
+			CustomSetValue: utils.SetConfigOptionStringList,
+			ConfigKey:      &cfg.LoadtestMetaPipePaths,
+			FlagDefault:    "",
+			Required:       false,
+		},
+		{
+			Name:           "loadtest-ledger-close-duration",
+			Usage:          "Dev-only. Minimum interval between ledgers in streaming-loadtest mode (Go duration string, e.g. \"5s\"). \"0s\" leaves the stream uncapped.",
+			OptType:        types.String,
+			CustomSetValue: utils.SetConfigOptionDuration,
+			ConfigKey:      &cfg.LoadtestLedgerCloseDuration,
+			FlagDefault:    "0s",
+			Required:       false,
 		},
 		{
 			Name:        "chunk-interval",
@@ -173,8 +191,20 @@ func (c *ingestCmd) Command() *cobra.Command {
 				cfg.LedgerBackendType = ingest.LedgerBackendTypeRPC
 			case string(ingest.LedgerBackendTypeDatastore):
 				cfg.LedgerBackendType = ingest.LedgerBackendTypeDatastore
+			case string(ingest.LedgerBackendTypeStreamingLoadtest):
+				cfg.LedgerBackendType = ingest.LedgerBackendTypeStreamingLoadtest
 			default:
-				return fmt.Errorf("invalid ledger-backend-type '%s', must be 'rpc' or 'datastore'", ledgerBackendType)
+				return fmt.Errorf("invalid ledger-backend-type '%s', must be 'rpc', 'datastore', or 'streaming-loadtest'", ledgerBackendType)
+			}
+
+			// The streaming-loadtest backend needs its pipes and runs without a history
+			// archive; every other backend reads a history archive to build initial state.
+			if cfg.LedgerBackendType == ingest.LedgerBackendTypeStreamingLoadtest {
+				if len(cfg.LoadtestMetaPipePaths) == 0 {
+					return fmt.Errorf("loadtest-meta-pipe-paths is required when ledger-backend-type is 'streaming-loadtest'")
+				}
+			} else if cfg.ArchiveURL == "" {
+				return fmt.Errorf("archive-url is required when ledger-backend-type is '%s'", ledgerBackendType)
 			}
 
 			appTracker, err := sentry.NewSentryTracker(sentryDSN, stellarEnvironment, 5)

--- a/cmd/protocol_migrate.go
+++ b/cmd/protocol_migrate.go
@@ -131,6 +131,10 @@ func buildMigrationCommand(
 				}
 			case string(ingest.LedgerBackendTypeDatastore):
 				// datastore-bucket-path is validated via Required:true in DatastoreOptions.
+			case string(ingest.LedgerBackendTypeStreamingLoadtest):
+				// Migrations replay arbitrary historical ranges; the streaming backend only
+				// ever yields the synthetic ledgers currently being written to its pipes.
+				return fmt.Errorf("--ledger-backend-type %q is not supported for protocol migration", opts.ledgerBackendType)
 			default:
 				return fmt.Errorf("invalid --ledger-backend-type %q, must be 'rpc' or 'datastore'", opts.ledgerBackendType)
 			}

--- a/cmd/utils/custom_set_value.go
+++ b/cmd/utils/custom_set_value.go
@@ -108,6 +108,27 @@ func SetConfigOptionAssets(co *config.ConfigOption) error {
 	return nil
 }
 
+// SetConfigOptionStringList parses a comma-separated list from the CLI flag or environment
+// variable and stores the result in a *[]string ConfigKey. Surrounding whitespace is trimmed
+// from each element and empty elements are dropped, so "a, b," yields ["a", "b"]. An empty
+// input yields an empty slice.
+func SetConfigOptionStringList(co *config.ConfigOption) error {
+	key, ok := co.ConfigKey.(*[]string)
+	if !ok {
+		return unexpectedTypeError(key, co)
+	}
+
+	values := []string{}
+	for _, value := range strings.Split(viper.GetString(co.Name), ",") {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			values = append(values, trimmed)
+		}
+	}
+	*key = values
+
+	return nil
+}
+
 // SetConfigOptionDuration parses a Go duration string (e.g. "5m", "10s") from the CLI flag
 // or environment variable and stores the result in a *time.Duration ConfigKey.
 func SetConfigOptionDuration(co *config.ConfigOption) error {

--- a/cmd/utils/custom_set_value_test.go
+++ b/cmd/utils/custom_set_value_test.go
@@ -252,6 +252,46 @@ func TestSetConfigOptionAssets(t *testing.T) {
 	}
 }
 
+func TestSetConfigOptionStringList(t *testing.T) {
+	opts := struct{ paths []string }{}
+
+	co := config.ConfigOption{
+		Name:           "loadtest-meta-pipe-paths",
+		OptType:        types.String,
+		CustomSetValue: SetConfigOptionStringList,
+		ConfigKey:      &opts.paths,
+	}
+
+	testCases := []customSetterTestCase[[]string]{
+		{
+			name:       "yields an empty slice if the value is empty",
+			wantResult: []string{},
+		},
+		{
+			name:       "handles a single value through the CLI flag",
+			args:       []string{"--loadtest-meta-pipe-paths", "/tmp/a.pipe"},
+			wantResult: []string{"/tmp/a.pipe"},
+		},
+		{
+			name:       "trims whitespace and drops empty elements",
+			args:       []string{"--loadtest-meta-pipe-paths", " /tmp/a.pipe , ,/tmp/b.pipe,"},
+			wantResult: []string{"/tmp/a.pipe", "/tmp/b.pipe"},
+		},
+		{
+			name:       "handles a list through the ENV var",
+			envValue:   "/tmp/a.pipe,/tmp/b.pipe",
+			wantResult: []string{"/tmp/a.pipe", "/tmp/b.pipe"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts.paths = nil
+			customSetterTester(t, tc, co)
+		})
+	}
+}
+
 func TestSetConfigOptionDuration(t *testing.T) {
 	opts := struct{ d time.Duration }{}
 

--- a/go.mod
+++ b/go.mod
@@ -156,6 +156,7 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
+	github.com/xdrpp/goxdr v0.1.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.38.0 // indirect
@@ -172,6 +173,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
+	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.32.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -465,6 +465,8 @@ golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 h1:mgKeJMpvi0yx/sU5GsxQ7p6s2
 golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546/go.mod h1:j/pmGrbnkbPtQfxEe5D0VQhZC6qKbfKifgD0oM7sR70=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
+golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -44,6 +44,10 @@ const (
 	LedgerBackendTypeRPC LedgerBackendType = "rpc"
 	// LedgerBackendTypeDatastore uses cloud storage (S3/GCS) to fetch ledgers
 	LedgerBackendTypeDatastore LedgerBackendType = "datastore"
+	// LedgerBackendTypeStreamingLoadtest reads synthetic ledgers from named
+	// pipes written by stellar-core apply-load. Dev-only, for load testing
+	// the standard ingestion path.
+	LedgerBackendTypeStreamingLoadtest LedgerBackendType = "streaming-loadtest"
 )
 
 type Configs struct {
@@ -66,6 +70,12 @@ type Configs struct {
 	LedgerBackendType LedgerBackendType
 	// Datastore holds the datastore ledger backend configuration (flag/env driven).
 	Datastore DatastoreConfig
+	// LoadtestMetaPipePaths are the FIFO paths for the streaming-loadtest
+	// backend, one per apply-load process (their frames are merged per ledger).
+	LoadtestMetaPipePaths []string
+	// LoadtestLedgerCloseDuration is the minimum interval between ledgers in
+	// streaming-loadtest mode. 0 = uncapped.
+	LoadtestLedgerCloseDuration time.Duration
 	// BackfillWorkers limits concurrent batch processing during backfill.
 	// Defaults to runtime.NumCPU(). Lower values reduce RAM usage.
 	BackfillWorkers int
@@ -217,16 +227,24 @@ func setupDeps(ctx context.Context, cfg Configs) (services.IngestService, func()
 		MetricsService:          m,
 	}
 
-	// Initialize history archive once for use by both TokenIngestionService and IngestService
-	archive, err := historyarchive.Connect(
-		cfg.ArchiveURL,
-		historyarchive.ArchiveOptions{
-			NetworkPassphrase:   cfg.NetworkPassphrase,
-			CheckpointFrequency: uint32(cfg.CheckpointFrequency),
-		},
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf("connecting to history archive: %w", err)
+	// Initialize history archive once for use by both TokenIngestionService and IngestService.
+	// The streaming-loadtest backend runs without one: apply-load's benchmark mode
+	// publishes no history archive, so ingestion starts from an empty database and
+	// balance state materializes from the ledger stream itself. archive must stay a
+	// nil interface (not a typed-nil *Archive) — downstream code branches on == nil.
+	var archive historyarchive.ArchiveInterface
+	if cfg.LedgerBackendType != LedgerBackendTypeStreamingLoadtest {
+		connectedArchive, err := historyarchive.Connect(
+			cfg.ArchiveURL,
+			historyarchive.ArchiveOptions{
+				NetworkPassphrase:   cfg.NetworkPassphrase,
+				CheckpointFrequency: uint32(cfg.CheckpointFrequency),
+			},
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("connecting to history archive: %w", err)
+		}
+		archive = connectedArchive
 	}
 
 	tokenIngestionService := services.NewTokenIngestionService(services.TokenIngestionServiceConfig{

--- a/internal/ingest/ledger_backend.go
+++ b/internal/ingest/ledger_backend.go
@@ -16,6 +16,11 @@ func NewLedgerBackend(ctx context.Context, cfg Configs) (ledgerbackend.LedgerBac
 		return newDatastoreLedgerBackend(ctx, cfg.Datastore, cfg.NetworkPassphrase)
 	case LedgerBackendTypeRPC:
 		return newRPCLedgerBackend(cfg)
+	case LedgerBackendTypeStreamingLoadtest:
+		return NewStreamingLoadtestLedgerBackend(StreamingLoadtestBackendConfig{
+			MetaPipePaths:       cfg.LoadtestMetaPipePaths,
+			LedgerCloseDuration: cfg.LoadtestLedgerCloseDuration,
+		})
 	default:
 		return nil, fmt.Errorf("unsupported ledger backend type: %s", cfg.LedgerBackendType)
 	}

--- a/internal/ingest/streaming_loadtest_corpus_test.go
+++ b/internal/ingest/streaming_loadtest_corpus_test.go
@@ -1,0 +1,75 @@
+package ingest
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/indexer"
+)
+
+// TestStreamingLoadtestBackendRealCorpus replays real `stellar-core apply-load`
+// meta through the backend and the production transaction reader. It proves,
+// against real core output rather than hand-built fixtures, that renumbered
+// and merged ledgers still parse through the exact code path live ingestion
+// uses (transaction-set-to-result pairing included).
+//
+// Opt-in: set STREAMING_LOADTEST_CORPUS to a comma-separated list of meta.xdr
+// files (regular files work; EOF exercises the reopen path by replaying the
+// file as a new stream epoch). Generate them by running
+// `stellar-core apply-load` (BUILD_TESTS image) with METADATA_OUTPUT_STREAM
+// pointed at a file, one run per transaction profile.
+func TestStreamingLoadtestBackendRealCorpus(t *testing.T) {
+	corpus := os.Getenv("STREAMING_LOADTEST_CORPUS")
+	if corpus == "" {
+		t.Skip("set STREAMING_LOADTEST_CORPUS=<meta.xdr>[,<meta.xdr>...] to run")
+	}
+	paths := strings.Split(corpus, ",")
+
+	// apply-load hard-overrides its network passphrase to this value.
+	const passphrase = "Apply Load"
+	// Enough ledgers to cross at least one EOF/reopen boundary per file with
+	// the reference smoke corpora (50 benchmark ledgers plus setup each).
+	const ledgersToRead = 200
+
+	backend, err := NewStreamingLoadtestLedgerBackend(StreamingLoadtestBackendConfig{
+		MetaPipePaths: paths,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	require.NoError(t, backend.PrepareRange(ctx, ledgerbackend.UnboundedRange(1)))
+	defer func() {
+		cancel()
+		require.NoError(t, backend.Close())
+	}()
+
+	var lastCloseTime int64
+	totalTxs := 0
+	for seq := uint32(1); seq <= ledgersToRead; seq++ {
+		lcm, err := backend.GetLedger(ctx, seq)
+		require.NoError(t, err, "ledger %d", seq)
+
+		require.Equal(t, seq, lcm.LedgerSequence())
+		ct := lcm.LedgerCloseTime()
+		require.Positive(t, ct, "ledger %d close time", seq)
+		require.GreaterOrEqual(t, ct, lastCloseTime, "ledger %d close time regressed", seq)
+		lastCloseTime = ct
+
+		// The production read path: this is what live ingestion runs on every
+		// ledger, so a merged ledger it cannot parse would fail here first.
+		txs, err := indexer.GetLedgerTransactions(ctx, passphrase, lcm)
+		require.NoError(t, err, "reading transactions of ledger %d", seq)
+		totalTxs += len(txs)
+	}
+
+	assert.Positive(t, totalTxs)
+	t.Logf("read %d ledgers, %d transactions total from %d file(s)", ledgersToRead, totalTxs, len(paths))
+}

--- a/internal/ingest/streaming_loadtest_ledger_backend.go
+++ b/internal/ingest/streaming_loadtest_ledger_backend.go
@@ -1,0 +1,429 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
+	"github.com/stellar/go-stellar-sdk/ingest/loadtest"
+	"github.com/stellar/go-stellar-sdk/support/log"
+	"github.com/stellar/go-stellar-sdk/xdr"
+)
+
+// StreamingLoadtestBackendConfig configures the StreamingLoadtestLedgerBackend.
+type StreamingLoadtestBackendConfig struct {
+	// MetaPipePaths are filesystem paths of FIFOs carrying stream-framed XDR
+	// LedgerCloseMeta records, each written by a `stellar-core apply-load`
+	// process via its METADATA_OUTPUT_STREAM setting. With more than one path,
+	// each emitted ledger is the per-sequence merge of one frame from every
+	// pipe (union of their transaction sets), so N apply-load processes with
+	// different transaction profiles combine into a single mixed-traffic
+	// ledger stream.
+	MetaPipePaths []string
+	// LedgerCloseDuration is the minimum interval between GetLedger emits.
+	// 0 = uncapped: the consumer ingests as fast as the generators produce.
+	// Because apply-load blocks on FIFO writes once the kernel pipe buffer
+	// fills, this pacing propagates back and throttles the generators too.
+	LedgerCloseDuration time.Duration
+}
+
+type pipeReadResult struct {
+	lcm xdr.LedgerCloseMeta
+	err error
+}
+
+type openPipeResult struct {
+	file *os.File
+	err  error
+}
+
+// metaPipe tracks one FIFO and the renumbering state of its current stream
+// epoch. An epoch is one apply-load process lifetime: apply-load always starts
+// a fresh chain at ledger sequence 1 (genesis emits no meta, so the first
+// frame is sequence 2), so every time the writer restarts, the raw sequences
+// reset and a new seqDiff must be derived from the next requested ledger.
+type metaPipe struct {
+	path string
+	file *os.File
+	// opening carries the result of an in-flight blocking FIFO open. It is
+	// retained across a context cancellation so a retried GetLedger reuses
+	// the pending open instead of leaking the file descriptor.
+	opening chan openPipeResult
+	// frames delivers one decoded frame at a time from the reader goroutine.
+	// The channel is unbuffered and the goroutine holds at most one frame,
+	// so consumption stays lockstep with GetLedger and FIFO backpressure
+	// reaches the writer.
+	frames chan pipeReadResult
+	// peeked holds a frame that was consumed from the reader but not yet
+	// emitted, so that a GetLedger attempt that fails partway through a
+	// multi-pipe merge (context cancelled, another pipe mid-reopen) can be
+	// retried without this pipe skipping a frame.
+	peeked *xdr.LedgerCloseMeta
+	// seqDiff maps this epoch's raw frame sequences onto emitted ledger
+	// sequences: emitted = raw + seqDiff.
+	seqDiff   int64
+	diffValid bool
+}
+
+// StreamingLoadtestLedgerBackend reads stream-framed XDR LedgerCloseMeta from
+// one or more named pipes written by `stellar-core apply-load`, renumbers each
+// stream onto the consumer's requested sequence, merges the per-sequence
+// frames into one ledger, and stamps advancing close times. It implements
+// ledgerbackend.LedgerBackend. Dev-only: it exists so a load-test deployment
+// can exercise the standard ingestion path against synthetic traffic.
+//
+// Properties the renumbering provides:
+//   - The consumer's database survives generator restarts: a restarted
+//     apply-load resets to raw sequence 1, and the new epoch is simply mapped
+//     onto the next requested ledger.
+//   - The consumer itself can restart and resume from its cursor: whatever
+//     sequence it asks for first becomes the anchor for fresh diffs.
+//
+// Close times are stamped with the wall clock (monotone non-decreasing)
+// because apply-load emits every ledger with closeTime 0, which would collapse
+// all time-partitioned storage into one partition.
+//
+// Shutdown contract: cancel the context passed to GetLedger before calling
+// Close. GetLedger holds the backend mutex while waiting for frames, and Close
+// takes the same mutex.
+type StreamingLoadtestLedgerBackend struct {
+	config StreamingLoadtestBackendConfig
+
+	mu            sync.Mutex
+	pipes         []*metaPipe
+	prepared      bool
+	preparedFrom  uint32
+	latestEmitted uint32
+	cached        xdr.LedgerCloseMeta
+	lastCloseTime xdr.TimePoint
+	lastEmitTime  time.Time
+	closed        bool
+	// done unblocks reader goroutines parked on a channel send when the
+	// backend closes.
+	done chan struct{}
+}
+
+// Verify interface implementation at compile time.
+var _ ledgerbackend.LedgerBackend = (*StreamingLoadtestLedgerBackend)(nil)
+
+func NewStreamingLoadtestLedgerBackend(cfg StreamingLoadtestBackendConfig) (*StreamingLoadtestLedgerBackend, error) {
+	if len(cfg.MetaPipePaths) == 0 {
+		return nil, fmt.Errorf("MetaPipePaths is required")
+	}
+	pipes := make([]*metaPipe, len(cfg.MetaPipePaths))
+	for i, path := range cfg.MetaPipePaths {
+		if path == "" {
+			return nil, fmt.Errorf("MetaPipePaths[%d] is empty", i)
+		}
+		pipes[i] = &metaPipe{path: path}
+	}
+	return &StreamingLoadtestLedgerBackend{
+		config: cfg,
+		pipes:  pipes,
+		done:   make(chan struct{}),
+	}, nil
+}
+
+func (b *StreamingLoadtestLedgerBackend) PrepareRange(ctx context.Context, ledgerRange ledgerbackend.Range) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return fmt.Errorf("backend closed")
+	}
+	if b.prepared {
+		return nil
+	}
+	if ledgerRange.Bounded() {
+		return fmt.Errorf("streaming-loadtest backend only supports unbounded ranges")
+	}
+	// Pipes open lazily in GetLedger: opening a FIFO read side blocks until
+	// the writer attaches, and PrepareRange should not stall startup on
+	// generators that are still booting.
+	b.preparedFrom = ledgerRange.From()
+	b.prepared = true
+	return nil
+}
+
+func (b *StreamingLoadtestLedgerBackend) GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if !b.prepared {
+		return xdr.LedgerCloseMeta{}, fmt.Errorf("GetLedger called before PrepareRange")
+	}
+	if b.closed {
+		return xdr.LedgerCloseMeta{}, fmt.Errorf("backend closed")
+	}
+
+	// Re-serving the last emitted ledger keeps a retrying consumer (its
+	// GetLedger call sits inside a retry-with-backoff wrapper) from
+	// desynchronizing the pipes: the frames for that ledger are already
+	// consumed and must not be read twice.
+	if b.latestEmitted != 0 && sequence == b.latestEmitted {
+		return b.cached, nil
+	}
+	expected := b.preparedFrom
+	if b.latestEmitted != 0 {
+		expected = b.latestEmitted + 1
+	}
+	if sequence != expected {
+		return xdr.LedgerCloseMeta{}, fmt.Errorf(
+			"non-sequential ledger request: expected %d, got %d", expected, sequence)
+	}
+
+	// Pace: sleep until LedgerCloseDuration has elapsed since the last emit.
+	if b.config.LedgerCloseDuration > 0 && !b.lastEmitTime.IsZero() {
+		wait := time.Until(b.lastEmitTime.Add(b.config.LedgerCloseDuration))
+		if wait > 0 {
+			timer := time.NewTimer(wait)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				timer.Stop()
+				return xdr.LedgerCloseMeta{}, fmt.Errorf("paced GetLedger cancelled: %w", ctx.Err())
+			}
+		}
+	}
+
+	var merged xdr.LedgerCloseMeta
+	for i, p := range b.pipes {
+		frame, err := b.nextFrame(ctx, p, sequence)
+		if err != nil {
+			return xdr.LedgerCloseMeta{}, fmt.Errorf("pipe %s: %w", p.path, err)
+		}
+		mapSeq := b.mapSeqFunc(p.seqDiff)
+		if i == 0 {
+			merged = frame
+			if err := loadtest.UpdateLedgerSeqInLedgerEntries(&merged, mapSeq); err != nil {
+				return xdr.LedgerCloseMeta{}, fmt.Errorf("renumbering entries from pipe %s: %w", p.path, err)
+			}
+			if err := setLedgerSeq(&merged, sequence); err != nil {
+				return xdr.LedgerCloseMeta{}, err
+			}
+		} else {
+			if err := loadtest.MergeLedgers(&merged, frame, mapSeq); err != nil {
+				return xdr.LedgerCloseMeta{}, fmt.Errorf("merging frame from pipe %s: %w", p.path, err)
+			}
+		}
+	}
+	if err := b.stampCloseTime(&merged); err != nil {
+		return xdr.LedgerCloseMeta{}, err
+	}
+
+	// The merge succeeded: only now release the peeked frames so a failed
+	// attempt above replays the same frames on retry.
+	for _, p := range b.pipes {
+		p.peeked = nil
+	}
+	b.cached = merged
+	b.latestEmitted = sequence
+	b.lastEmitTime = time.Now()
+	return merged, nil
+}
+
+// nextFrame returns the frame of p that must merge into the requested
+// sequence, (re)opening the pipe and deriving the epoch's sequence diff as
+// needed. The returned frame stays parked in p.peeked until the caller
+// completes the whole merge.
+func (b *StreamingLoadtestLedgerBackend) nextFrame(ctx context.Context, p *metaPipe, sequence uint32) (xdr.LedgerCloseMeta, error) {
+	if p.peeked != nil {
+		return *p.peeked, nil
+	}
+	for {
+		if p.frames == nil {
+			if err := b.openPipe(ctx, p); err != nil {
+				return xdr.LedgerCloseMeta{}, err
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return xdr.LedgerCloseMeta{}, fmt.Errorf("waiting for frame: %w", ctx.Err())
+		case res := <-p.frames:
+			if res.err != nil {
+				// Any read error ends the stream epoch: EOF means the writer
+				// exited (normal end of an apply-load run), and a decode error
+				// means a killed writer left a truncated frame. Either way the
+				// only recovery is a fresh stream from the restarted writer.
+				log.Warnf("streaming-loadtest: pipe %s stream ended (%v); reopening and waiting for writer", p.path, res.err)
+				b.resetPipe(p)
+				continue
+			}
+			frameSeq := res.lcm.LedgerSequence()
+			if !p.diffValid {
+				p.seqDiff = int64(sequence) - int64(frameSeq)
+				p.diffValid = true
+				log.Infof("streaming-loadtest: pipe %s new epoch: raw ledger %d maps to %d (diff %d)", p.path, frameSeq, sequence, p.seqDiff)
+			} else if int64(frameSeq)+p.seqDiff != int64(sequence) {
+				// apply-load emits every ledger it closes, in order, with no
+				// gaps. A mismatch inside an epoch means frames were lost or
+				// reordered — unrecoverable, unlike a writer restart.
+				return xdr.LedgerCloseMeta{}, fmt.Errorf(
+					"sequence mismatch within stream epoch: raw ledger %d + diff %d != requested %d",
+					frameSeq, p.seqDiff, sequence)
+			}
+			p.peeked = &res.lcm
+			return res.lcm, nil
+		}
+	}
+}
+
+// openPipe blocking-opens the FIFO read side (the open(2) itself blocks until
+// a writer attaches) and starts the reader goroutine. Cancellation-safe: a
+// cancelled open stays pending on p.opening and is adopted by the next call.
+func (b *StreamingLoadtestLedgerBackend) openPipe(ctx context.Context, p *metaPipe) error {
+	if p.opening == nil {
+		p.opening = make(chan openPipeResult, 1)
+		go func(path string, ch chan<- openPipeResult) {
+			f, err := os.OpenFile(path, os.O_RDONLY, 0)
+			ch <- openPipeResult{file: f, err: err}
+		}(p.path, p.opening)
+	}
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("waiting for pipe writer: %w", ctx.Err())
+	case res := <-p.opening:
+		p.opening = nil
+		if res.err != nil {
+			return fmt.Errorf("opening meta pipe: %w", res.err)
+		}
+		p.file = res.file
+		p.frames = make(chan pipeReadResult)
+		go readFrames(res.file, p.frames, b.done)
+		return nil
+	}
+}
+
+func (b *StreamingLoadtestLedgerBackend) resetPipe(p *metaPipe) {
+	// The xdr.Stream closes the descriptor itself on every read error
+	// (including plain EOF), so this close usually finds it already closed.
+	if p.file != nil {
+		if err := p.file.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+			log.Warnf("streaming-loadtest: closing pipe %s: %v", p.path, err)
+		}
+	}
+	p.file = nil
+	p.frames = nil
+	p.diffValid = false
+}
+
+// readFrames decodes frames off the pipe and hands them over one at a time.
+// It exits after delivering a read error (the epoch is over) or when the
+// backend closes.
+func readFrames(f *os.File, frames chan<- pipeReadResult, done <-chan struct{}) {
+	stream := xdr.NewStream(f)
+	for {
+		var lcm xdr.LedgerCloseMeta
+		err := stream.ReadOne(&lcm)
+		select {
+		case frames <- pipeReadResult{lcm: lcm, err: err}:
+		case <-done:
+			return
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// mapSeqFunc renumbers ledger sequence references inside ledger entries
+// (lastModified, TTLEntry liveUntil, account seqLedger) by the epoch diff.
+// References at or below the first emitted ledger clamp to it — on the very
+// first epoch the diff is negative (the raw stream starts at 2) and genesis-
+// created entries carry lastModified 1. References that overflow clamp to
+// MaxUint32 — apply-load's setup writes TTLs near the raw sequence horizon.
+func (b *StreamingLoadtestLedgerBackend) mapSeqFunc(diff int64) func(uint32) uint32 {
+	floor := b.preparedFrom
+	return func(old uint32) uint32 {
+		n := int64(old) + diff
+		if n <= int64(floor) {
+			return floor
+		}
+		if n > math.MaxUint32 {
+			return math.MaxUint32
+		}
+		return uint32(n)
+	}
+}
+
+// setLedgerSeq rewrites the ledger header sequence. Only V1/V2 are accepted:
+// that is what protocol-27+ cores emit, and merging requires generalized
+// transaction sets, which V0 predates.
+func setLedgerSeq(lcm *xdr.LedgerCloseMeta, sequence uint32) error {
+	switch lcm.V {
+	case 1:
+		lcm.V1.LedgerHeader.Header.LedgerSeq = xdr.Uint32(sequence)
+	case 2:
+		lcm.V2.LedgerHeader.Header.LedgerSeq = xdr.Uint32(sequence)
+	default:
+		return fmt.Errorf("ledger version %d is not supported", lcm.V)
+	}
+	return nil
+}
+
+// stampCloseTime overwrites the header close time with the wall clock,
+// clamped to be non-decreasing. apply-load emits closeTime 0 on every ledger;
+// downstream storage partitions rows by this timestamp, so it must advance.
+func (b *StreamingLoadtestLedgerBackend) stampCloseTime(lcm *xdr.LedgerCloseMeta) error {
+	ct := xdr.TimePoint(time.Now().Unix())
+	if ct < b.lastCloseTime {
+		ct = b.lastCloseTime
+	}
+	switch lcm.V {
+	case 1:
+		lcm.V1.LedgerHeader.Header.ScpValue.CloseTime = ct
+	case 2:
+		lcm.V2.LedgerHeader.Header.ScpValue.CloseTime = ct
+	default:
+		return fmt.Errorf("ledger version %d is not supported", lcm.V)
+	}
+	b.lastCloseTime = ct
+	return nil
+}
+
+// GetLatestLedgerSequence reports the last emitted ledger. There is no
+// meaningful "network tip" for a paced synthetic stream, so consumers see a
+// lag of at most one ledger; ingestion throughput (ledgers per second versus
+// the configured pacing) is the signal to watch instead of lag.
+func (b *StreamingLoadtestLedgerBackend) GetLatestLedgerSequence(ctx context.Context) (uint32, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.prepared {
+		return 0, fmt.Errorf("GetLatestLedgerSequence called before PrepareRange")
+	}
+	if b.latestEmitted != 0 {
+		return b.latestEmitted, nil
+	}
+	return b.preparedFrom, nil
+}
+
+func (b *StreamingLoadtestLedgerBackend) IsPrepared(ctx context.Context, ledgerRange ledgerbackend.Range) (bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.prepared && !ledgerRange.Bounded() && ledgerRange.From() >= b.preparedFrom, nil
+}
+
+func (b *StreamingLoadtestLedgerBackend) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return nil
+	}
+	b.closed = true
+	close(b.done)
+	for _, p := range b.pipes {
+		if p.file != nil {
+			// Already closed by the xdr.Stream when the last read errored.
+			if err := p.file.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+				log.Warnf("streaming-loadtest: closing pipe %s: %v", p.path, err)
+			}
+			p.file = nil
+			p.frames = nil
+		}
+	}
+	return nil
+}

--- a/internal/ingest/streaming_loadtest_ledger_backend_test.go
+++ b/internal/ingest/streaming_loadtest_ledger_backend_test.go
@@ -1,0 +1,666 @@
+package ingest
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
+	"github.com/stellar/go-stellar-sdk/xdr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// streamTestTimeout bounds every test: the backend blocks on FIFO reads, so a
+// wiring mistake would otherwise hang the package.
+const streamTestTimeout = 10 * time.Second
+
+// reopenGrace is how long a test waits, after triggering a stream-epoch end,
+// before attaching the replacement writer. A FIFO is a single shared object:
+// a writer that attaches while the backend still holds the dead epoch's read
+// descriptor writes into a buffer that is discarded when that descriptor
+// closes, and the backend would then block forever on the reopened pipe.
+const reopenGrace = 250 * time.Millisecond
+
+// mkFIFOs creates n named pipes in one temp dir and returns their paths.
+func mkFIFOs(t *testing.T, n int) []string {
+	t.Helper()
+	dir := t.TempDir()
+	paths := make([]string, n)
+	for i := range paths {
+		paths[i] = filepath.Join(dir, fmt.Sprintf("meta-%d.pipe", i))
+		require.NoError(t, syscall.Mkfifo(paths[i], 0o600))
+	}
+	return paths
+}
+
+func newStreamingBackend(t *testing.T, paths []string, pace time.Duration) *StreamingLoadtestLedgerBackend {
+	t.Helper()
+	backend, err := NewStreamingLoadtestLedgerBackend(StreamingLoadtestBackendConfig{
+		MetaPipePaths:       paths,
+		LedgerCloseDuration: pace,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, backend.Close()) })
+	return backend
+}
+
+// pipeFeeder writes stream-framed records onto one FIFO from a background
+// goroutine. The goroutine is required: opening a FIFO for writing blocks
+// until a reader attaches, and the backend opens its read side lazily inside
+// GetLedger. Queued writes are delivered in order, so a send followed by a
+// close reaches the reader as data-then-EOF.
+type pipeFeeder struct {
+	t         *testing.T
+	path      string
+	jobs      chan []byte
+	closeOnce sync.Once
+}
+
+func newPipeFeeder(t *testing.T, path string) *pipeFeeder {
+	t.Helper()
+	f := &pipeFeeder{t: t, path: path, jobs: make(chan []byte, 256)}
+	go f.run()
+	t.Cleanup(f.close)
+	return f
+}
+
+func (p *pipeFeeder) run() {
+	file, err := os.OpenFile(p.path, os.O_WRONLY, 0)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+	for job := range p.jobs {
+		if job == nil {
+			return
+		}
+		if _, err := file.Write(job); err != nil {
+			return // the backend closed its read side; nothing left to deliver
+		}
+	}
+}
+
+// send queues one stream frame per ledger. Marshalling happens on the calling
+// goroutine so a malformed fixture fails the test directly.
+func (p *pipeFeeder) send(ledgers ...xdr.LedgerCloseMeta) {
+	p.t.Helper()
+	for _, ledger := range ledgers {
+		var buf bytes.Buffer
+		require.NoError(p.t, xdr.MarshalFramed(&buf, ledger))
+		p.jobs <- buf.Bytes()
+	}
+}
+
+// sendRaw queues bytes verbatim, for fixtures that are not valid frames.
+func (p *pipeFeeder) sendRaw(b []byte) {
+	p.jobs <- b
+}
+
+// close flushes queued writes and then closes the write side, which the
+// backend observes as end of stream.
+func (p *pipeFeeder) close() {
+	p.closeOnce.Do(func() { p.jobs <- nil })
+}
+
+// truncatedFrame is a stream frame whose header promises 64 payload bytes but
+// which carries only 8, the way a killed writer leaves the pipe.
+func truncatedFrame() []byte {
+	var header [4]byte
+	binary.BigEndian.PutUint32(header[:], 64|0x80000000)
+	return append(header[:], make([]byte, 8)...)
+}
+
+// makeStreamLedger builds a marshalable LedgerCloseMeta (version 1 or 2) with
+// the given header sequence, txCount transactions, and one ledger entry per
+// entrySeq value carried as an upgrade change. Close time is 0, matching what
+// apply-load emits. The transaction set is a generalized V1 set with one
+// phase, which is what loadtest.MergeLedgers requires of both sides.
+func makeStreamLedger(version int32, seq uint32, txCount int, entrySeqs ...uint32) xdr.LedgerCloseMeta {
+	header := xdr.LedgerHeaderHistoryEntry{
+		Header: xdr.LedgerHeader{
+			LedgerSeq: xdr.Uint32(seq),
+			ScpValue:  xdr.StellarValue{CloseTime: 0},
+		},
+	}
+	txSet := xdr.GeneralizedTransactionSet{
+		V: 1,
+		V1TxSet: &xdr.TransactionSetV1{
+			Phases: []xdr.TransactionPhase{{V: 0, V0Components: &[]xdr.TxSetComponent{}}},
+		},
+	}
+
+	if version == 2 {
+		txProcessing := make([]xdr.TransactionResultMetaV1, txCount)
+		for i := range txProcessing {
+			txProcessing[i] = xdr.TransactionResultMetaV1{
+				Result:            successfulTxResult(),
+				TxApplyProcessing: xdr.TransactionMeta{V: 3, V3: &xdr.TransactionMetaV3{}},
+			}
+		}
+		return xdr.LedgerCloseMeta{V: 2, V2: &xdr.LedgerCloseMetaV2{
+			LedgerHeader:       header,
+			TxSet:              txSet,
+			TxProcessing:       txProcessing,
+			UpgradesProcessing: entryUpgrades(entrySeqs),
+		}}
+	}
+
+	txProcessing := make([]xdr.TransactionResultMeta, txCount)
+	for i := range txProcessing {
+		txProcessing[i] = xdr.TransactionResultMeta{
+			Result:            successfulTxResult(),
+			TxApplyProcessing: xdr.TransactionMeta{V: 3, V3: &xdr.TransactionMetaV3{}},
+		}
+	}
+	return xdr.LedgerCloseMeta{V: 1, V1: &xdr.LedgerCloseMetaV1{
+		LedgerHeader:       header,
+		TxSet:              txSet,
+		TxProcessing:       txProcessing,
+		UpgradesProcessing: entryUpgrades(entrySeqs),
+	}}
+}
+
+// makeV0StreamLedger builds a V0 LedgerCloseMeta, the pre-generalized-txset
+// shape the backend refuses to renumber or merge.
+func makeV0StreamLedger(seq uint32) xdr.LedgerCloseMeta {
+	return xdr.LedgerCloseMeta{V: 0, V0: &xdr.LedgerCloseMetaV0{
+		LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+			Header: xdr.LedgerHeader{LedgerSeq: xdr.Uint32(seq)},
+		},
+	}}
+}
+
+func successfulTxResult() xdr.TransactionResultPair {
+	return xdr.TransactionResultPair{
+		Result: xdr.TransactionResult{
+			FeeCharged: 100,
+			Result: xdr.TransactionResultResult{
+				Code:    xdr.TransactionResultCodeTxSuccess,
+				Results: &[]xdr.OperationResult{},
+			},
+		},
+	}
+}
+
+// entryUpgrades parks one ledger entry per sequence in a base-fee upgrade's
+// changes. Upgrade changes are a convenient carrier because MergeLedgers
+// appends them in pipe order, so a merged ledger exposes each source stream's
+// entries separately.
+func entryUpgrades(entrySeqs []uint32) []xdr.UpgradeEntryMeta {
+	if len(entrySeqs) == 0 {
+		return nil
+	}
+	newBaseFee := xdr.Uint32(100)
+	changes := make(xdr.LedgerEntryChanges, 0, len(entrySeqs))
+	for _, seq := range entrySeqs {
+		changes = append(changes, xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+			State: &xdr.LedgerEntry{
+				LastModifiedLedgerSeq: xdr.Uint32(seq),
+				Data: xdr.LedgerEntryData{
+					Type: xdr.LedgerEntryTypeTtl,
+					Ttl:  &xdr.TtlEntry{},
+				},
+			},
+		})
+	}
+	return []xdr.UpgradeEntryMeta{{
+		Upgrade: xdr.LedgerUpgrade{
+			Type:       xdr.LedgerUpgradeTypeLedgerUpgradeBaseFee,
+			NewBaseFee: &newBaseFee,
+		},
+		Changes: changes,
+	}}
+}
+
+// streamEntrySeqs returns the LastModifiedLedgerSeq of every entry the ledger
+// carries, in merge order (first pipe's entries first).
+func streamEntrySeqs(t *testing.T, lcm xdr.LedgerCloseMeta) []uint32 {
+	t.Helper()
+	var upgrades []xdr.UpgradeEntryMeta
+	switch lcm.V {
+	case 1:
+		upgrades = lcm.V1.UpgradesProcessing
+	case 2:
+		upgrades = lcm.V2.UpgradesProcessing
+	default:
+		t.Fatalf("unexpected ledger version %d", lcm.V)
+	}
+	var seqs []uint32
+	for _, upgrade := range upgrades {
+		for _, change := range upgrade.Changes {
+			require.NotNil(t, change.State)
+			seqs = append(seqs, uint32(change.State.LastModifiedLedgerSeq))
+		}
+	}
+	return seqs
+}
+
+func streamTxCount(t *testing.T, lcm xdr.LedgerCloseMeta) int {
+	t.Helper()
+	switch lcm.V {
+	case 1:
+		return len(lcm.V1.TxProcessing)
+	case 2:
+		return len(lcm.V2.TxProcessing)
+	}
+	t.Fatalf("unexpected ledger version %d", lcm.V)
+	return 0
+}
+
+func streamPhaseCount(t *testing.T, lcm xdr.LedgerCloseMeta) int {
+	t.Helper()
+	switch lcm.V {
+	case 1:
+		return len(lcm.V1.TxSet.V1TxSet.Phases)
+	case 2:
+		return len(lcm.V2.TxSet.V1TxSet.Phases)
+	}
+	t.Fatalf("unexpected ledger version %d", lcm.V)
+	return 0
+}
+
+func streamCloseTime(t *testing.T, lcm xdr.LedgerCloseMeta) xdr.TimePoint {
+	t.Helper()
+	switch lcm.V {
+	case 1:
+		return lcm.V1.LedgerHeader.Header.ScpValue.CloseTime
+	case 2:
+		return lcm.V2.LedgerHeader.Header.ScpValue.CloseTime
+	}
+	t.Fatalf("unexpected ledger version %d", lcm.V)
+	return 0
+}
+
+type getLedgerResult struct {
+	lcm xdr.LedgerCloseMeta
+	err error
+}
+
+// getLedgerAsync runs GetLedger on its own goroutine, for the cases where it
+// must block until the test attaches a new writer.
+func getLedgerAsync(backend *StreamingLoadtestLedgerBackend, ctx context.Context, sequence uint32) <-chan getLedgerResult {
+	ch := make(chan getLedgerResult, 1)
+	go func() {
+		lcm, err := backend.GetLedger(ctx, sequence)
+		ch <- getLedgerResult{lcm: lcm, err: err}
+	}()
+	return ch
+}
+
+func TestNewStreamingLoadtestLedgerBackend_RejectsBadConfig(t *testing.T) {
+	_, err := NewStreamingLoadtestLedgerBackend(StreamingLoadtestBackendConfig{})
+	require.ErrorContains(t, err, "MetaPipePaths is required")
+
+	_, err = NewStreamingLoadtestLedgerBackend(StreamingLoadtestBackendConfig{
+		MetaPipePaths: []string{"/tmp/a.pipe", ""},
+	})
+	require.ErrorContains(t, err, "MetaPipePaths[1] is empty")
+}
+
+func TestStreamingLoadtestBackend_RenumbersFirstEpoch(t *testing.T) {
+	paths := mkFIFOs(t, 1)
+	backend := newStreamingBackend(t, paths, 0)
+
+	// apply-load starts each run at raw ledger 2 (genesis emits no meta) and
+	// tags genesis-created entries with lastModified 1.
+	feeder := newPipeFeeder(t, paths[0])
+	for raw := uint32(2); raw <= 4; raw++ {
+		feeder.send(makeStreamLedger(1, raw, 1, 1, raw+5))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), streamTestTimeout)
+	defer cancel()
+	require.NoError(t, backend.PrepareRange(ctx, ledgerbackend.UnboundedRange(1)))
+
+	for _, want := range []uint32{1, 2, 3} {
+		lcm, err := backend.GetLedger(ctx, want)
+		require.NoError(t, err)
+		assert.Equal(t, want, lcm.LedgerSequence())
+		// The epoch diff is -1. The genesis entry lands below the floor (the
+		// range's first ledger) and clamps to it; the other entry tracks the
+		// emitted sequence.
+		assert.Equal(t, []uint32{1, want + 5}, streamEntrySeqs(t, lcm))
+	}
+}
+
+func TestStreamingLoadtestBackend_MergesEveryPipe(t *testing.T) {
+	paths := mkFIFOs(t, 3)
+	backend := newStreamingBackend(t, paths, 0)
+
+	// Different raw starting sequences per pipe: a single shared diff would
+	// renumber the three streams' entries to three different values, so the
+	// entries agreeing is what proves the diff is derived per pipe.
+	rawStarts := []uint32{2, 100, 7}
+	txCounts := []int{1, 2, 3}
+	for i, path := range paths {
+		feeder := newPipeFeeder(t, path)
+		for n := uint32(0); n < 2; n++ {
+			raw := rawStarts[i] + n
+			feeder.send(makeStreamLedger(1, raw, txCounts[i], raw+5))
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), streamTestTimeout)
+	defer cancel()
+	require.NoError(t, backend.PrepareRange(ctx, ledgerbackend.UnboundedRange(1)))
+
+	for _, want := range []uint32{1, 2} {
+		lcm, err := backend.GetLedger(ctx, want)
+		require.NoError(t, err)
+		assert.Equal(t, want, lcm.LedgerSequence())
+		assert.Equal(t, 6, streamTxCount(t, lcm), "merged ledger holds every pipe's transactions")
+		assert.Equal(t, 3, streamPhaseCount(t, lcm), "merged ledger holds every pipe's txset phases")
+		assert.Equal(t, []uint32{want + 5, want + 5, want + 5}, streamEntrySeqs(t, lcm))
+	}
+}
+
+func TestStreamingLoadtestBackend_MergesV2Ledgers(t *testing.T) {
+	paths := mkFIFOs(t, 2)
+	backend := newStreamingBackend(t, paths, 0)
+
+	rawStarts := []uint32{2, 50}
+	for i, path := range paths {
+		feeder := newPipeFeeder(t, path)
+		feeder.send(makeStreamLedger(2, rawStarts[i], 2, rawStarts[i]+5))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), streamTestTimeout)
+	defer cancel()
+	require.NoError(t, backend.PrepareRange(ctx, ledgerbackend.UnboundedRange(10)))
+
+	lcm, err := backend.GetLedger(ctx, 10)
+	require.NoError(t, err)
+	require.Equal(t, int32(2), lcm.V)
+	assert.Equal(t, uint32(10), lcm.LedgerSequence())
+	assert.Equal(t, 4, streamTxCount(t, lcm))
+	assert.Equal(t, []uint32{15, 15}, streamEntrySeqs(t, lcm))
+	assert.Greater(t, uint64(streamCloseTime(t, lcm)), uint64(0))
+}
+
+func TestStreamingLoadtestBackend_RestartsOnePipeOnly(t *testing.T) {
+	paths := mkFIFOs(t, 3)
+	backend := newStreamingBackend(t, paths, 0)
+
+	// Pipes 0 and 2 run for the whole test. Pipe 1's writer exits after two
+	// ledgers and a fresh one attaches, the way a restarted apply-load does.
+	for _, i := range []int{0, 2} {
+		feeder := newPipeFeeder(t, paths[i])
+		for raw := uint32(2); raw <= 8; raw++ {
+			feeder.send(makeStreamLedger(1, raw, 1))
+		}
+	}
+	shortLived := newPipeFeeder(t, paths[1])
+	shortLived.send(makeStreamLedger(1, 2, 1), makeStreamLedger(1, 3, 1))
+
+	ctx, cancel := context.WithTimeout(context.Background(), streamTestTimeout)
+	defer cancel()
+	require.NoError(t, backend.PrepareRange(ctx, ledgerbackend.UnboundedRange(1)))
+
+	for _, want := range []uint32{1, 2} {
+		lcm, err := backend.GetLedger(ctx, want)
+		require.NoError(t, err)
+		require.Equal(t, want, lcm.LedgerSequence())
+		require.Equal(t, 3, streamTxCount(t, lcm))
+	}
+	shortLived.close()
+
+	// This call blocks: pipe 1 hits EOF, the backend drops that epoch and
+	// waits in open(2) for a new writer while pipes 0 and 2 hold their peeked
+	// frames.
+	pending := getLedgerAsync(backend, ctx, 3)
+	time.Sleep(reopenGrace)
+	restarted := newPipeFeeder(t, paths[1])
+	restarted.send(makeStreamLedger(1, 2, 1), makeStreamLedger(1, 3, 1))
+
+	res := <-pending
+	require.NoError(t, res.err)
+	assert.Equal(t, uint32(3), res.lcm.LedgerSequence())
+	assert.Equal(t, 3, streamTxCount(t, res.lcm), "the restarted pipe's frame is merged in")
+
+	// The restarted pipe advances on its own diff (raw 3 -> 4) while the
+	// untouched pipes stay in lockstep on theirs (raw 5 -> 4).
+	lcm, err := backend.GetLedger(ctx, 4)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(4), lcm.LedgerSequence())
+	assert.Equal(t, 3, streamTxCount(t, lcm))
+}
+
+func TestStreamingLoadtestBackend_RecoversFromTruncatedFrame(t *testing.T) {
+	paths := mkFIFOs(t, 1)
+	backend := newStreamingBackend(t, paths, 0)
+
+	killed := newPipeFeeder(t, paths[0])
+	killed.send(makeStreamLedger(1, 2, 1))
+	killed.sendRaw(truncatedFrame())
+	killed.close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), streamTestTimeout)
+	defer cancel()
+	require.NoError(t, backend.PrepareRange(ctx, ledgerbackend.UnboundedRange(1)))
+
+	lcm, err := backend.GetLedger(ctx, 1)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), lcm.LedgerSequence())
+
+	// The decode error must end the epoch and wait for a new writer, not
+	// surface to the consumer.
+	pending := getLedgerAsync(backend, ctx, 2)
+	time.Sleep(reopenGrace)
+	clean := newPipeFeeder(t, paths[0])
+	clean.send(makeStreamLedger(1, 2, 1), makeStreamLedger(1, 3, 1))
+
+	res := <-pending
+	require.NoError(t, res.err)
+	assert.Equal(t, uint32(2), res.lcm.LedgerSequence())
+
+	lcm, err = backend.GetLedger(ctx, 3)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(3), lcm.LedgerSequence())
+}
+
+func TestStreamingLoadtestBackend_StampsAdvancingCloseTime(t *testing.T) {
+	paths := mkFIFOs(t, 1)
+	backend := newStreamingBackend(t, paths, 0)
+
+	feeder := newPipeFeeder(t, paths[0])
+	for raw := uint32(2); raw <= 4; raw++ {
+		feeder.send(makeStreamLedger(1, raw, 1))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), streamTestTimeout)
+	defer cancel()
+	require.NoError(t, backend.PrepareRange(ctx, ledgerbackend.UnboundedRange(1)))
+
+	var previous xdr.TimePoint
+	for _, want := range []uint32{1, 2, 3} {
+		lcm, err := backend.GetLedger(ctx, want)
+		require.NoError(t, err)
+		closeTime := streamCloseTime(t, lcm)
+		assert.Greater(t, uint64(closeTime), uint64(0), "apply-load's closeTime 0 must be replaced")
+		assert.GreaterOrEqual(t, uint64(closeTime), uint64(previous))
+		previous = closeTime
+	}
+}
+
+func TestStreamingLoadtestBackend_RetryServesCachedLedger(t *testing.T) {
+	paths := mkFIFOs(t, 1)
+	backend := newStreamingBackend(t, paths, 0)
+
+	// Exactly one frame per emitted ledger: a retry that consumed another
+	// frame would leave nothing for the follow-up request.
+	feeder := newPipeFeeder(t, paths[0])
+	feeder.send(makeStreamLedger(1, 2, 1), makeStreamLedger(1, 3, 1))
+
+	ctx, cancel := context.WithTimeout(context.Background(), streamTestTimeout)
+	defer cancel()
+	require.NoError(t, backend.PrepareRange(ctx, ledgerbackend.UnboundedRange(1)))
+
+	_, err := backend.GetLedger(ctx, 1)
+	require.NoError(t, err)
+	first, err := backend.GetLedger(ctx, 2)
+	require.NoError(t, err)
+
+	retried, err := backend.GetLedger(ctx, 2)
+	require.NoError(t, err)
+	assert.Equal(t, first, retried, "a repeat request replays the cached ledger verbatim")
+
+	feeder.send(makeStreamLedger(1, 4, 1))
+	lcm, err := backend.GetLedger(ctx, 3)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(3), lcm.LedgerSequence(), "the retry left the stream position untouched")
+}
+
+func TestStreamingLoadtestBackend_PacesEmits(t *testing.T) {
+	paths := mkFIFOs(t, 1)
+	pace := 100 * time.Millisecond
+	backend := newStreamingBackend(t, paths, pace)
+
+	feeder := newPipeFeeder(t, paths[0])
+	for raw := uint32(2); raw <= 4; raw++ {
+		feeder.send(makeStreamLedger(1, raw, 1))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), streamTestTimeout)
+	defer cancel()
+	require.NoError(t, backend.PrepareRange(ctx, ledgerbackend.UnboundedRange(1)))
+
+	start := time.Now()
+	_, err := backend.GetLedger(ctx, 1)
+	require.NoError(t, err)
+	assert.Less(t, time.Since(start), pace, "the first emit has nothing to pace against")
+
+	for _, want := range []uint32{2, 3} {
+		start = time.Now()
+		_, err = backend.GetLedger(ctx, want)
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, time.Since(start), pace-10*time.Millisecond,
+			"emit %d should wait out the close duration", want)
+	}
+}
+
+func TestStreamingLoadtestBackend_TracksLatestLedgerSequence(t *testing.T) {
+	paths := mkFIFOs(t, 1)
+	backend := newStreamingBackend(t, paths, 0)
+
+	feeder := newPipeFeeder(t, paths[0])
+	feeder.send(makeStreamLedger(1, 2, 1), makeStreamLedger(1, 3, 1))
+
+	ctx, cancel := context.WithTimeout(context.Background(), streamTestTimeout)
+	defer cancel()
+
+	_, err := backend.GetLatestLedgerSequence(ctx)
+	require.ErrorContains(t, err, "before PrepareRange")
+
+	require.NoError(t, backend.PrepareRange(ctx, ledgerbackend.UnboundedRange(100)))
+	seq, err := backend.GetLatestLedgerSequence(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(100), seq, "before the first emit the range start is the tip")
+
+	for _, want := range []uint32{100, 101} {
+		_, err = backend.GetLedger(ctx, want)
+		require.NoError(t, err)
+		seq, err = backend.GetLatestLedgerSequence(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, want, seq)
+	}
+
+	prepared, err := backend.IsPrepared(ctx, ledgerbackend.UnboundedRange(100))
+	require.NoError(t, err)
+	assert.True(t, prepared)
+
+	prepared, err = backend.IsPrepared(ctx, ledgerbackend.BoundedRange(100, 101))
+	require.NoError(t, err)
+	assert.False(t, prepared, "the backend never serves a bounded range")
+}
+
+func TestStreamingLoadtestBackend_RejectsBadRequests(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), streamTestTimeout)
+	defer cancel()
+
+	t.Run("bounded range", func(t *testing.T) {
+		backend := newStreamingBackend(t, mkFIFOs(t, 1), 0)
+		err := backend.PrepareRange(ctx, ledgerbackend.BoundedRange(1, 5))
+		require.ErrorContains(t, err, "only supports unbounded ranges")
+	})
+
+	t.Run("get before prepare", func(t *testing.T) {
+		backend := newStreamingBackend(t, mkFIFOs(t, 1), 0)
+		_, err := backend.GetLedger(ctx, 1)
+		require.ErrorContains(t, err, "GetLedger called before PrepareRange")
+	})
+
+	t.Run("first request is not the range start", func(t *testing.T) {
+		backend := newStreamingBackend(t, mkFIFOs(t, 1), 0)
+		require.NoError(t, backend.PrepareRange(ctx, ledgerbackend.UnboundedRange(5)))
+		_, err := backend.GetLedger(ctx, 6)
+		require.ErrorContains(t, err, "non-sequential ledger request: expected 5, got 6")
+	})
+
+	t.Run("request skips ahead after an emit", func(t *testing.T) {
+		paths := mkFIFOs(t, 1)
+		backend := newStreamingBackend(t, paths, 0)
+		feeder := newPipeFeeder(t, paths[0])
+		feeder.send(makeStreamLedger(1, 2, 1), makeStreamLedger(1, 3, 1))
+
+		require.NoError(t, backend.PrepareRange(ctx, ledgerbackend.UnboundedRange(1)))
+		_, err := backend.GetLedger(ctx, 1)
+		require.NoError(t, err)
+		_, err = backend.GetLedger(ctx, 3)
+		require.ErrorContains(t, err, "non-sequential ledger request: expected 2, got 3")
+	})
+
+	t.Run("unsupported ledger version", func(t *testing.T) {
+		paths := mkFIFOs(t, 1)
+		backend := newStreamingBackend(t, paths, 0)
+		feeder := newPipeFeeder(t, paths[0])
+		feeder.send(makeV0StreamLedger(2))
+
+		require.NoError(t, backend.PrepareRange(ctx, ledgerbackend.UnboundedRange(1)))
+		_, err := backend.GetLedger(ctx, 1)
+		require.ErrorContains(t, err, "version")
+	})
+}
+
+func TestStreamingLoadtestBackend_RejectsSequenceGapWithinEpoch(t *testing.T) {
+	paths := mkFIFOs(t, 1)
+	backend := newStreamingBackend(t, paths, 0)
+
+	// A gap inside one writer's lifetime means frames were lost, which is not
+	// the same as the writer restarting and is not recoverable by reopening.
+	feeder := newPipeFeeder(t, paths[0])
+	feeder.send(makeStreamLedger(1, 2, 1), makeStreamLedger(1, 5, 1))
+
+	ctx, cancel := context.WithTimeout(context.Background(), streamTestTimeout)
+	defer cancel()
+	require.NoError(t, backend.PrepareRange(ctx, ledgerbackend.UnboundedRange(1)))
+
+	_, err := backend.GetLedger(ctx, 1)
+	require.NoError(t, err)
+
+	_, err = backend.GetLedger(ctx, 2)
+	require.ErrorContains(t, err, "sequence mismatch within stream epoch")
+}
+
+func TestNewLedgerBackend_StreamingLoadtest(t *testing.T) {
+	backend, err := NewLedgerBackend(context.Background(), Configs{
+		LedgerBackendType:           LedgerBackendTypeStreamingLoadtest,
+		LoadtestMetaPipePaths:       mkFIFOs(t, 2),
+		LoadtestLedgerCloseDuration: 500 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, backend)
+	streaming, ok := backend.(*StreamingLoadtestLedgerBackend)
+	require.True(t, ok, "NewLedgerBackend should return a StreamingLoadtestLedgerBackend")
+	assert.Len(t, streaming.pipes, 2)
+	assert.Equal(t, 500*time.Millisecond, streaming.config.LedgerCloseDuration)
+	assert.NoError(t, backend.Close())
+}

--- a/internal/services/ingest_live.go
+++ b/internal/services/ingest_live.go
@@ -299,7 +299,21 @@ func (m *ingestService) startLiveIngestion(ctx context.Context) error {
 	}
 
 	startLedger := latestIngestedLedger + 1
-	if latestIngestedLedger == 0 {
+	if latestIngestedLedger == 0 && m.archive == nil {
+		// No history archive (streaming-loadtest backend): there is no
+		// checkpoint state to bootstrap from, so start from ledger 1 with an
+		// empty database — balance state accumulates from the ledger stream.
+		// The cursor row must exist before the first guarded cursor update.
+		startLedger = 1
+		err = db.RunInTransaction(ctx, m.models.DB, func(dbTx pgx.Tx) error {
+			return m.initializeCursors(ctx, dbTx, startLedger)
+		})
+		if err != nil {
+			return fmt.Errorf("initializing cursors without archive bootstrap: %w", err)
+		}
+		m.appMetrics.Ingestion.LatestLedger.Set(float64(startLedger))
+		m.appMetrics.Ingestion.OldestLedger.Set(float64(startLedger))
+	} else if latestIngestedLedger == 0 {
 		startLedger, err = m.archive.GetLatestLedgerSequence()
 		if err != nil {
 			return fmt.Errorf("getting latest ledger sequence: %w", err)


### PR DESCRIPTION
### What
- New dev-only `LEDGER_BACKEND_TYPE=streaming-loadtest`: reads ledger meta from named pipes written by `stellar-core apply-load` (one FIFO per tx profile), merges the streams into one ledger sequence, renumbers so restarts on either side never need a DB reset, and stamps advancing close times (apply-load emits closeTime 0).
- Two flags: `--loadtest-meta-pipe-paths`, `--loadtest-ledger-close-duration` (pacing; FIFO backpressure throttles the generators to match).
- This backend type skips the history-archive connect and checkpoint bootstrap (apply-load publishes no archive); ingestion starts from ledger 1 on an empty DB.

### Why
Load-test ingestion at rates the dev loadtest network can't produce (thousands of soroban TPL, sub-second ledgers). Only the ledger backend is swapped — the live ingest loop, processors, and persistence are unchanged, so results predict production behavior.

### Testing
- Unit tests for renumbering, 3-pipe merge, per-pipe generator restart, truncated frames, pacing, retry idempotence (green under `-race`).
- Opt-in corpus test (`STREAMING_LOADTEST_CORPUS`) replayed real v27 sac/custom_token/soroswap apply-load output: 200 merged ledgers, ~57k txs, all parsed by the production transaction reader.
- `rpc`/`datastore` behavior unchanged (validation branches exercised manually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)