### PR TITLE
Cut process-stage CPU and allocations across the indexer and processors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/go-playground/validator/v10 v10.27.0
 	github.com/golang-jwt/jwt/v5 v5.2.3
 	github.com/google/uuid v1.6.0
-	github.com/guregu/null v4.0.0+incompatible
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/lib/pq v1.10.9
 	github.com/pkg/errors v0.9.1

--- a/internal/data/accounts.go
+++ b/internal/data/accounts.go
@@ -95,6 +95,10 @@ func batchCopyAccounts[T any](
 
 	// COPY the link table using pgx binary format with native pgtype types. Upstream
 	// participants handling ensures that account address is not NULL here.
+	// Participants are deduplicated per parent row upstream, so a busy account
+	// repeats once per transaction/operation here; the memo collapses that to
+	// one decode per unique address per batch.
+	memo := make(types.AddressByteaMemo)
 	var rows [][]any
 	for id, addresses := range addressesByID {
 		ledgerCreatedAt, ok := ledgerCreatedAtByID[id]
@@ -107,7 +111,7 @@ func batchCopyAccounts[T any](
 		ledgerCreatedAtPgtype := pgtype.Timestamptz{Time: ledgerCreatedAt, Valid: true}
 		idPgtype := pgtype.Int8{Int64: id, Valid: true}
 		for addr := range addresses {
-			addrBytes, addrErr := types.AddressBytea(addr).Value()
+			addrBytes, addrErr := memo.Bytes(types.AddressBytea(addr))
 			if addrErr != nil {
 				return fmt.Errorf("converting address %s to bytes: %w", addr, addrErr)
 			}

--- a/internal/data/query_utils.go
+++ b/internal/data/query_utils.go
@@ -74,21 +74,6 @@ func pgtypeInt2FromNullInt16(ni sql.NullInt16) pgtype.Int2 {
 	return pgtype.Int2{Int16: ni.Int16, Valid: ni.Valid}
 }
 
-// pgtypeBytesFromNullAddressBytea converts NullAddressBytea to bytes for BYTEA insert.
-func pgtypeBytesFromNullAddressBytea(na types.NullAddressBytea) ([]byte, error) {
-	if !na.Valid {
-		return nil, nil
-	}
-	val, err := na.Value()
-	if err != nil {
-		return nil, fmt.Errorf("converting address to bytes: %w", err)
-	}
-	if val == nil {
-		return nil, nil
-	}
-	return val.([]byte), nil
-}
-
 // CursorColumn represents a column name and its cursor value for decomposed pagination.
 type CursorColumn struct {
 	Name  string

--- a/internal/data/statechanges.go
+++ b/internal/data/statechanges.go
@@ -154,6 +154,9 @@ func (m *StateChangeModel) BatchCopy(
 
 	start := time.Now()
 
+	// One memo shared by every row of this COPY, used only from pgx's single row-callback goroutine.
+	memo := make(types.AddressByteaMemo)
+
 	// COPY state_changes using pgx binary format with native pgtype types
 	copyCount, err := pgxTx.CopyFrom(
 		ctx,
@@ -174,29 +177,29 @@ func (m *StateChangeModel) BatchCopy(
 			sc := stateChanges[i]
 
 			// Convert account_id to BYTEA (required field)
-			accountBytes, err := sc.AccountID.Value()
+			accountBytes, err := memo.Bytes(sc.AccountID)
 			if err != nil {
 				return nil, fmt.Errorf("converting account_id: %w", err)
 			}
 
 			// Convert nullable account_id fields to BYTEA
-			signerBytes, err := pgtypeBytesFromNullAddressBytea(sc.SignerAccountID)
+			signerBytes, err := memo.NullBytes(sc.SignerAccountID)
 			if err != nil {
 				return nil, fmt.Errorf("converting signer_account_id: %w", err)
 			}
-			spenderBytes, err := pgtypeBytesFromNullAddressBytea(sc.SpenderAccountID)
+			spenderBytes, err := memo.NullBytes(sc.SpenderAccountID)
 			if err != nil {
 				return nil, fmt.Errorf("converting spender_account_id: %w", err)
 			}
-			creatorBytes, err := pgtypeBytesFromNullAddressBytea(sc.CreatorAccountID)
+			creatorBytes, err := memo.NullBytes(sc.CreatorAccountID)
 			if err != nil {
 				return nil, fmt.Errorf("converting creator_account_id: %w", err)
 			}
-			destinationBytes, err := pgtypeBytesFromNullAddressBytea(sc.DestinationAccountID)
+			destinationBytes, err := memo.NullBytes(sc.DestinationAccountID)
 			if err != nil {
 				return nil, fmt.Errorf("converting destination_account_id: %w", err)
 			}
-			tokenBytes, err := pgtypeBytesFromNullAddressBytea(sc.TokenID)
+			tokenBytes, err := memo.NullBytes(sc.TokenID)
 			if err != nil {
 				return nil, fmt.Errorf("converting token_id: %w", err)
 			}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -723,7 +723,7 @@ func ExtractContractDataChangesForLedger(ledgerMeta xdr.LedgerCloseMeta, tracked
 			Ledger:        ledgerMeta,
 			Hash:          resultPair.TransactionHash,
 		}
-		if err := collectContractDataChanges(&tx, ledgerSeq, out); err != nil {
+		if err := collectContractDataChanges(&tx, ledgerSeq, &out); err != nil {
 			return nil, err
 		}
 	}
@@ -779,7 +779,7 @@ func ledgerTouchesTrackedContractData(ledgerMeta xdr.LedgerCloseMeta, trackedCon
 // last-write-wins folding per entry key is deterministic. Ledger-level
 // archival evictions are NOT surfaced (GetChanges only walks fee/tx/op meta);
 // per-tx entry removals appear with Post == nil.
-func collectContractDataChanges(tx *ingest.LedgerTransaction, ledgerSeq uint32, out map[string][]ingest.Change) error {
+func collectContractDataChanges(tx *ingest.LedgerTransaction, ledgerSeq uint32, out *map[string][]ingest.Change) error {
 	changes, chErr := tx.GetChanges()
 	if chErr != nil {
 		return fmt.Errorf("getting changes for ledger %d tx %d: %w", ledgerSeq, tx.Index, chErr)
@@ -792,10 +792,11 @@ func collectContractDataChanges(tx *ingest.LedgerTransaction, ledgerSeq uint32, 
 	return nil
 }
 
-// appendIfContractDataChange appends change into out under its owning
+// appendIfContractDataChange appends change into *out under its owning
 // contract's C-address strkey when it is a ContractData change carrying an
-// entry; every other change is ignored.
-func appendIfContractDataChange(out map[string][]ingest.Change, change ingest.Change, ledgerSeq uint32, txIndex uint32) error {
+// entry; every other change is ignored. *out is allocated on the first change
+// actually appended, so a caller that collects nothing keeps its nil map.
+func appendIfContractDataChange(out *map[string][]ingest.Change, change ingest.Change, ledgerSeq uint32, txIndex uint32) error {
 	if change.Type != xdr.LedgerEntryTypeContractData {
 		return nil
 	}
@@ -820,7 +821,10 @@ func appendIfContractDataChange(out map[string][]ingest.Change, change ingest.Ch
 		// dropping one would corrupt downstream state.
 		return fmt.Errorf("encoding contract id for ledger %d tx %d: %w", ledgerSeq, txIndex, encErr)
 	}
-	out[addr] = append(out[addr], change)
+	if *out == nil {
+		*out = make(map[string][]ingest.Change)
+	}
+	(*out)[addr] = append((*out)[addr], change)
 	return nil
 }
 
@@ -869,9 +873,16 @@ func ledgerEntryChangesContainContractData(changes xdr.LedgerEntryChanges) bool 
 // Composition mirrors ingest.LedgerTransaction.GetChanges per meta version:
 // transaction-level changes before, each operation's changes in operation
 // order, then (V2+) transaction-level changes after. Returns nil when the
-// transaction is unsuccessful or contributes no ContractData changes.
+// transaction is unsuccessful, is not a Soroban transaction, or contributes no
+// ContractData changes.
 func transactionContractDataChanges(tx *ingest.LedgerTransaction, opsParticipants map[int64]processors.OperationParticipants) (map[string][]ingest.Change, error) {
 	if !tx.Result.Successful() {
+		return nil, nil
+	}
+	// Only Soroban host functions write ContractData entries, and every Soroban
+	// transaction carries the SorobanTransactionData that IsSorobanTx tests, so
+	// a classic transaction is done before the walk allocates anything.
+	if !tx.IsSorobanTx() {
 		return nil, nil
 	}
 	ledgerSeq := tx.Ledger.LedgerSequence()
@@ -899,7 +910,7 @@ func transactionContractDataChanges(tx *ingest.LedgerTransaction, opsParticipant
 		return nil, fmt.Errorf("unsupported TransactionMeta version %d in ledger %d tx %d", tx.UnsafeMeta.V, ledgerSeq, tx.Index)
 	}
 
-	out := map[string][]ingest.Change{}
+	var out map[string][]ingest.Change
 	txLevel := func(ledgerEntryChanges xdr.LedgerEntryChanges) error {
 		if !ledgerEntryChangesContainContractData(ledgerEntryChanges) {
 			return nil
@@ -911,7 +922,7 @@ func transactionContractDataChanges(tx *ingest.LedgerTransaction, opsParticipant
 			changes[i].Ledger = &tx.Ledger
 		}
 		for _, change := range changes {
-			if err := appendIfContractDataChange(out, change, ledgerSeq, tx.Index); err != nil {
+			if err := appendIfContractDataChange(&out, change, ledgerSeq, tx.Index); err != nil {
 				return err
 			}
 		}
@@ -922,14 +933,20 @@ func transactionContractDataChanges(tx *ingest.LedgerTransaction, opsParticipant
 		return nil, err
 	}
 
-	wrappersByIndex := make(map[uint32]*processors.TransactionOperationWrapper, len(opsParticipants))
+	// Wrapper indices count the envelope's operations while opCount counts the
+	// meta's, one per operation for a successful transaction; the loop below only
+	// ever asks for indices below opCount, so a wrapper outside that range is
+	// unreachable either way.
+	wrappersByIndex := make([]*processors.TransactionOperationWrapper, opCount)
 	for _, opParticipants := range opsParticipants {
-		wrappersByIndex[opParticipants.OpWrapper.Index] = opParticipants.OpWrapper
+		if idx := opParticipants.OpWrapper.Index; idx < uint32(opCount) {
+			wrappersByIndex[idx] = opParticipants.OpWrapper
+		}
 	}
 	for opIdx := 0; opIdx < opCount; opIdx++ {
 		var changes []ingest.Change
 		var chErr error
-		if wrapper := wrappersByIndex[uint32(opIdx)]; wrapper != nil {
+		if wrapper := wrappersByIndex[opIdx]; wrapper != nil {
 			changes, chErr = wrapper.Changes()
 		} else {
 			// Every operation normally has a wrapper — its source account is
@@ -941,7 +958,7 @@ func transactionContractDataChanges(tx *ingest.LedgerTransaction, opsParticipant
 			return nil, fmt.Errorf("getting operation %d changes for ledger %d tx %d: %w", opIdx, ledgerSeq, tx.Index, chErr)
 		}
 		for _, change := range changes {
-			if err := appendIfContractDataChange(out, change, ledgerSeq, tx.Index); err != nil {
+			if err := appendIfContractDataChange(&out, change, ledgerSeq, tx.Index); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -228,20 +228,18 @@ func (i *Indexer) processTransaction(ctx context.Context, tx ingest.LedgerTransa
 		return nil, fmt.Errorf("creating data transaction: %w", err)
 	}
 
-	// Counts unique participants across tx, ops, and state changes for metrics.
+	// Counts unique participants across tx, ops, and state changes for metrics. The tx-level
+	// slice is snapshotted first, so folding the op and state-change accounts into the set
+	// leaves the reported tx participants untouched.
 	txParticipantsSlice := txParticipants.ToSlice()
-	allParticipants := make(map[string]struct{}, len(txParticipantsSlice))
-	for _, participant := range txParticipantsSlice {
-		allParticipants[participant] = struct{}{}
-	}
 	for _, opParticipants := range opsParticipants {
 		opParticipants.Participants.Each(func(participant string) bool {
-			allParticipants[participant] = struct{}{}
+			txParticipants.Add(participant)
 			return false
 		})
 	}
 	for _, stateChange := range stateChanges {
-		allParticipants[string(stateChange.AccountID)] = struct{}{}
+		txParticipants.Add(string(stateChange.AccountID))
 	}
 
 	result := &TransactionResult{
@@ -249,7 +247,7 @@ func (i *Indexer) processTransaction(ctx context.Context, tx ingest.LedgerTransa
 		TxParticipants:   txParticipantsSlice,
 		Operations:       make(map[int64]*types.Operation, len(opsParticipants)),
 		OpParticipants:   make(map[int64][]string, len(opsParticipants)),
-		ParticipantCount: len(allParticipants),
+		ParticipantCount: txParticipants.Cardinality(),
 	}
 
 	// Get operation results for extracting result codes

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -370,6 +370,16 @@ func (i *Indexer) processTransaction(ctx context.Context, tx ingest.LedgerTransa
 		}
 	}
 
+	// Collect ContractData changes off the wrappers' memoized change slices, so
+	// the persist stage reads them from the ledger buffer instead of rebuilding
+	// (and re-sorting) every operation's changes via tx.GetChanges on the serial
+	// persist goroutine.
+	contractDataChanges, cdErr := transactionContractDataChanges(&tx, opsParticipants)
+	if cdErr != nil {
+		return nil, fmt.Errorf("collecting contract data changes: %w", cdErr)
+	}
+	result.ContractDataChanges = contractDataChanges
+
 	// Collect state changes, dropping those whose operation is missing. Empty-AccountID entries
 	// are already filtered (and IDs assigned per processor stream) by getTransactionStateChanges.
 	// The fold resolves each change's operation from result.Operations by OperationID.
@@ -764,26 +774,6 @@ func ledgerTouchesTrackedContractData(ledgerMeta xdr.LedgerCloseMeta, trackedCon
 	return false
 }
 
-// ExtractContractDataChangesFromTransactions extracts the same
-// contract-grouped ContractData changes as ExtractContractDataChangesForLedger
-// over already-materialized transactions, ungated — live ingestion's main
-// pipeline has the transactions in hand and processes one ledger per close,
-// so a footprint gate buys nothing there. ledgerSeq is used only for error
-// context.
-func ExtractContractDataChangesFromTransactions(transactions []ingest.LedgerTransaction, ledgerSeq uint32) (map[string][]ingest.Change, error) {
-	out := make(map[string][]ingest.Change)
-	for i := range transactions {
-		tx := transactions[i]
-		if !tx.Result.Successful() {
-			continue
-		}
-		if err := collectContractDataChanges(&tx, ledgerSeq, out); err != nil {
-			return nil, err
-		}
-	}
-	return out, nil
-}
-
 // collectContractDataChanges appends tx's ContractData changes into out,
 // grouped by the owning contract's C-address strkey.
 //
@@ -797,52 +787,192 @@ func collectContractDataChanges(tx *ingest.LedgerTransaction, ledgerSeq uint32, 
 		return fmt.Errorf("getting changes for ledger %d tx %d: %w", ledgerSeq, tx.Index, chErr)
 	}
 	for _, change := range changes {
-		if change.Type != xdr.LedgerEntryTypeContractData {
-			continue
+		if err := appendIfContractDataChange(out, change, ledgerSeq, tx.Index); err != nil {
+			return err
 		}
-		entry := change.Post
-		if entry == nil {
-			entry = change.Pre
-		}
-		if entry == nil {
-			continue
-		}
-		contractData, ok := entry.Data.GetContractData()
-		if !ok {
-			continue
-		}
-		contractIDBytes, ok := contractData.Contract.GetContractId()
-		if !ok {
-			continue
-		}
-		addr, encErr := strkey.Encode(strkey.VersionByteContract, contractIDBytes[:])
-		if encErr != nil {
-			// Callers rely on this function returning every ContractData
-			// change; silently dropping one would corrupt downstream state.
-			return fmt.Errorf("encoding contract id for ledger %d tx %d: %w", ledgerSeq, tx.Index, encErr)
-		}
-		out[addr] = append(out[addr], change)
 	}
 	return nil
 }
 
+// appendIfContractDataChange appends change into out under its owning
+// contract's C-address strkey when it is a ContractData change carrying an
+// entry; every other change is ignored.
+func appendIfContractDataChange(out map[string][]ingest.Change, change ingest.Change, ledgerSeq uint32, txIndex uint32) error {
+	if change.Type != xdr.LedgerEntryTypeContractData {
+		return nil
+	}
+	entry := change.Post
+	if entry == nil {
+		entry = change.Pre
+	}
+	if entry == nil {
+		return nil
+	}
+	contractData, ok := entry.Data.GetContractData()
+	if !ok {
+		return nil
+	}
+	contractIDBytes, ok := contractData.Contract.GetContractId()
+	if !ok {
+		return nil
+	}
+	addr, encErr := strkey.Encode(strkey.VersionByteContract, contractIDBytes[:])
+	if encErr != nil {
+		// Callers rely on receiving every ContractData change; silently
+		// dropping one would corrupt downstream state.
+		return fmt.Errorf("encoding contract id for ledger %d tx %d: %w", ledgerSeq, txIndex, encErr)
+	}
+	out[addr] = append(out[addr], change)
+	return nil
+}
+
+// ledgerEntryChangesContainContractData reports whether any element of the
+// group references a ContractData entry or key. It lets the transaction-level
+// segments of transactionContractDataChanges skip the Change build (and its
+// per-change ledger-key sort) entirely — for almost every transaction those
+// segments hold only fee-account entries.
+func ledgerEntryChangesContainContractData(changes xdr.LedgerEntryChanges) bool {
+	for _, c := range changes {
+		switch c.Type {
+		case xdr.LedgerEntryChangeTypeLedgerEntryCreated:
+			if c.MustCreated().Data.Type == xdr.LedgerEntryTypeContractData {
+				return true
+			}
+		case xdr.LedgerEntryChangeTypeLedgerEntryUpdated:
+			if c.MustUpdated().Data.Type == xdr.LedgerEntryTypeContractData {
+				return true
+			}
+		case xdr.LedgerEntryChangeTypeLedgerEntryRemoved:
+			if c.MustRemoved().Type == xdr.LedgerEntryTypeContractData {
+				return true
+			}
+		case xdr.LedgerEntryChangeTypeLedgerEntryState:
+			if c.MustState().Data.Type == xdr.LedgerEntryTypeContractData {
+				return true
+			}
+		case xdr.LedgerEntryChangeTypeLedgerEntryRestored:
+			if c.MustRestored().Data.Type == xdr.LedgerEntryTypeContractData {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// transactionContractDataChanges returns tx's ContractData changes grouped by
+// the owning contract's C-address strkey — the same sequence
+// collectContractDataChanges derives from tx.GetChanges() — while serving
+// every operation segment from the wrappers' memoized Changes() slices, so
+// each operation's meta is materialized and ledger-key-sorted once for the
+// whole pipeline instead of a second time here. Only the small
+// transaction-level segments are built in place, and only when their raw
+// change groups mention a ContractData entry at all.
+//
+// Composition mirrors ingest.LedgerTransaction.GetChanges per meta version:
+// transaction-level changes before, each operation's changes in operation
+// order, then (V2+) transaction-level changes after. Returns nil when the
+// transaction is unsuccessful or contributes no ContractData changes.
+func transactionContractDataChanges(tx *ingest.LedgerTransaction, opsParticipants map[int64]processors.OperationParticipants) (map[string][]ingest.Change, error) {
+	if !tx.Result.Successful() {
+		return nil, nil
+	}
+	ledgerSeq := tx.Ledger.LedgerSequence()
+
+	var before, after xdr.LedgerEntryChanges
+	var opCount int
+	switch tx.UnsafeMeta.V {
+	case 1:
+		meta := tx.UnsafeMeta.MustV1()
+		before = meta.TxChanges
+		opCount = len(meta.Operations)
+	case 2:
+		meta := tx.UnsafeMeta.MustV2()
+		before, after = meta.TxChangesBefore, meta.TxChangesAfter
+		opCount = len(meta.Operations)
+	case 3:
+		meta := tx.UnsafeMeta.MustV3()
+		before, after = meta.TxChangesBefore, meta.TxChangesAfter
+		opCount = len(meta.Operations)
+	case 4:
+		meta := tx.UnsafeMeta.MustV4()
+		before, after = meta.TxChangesBefore, meta.TxChangesAfter
+		opCount = len(meta.Operations)
+	default:
+		return nil, fmt.Errorf("unsupported TransactionMeta version %d in ledger %d tx %d", tx.UnsafeMeta.V, ledgerSeq, tx.Index)
+	}
+
+	out := map[string][]ingest.Change{}
+	txLevel := func(ledgerEntryChanges xdr.LedgerEntryChanges) error {
+		if !ledgerEntryChangesContainContractData(ledgerEntryChanges) {
+			return nil
+		}
+		changes := ingest.GetChangesFromLedgerEntryChanges(ledgerEntryChanges)
+		for i := range changes {
+			changes[i].Reason = ingest.LedgerEntryChangeReasonTransaction
+			changes[i].Transaction = tx
+			changes[i].Ledger = &tx.Ledger
+		}
+		for _, change := range changes {
+			if err := appendIfContractDataChange(out, change, ledgerSeq, tx.Index); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if err := txLevel(before); err != nil {
+		return nil, err
+	}
+
+	wrappersByIndex := make(map[uint32]*processors.TransactionOperationWrapper, len(opsParticipants))
+	for _, opParticipants := range opsParticipants {
+		wrappersByIndex[opParticipants.OpWrapper.Index] = opParticipants.OpWrapper
+	}
+	for opIdx := 0; opIdx < opCount; opIdx++ {
+		var changes []ingest.Change
+		var chErr error
+		if wrapper := wrappersByIndex[uint32(opIdx)]; wrapper != nil {
+			changes, chErr = wrapper.Changes()
+		} else {
+			// Every operation normally has a wrapper — its source account is
+			// always a participant — so this is a correctness backstop for an
+			// operation filtered out of opsParticipants, not a hot path.
+			changes, chErr = tx.GetOperationChanges(uint32(opIdx))
+		}
+		if chErr != nil {
+			return nil, fmt.Errorf("getting operation %d changes for ledger %d tx %d: %w", opIdx, ledgerSeq, tx.Index, chErr)
+		}
+		for _, change := range changes {
+			if err := appendIfContractDataChange(out, change, ledgerSeq, tx.Index); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if err := txLevel(after); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
 // ProcessLedger extracts transactions from a ledger and indexes them.
-// Returns the participant count for optional metrics recording, plus the
-// materialized transactions so callers with further per-transaction work
-// (live ingestion's ContractData extraction) can reuse them instead of
-// paying for a second LedgerTransactionReader build — its constructor
-// re-hashes every transaction envelope.
-func ProcessLedger(ctx context.Context, networkPassphrase string, ledgerMeta xdr.LedgerCloseMeta, ledgerIndexer *Indexer, buffer *IndexerBuffer) (int, []ingest.LedgerTransaction, error) {
+// Returns the participant count for optional metrics recording. Everything a
+// downstream stage needs — including the ledger's ContractData changes — is
+// folded into the buffer.
+func ProcessLedger(ctx context.Context, networkPassphrase string, ledgerMeta xdr.LedgerCloseMeta, ledgerIndexer *Indexer, buffer *IndexerBuffer) (int, error) {
 	ledgerSeq := ledgerMeta.LedgerSequence()
 	transactions, err := GetLedgerTransactions(ctx, networkPassphrase, ledgerMeta, ledgerIndexer.pool)
 	if err != nil {
-		return 0, nil, fmt.Errorf("getting transactions for ledger %d: %w", ledgerSeq, err)
+		return 0, fmt.Errorf("getting transactions for ledger %d: %w", ledgerSeq, err)
 	}
 
 	participantCount, err := ledgerIndexer.ProcessLedgerTransactions(ctx, transactions, buffer)
 	if err != nil {
-		return 0, nil, fmt.Errorf("processing transactions for ledger %d: %w", ledgerSeq, err)
+		return 0, fmt.Errorf("processing transactions for ledger %d: %w", ledgerSeq, err)
 	}
 
-	return participantCount, transactions, nil
+	return participantCount, nil
 }

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -2,15 +2,19 @@ package indexer
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
+	"runtime"
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/alitto/pond/v2"
 	set "github.com/deckarep/golang-set/v2"
+	"github.com/stellar/go-stellar-sdk/hash"
 	"github.com/stellar/go-stellar-sdk/ingest"
+	"github.com/stellar/go-stellar-sdk/network"
 	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/xdr"
@@ -20,7 +24,6 @@ import (
 	contract_processors "github.com/stellar/wallet-backend/internal/indexer/processors/contracts"
 	"github.com/stellar/wallet-backend/internal/indexer/types"
 	"github.com/stellar/wallet-backend/internal/metrics"
-	"github.com/stellar/wallet-backend/internal/utils"
 )
 
 // IndexerBufferInterface is the buffer seam the indexer writes through and the
@@ -438,27 +441,185 @@ func assignStateChangeStream(dst, stream []types.StateChange, subBase int64) []t
 	return append(dst, retained...)
 }
 
-// GetLedgerTransactions extracts transactions from ledger close meta.
-func GetLedgerTransactions(ctx context.Context, networkPassphrase string, ledgerMeta xdr.LedgerCloseMeta) ([]ingest.LedgerTransaction, error) {
-	ledgerTxReader, err := ingest.NewLedgerTransactionReaderFromLedgerCloseMeta(networkPassphrase, ledgerMeta)
-	if err != nil {
-		return nil, fmt.Errorf("creating ledger transaction reader: %w", err)
-	}
-	defer utils.DeferredClose(ctx, ledgerTxReader, "closing ledger transaction reader")
+// errBadMetaVersion rejects a ledger whose metas predate TransactionMeta v2 on
+// a protocol old enough that stellar-core wrote them ambiguously.
+var errBadMetaVersion = errors.New("TransactionMeta.V=2 is required in protocol version older than version 10; " +
+	"please process ledgers again using the latest stellar-core version")
 
-	transactions := make([]ingest.LedgerTransaction, 0)
-	for {
-		tx, err := ledgerTxReader.Read()
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				break
+// GetLedgerTransactions extracts transactions from ledger close meta, pairing
+// each meta with the envelope that produced it.
+//
+// Pairing needs every envelope's hash. The transaction set carries envelopes in
+// the order validators agreed on while the metas are sorted by hash, so the
+// hash is the only thing that identifies which envelope belongs to which meta.
+// Hashing is essentially this function's whole cost — it marshals every
+// envelope's signature payload — and each envelope is independent of the rest,
+// so it runs across pool's workers rather than on the caller's goroutine, where
+// at loadtest ledger sizes it was the pipeline's largest serial stretch.
+func GetLedgerTransactions(ctx context.Context, networkPassphrase string, ledgerMeta xdr.LedgerCloseMeta, pool pond.Pool) ([]ingest.LedgerTransaction, error) {
+	envelopes := ledgerMeta.TransactionEnvelopes()
+
+	// Protocol versions below 10 predate TransactionMeta v2, where a v0/v1 meta
+	// carrying fee processing is ambiguous. The version is a property of the
+	// ledger, so the guard is evaluated once here instead of per transaction.
+	if ledgerMeta.ProtocolVersion() < 10 {
+		for i := range envelopes {
+			if ledgerMeta.TxApplyProcessing(i).V < 2 && len(ledgerMeta.FeeProcessing(i)) > 0 {
+				return nil, errBadMetaVersion
 			}
-			return nil, fmt.Errorf("reading ledger: %w", err)
 		}
-		transactions = append(transactions, tx)
+	}
+
+	hashes, err := hashEnvelopes(ctx, networkPassphrase, envelopes, pool)
+	if err != nil {
+		return nil, fmt.Errorf("hashing transaction set of ledger %d: %w", ledgerMeta.LedgerSequence(), err)
+	}
+
+	// Envelope order decides collisions and the last envelope wins: a
+	// transaction hash covers the signature payload but not the signatures, so
+	// one ledger can hold the same transaction body signed two different ways
+	// as two distinct envelopes sharing a hash. Merged loadtest ledgers do
+	// repeat transactions, so this is load-bearing rather than theoretical.
+	envelopeByHash := make(map[xdr.Hash]int, len(envelopes))
+	for i, hash := range hashes {
+		envelopeByHash[hash] = i
+	}
+
+	// Hoisted out of the loop: both return their struct by value, so reading
+	// them per transaction copied the whole ledger header and V2 body each time.
+	ledgerVersion := uint32(ledgerMeta.LedgerHeaderHistoryEntry().Header.LedgerVersion)
+	metaV2, hasMetaV2 := ledgerMeta.GetV2()
+
+	transactions := make([]ingest.LedgerTransaction, ledgerMeta.CountTransactions())
+	for i := range transactions {
+		txHash := ledgerMeta.TransactionHash(i)
+		envelopeIdx, ok := envelopeByHash[txHash]
+		if !ok {
+			return nil, fmt.Errorf("unknown tx hash in LedgerCloseMeta: %s", hex.EncodeToString(txHash[:]))
+		}
+
+		var postTxApplyFeeChanges xdr.LedgerEntryChanges
+		if hasMetaV2 {
+			postTxApplyFeeChanges = metaV2.TxProcessing[i].PostTxApplyFeeProcessing
+		}
+
+		transactions[i] = ingest.LedgerTransaction{
+			Index:                 uint32(i + 1), // Transactions start at '1'.
+			Envelope:              envelopes[envelopeIdx],
+			Result:                ledgerMeta.TransactionResultPair(i),
+			UnsafeMeta:            ledgerMeta.TxApplyProcessing(i),
+			FeeChanges:            ledgerMeta.FeeProcessing(i),
+			PostTxApplyFeeChanges: postTxApplyFeeChanges,
+			LedgerVersion:         ledgerVersion,
+			Ledger:                ledgerMeta,
+			Hash:                  txHash,
+		}
 	}
 
 	return transactions, nil
+}
+
+// hashEnvelopes returns the network-specific hash of every envelope, indexed as
+// envelopes is. Work is split into one contiguous chunk per pool worker so each
+// chunk can hold a single xdr.EncodingBuffer: the buffer reuses its scratch
+// space across marshals, which is what keeps this off the allocator, and the
+// SDK documents it as unsafe to share between goroutines.
+func hashEnvelopes(ctx context.Context, networkPassphrase string, envelopes []xdr.TransactionEnvelope, pool pond.Pool) ([]xdr.Hash, error) {
+	if strings.TrimSpace(networkPassphrase) == "" {
+		return nil, errors.New("empty network passphrase")
+	}
+	hashes := make([]xdr.Hash, len(envelopes))
+	if len(envelopes) == 0 {
+		return hashes, nil
+	}
+	// The network id is a hash of the passphrase alone, so it is the same for
+	// every transaction in the process.
+	networkID := xdr.Hash(network.ID(networkPassphrase))
+
+	// One chunk per worker, but never more than the machine can actually run at
+	// once: an unbounded pool reports its concurrency as unlimited, which would
+	// otherwise make a chunk — and a buffer — per transaction and defeat the
+	// reuse this is built around.
+	chunkCount := min(pool.MaxConcurrency(), runtime.GOMAXPROCS(0), len(envelopes))
+	chunkSize := (len(envelopes) + chunkCount - 1) / chunkCount
+
+	group := pool.NewGroupContext(ctx)
+	var errs []error
+	errMu := sync.Mutex{}
+
+	for chunkStart := 0; chunkStart < len(envelopes); chunkStart += chunkSize {
+		start, end := chunkStart, min(chunkStart+chunkSize, len(envelopes))
+		group.Submit(func() {
+			buf := xdr.NewEncodingBuffer()
+			for i := start; i < end; i++ {
+				envelopeHash, err := hashEnvelope(buf, networkID, &envelopes[i])
+				if err != nil {
+					errMu.Lock()
+					errs = append(errs, fmt.Errorf("hashing transaction %d in tx set: %w", i, err))
+					errMu.Unlock()
+					return
+				}
+				hashes[i] = envelopeHash
+			}
+		})
+	}
+
+	if err := group.Wait(); err != nil {
+		return nil, fmt.Errorf("waiting for envelope hashing: %w", err)
+	}
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+	return hashes, nil
+}
+
+// hashEnvelope computes one transaction's network-specific hash. It mirrors
+// network.HashTransactionInEnvelope, but marshals through the caller's buffer
+// and a precomputed network id rather than allocating a fresh buffer and
+// re-hashing the passphrase for every transaction, and it tags the envelope's
+// transaction in place rather than by value.
+func hashEnvelope(buf *xdr.EncodingBuffer, networkID xdr.Hash, envelope *xdr.TransactionEnvelope) (xdr.Hash, error) {
+	var tagged xdr.TransactionSignaturePayloadTaggedTransaction
+	//exhaustive:ignore
+	switch envelope.Type {
+	case xdr.EnvelopeTypeEnvelopeTypeTx:
+		tagged = xdr.TransactionSignaturePayloadTaggedTransaction{
+			Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+			Tx:   &envelope.V1.Tx,
+		}
+	case xdr.EnvelopeTypeEnvelopeTypeTxV0:
+		// A v0 transaction is hashed as the v1 transaction it maps onto.
+		v0 := envelope.V0.Tx
+		sourceAccount, err := xdr.NewMuxedAccount(xdr.CryptoKeyTypeKeyTypeEd25519, v0.SourceAccountEd25519)
+		if err != nil {
+			return xdr.Hash{}, fmt.Errorf("converting v0 source account: %w", err)
+		}
+		tagged = xdr.TransactionSignaturePayloadTaggedTransaction{
+			Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+			Tx: &xdr.Transaction{
+				SourceAccount: sourceAccount,
+				Fee:           v0.Fee,
+				SeqNum:        v0.SeqNum,
+				Cond:          xdr.NewPreconditionsWithTimeBounds(v0.TimeBounds),
+				Memo:          v0.Memo,
+				Operations:    v0.Operations,
+			},
+		}
+	case xdr.EnvelopeTypeEnvelopeTypeTxFeeBump:
+		tagged = xdr.TransactionSignaturePayloadTaggedTransaction{
+			Type:    xdr.EnvelopeTypeEnvelopeTypeTxFeeBump,
+			FeeBump: &envelope.FeeBump.Tx,
+		}
+	default:
+		return xdr.Hash{}, fmt.Errorf("invalid transaction type %s", envelope.Type)
+	}
+
+	payload := xdr.TransactionSignaturePayload{NetworkId: networkID, TaggedTransaction: tagged}
+	encoded, err := buf.UnsafeMarshalBinary(&payload)
+	if err != nil {
+		return xdr.Hash{}, fmt.Errorf("marshalling transaction signature payload: %w", err)
+	}
+	return xdr.Hash(hash.Hash(encoded)), nil
 }
 
 // ExtractContractEventsForLedger walks a ledger's transactions directly from the
@@ -673,7 +834,7 @@ func collectContractDataChanges(tx *ingest.LedgerTransaction, ledgerSeq uint32, 
 // re-hashes every transaction envelope.
 func ProcessLedger(ctx context.Context, networkPassphrase string, ledgerMeta xdr.LedgerCloseMeta, ledgerIndexer *Indexer, buffer *IndexerBuffer) (int, []ingest.LedgerTransaction, error) {
 	ledgerSeq := ledgerMeta.LedgerSequence()
-	transactions, err := GetLedgerTransactions(ctx, networkPassphrase, ledgerMeta)
+	transactions, err := GetLedgerTransactions(ctx, networkPassphrase, ledgerMeta, ledgerIndexer.pool)
 	if err != nil {
 		return 0, nil, fmt.Errorf("getting transactions for ledger %d: %w", ledgerSeq, err)
 	}

--- a/internal/indexer/indexer_buffer.go
+++ b/internal/indexer/indexer_buffer.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/stellar/go-stellar-sdk/ingest"
 	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/txnbuild"
 	"github.com/stellar/go-stellar-sdk/xdr"
@@ -103,6 +104,11 @@ type IndexerBuffer struct {
 	wasmBytecodesByHash   map[string][]byte                 // wasmHash → raw bytecode (consumed by classification dispatch)
 	protocolContractsByID map[string]data.ProtocolContracts // contractID → ProtocolContracts
 	contractEventsByKey   map[ContractEventKey][]xdr.ContractEvent
+	// contractDataChangesByContract groups the ledger's ContractData changes by the owning
+	// contract's C-address strkey. Within a contract, changes arrive in transaction application
+	// order (the fold is serial in transaction order), so last-write-wins folding per entry key
+	// stays deterministic for the protocol processors that consume this at persist time.
+	contractDataChangesByContract map[string][]ingest.Change
 }
 
 // NewIndexerBuffer creates a new IndexerBuffer with initialized data structures.
@@ -131,6 +137,7 @@ func NewIndexerBuffer() *IndexerBuffer {
 		wasmBytecodesByHash:            make(map[string][]byte),
 		protocolContractsByID:          make(map[string]data.ProtocolContracts),
 		contractEventsByKey:            make(map[ContractEventKey][]xdr.ContractEvent),
+		contractDataChangesByContract:  make(map[string][]ingest.Change),
 	}
 }
 
@@ -453,7 +460,11 @@ type TransactionResult struct {
 	ProtocolWasmBytecodes map[string][]byte
 	ProtocolContracts     []data.ProtocolContracts
 	ContractEvents        map[ContractEventKey][]xdr.ContractEvent
-	ParticipantCount      int
+	// ContractDataChanges groups the transaction's ContractData changes by owning contract
+	// C-address, composed in GetChanges order (tx-level before, operations ascending, tx-level
+	// after); nil when the transaction is unsuccessful or touches no ContractData.
+	ContractDataChanges map[string][]ingest.Change
+	ParticipantCount    int
 }
 
 // IngestTransactionResult folds a single transaction's result into the buffer, applying the same
@@ -515,6 +526,20 @@ func (b *IndexerBuffer) IngestTransactionResult(r *TransactionResult) {
 	for key, events := range r.ContractEvents {
 		b.PushContractEvents(key, events)
 	}
+
+	// Random map order over contract addresses is fine here: each per-address
+	// slice is appended as one unit, and the fold itself runs in transaction
+	// application order, which is the only ordering consumers rely on.
+	for addr, changes := range r.ContractDataChanges {
+		b.contractDataChangesByContract[addr] = append(b.contractDataChangesByContract[addr], changes...)
+	}
+}
+
+// GetContractDataChanges returns the buffer's ContractData changes grouped by
+// owning contract C-address, in transaction application order within each
+// contract; callers must not modify it.
+func (b *IndexerBuffer) GetContractDataChanges() map[string][]ingest.Change {
+	return b.contractDataChangesByContract
 }
 
 // Clear resets the buffer to its initial empty state while preserving allocated capacity. Both
@@ -539,6 +564,7 @@ func (b *IndexerBuffer) Clear() {
 	clear(b.wasmBytecodesByHash)
 	clear(b.protocolContractsByID)
 	clear(b.contractEventsByKey)
+	clear(b.contractDataChangesByContract)
 
 	// Reset slices (reuse underlying arrays by slicing to zero)
 	b.stateChanges = b.stateChanges[:0]

--- a/internal/indexer/indexer_buffer.go
+++ b/internal/indexer/indexer_buffer.go
@@ -537,7 +537,9 @@ func (b *IndexerBuffer) IngestTransactionResult(r *TransactionResult) {
 
 // GetContractDataChanges returns the buffer's ContractData changes grouped by
 // owning contract C-address, in transaction application order within each
-// contract; callers must not modify it.
+// contract; callers must not modify it. The map is allocated at construction
+// and never replaced, so a buffer from NewIndexerBuffer never returns nil here
+// — the RequiresContractData processors range over the result unconditionally.
 func (b *IndexerBuffer) GetContractDataChanges() map[string][]ingest.Change {
 	return b.contractDataChangesByContract
 }

--- a/internal/indexer/indexer_buffer_bench_test.go
+++ b/internal/indexer/indexer_buffer_bench_test.go
@@ -25,6 +25,33 @@ func benchIndexer(tb testing.TB) *Indexer {
 	return idx
 }
 
+// BenchmarkGetLedgerTransactions measures the envelope↔meta pairing pass that opens every
+// ledger: hashing each transaction's signature payload, then materializing the transactions.
+// The fixtures are pubnet-sized (hundreds of transactions, not the loadtest rig's ~20,000), so
+// allocs/op is the portable signal here — the fan-out's wall-clock win scales with ledger size.
+// One sub-benchmark per fixture.
+func BenchmarkGetLedgerTransactions(b *testing.B) {
+	ctx := context.Background()
+	pool := pond.NewPool(runtime.NumCPU())
+
+	paths, err := filepath.Glob("testdata/*.xdr.gz")
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, path := range paths {
+		lcm := loadLedgerFixture(b, path)
+
+		b.Run(filepath.Base(path), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := GetLedgerTransactions(ctx, network.PublicNetworkPassphrase, lcm, pool); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
 // BenchmarkProcessRealLedger measures a full per-ledger indexing pass: parallel workers build a
 // per-tx TransactionResult, which are folded into one ledger buffer. One sub-benchmark per fixture.
 func BenchmarkProcessRealLedger(b *testing.B) {
@@ -37,7 +64,7 @@ func BenchmarkProcessRealLedger(b *testing.B) {
 	}
 	for _, path := range paths {
 		lcm := loadLedgerFixture(b, path)
-		txs, err := GetLedgerTransactions(ctx, network.PublicNetworkPassphrase, lcm)
+		txs, err := GetLedgerTransactions(ctx, network.PublicNetworkPassphrase, lcm, idx.pool)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -68,7 +95,7 @@ func BenchmarkFoldRealLedger(b *testing.B) {
 	}
 	for _, path := range paths {
 		lcm := loadLedgerFixture(b, path)
-		txs, err := GetLedgerTransactions(ctx, network.PublicNetworkPassphrase, lcm)
+		txs, err := GetLedgerTransactions(ctx, network.PublicNetworkPassphrase, lcm, idx.pool)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/indexer/indexer_buffer_test.go
+++ b/internal/indexer/indexer_buffer_test.go
@@ -3,6 +3,8 @@ package indexer
 import (
 	"testing"
 
+	"github.com/stellar/go-stellar-sdk/ingest"
+	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -346,6 +348,63 @@ func TestIndexerBuffer_IngestTransactionResult(t *testing.T) {
 		buffer.IngestTransactionResult(remove)
 
 		assert.Len(t, buffer.GetAccountChanges(), 0)
+	})
+}
+
+func TestIndexerBuffer_ContractDataChanges(t *testing.T) {
+	// OperationIndex is only an identity marker here: it makes each change
+	// distinguishable so the assertions can pin concatenation order.
+	change := func(operationIndex uint32) ingest.Change {
+		return ingest.Change{Type: xdr.LedgerEntryTypeContractData, OperationIndex: operationIndex}
+	}
+
+	t.Run("🟢 folds per-contract changes in fold order", func(t *testing.T) {
+		buffer := NewIndexerBuffer()
+		tx := types.Transaction{Hash: "e76b7b0133690fbfb2de8fa9ca2273cb4f2e29447e0cf0e14a5f82d0daa48760", ToID: 1}
+
+		// The two results overlap on "CSHARED" and each also touches a contract
+		// the other does not.
+		first := &TransactionResult{
+			Transaction: &tx,
+			ContractDataChanges: map[string][]ingest.Change{
+				"CSHARED": {change(0), change(1)},
+				"CONLY1":  {change(2)},
+			},
+		}
+		second := &TransactionResult{
+			Transaction: &tx,
+			ContractDataChanges: map[string][]ingest.Change{
+				"CSHARED": {change(3)},
+				"CONLY2":  {change(4)},
+			},
+		}
+
+		buffer.IngestTransactionResult(first)
+		buffer.IngestTransactionResult(second)
+
+		got := buffer.GetContractDataChanges()
+		require.Len(t, got, 3)
+		assert.Equal(t, []ingest.Change{change(0), change(1), change(3)}, got["CSHARED"],
+			"overlapping contract's changes must concatenate in fold order")
+		assert.Equal(t, []ingest.Change{change(2)}, got["CONLY1"])
+		assert.Equal(t, []ingest.Change{change(4)}, got["CONLY2"])
+	})
+
+	t.Run("🟢 Clear empties the map without nilling it", func(t *testing.T) {
+		buffer := NewIndexerBuffer()
+		tx := types.Transaction{Hash: "e76b7b0133690fbfb2de8fa9ca2273cb4f2e29447e0cf0e14a5f82d0daa48760", ToID: 1}
+
+		buffer.IngestTransactionResult(&TransactionResult{
+			Transaction:         &tx,
+			ContractDataChanges: map[string][]ingest.Change{"CSHARED": {change(0)}},
+		})
+		require.NotEmpty(t, buffer.GetContractDataChanges())
+
+		buffer.Clear()
+
+		got := buffer.GetContractDataChanges()
+		assert.NotNil(t, got, "Clear must keep the map allocated for the next ledger")
+		assert.Empty(t, got)
 	})
 }
 

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -244,7 +244,7 @@ func TestIndexer_ProcessLedgerTransactions(t *testing.T) {
 			1: {
 				OpWrapper: &processors.TransactionOperationWrapper{
 					Index:          0,
-					Transaction:    testTx,
+					Transaction:    &testTx,
 					Operation:      createAccountOp,
 					Network:        network.TestNetworkPassphrase,
 					LedgerSequence: 12345,
@@ -351,7 +351,7 @@ func TestIndexer_ProcessLedgerTransactions(t *testing.T) {
 			1: {
 				OpWrapper: &processors.TransactionOperationWrapper{
 					Index:          0,
-					Transaction:    testTx,
+					Transaction:    &testTx,
 					Operation:      createAccountOp,
 					Network:        network.TestNetworkPassphrase,
 					LedgerSequence: 12345,
@@ -368,7 +368,7 @@ func TestIndexer_ProcessLedgerTransactions(t *testing.T) {
 			2: {
 				OpWrapper: &processors.TransactionOperationWrapper{
 					Index:          0,
-					Transaction:    testTx2,
+					Transaction:    &testTx2,
 					Operation:      paymentOp,
 					Network:        network.TestNetworkPassphrase,
 					LedgerSequence: 12345,
@@ -633,7 +633,7 @@ func TestIndexer_ProcessLedgerTransactions(t *testing.T) {
 			1: {
 				OpWrapper: &processors.TransactionOperationWrapper{
 					Index:          0,
-					Transaction:    testTx,
+					Transaction:    &testTx,
 					Operation:      createAccountOp,
 					Network:        network.TestNetworkPassphrase,
 					LedgerSequence: 12345,
@@ -694,7 +694,7 @@ func TestIndexer_ProcessLedgerTransactions(t *testing.T) {
 			1: {
 				OpWrapper: &processors.TransactionOperationWrapper{
 					Index:          0,
-					Transaction:    testTx,
+					Transaction:    &testTx,
 					Operation:      createAccountOp,
 					Network:        network.TestNetworkPassphrase,
 					LedgerSequence: 12345,
@@ -848,7 +848,7 @@ func TestIndexer_getTransactionStateChanges(t *testing.T) {
 			1: {
 				OpWrapper: &processors.TransactionOperationWrapper{
 					Index:          0,
-					Transaction:    testTx,
+					Transaction:    &testTx,
 					Operation:      createAccountOp,
 					Network:        network.TestNetworkPassphrase,
 					LedgerSequence: 12345,
@@ -960,7 +960,7 @@ func TestIndexer_getTransactionStateChanges(t *testing.T) {
 			1: {
 				OpWrapper: &processors.TransactionOperationWrapper{
 					Index:          0,
-					Transaction:    testTx,
+					Transaction:    &testTx,
 					Operation:      createAccountOp,
 					Network:        network.TestNetworkPassphrase,
 					LedgerSequence: 12345,
@@ -1041,7 +1041,7 @@ func TestIndexer_getTransactionStateChanges(t *testing.T) {
 			1: {
 				OpWrapper: &processors.TransactionOperationWrapper{
 					Index:          0,
-					Transaction:    testTx,
+					Transaction:    &testTx,
 					Operation:      createAccountOp,
 					Network:        network.TestNetworkPassphrase,
 					LedgerSequence: 12345,
@@ -1789,7 +1789,7 @@ func TestTransactionContractDataChanges(t *testing.T) {
 
 	t.Run("operation and transaction-level segments both contribute", func(t *testing.T) {
 		tx := contractDataTx(true, opContract, &afterContract)
-		wrapper := &processors.TransactionOperationWrapper{Index: 0, Transaction: tx}
+		wrapper := &processors.TransactionOperationWrapper{Index: 0, Transaction: &tx}
 
 		got, err := transactionContractDataChanges(&tx, map[int64]processors.OperationParticipants{
 			1: {OpWrapper: wrapper},
@@ -1809,7 +1809,7 @@ func TestTransactionContractDataChanges(t *testing.T) {
 	t.Run("operation segment is served from the wrapper memo", func(t *testing.T) {
 		tx := contractDataTx(true, opContract, nil)
 		wrapperTx := contractDataTx(true, wrapperContract, nil)
-		wrapper := &processors.TransactionOperationWrapper{Index: 0, Transaction: wrapperTx}
+		wrapper := &processors.TransactionOperationWrapper{Index: 0, Transaction: &wrapperTx}
 
 		got, err := transactionContractDataChanges(&tx, map[int64]processors.OperationParticipants{
 			1: {OpWrapper: wrapper},
@@ -1954,7 +1954,7 @@ func TestIndexer_ProcessTransaction_EmitsChangesInOpOrder(t *testing.T) {
 		opID := int64(i)
 		wrapper := &processors.TransactionOperationWrapper{
 			Index:          uint32(i - 1),
-			Transaction:    testTx,
+			Transaction:    &testTx,
 			Operation:      createAccountOp,
 			Network:        network.TestNetworkPassphrase,
 			LedgerSequence: 12345,

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stellar/wallet-backend/internal/data"
 	"github.com/stellar/wallet-backend/internal/indexer/processors"
 	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/utils"
 )
 
 const (
@@ -1106,7 +1107,7 @@ func TestIndexer_GetLedgerTransactions(t *testing.T) {
 			var xdrLedgerCloseMeta xdr.LedgerCloseMeta
 			err := xdr.SafeUnmarshalBase64(tc.inputLedgerCloseMetaStr, &xdrLedgerCloseMeta)
 			require.NoError(t, err)
-			transactions, err := GetLedgerTransactions(ctx, network.TestNetworkPassphrase, xdrLedgerCloseMeta)
+			transactions, err := GetLedgerTransactions(ctx, network.TestNetworkPassphrase, xdrLedgerCloseMeta, testPool())
 
 			// Verify results
 			if tc.wantErrContains != "" {
@@ -1127,14 +1128,70 @@ func TestIndexer_GetLedgerTransactions(t *testing.T) {
 	}
 }
 
+// testPool is the worker pool the transaction-hashing fan-out runs on in tests.
+func testPool() pond.Pool {
+	return pond.NewPool(runtime.NumCPU())
+}
+
+// getLedgerTransactionsViaReader is the SDK-reader reference implementation of
+// GetLedgerTransactions, kept as the oracle for the differential equivalence
+// test and as the independent leaf under the other reader-based oracles below.
+// It drives ingest.LedgerTransactionReader, which hashes every envelope
+// serially, so it shares no code with the production fan-out.
+func getLedgerTransactionsViaReader(ctx context.Context, networkPassphrase string, ledgerMeta xdr.LedgerCloseMeta) ([]ingest.LedgerTransaction, error) {
+	ledgerTxReader, err := ingest.NewLedgerTransactionReaderFromLedgerCloseMeta(networkPassphrase, ledgerMeta)
+	if err != nil {
+		return nil, fmt.Errorf("creating ledger transaction reader: %w", err)
+	}
+	defer utils.DeferredClose(ctx, ledgerTxReader, "closing ledger transaction reader")
+
+	transactions := make([]ingest.LedgerTransaction, 0)
+	for {
+		tx, readErr := ledgerTxReader.Read()
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("reading ledger: %w", readErr)
+		}
+		transactions = append(transactions, tx)
+	}
+	return transactions, nil
+}
+
+// TestGetLedgerTransactions_EquivalenceOnRealLedgers is the merge gate on the
+// parallel envelope hashing: the fan-out must reproduce the SDK reader's output
+// exactly, transaction for transaction, on every committed pubnet fixture.
+func TestGetLedgerTransactions_EquivalenceOnRealLedgers(t *testing.T) {
+	ctx := context.Background()
+
+	paths, err := filepath.Glob("testdata/*.xdr.gz")
+	require.NoError(t, err)
+	require.NotEmpty(t, paths, "no ledger fixtures under testdata/ — regenerate per the loadLedgerFixture recipe")
+
+	for _, path := range paths {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			lcm := loadLedgerFixture(t, path)
+
+			want, err := getLedgerTransactionsViaReader(ctx, network.PublicNetworkPassphrase, lcm)
+			require.NoError(t, err)
+			require.NotEmpty(t, want, "fixture has no transactions")
+
+			got, err := GetLedgerTransactions(ctx, network.PublicNetworkPassphrase, lcm, testPool())
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+		})
+	}
+}
+
 // extractContractEventsViaReader is the reader-based reference implementation of
 // ExtractContractEventsForLedger, kept as the oracle for the differential
-// equivalence test. It constructs a LedgerTransactionReader (which re-hashes
-// every transaction envelope) and reads events through the resulting
-// LedgerTransaction values. The production function must produce output equal to
+// equivalence test. It reads events through the LedgerTransaction values the
+// SDK reader produces (getLedgerTransactionsViaReader, which re-hashes every
+// transaction envelope). The production function must produce output equal to
 // this oracle for every committed ledger fixture.
 func extractContractEventsViaReader(ctx context.Context, networkPassphrase string, ledgerMeta xdr.LedgerCloseMeta) (map[ContractEventKey][]xdr.ContractEvent, error) {
-	transactions, err := GetLedgerTransactions(ctx, networkPassphrase, ledgerMeta)
+	transactions, err := getLedgerTransactionsViaReader(ctx, networkPassphrase, ledgerMeta)
 	if err != nil {
 		return nil, fmt.Errorf("getting transactions for ledger %d: %w", ledgerMeta.LedgerSequence(), err)
 	}
@@ -1448,7 +1505,7 @@ func projectContractDataChanges(m map[string][]ingest.Change) map[string][]contr
 // from those. Kept test-only as the merge gate for the production meta-based
 // path, mirroring extractContractEventsViaReader.
 func extractContractDataChangesViaReader(ctx context.Context, networkPassphrase string, ledgerMeta xdr.LedgerCloseMeta) ([]ingest.LedgerTransaction, map[string][]ingest.Change, error) {
-	transactions, err := GetLedgerTransactions(ctx, networkPassphrase, ledgerMeta)
+	transactions, err := getLedgerTransactionsViaReader(ctx, networkPassphrase, ledgerMeta)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1660,7 +1717,7 @@ func TestIndexer_ProcessLedgerTransactions_RealLedgerParallel(t *testing.T) {
 	for _, path := range paths {
 		t.Run(filepath.Base(path), func(t *testing.T) {
 			lcm := loadLedgerFixture(t, path)
-			txs, err := GetLedgerTransactions(ctx, network.PublicNetworkPassphrase, lcm)
+			txs, err := GetLedgerTransactions(ctx, network.PublicNetworkPassphrase, lcm, testPool())
 			require.NoError(t, err)
 			if len(txs) < 2 {
 				t.Skipf("fixture has %d transaction(s); need ≥2 to exercise parallelism", len(txs))

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -1525,7 +1525,7 @@ func extractContractDataChangesViaReader(ctx context.Context, networkPassphrase 
 		if !tx.Result.Successful() {
 			continue
 		}
-		if err := collectContractDataChanges(&tx, ledgerMeta.LedgerSequence(), changes); err != nil {
+		if err := collectContractDataChanges(&tx, ledgerMeta.LedgerSequence(), &changes); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -1732,6 +1732,8 @@ func contractDataCreateChanges(contractID xdr.ContractId) xdr.LedgerEntryChanges
 
 // contractDataTx builds a synthetic V3-meta transaction whose single operation
 // and (optionally) transaction-level-after segment carry ContractData changes.
+// The envelope carries SorobanTransactionData because that is the only shape
+// that can produce ContractData changes, and the collection path gates on it.
 func contractDataTx(successful bool, opContract xdr.ContractId, afterContract *xdr.ContractId) ingest.LedgerTransaction {
 	code := xdr.TransactionResultCodeTxSuccess
 	if !successful {
@@ -1746,6 +1748,14 @@ func contractDataTx(successful bool, opContract xdr.ContractId, afterContract *x
 	return ingest.LedgerTransaction{
 		Index:  1,
 		Ledger: testLcm,
+		Envelope: xdr.TransactionEnvelope{
+			Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+			V1: &xdr.TransactionV1Envelope{
+				Tx: xdr.Transaction{
+					Ext: xdr.TransactionExt{V: 1, SorobanData: &xdr.SorobanTransactionData{}},
+				},
+			},
+		},
 		Result: xdr.TransactionResultPair{
 			Result: xdr.TransactionResult{
 				Result: xdr.TransactionResultResult{Code: code, Results: &[]xdr.OperationResult{}},
@@ -1771,6 +1781,18 @@ func TestTransactionContractDataChanges(t *testing.T) {
 		tx := contractDataTx(false, opContract, &afterContract)
 		// Guard against a vacuous pass: the meta really does carry ContractData
 		// changes, so the nil result can only come from the success check.
+		require.True(t, ledgerEntryChangesContainContractData(tx.UnsafeMeta.MustV3().Operations[0].Changes))
+
+		got, err := transactionContractDataChanges(&tx, nil)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("classic transaction contributes nothing", func(t *testing.T) {
+		tx := contractDataTx(true, opContract, &afterContract)
+		tx.Envelope = xdr.TransactionEnvelope{Type: xdr.EnvelopeTypeEnvelopeTypeTxV0, V0: &xdr.TransactionV0Envelope{}}
+		// Guard against a vacuous pass: the meta really does carry ContractData
+		// changes, so the nil result can only come from the Soroban check.
 		require.True(t, ledgerEntryChangesContainContractData(tx.UnsafeMeta.MustV3().Operations[0].Changes))
 
 		got, err := transactionContractDataChanges(&tx, nil)

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -244,6 +244,7 @@ func TestIndexer_ProcessLedgerTransactions(t *testing.T) {
 			1: {
 				OpWrapper: &processors.TransactionOperationWrapper{
 					Index:          0,
+					Transaction:    testTx,
 					Operation:      createAccountOp,
 					Network:        network.TestNetworkPassphrase,
 					LedgerSequence: 12345,
@@ -350,6 +351,7 @@ func TestIndexer_ProcessLedgerTransactions(t *testing.T) {
 			1: {
 				OpWrapper: &processors.TransactionOperationWrapper{
 					Index:          0,
+					Transaction:    testTx,
 					Operation:      createAccountOp,
 					Network:        network.TestNetworkPassphrase,
 					LedgerSequence: 12345,
@@ -366,6 +368,7 @@ func TestIndexer_ProcessLedgerTransactions(t *testing.T) {
 			2: {
 				OpWrapper: &processors.TransactionOperationWrapper{
 					Index:          0,
+					Transaction:    testTx2,
 					Operation:      paymentOp,
 					Network:        network.TestNetworkPassphrase,
 					LedgerSequence: 12345,
@@ -630,6 +633,7 @@ func TestIndexer_ProcessLedgerTransactions(t *testing.T) {
 			1: {
 				OpWrapper: &processors.TransactionOperationWrapper{
 					Index:          0,
+					Transaction:    testTx,
 					Operation:      createAccountOp,
 					Network:        network.TestNetworkPassphrase,
 					LedgerSequence: 12345,
@@ -690,6 +694,7 @@ func TestIndexer_ProcessLedgerTransactions(t *testing.T) {
 			1: {
 				OpWrapper: &processors.TransactionOperationWrapper{
 					Index:          0,
+					Transaction:    testTx,
 					Operation:      createAccountOp,
 					Network:        network.TestNetworkPassphrase,
 					LedgerSequence: 12345,
@@ -843,6 +848,7 @@ func TestIndexer_getTransactionStateChanges(t *testing.T) {
 			1: {
 				OpWrapper: &processors.TransactionOperationWrapper{
 					Index:          0,
+					Transaction:    testTx,
 					Operation:      createAccountOp,
 					Network:        network.TestNetworkPassphrase,
 					LedgerSequence: 12345,
@@ -954,6 +960,7 @@ func TestIndexer_getTransactionStateChanges(t *testing.T) {
 			1: {
 				OpWrapper: &processors.TransactionOperationWrapper{
 					Index:          0,
+					Transaction:    testTx,
 					Operation:      createAccountOp,
 					Network:        network.TestNetworkPassphrase,
 					LedgerSequence: 12345,
@@ -1034,6 +1041,7 @@ func TestIndexer_getTransactionStateChanges(t *testing.T) {
 			1: {
 				OpWrapper: &processors.TransactionOperationWrapper{
 					Index:          0,
+					Transaction:    testTx,
 					Operation:      createAccountOp,
 					Network:        network.TestNetworkPassphrase,
 					LedgerSequence: 12345,
@@ -1502,15 +1510,26 @@ func projectContractDataChanges(m map[string][]ingest.Change) map[string][]contr
 // extractContractDataChangesViaReader is the reader-based reference
 // implementation: materialize transactions through the
 // LedgerTransactionReader (envelope↔meta pairing via hashing) and extract
-// from those. Kept test-only as the merge gate for the production meta-based
-// path, mirroring extractContractEventsViaReader.
+// each successful transaction's changes through tx.GetChanges (the SDK's own
+// composition). Kept test-only as the merge gate for both production paths —
+// the footprint-gated meta-based extraction and the wrapper-memo collection
+// in processTransaction — mirroring extractContractEventsViaReader.
 func extractContractDataChangesViaReader(ctx context.Context, networkPassphrase string, ledgerMeta xdr.LedgerCloseMeta) ([]ingest.LedgerTransaction, map[string][]ingest.Change, error) {
 	transactions, err := getLedgerTransactionsViaReader(ctx, networkPassphrase, ledgerMeta)
 	if err != nil {
 		return nil, nil, err
 	}
-	changes, err := ExtractContractDataChangesFromTransactions(transactions, ledgerMeta.LedgerSequence())
-	return transactions, changes, err
+	changes := make(map[string][]ingest.Change)
+	for i := range transactions {
+		tx := transactions[i]
+		if !tx.Result.Successful() {
+			continue
+		}
+		if err := collectContractDataChanges(&tx, ledgerMeta.LedgerSequence(), changes); err != nil {
+			return nil, nil, err
+		}
+	}
+	return transactions, changes, nil
 }
 
 // TestExtractContractDataChangesForLedger_Fixtures checks the ContractData
@@ -1644,6 +1663,175 @@ func TestExtractContractDataChangesForLedger_Fixtures(t *testing.T) {
 	require.Greater(t, totalChanges, 0, "fixture corpus must produce at least one ContractData change")
 }
 
+// TestProcessLedgerTransactions_ContractDataChangesMatchReaderExtraction is the
+// merge gate for collecting ContractData changes during the process stage: what
+// ProcessLedgerTransactions folds into the buffer must equal what the
+// reader-based reference derives, for every fixture in the corpus.
+//
+// The two sides are independent by construction. The reference composes each
+// transaction's changes through the SDK's own tx.GetChanges(); the production
+// side composes them per meta version from the operation wrappers' memoized
+// Changes() plus the transaction-level segments, then folds the per-transaction
+// results into the buffer. Both are handed the same reader-materialized
+// transactions, so composition is the only thing that differs.
+func TestProcessLedgerTransactions_ContractDataChangesMatchReaderExtraction(t *testing.T) {
+	ctx := context.Background()
+
+	paths, err := filepath.Glob("testdata/*.xdr.gz")
+	require.NoError(t, err)
+	require.NotEmpty(t, paths, "no ledger fixtures under testdata/ — regenerate per the loadLedgerFixture recipe")
+
+	idx, err := NewIndexer(network.PublicNetworkPassphrase, pond.NewPool(runtime.NumCPU()), nil)
+	require.NoError(t, err)
+
+	totalChanges := 0
+	for _, path := range paths {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			lcm := loadLedgerFixture(t, path)
+
+			transactions, want, refErr := extractContractDataChangesViaReader(ctx, network.PublicNetworkPassphrase, lcm)
+			require.NoError(t, refErr)
+
+			buffer := NewIndexerBuffer()
+			_, procErr := idx.ProcessLedgerTransactions(ctx, transactions, buffer)
+			require.NoError(t, procErr)
+
+			assert.Equal(t, projectContractDataChanges(want), projectContractDataChanges(buffer.GetContractDataChanges()),
+				"buffer's ContractData changes must match the reader-based reference")
+
+			for _, changes := range want {
+				totalChanges += len(changes)
+			}
+		})
+	}
+
+	require.Greater(t, totalChanges, 0, "fixture corpus must produce at least one ContractData change")
+}
+
+// contractDataCreateChanges is a one-entry CREATE change group owning a
+// ContractData entry under contractID — the minimal shape the ContractData
+// grouping keys on.
+func contractDataCreateChanges(contractID xdr.ContractId) xdr.LedgerEntryChanges {
+	return xdr.LedgerEntryChanges{
+		{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+			Created: &xdr.LedgerEntry{
+				Data: xdr.LedgerEntryData{
+					Type: xdr.LedgerEntryTypeContractData,
+					ContractData: &xdr.ContractDataEntry{
+						Contract:   xdr.ScAddress{Type: xdr.ScAddressTypeScAddressTypeContract, ContractId: &contractID},
+						Key:        xdr.ScVal{Type: xdr.ScValTypeScvLedgerKeyContractInstance},
+						Durability: xdr.ContractDataDurabilityPersistent,
+						Val:        xdr.ScVal{Type: xdr.ScValTypeScvVoid},
+					},
+				},
+			},
+		},
+	}
+}
+
+// contractDataTx builds a synthetic V3-meta transaction whose single operation
+// and (optionally) transaction-level-after segment carry ContractData changes.
+func contractDataTx(successful bool, opContract xdr.ContractId, afterContract *xdr.ContractId) ingest.LedgerTransaction {
+	code := xdr.TransactionResultCodeTxSuccess
+	if !successful {
+		code = xdr.TransactionResultCodeTxFailed
+	}
+	meta := xdr.TransactionMetaV3{
+		Operations: []xdr.OperationMeta{{Changes: contractDataCreateChanges(opContract)}},
+	}
+	if afterContract != nil {
+		meta.TxChangesAfter = contractDataCreateChanges(*afterContract)
+	}
+	return ingest.LedgerTransaction{
+		Index:  1,
+		Ledger: testLcm,
+		Result: xdr.TransactionResultPair{
+			Result: xdr.TransactionResult{
+				Result: xdr.TransactionResultResult{Code: code, Results: &[]xdr.OperationResult{}},
+			},
+		},
+		UnsafeMeta: xdr.TransactionMeta{V: 3, V3: &meta},
+	}
+}
+
+func mustContractAddress(t *testing.T, contractID xdr.ContractId) string {
+	t.Helper()
+	addr, err := strkey.Encode(strkey.VersionByteContract, contractID[:])
+	require.NoError(t, err)
+	return addr
+}
+
+func TestTransactionContractDataChanges(t *testing.T) {
+	opContract := xdr.ContractId{0xaa}
+	afterContract := xdr.ContractId{0xbb}
+	wrapperContract := xdr.ContractId{0xcc}
+
+	t.Run("unsuccessful transaction contributes nothing", func(t *testing.T) {
+		tx := contractDataTx(false, opContract, &afterContract)
+		// Guard against a vacuous pass: the meta really does carry ContractData
+		// changes, so the nil result can only come from the success check.
+		require.True(t, ledgerEntryChangesContainContractData(tx.UnsafeMeta.MustV3().Operations[0].Changes))
+
+		got, err := transactionContractDataChanges(&tx, nil)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("meta version 0 errors", func(t *testing.T) {
+		tx := contractDataTx(true, opContract, nil)
+		tx.UnsafeMeta = xdr.TransactionMeta{V: 0}
+
+		_, err := transactionContractDataChanges(&tx, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported TransactionMeta version")
+	})
+
+	t.Run("operation and transaction-level segments both contribute", func(t *testing.T) {
+		tx := contractDataTx(true, opContract, &afterContract)
+		wrapper := &processors.TransactionOperationWrapper{Index: 0, Transaction: tx}
+
+		got, err := transactionContractDataChanges(&tx, map[int64]processors.OperationParticipants{
+			1: {OpWrapper: wrapper},
+		})
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		assert.Len(t, got[mustContractAddress(t, opContract)], 1)
+		assert.Len(t, got[mustContractAddress(t, afterContract)], 1)
+	})
+
+	// The operation segment must be served from the wrapper's memoized
+	// Changes(), not re-derived via tx.GetOperationChanges — that memo is the
+	// whole point of collecting here rather than in a later stage. To make the
+	// source observable, the wrapper is given a transaction whose operation meta
+	// disagrees with the one being walked; only a wrapper-served walk can
+	// return the wrapper's contract.
+	t.Run("operation segment is served from the wrapper memo", func(t *testing.T) {
+		tx := contractDataTx(true, opContract, nil)
+		wrapperTx := contractDataTx(true, wrapperContract, nil)
+		wrapper := &processors.TransactionOperationWrapper{Index: 0, Transaction: wrapperTx}
+
+		got, err := transactionContractDataChanges(&tx, map[int64]processors.OperationParticipants{
+			1: {OpWrapper: wrapper},
+		})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Contains(t, got, mustContractAddress(t, wrapperContract))
+		assert.NotContains(t, got, mustContractAddress(t, opContract))
+	})
+
+	// An operation with no wrapper in opsParticipants still has to contribute:
+	// the walk falls back to the SDK accessor rather than dropping the segment.
+	t.Run("operation without a wrapper falls back to the SDK accessor", func(t *testing.T) {
+		tx := contractDataTx(true, opContract, nil)
+
+		got, err := transactionContractDataChanges(&tx, nil)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Len(t, got[mustContractAddress(t, opContract)], 1)
+	})
+}
+
 func TestAssignStateChangeStream_SubNamespaces(t *testing.T) {
 	effects := []types.StateChange{
 		{OperationID: 42, AccountID: "GA"},
@@ -1766,6 +1954,7 @@ func TestIndexer_ProcessTransaction_EmitsChangesInOpOrder(t *testing.T) {
 		opID := int64(i)
 		wrapper := &processors.TransactionOperationWrapper{
 			Index:          uint32(i - 1),
+			Transaction:    testTx,
 			Operation:      createAccountOp,
 			Network:        network.TestNetworkPassphrase,
 			LedgerSequence: 12345,

--- a/internal/indexer/processors/accounts.go
+++ b/internal/indexer/processors/accounts.go
@@ -90,7 +90,7 @@ func (p *AccountsProcessor) ProcessOperation(ctx context.Context, opWrapper *Tra
 		return nil, fmt.Errorf("getting operation changes: %w", err)
 	}
 
-	return p.buildAccountChanges(changes, opWrapper.Transaction.Ledger.LedgerSequence(), accountSortKey(phaseOperation, opWrapper.Transaction.Index, opWrapper.Index))
+	return p.buildAccountChanges(changes, opWrapper.Transaction.Ledger.LedgerSequence(), accountSortKey(phaseOperation, opWrapper.Transaction.Index, opWrapper.Index)), nil
 }
 
 // ProcessTransactionFees extracts native balance changes from a transaction's fee
@@ -116,33 +116,22 @@ func (p *AccountsProcessor) ProcessTransactionFees(ctx context.Context, tx inges
 
 	ledgerSeq := tx.Ledger.LedgerSequence()
 
-	feeChanges, err := p.buildAccountChanges(tx.GetFeeChanges(), ledgerSeq, accountSortKey(phaseFee, tx.Index, 0))
-	if err != nil {
-		return nil, err
-	}
-
-	refundChanges, err := p.buildAccountChanges(tx.GetPostApplyFeeChanges(), ledgerSeq, accountSortKey(phaseRefund, tx.Index, 0))
-	if err != nil {
-		return nil, err
-	}
-
+	feeChanges := p.buildAccountChanges(tx.GetFeeChanges(), ledgerSeq, accountSortKey(phaseFee, tx.Index, 0))
+	refundChanges := p.buildAccountChanges(tx.GetPostApplyFeeChanges(), ledgerSeq, accountSortKey(phaseRefund, tx.Index, 0))
 	return append(feeChanges, refundChanges...), nil
 }
 
 // buildAccountChanges converts the account-typed entries in a ledger change set into
 // AccountChanges stamped with the given sort key. The per-operation and fee-phase paths share
 // it; they differ only in that sort key, which is constant across all changes in one call.
-func (p *AccountsProcessor) buildAccountChanges(changes []ingest.Change, ledgerSeq uint32, sortKey int64) ([]types.AccountChange, error) {
+func (p *AccountsProcessor) buildAccountChanges(changes []ingest.Change, ledgerSeq uint32, sortKey int64) []types.AccountChange {
 	var accountChanges []types.AccountChange
 	for _, change := range changes {
 		if change.Type != xdr.LedgerEntryTypeAccount {
 			continue
 		}
 
-		accChange, skip, err := p.buildAccountChange(change, ledgerSeq, sortKey)
-		if err != nil {
-			return nil, err
-		}
+		accChange, skip := p.buildAccountChange(change, ledgerSeq, sortKey)
 		if skip {
 			continue
 		}
@@ -150,22 +139,113 @@ func (p *AccountsProcessor) buildAccountChanges(changes []ingest.Change, ledgerS
 		accountChanges = append(accountChanges, accChange)
 	}
 
-	return accountChanges, nil
+	return accountChanges
+}
+
+// accountChangedExceptSigners reports whether anything about the account changed
+// other than its signer list. It mirrors the byte-comparison semantics of the
+// SDK's ingest.Change.AccountChangedExceptSigners — only the Signers slice is
+// ignored, so side effects of signer changes (NumSubEntries, the V2
+// signer-sponsoring IDs) still count as changes, a missing extension compares
+// equal to a V1 extension with zero liabilities, and a differing
+// LastModifiedLedgerSeq counts on its own — without the two full XDR marshals
+// the byte comparison pays on every account change. The SDK function stays as
+// the differential oracle in the tests.
+func accountChangedExceptSigners(change ingest.Change) bool {
+	if change.Pre == nil || change.Post == nil {
+		return true
+	}
+	if change.Pre.LastModifiedLedgerSeq != change.Post.LastModifiedLedgerSeq {
+		return true
+	}
+	pre := change.Pre.Data.MustAccount()
+	post := change.Post.Data.MustAccount()
+	if !pre.AccountId.Equals(post.AccountId) ||
+		pre.Balance != post.Balance ||
+		pre.SeqNum != post.SeqNum ||
+		pre.NumSubEntries != post.NumSubEntries ||
+		pre.Flags != post.Flags ||
+		pre.HomeDomain != post.HomeDomain ||
+		pre.Thresholds != post.Thresholds {
+		return true
+	}
+	if !accountIDPtrEqual(pre.InflationDest, post.InflationDest) {
+		return true
+	}
+	return !accountExtEqual(pre.Ext, post.Ext)
+}
+
+func accountIDPtrEqual(a, b *xdr.AccountId) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	return a == nil || a.Equals(*b)
+}
+
+// accountExtEqual compares account extensions with a V0 extension reading as a
+// V1 extension carrying zero liabilities, exactly as the SDK normalizes before
+// its byte comparison.
+func accountExtEqual(a, b xdr.AccountEntryExt) bool {
+	if accountLiabilities(a) != accountLiabilities(b) {
+		return false
+	}
+	av2, bv2 := accountExtV2(a), accountExtV2(b)
+	if (av2 == nil) != (bv2 == nil) {
+		return false
+	}
+	if av2 == nil {
+		return true
+	}
+	if av2.NumSponsored != bv2.NumSponsored ||
+		av2.NumSponsoring != bv2.NumSponsoring ||
+		!sponsoringIDsEqual(av2.SignerSponsoringIDs, bv2.SignerSponsoringIDs) {
+		return false
+	}
+	av3, bv3 := av2.Ext.V3, bv2.Ext.V3
+	if (av3 == nil) != (bv3 == nil) {
+		return false
+	}
+	return av3 == nil || (av3.SeqLedger == bv3.SeqLedger && av3.SeqTime == bv3.SeqTime)
+}
+
+func accountLiabilities(ext xdr.AccountEntryExt) xdr.Liabilities {
+	if ext.V1 == nil {
+		return xdr.Liabilities{}
+	}
+	return ext.V1.Liabilities
+}
+
+func accountExtV2(ext xdr.AccountEntryExt) *xdr.AccountEntryExtensionV2 {
+	if ext.V1 == nil {
+		return nil
+	}
+	return ext.V1.Ext.V2
+}
+
+func sponsoringIDsEqual(a, b []xdr.SponsorshipDescriptor) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if (a[i] == nil) != (b[i] == nil) {
+			return false
+		}
+		if a[i] != nil && !a[i].Equals(*b[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // buildAccountChange converts a ledger change to an AccountChange, stamped with the
-// given ledger sequence and sort key. Returns (change, skip, error) where
+// given ledger sequence and sort key. Returns (change, skip) where
 // skip=true means the change should be ignored.
-func (p *AccountsProcessor) buildAccountChange(change ingest.Change, ledgerSeq uint32, sortKey int64) (types.AccountChange, bool, error) {
+func (p *AccountsProcessor) buildAccountChange(change ingest.Change, ledgerSeq uint32, sortKey int64) (types.AccountChange, bool) {
 	var accChange types.AccountChange
 
 	// Skip if only signers changed (no balance/state change)
-	changed, err := change.AccountChangedExceptSigners()
-	if err != nil {
-		return accChange, false, fmt.Errorf("checking account changes: %w", err)
-	}
-	if !changed {
-		return accChange, true, nil
+	if !accountChangedExceptSigners(change) {
+		return accChange, true
 	}
 
 	// Determine operation type and get the relevant entry
@@ -184,7 +264,7 @@ func (p *AccountsProcessor) buildAccountChange(change ingest.Change, ledgerSeq u
 		accChange.Operation = types.AccountOpRemove
 		entry = change.Pre
 	default:
-		return accChange, true, nil // Invalid change, skip
+		return accChange, true // Invalid change, skip
 	}
 
 	account := entry.Data.MustAccount()
@@ -201,5 +281,5 @@ func (p *AccountsProcessor) buildAccountChange(change ingest.Change, ledgerSeq u
 	accChange.NumSubEntries = uint32(account.NumSubEntries)
 	accChange.MinimumBalance = MinimumBalance(account)
 
-	return accChange, false, nil
+	return accChange, false
 }

--- a/internal/indexer/processors/accounts.go
+++ b/internal/indexer/processors/accounts.go
@@ -85,7 +85,7 @@ func (p *AccountsProcessor) ProcessOperation(ctx context.Context, opWrapper *Tra
 		}
 	}()
 
-	changes, err := opWrapper.Transaction.GetOperationChanges(opWrapper.Index)
+	changes, err := opWrapper.Changes()
 	if err != nil {
 		return nil, fmt.Errorf("getting operation changes: %w", err)
 	}

--- a/internal/indexer/processors/accounts_test.go
+++ b/internal/indexer/processors/accounts_test.go
@@ -172,7 +172,7 @@ func TestAccountsProcessor_ProcessOperation(t *testing.T) {
 			tx := createTx(op, tc.changes, nil, false)
 			wrapper := &TransactionOperationWrapper{
 				Index:          0,
-				Transaction:    tx,
+				Transaction:    &tx,
 				Operation:      op,
 				LedgerSequence: 12345,
 				Network:        networkPassphrase,
@@ -223,7 +223,7 @@ func TestAccountsProcessor_ProcessOperation_PersistsNumSubEntries(t *testing.T) 
 	tx := createTx(op, changes, nil, false)
 	wrapper := &TransactionOperationWrapper{
 		Index:          0,
-		Transaction:    tx,
+		Transaction:    &tx,
 		Operation:      op,
 		LedgerSequence: 12345,
 		Network:        networkPassphrase,

--- a/internal/indexer/processors/accounts_test.go
+++ b/internal/indexer/processors/accounts_test.go
@@ -424,6 +424,7 @@ func TestAccountChangedExceptSigners_MatchesSDK(t *testing.T) {
 		{"removed account", entry(baseAccount(), seq), nil},
 		{"identical", entry(baseAccount(), seq), entry(baseAccount(), seq)},
 		{"last modified differs", entry(baseAccount(), seq), entry(baseAccount(), seq+1)},
+		{"account id", entry(baseAccount(), seq), entry(mutate(func(a *xdr.AccountEntry) { a.AccountId = otherAccountID }), seq)},
 		{"balance", entry(baseAccount(), seq), entry(mutate(func(a *xdr.AccountEntry) { a.Balance = 2000 }), seq)},
 		{"seqnum", entry(baseAccount(), seq), entry(mutate(func(a *xdr.AccountEntry) { a.SeqNum = 43 }), seq)},
 		{"num sub entries", entry(baseAccount(), seq), entry(mutate(func(a *xdr.AccountEntry) { a.NumSubEntries = 3 }), seq)},
@@ -435,6 +436,11 @@ func TestAccountChangedExceptSigners_MatchesSDK(t *testing.T) {
 			"inflation dest changed",
 			entry(mutate(func(a *xdr.AccountEntry) { a.InflationDest = &baseAccountID }), seq),
 			entry(mutate(func(a *xdr.AccountEntry) { a.InflationDest = &otherAccountID }), seq),
+		},
+		{
+			"inflation dest cleared",
+			entry(mutate(func(a *xdr.AccountEntry) { a.InflationDest = &otherAccountID }), seq),
+			entry(baseAccount(), seq),
 		},
 		{
 			"signers only",
@@ -452,6 +458,11 @@ func TestAccountChangedExceptSigners_MatchesSDK(t *testing.T) {
 		{
 			"sponsoring ids changed",
 			entry(withV2(baseAccount(), 0, 0, []xdr.SponsorshipDescriptor{nil}), seq),
+			entry(withV2(baseAccount(), 0, 0, []xdr.SponsorshipDescriptor{&otherAccountID}), seq),
+		},
+		{
+			"sponsoring ids length differs",
+			entry(withV2(baseAccount(), 0, 0, nil), seq),
 			entry(withV2(baseAccount(), 0, 0, []xdr.SponsorshipDescriptor{&otherAccountID}), seq),
 		},
 		{

--- a/internal/indexer/processors/accounts_test.go
+++ b/internal/indexer/processors/accounts_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stellar/go-stellar-sdk/ingest"
 	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -354,4 +355,122 @@ func TestAccountSortKey(t *testing.T) {
 	maxOp := accountSortKey(phaseOperation, (1<<20)-1, 4095)
 	assert.Positive(t, maxOp)
 	assert.Less(t, maxOp, accountSortKey(phaseRefund, 0, 0))
+}
+
+// TestAccountChangedExceptSigners_MatchesSDK differentially validates the
+// field-comparison implementation against the SDK's marshal-and-compare
+// original across every transition class the semantics distinguish.
+func TestAccountChangedExceptSigners_MatchesSDK(t *testing.T) {
+	const seq = xdr.Uint32(12345)
+	baseAccountID := xdr.MustAddress("GC4XF7RE3R4P77GY5XNGICM56IOKUURWAAANPXHFC7G5H6FCNQVVH3OH")
+	otherAccountID := xdr.MustAddress("GAQHWQYBBW272OOXNQMMLCA5WY2XAZPODGB7Q3S5OKKIXVESKO55ZQ7C")
+	signerKey := xdr.MustSigner("GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON")
+
+	baseAccount := func() xdr.AccountEntry {
+		return xdr.AccountEntry{
+			AccountId:     baseAccountID,
+			Balance:       1000,
+			SeqNum:        42,
+			NumSubEntries: 2,
+			Flags:         1,
+			HomeDomain:    "example.org",
+			Thresholds:    xdr.Thresholds{1, 2, 3, 4},
+		}
+	}
+	entry := func(account xdr.AccountEntry, lastModified xdr.Uint32) *xdr.LedgerEntry {
+		return &xdr.LedgerEntry{
+			LastModifiedLedgerSeq: lastModified,
+			Data: xdr.LedgerEntryData{
+				Type:    xdr.LedgerEntryTypeAccount,
+				Account: &account,
+			},
+		}
+	}
+	withV1 := func(account xdr.AccountEntry, buying, selling xdr.Int64) xdr.AccountEntry {
+		account.Ext = xdr.AccountEntryExt{V: 1, V1: &xdr.AccountEntryExtensionV1{
+			Liabilities: xdr.Liabilities{Buying: buying, Selling: selling},
+		}}
+		return account
+	}
+	withV2 := func(account xdr.AccountEntry, numSponsored, numSponsoring xdr.Uint32, ids []xdr.SponsorshipDescriptor) xdr.AccountEntry {
+		account = withV1(account, 0, 0)
+		account.Ext.V1.Ext = xdr.AccountEntryExtensionV1Ext{V: 2, V2: &xdr.AccountEntryExtensionV2{
+			NumSponsored:        numSponsored,
+			NumSponsoring:       numSponsoring,
+			SignerSponsoringIDs: ids,
+		}}
+		return account
+	}
+	withV3 := func(account xdr.AccountEntry, seqLedger xdr.Uint32, seqTime xdr.TimePoint) xdr.AccountEntry {
+		account = withV2(account, 0, 0, nil)
+		account.Ext.V1.Ext.V2.Ext = xdr.AccountEntryExtensionV2Ext{V: 3, V3: &xdr.AccountEntryExtensionV3{
+			SeqLedger: seqLedger,
+			SeqTime:   seqTime,
+		}}
+		return account
+	}
+	mutate := func(f func(*xdr.AccountEntry)) xdr.AccountEntry {
+		account := baseAccount()
+		f(&account)
+		return account
+	}
+
+	testCases := []struct {
+		name string
+		pre  *xdr.LedgerEntry
+		post *xdr.LedgerEntry
+	}{
+		{"created account", nil, entry(baseAccount(), seq)},
+		{"removed account", entry(baseAccount(), seq), nil},
+		{"identical", entry(baseAccount(), seq), entry(baseAccount(), seq)},
+		{"last modified differs", entry(baseAccount(), seq), entry(baseAccount(), seq+1)},
+		{"balance", entry(baseAccount(), seq), entry(mutate(func(a *xdr.AccountEntry) { a.Balance = 2000 }), seq)},
+		{"seqnum", entry(baseAccount(), seq), entry(mutate(func(a *xdr.AccountEntry) { a.SeqNum = 43 }), seq)},
+		{"num sub entries", entry(baseAccount(), seq), entry(mutate(func(a *xdr.AccountEntry) { a.NumSubEntries = 3 }), seq)},
+		{"flags", entry(baseAccount(), seq), entry(mutate(func(a *xdr.AccountEntry) { a.Flags = 5 }), seq)},
+		{"home domain", entry(baseAccount(), seq), entry(mutate(func(a *xdr.AccountEntry) { a.HomeDomain = "other.org" }), seq)},
+		{"thresholds", entry(baseAccount(), seq), entry(mutate(func(a *xdr.AccountEntry) { a.Thresholds = xdr.Thresholds{4, 3, 2, 1} }), seq)},
+		{"inflation dest set", entry(baseAccount(), seq), entry(mutate(func(a *xdr.AccountEntry) { a.InflationDest = &otherAccountID }), seq)},
+		{
+			"inflation dest changed",
+			entry(mutate(func(a *xdr.AccountEntry) { a.InflationDest = &baseAccountID }), seq),
+			entry(mutate(func(a *xdr.AccountEntry) { a.InflationDest = &otherAccountID }), seq),
+		},
+		{
+			"signers only",
+			entry(baseAccount(), seq),
+			entry(mutate(func(a *xdr.AccountEntry) {
+				a.Signers = []xdr.Signer{{Key: signerKey, Weight: 1}}
+			}), seq),
+		},
+		{"v0 vs v1 zero liabilities", entry(baseAccount(), seq), entry(withV1(baseAccount(), 0, 0), seq)},
+		{"v0 vs v1 nonzero liabilities", entry(baseAccount(), seq), entry(withV1(baseAccount(), 10, 0), seq)},
+		{"liabilities changed", entry(withV1(baseAccount(), 10, 20), seq), entry(withV1(baseAccount(), 10, 30), seq)},
+		{"v2 present vs absent", entry(withV1(baseAccount(), 0, 0), seq), entry(withV2(baseAccount(), 0, 0, nil), seq)},
+		{"num sponsored changed", entry(withV2(baseAccount(), 0, 0, nil), seq), entry(withV2(baseAccount(), 1, 0, nil), seq)},
+		{"num sponsoring changed", entry(withV2(baseAccount(), 0, 0, nil), seq), entry(withV2(baseAccount(), 0, 1, nil), seq)},
+		{
+			"sponsoring ids changed",
+			entry(withV2(baseAccount(), 0, 0, []xdr.SponsorshipDescriptor{nil}), seq),
+			entry(withV2(baseAccount(), 0, 0, []xdr.SponsorshipDescriptor{&otherAccountID}), seq),
+		},
+		{
+			"sponsoring ids equal",
+			entry(withV2(baseAccount(), 0, 0, []xdr.SponsorshipDescriptor{&otherAccountID}), seq),
+			entry(withV2(baseAccount(), 0, 0, []xdr.SponsorshipDescriptor{&otherAccountID}), seq),
+		},
+		{"v3 present vs absent", entry(withV2(baseAccount(), 0, 0, nil), seq), entry(withV3(baseAccount(), 0, 0), seq)},
+		{"v3 seq ledger changed", entry(withV3(baseAccount(), 7, 9), seq), entry(withV3(baseAccount(), 8, 9), seq)},
+		{"v3 seq time changed", entry(withV3(baseAccount(), 7, 9), seq), entry(withV3(baseAccount(), 7, 10), seq)},
+		{"v3 identical", entry(withV3(baseAccount(), 7, 9), seq), entry(withV3(baseAccount(), 7, 9), seq)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			change := ingest.Change{Type: xdr.LedgerEntryTypeAccount, Pre: tc.pre, Post: tc.post}
+			want, err := change.AccountChangedExceptSigners()
+			require.NoError(t, err)
+			assert.Equal(t, want, accountChangedExceptSigners(change), "disagrees with SDK oracle")
+		})
+	}
 }

--- a/internal/indexer/processors/contract_deploy.go
+++ b/internal/indexer/processors/contract_deploy.go
@@ -49,7 +49,7 @@ func (p *ContractDeployProcessor) ProcessOperation(_ context.Context, op *Transa
 	invokeHostOp := op.Operation.Body.MustInvokeHostFunctionOp()
 
 	opID := op.ID()
-	builder := NewStateChangeBuilder(op.Transaction.Ledger.LedgerSequence(), op.LedgerClosed.Unix(), op.TransactionID(), p.metricsService).
+	builder := NewStateChangeBuilder(op.Transaction.Ledger.LedgerSequence(), op.LedgerClosed.Unix(), op.TransactionID()).
 		WithOperationID(opID).
 		WithCategory(types.StateChangeCategoryAccount).
 		WithReason(types.StateChangeReasonCreate)
@@ -76,7 +76,7 @@ func (p *ContractDeployProcessor) ProcessOperation(_ context.Context, op *Transa
 			seen = make(map[string]struct{})
 		}
 		seen[contractID] = struct{}{}
-		stateChanges = append(stateChanges, builder.Clone().WithAccount(contractID).WithCreator(deployerAddr).Build())
+		stateChanges = append(stateChanges, builder.WithAccount(contractID).WithCreator(deployerAddr).Build())
 		return nil
 	}
 

--- a/internal/indexer/processors/contract_deploy.go
+++ b/internal/indexer/processors/contract_deploy.go
@@ -34,6 +34,10 @@ func (p *ContractDeployProcessor) StateChangeSubBase() int64 {
 
 // ProcessOperation emits a state change for each contract deployment (including subinvocations).
 func (p *ContractDeployProcessor) ProcessOperation(_ context.Context, op *TransactionOperationWrapper) ([]types.StateChange, error) {
+	if op.OperationType() != xdr.OperationTypeInvokeHostFunction {
+		return nil, ErrInvalidOpType
+	}
+
 	startTime := time.Now()
 	defer func() {
 		if p.metricsService != nil {
@@ -42,9 +46,6 @@ func (p *ContractDeployProcessor) ProcessOperation(_ context.Context, op *Transa
 		}
 	}()
 
-	if op.OperationType() != xdr.OperationTypeInvokeHostFunction {
-		return nil, ErrInvalidOpType
-	}
 	invokeHostOp := op.Operation.Body.MustInvokeHostFunctionOp()
 
 	opID := op.ID()
@@ -54,7 +55,9 @@ func (p *ContractDeployProcessor) ProcessOperation(_ context.Context, op *Transa
 		WithReason(types.StateChangeReasonCreate)
 
 	var stateChanges []types.StateChange
-	seen := map[string]struct{}{}
+	// seen dedupes contract IDs across the host function and its subinvocations;
+	// most InvokeHostFunction operations deploy nothing and never populate it.
+	var seen map[string]struct{}
 
 	processCreate := func(fromAddr xdr.ContractIdPreimageFromAddress) error {
 		contractID, err := calculateContractID(p.networkPassphrase, fromAddr)
@@ -69,6 +72,9 @@ func (p *ContractDeployProcessor) ProcessOperation(_ context.Context, op *Transa
 			return fmt.Errorf("deployer address to string: %w", err)
 		}
 
+		if seen == nil {
+			seen = make(map[string]struct{})
+		}
 		seen[contractID] = struct{}{}
 		stateChanges = append(stateChanges, builder.Clone().WithAccount(contractID).WithCreator(deployerAddr).Build())
 		return nil

--- a/internal/indexer/processors/contract_deploy_test.go
+++ b/internal/indexer/processors/contract_deploy_test.go
@@ -36,7 +36,7 @@ func Test_ContractDeployProcessor_Process_createContract(t *testing.T) {
 
 	ctx := context.Background()
 
-	builder := NewStateChangeBuilder(12345, closeTime.Unix(), 53021371269120, nil).
+	builder := NewStateChangeBuilder(12345, closeTime.Unix(), 53021371269120).
 		WithOperationID(53021371269121).
 		WithReason(types.StateChangeReasonCreate).
 		WithCategory(types.StateChangeCategoryAccount)
@@ -59,7 +59,7 @@ func Test_ContractDeployProcessor_Process_createContract(t *testing.T) {
 				if withSubinvocations {
 					prefix = fmt.Sprintf("%s,withSubinvocations🔄", prefix)
 					subInvocationsStateChanges = []types.StateChange{
-						builder.Clone().
+						builder.
 							WithCreator(deployerAccountID).
 							WithAccount(deployedContractID).
 							Build(),
@@ -86,7 +86,7 @@ func Test_ContractDeployProcessor_Process_createContract(t *testing.T) {
 							return op
 						}(),
 						wantStateChanges: append(subInvocationsStateChanges,
-							builder.Clone().
+							builder.
 								WithCreator(fromSourceAccount).
 								WithAccount("CA7UGIYR2H63C2ETN2VE4WDQ6YX5XNEWNWC2DP7A64B2ZR7VJJWF3SBF").
 								Build(),
@@ -108,7 +108,7 @@ func Test_ContractDeployProcessor_Process_createContract(t *testing.T) {
 							return op
 						}(),
 						wantStateChanges: append(subInvocationsStateChanges,
-							builder.Clone().
+							builder.
 								WithCreator(fromSourceAccount).
 								WithAccount("CA7UGIYR2H63C2ETN2VE4WDQ6YX5XNEWNWC2DP7A64B2ZR7VJJWF3SBF").
 								Build(),
@@ -216,15 +216,15 @@ func Test_ContractDeployProcessor_Process_multipleContractsDeterministicOrder(t 
 	stateChanges, err := proc.ProcessOperation(ctx, op)
 	require.NoError(t, err)
 
-	builder := NewStateChangeBuilder(12345, closeTime.Unix(), 53021371269120, nil).
+	builder := NewStateChangeBuilder(12345, closeTime.Unix(), 53021371269120).
 		WithOperationID(53021371269121).
 		WithReason(types.StateChangeReasonCreate).
 		WithCategory(types.StateChangeCategoryAccount)
 
 	wantOrder := []types.StateChange{
-		builder.Clone().WithCreator(rootDeployer).WithAccount(contractA).Build(),
-		builder.Clone().WithCreator(subDeployerB).WithAccount(contractB).Build(),
-		builder.Clone().WithCreator(subDeployerC).WithAccount(contractC).Build(),
+		builder.WithCreator(rootDeployer).WithAccount(contractA).Build(),
+		builder.WithCreator(subDeployerB).WithAccount(contractB).Build(),
+		builder.WithCreator(subDeployerC).WithAccount(contractC).Build(),
 	}
 
 	require.Len(t, stateChanges, len(wantOrder))
@@ -274,7 +274,7 @@ func Test_ContractDeployProcessor_Process_invokeContract(t *testing.T) {
 		return op
 	}
 
-	builder := NewStateChangeBuilder(12345, closeTime.Unix(), 53021371269120, nil).
+	builder := NewStateChangeBuilder(12345, closeTime.Unix(), 53021371269120).
 		WithOperationID(53021371269121).
 		WithReason(types.StateChangeReasonCreate).
 		WithCategory(types.StateChangeCategoryAccount)
@@ -296,7 +296,7 @@ func Test_ContractDeployProcessor_Process_invokeContract(t *testing.T) {
 			if withSubinvocations {
 				prefix = "🔄WithSubinvocations🔄"
 				subInvocationsStateChanges = []types.StateChange{
-					builder.Clone().
+					builder.
 						WithCreator(deployerAccountID).
 						WithAccount(deployedContractID).
 						Build(),

--- a/internal/indexer/processors/contract_operations.go
+++ b/internal/indexer/processors/contract_operations.go
@@ -137,7 +137,7 @@ func participantsForAuthEntries(networkPassphrase string, authEntries []xdr.Soro
 // It can return `ErrNotSorobanOperation` if the operation is not a Soroban operation.
 //
 // The whole path folds into the single participants accumulator the caller passes in:
-// one set per operation instead of one per processor, auth entry, and invocation-tree
+// one set per operation instead of one per helper, auth entry, and invocation-tree
 // node, with no Union merges. The accumulator must be thread-unsafe — it is built and
 // consumed within a single indexer worker goroutine (see Indexer.ProcessLedgerTransactions),
 // so a thread-safe set's mutex would be pure overhead on the hot path.
@@ -147,7 +147,7 @@ func participantsForSorobanOp(op *TransactionOperationWrapper, participants set.
 	}
 
 	// The op source is the one participant every Soroban op shape shares; adding it
-	// here keeps the sub-processors source-free and encodes the address once.
+	// here keeps the per-host-function helpers source-free and encodes the address once.
 	sourceAccount := op.SourceAccount()
 	participants.Add(sourceAccount.Address())
 
@@ -160,20 +160,17 @@ func participantsForSorobanOp(op *TransactionOperationWrapper, participants set.
 
 		switch invokeHostOp.HostFunction.Type {
 		case xdr.HostFunctionTypeHostFunctionTypeCreateContract:
-			createContractOpProcessor := CreateContractV1OpProcessor{op: op}
-			if err := createContractOpProcessor.AddParticipants(participants); err != nil {
+			if err := addCreateContractV1Participants(op.Network, invokeHostOp, participants); err != nil {
 				return fmt.Errorf("getting create contract participants: %w", err)
 			}
 
 		case xdr.HostFunctionTypeHostFunctionTypeCreateContractV2:
-			createContractV2OpProcessor := CreateContractV2OpProcessor{op: op}
-			if err := createContractV2OpProcessor.AddParticipants(participants); err != nil {
+			if err := addCreateContractV2Participants(op.Network, invokeHostOp, participants); err != nil {
 				return fmt.Errorf("getting create contract participants: %w", err)
 			}
 
 		case xdr.HostFunctionTypeHostFunctionTypeInvokeContract:
-			invokeContractOpProcessor := InvokeContractOpProcessor{op: op}
-			if err := invokeContractOpProcessor.AddParticipants(participants); err != nil {
+			if err := addInvokeContractParticipants(op.Network, invokeHostOp, participants); err != nil {
 				return fmt.Errorf("getting invoke contract participants: %w", err)
 			}
 
@@ -223,79 +220,51 @@ func addContractIDsForPreimage(networkPassphrase string, preimage xdr.ContractId
 	}
 }
 
-type CreateContractV1OpProcessor struct {
-	op *TransactionOperationWrapper
-}
-
-// AddParticipants adds the operation's contract IDs and auth-entry participants to
-// the accumulator. The op source account is added by participantsForSorobanOp.
-func (p *CreateContractV1OpProcessor) AddParticipants(participants set.Set[string]) error {
-	if p.op.OperationType() != xdr.OperationTypeInvokeHostFunction {
-		return fmt.Errorf("not a create contract operation: %w", ErrInvalidOpType)
-	}
-	invokeHostFunctionOp := p.op.Operation.Body.MustInvokeHostFunctionOp()
-	if invokeHostFunctionOp.HostFunction.Type != xdr.HostFunctionTypeHostFunctionTypeCreateContract {
-		return fmt.Errorf("not a create contract operation: %w", ErrInvalidOpType)
-	}
-	createContractOp := invokeHostFunctionOp.HostFunction.MustCreateContract()
+// addCreateContractV1Participants adds the contract IDs derived from a
+// CreateContract host function's preimage, plus the operation's auth-entry
+// participants, to the accumulator. The op source account is added by
+// participantsForSorobanOp.
+func addCreateContractV1Participants(networkPassphrase string, invokeHostOp xdr.InvokeHostFunctionOp, participants set.Set[string]) error {
+	createContractOp := invokeHostOp.HostFunction.MustCreateContract()
 
 	// Contract IDs
-	if err := addContractIDsForPreimage(p.op.Network, createContractOp.ContractIdPreimage, participants); err != nil {
+	if err := addContractIDsForPreimage(networkPassphrase, createContractOp.ContractIdPreimage, participants); err != nil {
 		return fmt.Errorf("getting contract ID: %w", err)
 	}
 
 	// Auth participants
-	if err := participantsForAuthEntries(p.op.Network, invokeHostFunctionOp.Auth, participants); err != nil {
+	if err := participantsForAuthEntries(networkPassphrase, invokeHostOp.Auth, participants); err != nil {
 		return fmt.Errorf("getting auth participants: %w", err)
 	}
 
 	return nil
 }
 
-type CreateContractV2OpProcessor struct {
-	op *TransactionOperationWrapper
-}
-
-// AddParticipants adds the operation's contract IDs and auth-entry participants to
-// the accumulator. The op source account is added by participantsForSorobanOp.
-func (p *CreateContractV2OpProcessor) AddParticipants(participants set.Set[string]) error {
-	if p.op.OperationType() != xdr.OperationTypeInvokeHostFunction {
-		return fmt.Errorf("not a create contract v2 operation: %w", ErrInvalidOpType)
-	}
-	invokeHostFunctionOp := p.op.Operation.Body.MustInvokeHostFunctionOp()
-	if invokeHostFunctionOp.HostFunction.Type != xdr.HostFunctionTypeHostFunctionTypeCreateContractV2 {
-		return fmt.Errorf("not a create contract v2 operation: %w", ErrInvalidOpType)
-	}
-	createContractOp := invokeHostFunctionOp.HostFunction.MustCreateContractV2()
+// addCreateContractV2Participants adds the contract IDs derived from a
+// CreateContractV2 host function's preimage, plus the operation's auth-entry
+// participants, to the accumulator. The op source account is added by
+// participantsForSorobanOp.
+func addCreateContractV2Participants(networkPassphrase string, invokeHostOp xdr.InvokeHostFunctionOp, participants set.Set[string]) error {
+	createContractOp := invokeHostOp.HostFunction.MustCreateContractV2()
 
 	// Contract IDs
-	if err := addContractIDsForPreimage(p.op.Network, createContractOp.ContractIdPreimage, participants); err != nil {
+	if err := addContractIDsForPreimage(networkPassphrase, createContractOp.ContractIdPreimage, participants); err != nil {
 		return fmt.Errorf("getting contract ID: %w", err)
 	}
 
 	// Auth participants
-	if err := participantsForAuthEntries(p.op.Network, invokeHostFunctionOp.Auth, participants); err != nil {
+	if err := participantsForAuthEntries(networkPassphrase, invokeHostOp.Auth, participants); err != nil {
 		return fmt.Errorf("getting auth participants: %w", err)
 	}
 
 	return nil
 }
 
-type InvokeContractOpProcessor struct {
-	op *TransactionOperationWrapper
-}
-
-// AddParticipants adds the invoked contract ID and auth-entry participants to the
-// accumulator. The op source account is added by participantsForSorobanOp.
-func (p *InvokeContractOpProcessor) AddParticipants(participants set.Set[string]) error {
-	if p.op.OperationType() != xdr.OperationTypeInvokeHostFunction {
-		return fmt.Errorf("not a invoke contract operation: %w", ErrInvalidOpType)
-	}
-	invokeHostFunctionOp := p.op.Operation.Body.MustInvokeHostFunctionOp()
-	if invokeHostFunctionOp.HostFunction.Type != xdr.HostFunctionTypeHostFunctionTypeInvokeContract {
-		return fmt.Errorf("not a invoke contract operation: %w", ErrInvalidOpType)
-	}
-	invokeContractOp := invokeHostFunctionOp.HostFunction.MustInvokeContract()
+// addInvokeContractParticipants adds the invoked contract ID and the operation's
+// auth-entry participants to the accumulator. The op source account is added by
+// participantsForSorobanOp.
+func addInvokeContractParticipants(networkPassphrase string, invokeHostOp xdr.InvokeHostFunctionOp, participants set.Set[string]) error {
+	invokeContractOp := invokeHostOp.HostFunction.MustInvokeContract()
 
 	// Contract ID
 	contractID, err := invokeContractOp.ContractAddress.String()
@@ -307,7 +276,7 @@ func (p *InvokeContractOpProcessor) AddParticipants(participants set.Set[string]
 	}
 
 	// Auth participants
-	if err := participantsForAuthEntries(p.op.Network, invokeHostFunctionOp.Auth, participants); err != nil {
+	if err := participantsForAuthEntries(networkPassphrase, invokeHostOp.Auth, participants); err != nil {
 		return fmt.Errorf("getting auth participants: %w", err)
 	}
 

--- a/internal/indexer/processors/contract_operations.go
+++ b/internal/indexer/processors/contract_operations.go
@@ -148,7 +148,8 @@ func participantsForSorobanOp(op *TransactionOperationWrapper, participants set.
 
 	// The op source is the one participant every Soroban op shape shares; adding it
 	// here keeps the sub-processors source-free and encodes the address once.
-	participants.Add(op.SourceAccount().Address())
+	sourceAccount := op.SourceAccount()
+	participants.Add(sourceAccount.Address())
 
 	switch op.Operation.Body.Type {
 	case xdr.OperationTypeExtendFootprintTtl, xdr.OperationTypeRestoreFootprint:

--- a/internal/indexer/processors/contract_operations.go
+++ b/internal/indexer/processors/contract_operations.go
@@ -8,8 +8,6 @@ import (
 	set "github.com/deckarep/golang-set/v2"
 	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stellar/go-stellar-sdk/xdr"
-
-	"github.com/stellar/wallet-backend/internal/utils"
 )
 
 var (
@@ -48,12 +46,13 @@ func calculateContractID(networkPassphrase string, fromAddress xdr.ContractIdPre
 	return contractID, nil
 }
 
-// participantsFromInvocationAndSubInvocations recursively collects all ScAddresses from a SorobanAuthorizedInvocation
-// and its subinvocations.
-func participantsFromInvocationAndSubInvocations(networkPassphrase string, invocation xdr.SorobanAuthorizedInvocation) (set.Set[string], error) {
-	participants := set.NewThreadUnsafeSet[string]()
-	if utils.IsEmpty(invocation) {
-		return participants, nil
+// participantsFromInvocationAndSubInvocations recursively adds all ScAddresses from a
+// SorobanAuthorizedInvocation and its subinvocations to the participants accumulator.
+func participantsFromInvocationAndSubInvocations(networkPassphrase string, invocation *xdr.SorobanAuthorizedInvocation, participants set.Set[string]) error {
+	// A zero-value invocation reports the ContractFn arm (type 0) with a nil pointer,
+	// which GetContractFn would dereference. Skip such nodes entirely.
+	if invocation.Function.Type == xdr.SorobanAuthorizedFunctionTypeSorobanAuthorizedFunctionTypeContractFn && invocation.Function.ContractFn == nil {
+		return nil
 	}
 
 	switch invocation.Function.Type {
@@ -65,7 +64,7 @@ func participantsFromInvocationAndSubInvocations(networkPassphrase string, invoc
 
 		contractID, err := contractFn.ContractAddress.String()
 		if err != nil {
-			return nil, fmt.Errorf("converting contract address to string: %w", err)
+			return fmt.Errorf("converting contract address to string: %w", err)
 		}
 		participants.Add(contractID)
 
@@ -75,11 +74,9 @@ func participantsFromInvocationAndSubInvocations(networkPassphrase string, invoc
 			break
 		}
 
-		contractIDs, err := contractIDsForPreimage(networkPassphrase, createContractHostFn.ContractIdPreimage)
-		if err != nil {
-			return nil, fmt.Errorf("getting contract ID: %w", err)
+		if err := addContractIDsForPreimage(networkPassphrase, createContractHostFn.ContractIdPreimage, participants); err != nil {
+			return fmt.Errorf("getting contract ID: %w", err)
 		}
-		participants = participants.Union(contractIDs)
 
 	case xdr.SorobanAuthorizedFunctionTypeSorobanAuthorizedFunctionTypeCreateContractV2HostFn:
 		createContractV2HostFn, ok := invocation.Function.GetCreateContractV2HostFn()
@@ -87,44 +84,39 @@ func participantsFromInvocationAndSubInvocations(networkPassphrase string, invoc
 			break
 		}
 
-		contractIDs, err := contractIDsForPreimage(networkPassphrase, createContractV2HostFn.ContractIdPreimage)
-		if err != nil {
-			return nil, fmt.Errorf("getting contract ID: %w", err)
+		if err := addContractIDsForPreimage(networkPassphrase, createContractV2HostFn.ContractIdPreimage, participants); err != nil {
+			return fmt.Errorf("getting contract ID: %w", err)
 		}
-		participants = participants.Union(contractIDs)
 	}
 
-	for _, sub := range invocation.SubInvocations {
-		subParticipants, err := participantsFromInvocationAndSubInvocations(networkPassphrase, sub)
-		if err != nil {
-			return nil, fmt.Errorf("collecting participants from subinvocation: %w", err)
+	for i := range invocation.SubInvocations {
+		if err := participantsFromInvocationAndSubInvocations(networkPassphrase, &invocation.SubInvocations[i], participants); err != nil {
+			return fmt.Errorf("collecting participants from subinvocation: %w", err)
 		}
-		participants = participants.Union(subParticipants)
 	}
 
-	return participants, nil
+	return nil
 }
 
-// participantsForAuthEntries extracts all participant addresses from a []SorobanAuthorizationEntry.
-func participantsForAuthEntries(networkPassphrase string, authEntries []xdr.SorobanAuthorizationEntry) (set.Set[string], error) {
-	participants := set.NewThreadUnsafeSet[string]()
-	for _, authEntry := range authEntries {
+// participantsForAuthEntries adds all participant addresses from a
+// []SorobanAuthorizationEntry to the participants accumulator.
+func participantsForAuthEntries(networkPassphrase string, authEntries []xdr.SorobanAuthorizationEntry, participants set.Set[string]) error {
+	for i := range authEntries {
+		authEntry := &authEntries[i]
 		if authEntry.Credentials.Type == xdr.SorobanCredentialsTypeSorobanCredentialsAddress {
 			participant, err := authEntry.Credentials.MustAddress().Address.String()
 			if err != nil {
-				return nil, fmt.Errorf("converting ScAddress to string: %w", err)
+				return fmt.Errorf("converting ScAddress to string: %w", err)
 			}
 			participants.Add(participant)
 		}
 
-		invocationParticipants, err := participantsFromInvocationAndSubInvocations(networkPassphrase, authEntry.RootInvocation)
-		if err != nil {
-			return nil, fmt.Errorf("getting invocation participants: %w", err)
+		if err := participantsFromInvocationAndSubInvocations(networkPassphrase, &authEntry.RootInvocation, participants); err != nil {
+			return fmt.Errorf("getting invocation participants: %w", err)
 		}
-		participants = participants.Union(invocationParticipants)
 	}
 
-	return participants, nil
+	return nil
 }
 
 // participantsForSorobanOp identifies participants (AddressId or ContractId) from Soroban operations.
@@ -144,16 +136,19 @@ func participantsForAuthEntries(networkPassphrase string, authEntries []xdr.Soro
 //
 // It can return `ErrNotSorobanOperation` if the operation is not a Soroban operation.
 //
-// Every set on this path is thread-unsafe: they are built and consumed within a single indexer worker
-// goroutine (see Indexer.ProcessLedgerTransactions), so a thread-safe set's mutex would be pure
-// overhead on the hot path. Set.Union type-asserts its argument to the receiver's variant, so these
-// sets — and anything merged with them — must all stay thread-unsafe or the merge panics at runtime.
-func participantsForSorobanOp(op *TransactionOperationWrapper) (set.Set[string], error) {
+// The whole path folds into the single participants accumulator the caller passes in:
+// one set per operation instead of one per processor, auth entry, and invocation-tree
+// node, with no Union merges. The accumulator must be thread-unsafe — it is built and
+// consumed within a single indexer worker goroutine (see Indexer.ProcessLedgerTransactions),
+// so a thread-safe set's mutex would be pure overhead on the hot path.
+func participantsForSorobanOp(op *TransactionOperationWrapper, participants set.Set[string]) error {
 	if !op.Transaction.IsSorobanTx() {
-		return nil, ErrNotSorobanOperation
+		return ErrNotSorobanOperation
 	}
 
-	participants := set.NewThreadUnsafeSet(op.SourceAccount().Address())
+	// The op source is the one participant every Soroban op shape shares; adding it
+	// here keeps the sub-processors source-free and encodes the address once.
+	participants.Add(op.SourceAccount().Address())
 
 	switch op.Operation.Body.Type {
 	case xdr.OperationTypeExtendFootprintTtl, xdr.OperationTypeRestoreFootprint:
@@ -165,27 +160,21 @@ func participantsForSorobanOp(op *TransactionOperationWrapper) (set.Set[string],
 		switch invokeHostOp.HostFunction.Type {
 		case xdr.HostFunctionTypeHostFunctionTypeCreateContract:
 			createContractOpProcessor := CreateContractV1OpProcessor{op: op}
-			createContractOpParticipants, err := createContractOpProcessor.Participants()
-			if err != nil {
-				return nil, fmt.Errorf("getting create contract participants: %w", err)
+			if err := createContractOpProcessor.AddParticipants(participants); err != nil {
+				return fmt.Errorf("getting create contract participants: %w", err)
 			}
-			participants = participants.Union(createContractOpParticipants)
 
 		case xdr.HostFunctionTypeHostFunctionTypeCreateContractV2:
 			createContractV2OpProcessor := CreateContractV2OpProcessor{op: op}
-			createContractV2OpParticipants, err := createContractV2OpProcessor.Participants()
-			if err != nil {
-				return nil, fmt.Errorf("getting create contract participants: %w", err)
+			if err := createContractV2OpProcessor.AddParticipants(participants); err != nil {
+				return fmt.Errorf("getting create contract participants: %w", err)
 			}
-			participants = participants.Union(createContractV2OpParticipants)
 
 		case xdr.HostFunctionTypeHostFunctionTypeInvokeContract:
 			invokeContractOpProcessor := InvokeContractOpProcessor{op: op}
-			invokeContractOpParticipants, err := invokeContractOpProcessor.Participants()
-			if err != nil {
-				return nil, fmt.Errorf("getting invoke contract participants: %w", err)
+			if err := invokeContractOpProcessor.AddParticipants(participants); err != nil {
+				return fmt.Errorf("getting invoke contract participants: %w", err)
 			}
-			participants = participants.Union(invokeContractOpParticipants)
 
 		case xdr.HostFunctionTypeHostFunctionTypeUploadContractWasm:
 			break
@@ -195,37 +184,41 @@ func participantsForSorobanOp(op *TransactionOperationWrapper) (set.Set[string],
 		break
 	}
 
-	return participants, nil
+	return nil
 }
 
-// contractIDsForPreimage returns the contract IDs for a ContractIdPreimage.
-// if the preimage is FromAsset, it returns the SAC contract ID.
-// if the preimage is FromAddress, it returns the contract ID calculated from the deployer address, salt and the network passphrase.
-// It also returns the deployer account ID.
-func contractIDsForPreimage(networkPassphrase string, preimage xdr.ContractIdPreimage) (set.Set[string], error) {
+// addContractIDsForPreimage adds the contract IDs for a ContractIdPreimage to the
+// participants accumulator.
+// If the preimage is FromAsset, it adds the SAC contract ID.
+// If the preimage is FromAddress, it adds the contract ID calculated from the deployer
+// address, salt and the network passphrase, plus the deployer account ID.
+func addContractIDsForPreimage(networkPassphrase string, preimage xdr.ContractIdPreimage, participants set.Set[string]) error {
 	switch preimage.Type {
 	case xdr.ContractIdPreimageTypeContractIdPreimageFromAddress:
 		contractID, err := calculateContractID(networkPassphrase, preimage.MustFromAddress())
 		if err != nil {
-			return nil, fmt.Errorf("calculating contract ID: %w", err)
+			return fmt.Errorf("calculating contract ID: %w", err)
 		}
 
 		fromAccountID, err := preimage.MustFromAddress().Address.String()
 		if err != nil {
-			return nil, fmt.Errorf("getting from address' string representation: %w", err)
+			return fmt.Errorf("getting from address' string representation: %w", err)
 		}
-		return set.NewThreadUnsafeSet(contractID, fromAccountID), nil
+		participants.Add(contractID)
+		participants.Add(fromAccountID)
+		return nil
 
 	case xdr.ContractIdPreimageTypeContractIdPreimageFromAsset:
 		fromAsset := preimage.MustFromAsset()
 		assetContractID, err := fromAsset.ContractID(networkPassphrase)
 		if err != nil {
-			return nil, fmt.Errorf("getting asset contract ID: %w", err)
+			return fmt.Errorf("getting asset contract ID: %w", err)
 		}
-		return set.NewThreadUnsafeSet(strkey.MustEncode(strkey.VersionByteContract, assetContractID[:])), nil
+		participants.Add(strkey.MustEncode(strkey.VersionByteContract, assetContractID[:]))
+		return nil
 
 	default:
-		return nil, fmt.Errorf("invalid contract id preimage type")
+		return fmt.Errorf("invalid contract id preimage type")
 	}
 }
 
@@ -233,132 +226,89 @@ type CreateContractV1OpProcessor struct {
 	op *TransactionOperationWrapper
 }
 
-func (p *CreateContractV1OpProcessor) GetCreateContract() (xdr.CreateContractArgs, bool) {
+// AddParticipants adds the operation's contract IDs and auth-entry participants to
+// the accumulator. The op source account is added by participantsForSorobanOp.
+func (p *CreateContractV1OpProcessor) AddParticipants(participants set.Set[string]) error {
 	if p.op.OperationType() != xdr.OperationTypeInvokeHostFunction {
-		return xdr.CreateContractArgs{}, false
+		return fmt.Errorf("not a create contract operation: %w", ErrInvalidOpType)
 	}
-
 	invokeHostFunctionOp := p.op.Operation.Body.MustInvokeHostFunctionOp()
 	if invokeHostFunctionOp.HostFunction.Type != xdr.HostFunctionTypeHostFunctionTypeCreateContract {
-		return xdr.CreateContractArgs{}, false
+		return fmt.Errorf("not a create contract operation: %w", ErrInvalidOpType)
 	}
-
-	return invokeHostFunctionOp.HostFunction.MustCreateContract(), true
-}
-
-func (p *CreateContractV1OpProcessor) Participants() (set.Set[string], error) {
-	createContractOp, ok := p.GetCreateContract()
-	if !ok {
-		return nil, fmt.Errorf("not a create contract operation: %w", ErrInvalidOpType)
-	}
-
-	// Source account
-	participants := set.NewThreadUnsafeSet(p.op.SourceAccount().Address())
+	createContractOp := invokeHostFunctionOp.HostFunction.MustCreateContract()
 
 	// Contract IDs
-	contractIDs, err := contractIDsForPreimage(p.op.Network, createContractOp.ContractIdPreimage)
-	if err != nil {
-		return nil, fmt.Errorf("getting contract ID: %w", err)
+	if err := addContractIDsForPreimage(p.op.Network, createContractOp.ContractIdPreimage, participants); err != nil {
+		return fmt.Errorf("getting contract ID: %w", err)
 	}
-	participants = participants.Union(contractIDs)
 
 	// Auth participants
-	authEntries := p.op.Operation.Body.MustInvokeHostFunctionOp().Auth
-	authParticipants, err := participantsForAuthEntries(p.op.Network, authEntries)
-	if err != nil {
-		return nil, fmt.Errorf("getting auth participants: %w", err)
+	if err := participantsForAuthEntries(p.op.Network, invokeHostFunctionOp.Auth, participants); err != nil {
+		return fmt.Errorf("getting auth participants: %w", err)
 	}
-	participants = participants.Union(authParticipants)
 
-	return participants, nil
+	return nil
 }
 
 type CreateContractV2OpProcessor struct {
 	op *TransactionOperationWrapper
 }
 
-func (p *CreateContractV2OpProcessor) GetCreateContract() (xdr.CreateContractArgsV2, bool) {
+// AddParticipants adds the operation's contract IDs and auth-entry participants to
+// the accumulator. The op source account is added by participantsForSorobanOp.
+func (p *CreateContractV2OpProcessor) AddParticipants(participants set.Set[string]) error {
 	if p.op.OperationType() != xdr.OperationTypeInvokeHostFunction {
-		return xdr.CreateContractArgsV2{}, false
+		return fmt.Errorf("not a create contract v2 operation: %w", ErrInvalidOpType)
 	}
-
 	invokeHostFunctionOp := p.op.Operation.Body.MustInvokeHostFunctionOp()
 	if invokeHostFunctionOp.HostFunction.Type != xdr.HostFunctionTypeHostFunctionTypeCreateContractV2 {
-		return xdr.CreateContractArgsV2{}, false
+		return fmt.Errorf("not a create contract v2 operation: %w", ErrInvalidOpType)
 	}
-
-	return invokeHostFunctionOp.HostFunction.MustCreateContractV2(), true
-}
-
-func (p *CreateContractV2OpProcessor) Participants() (set.Set[string], error) {
-	createContractOp, ok := p.GetCreateContract()
-	if !ok {
-		return nil, fmt.Errorf("not a create contract v2 operation: %w", ErrInvalidOpType)
-	}
-
-	// Source account
-	participants := set.NewThreadUnsafeSet(p.op.SourceAccount().Address())
+	createContractOp := invokeHostFunctionOp.HostFunction.MustCreateContractV2()
 
 	// Contract IDs
-	contractIDs, err := contractIDsForPreimage(p.op.Network, createContractOp.ContractIdPreimage)
-	if err != nil {
-		return nil, fmt.Errorf("getting contract ID: %w", err)
+	if err := addContractIDsForPreimage(p.op.Network, createContractOp.ContractIdPreimage, participants); err != nil {
+		return fmt.Errorf("getting contract ID: %w", err)
 	}
-	participants = participants.Union(contractIDs)
 
 	// Auth participants
-	authEntries := p.op.Operation.Body.MustInvokeHostFunctionOp().Auth
-	authParticipants, err := participantsForAuthEntries(p.op.Network, authEntries)
-	if err != nil {
-		return nil, fmt.Errorf("getting auth participants: %w", err)
+	if err := participantsForAuthEntries(p.op.Network, invokeHostFunctionOp.Auth, participants); err != nil {
+		return fmt.Errorf("getting auth participants: %w", err)
 	}
-	participants = participants.Union(authParticipants)
 
-	return participants, nil
+	return nil
 }
 
 type InvokeContractOpProcessor struct {
 	op *TransactionOperationWrapper
 }
 
-func (p *InvokeContractOpProcessor) GetInvokeContract() (xdr.InvokeContractArgs, bool) {
+// AddParticipants adds the invoked contract ID and auth-entry participants to the
+// accumulator. The op source account is added by participantsForSorobanOp.
+func (p *InvokeContractOpProcessor) AddParticipants(participants set.Set[string]) error {
 	if p.op.OperationType() != xdr.OperationTypeInvokeHostFunction {
-		return xdr.InvokeContractArgs{}, false
+		return fmt.Errorf("not a invoke contract operation: %w", ErrInvalidOpType)
 	}
-
 	invokeHostFunctionOp := p.op.Operation.Body.MustInvokeHostFunctionOp()
 	if invokeHostFunctionOp.HostFunction.Type != xdr.HostFunctionTypeHostFunctionTypeInvokeContract {
-		return xdr.InvokeContractArgs{}, false
+		return fmt.Errorf("not a invoke contract operation: %w", ErrInvalidOpType)
 	}
-
-	return invokeHostFunctionOp.HostFunction.MustInvokeContract(), true
-}
-
-func (p *InvokeContractOpProcessor) Participants() (set.Set[string], error) {
-	invokeContractOp, ok := p.GetInvokeContract()
-	if !ok {
-		return nil, fmt.Errorf("not a invoke contract operation: %w", ErrInvalidOpType)
-	}
-
-	// Source account
-	participants := set.NewThreadUnsafeSet(p.op.SourceAccount().Address())
+	invokeContractOp := invokeHostFunctionOp.HostFunction.MustInvokeContract()
 
 	// Contract ID
 	contractID, err := invokeContractOp.ContractAddress.String()
 	if err != nil {
-		return nil, fmt.Errorf("converting contract address to string: %w", err)
+		return fmt.Errorf("converting contract address to string: %w", err)
 	}
 	if contractID != "" {
 		participants.Add(contractID)
 	}
 
 	// Auth participants
-	authEntries := p.op.Operation.Body.MustInvokeHostFunctionOp().Auth
-	authParticipants, err := participantsForAuthEntries(p.op.Network, authEntries)
-	if err != nil {
-		return nil, fmt.Errorf("getting auth participants: %w", err)
+	if err := participantsForAuthEntries(p.op.Network, invokeHostFunctionOp.Auth, participants); err != nil {
+		return fmt.Errorf("getting auth participants: %w", err)
 	}
-	participants = participants.Union(authParticipants)
 
-	return participants, nil
+	return nil
 }

--- a/internal/indexer/processors/contract_operations_test.go
+++ b/internal/indexer/processors/contract_operations_test.go
@@ -74,7 +74,8 @@ func Test_participantsForSorobanOp_nonSorobanOp(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			participants, err := participantsForSorobanOp(tc.op)
+			participants := set.NewThreadUnsafeSet[string]()
+			err := participantsForSorobanOp(tc.op, participants)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.wantErrContains)
 			assert.Empty(t, participants)
@@ -202,7 +203,8 @@ func Test_participantsForSorobanOp_footprintOps(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			participants, err := participantsForSorobanOp(tc.op)
+			participants := set.NewThreadUnsafeSet[string]()
+			err := participantsForSorobanOp(tc.op, participants)
 
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantParticipants, participants)
@@ -257,11 +259,53 @@ func Test_participantsForSorobanOp_invokeHostFunction_uploadWasm(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			participants, err := participantsForSorobanOp(tc.op)
+			participants := set.NewThreadUnsafeSet[string]()
+			err := participantsForSorobanOp(tc.op, participants)
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantParticipants, participants)
 		})
 	}
+}
+
+func Test_participantsFromInvocationAndSubInvocations_zeroValueInvocation(t *testing.T) {
+	// A zero-value invocation carries the ContractFn arm tag with a nil pointer; the
+	// walk must skip it instead of dereferencing (GetContractFn would panic).
+	participants := set.NewThreadUnsafeSet[string]()
+	err := participantsFromInvocationAndSubInvocations(network.TestNetworkPassphrase, &xdr.SorobanAuthorizedInvocation{}, participants)
+	require.NoError(t, err)
+	assert.True(t, participants.IsEmpty())
+}
+
+func Test_participantsForSorobanOp_muxedOpSourceKeepsMuxedForm(t *testing.T) {
+	op := makeBasicSorobanOp()
+	op.Operation = xdr.Operation{
+		Body: xdr.OperationBody{
+			Type: xdr.OperationTypeInvokeHostFunction,
+			InvokeHostFunctionOp: &xdr.InvokeHostFunctionOp{
+				HostFunction: xdr.HostFunction{
+					Type: xdr.HostFunctionTypeHostFunctionTypeUploadContractWasm,
+					Wasm: &[]byte{1, 2, 3, 4, 5},
+				},
+			},
+		},
+	}
+	muxedSource := xdr.MuxedAccount{
+		Type: xdr.CryptoKeyTypeKeyTypeMuxedEd25519,
+		Med25519: &xdr.MuxedAccountMed25519{
+			Id:      123,
+			Ed25519: xdr.Uint256{1, 2, 3},
+		},
+	}
+	op.Operation.SourceAccount = &muxedSource
+
+	participants := set.NewThreadUnsafeSet[string]()
+	err := participantsForSorobanOp(op, participants)
+	require.NoError(t, err)
+
+	// The Soroban path reports the source in its muxed (M...) form; the classic
+	// Participants() path separately reports the underlying G-account.
+	assert.Equal(t, set.NewThreadUnsafeSet(muxedSource.Address()), participants)
+	assert.NotEqual(t, muxedSource.ToAccountId().Address(), muxedSource.Address())
 }
 
 // makeAuthEntries receives a []xdr.ScAddress and returns a []xdr.SorobanAuthorizationEntry. It also populates the
@@ -479,7 +523,8 @@ func Test_participantsForSorobanOp_invokeHostFunction_createContract(t *testing.
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			participants, err := participantsForSorobanOp(tc.op)
+			participants := set.NewThreadUnsafeSet[string]()
+			err := participantsForSorobanOp(tc.op, participants)
 
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantParticipants, participants)
@@ -582,7 +627,8 @@ func Test_participantsForSorobanOp_invokeHostFunction_invokeContract(t *testing.
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			participants, err := participantsForSorobanOp(tc.op)
+			participants := set.NewThreadUnsafeSet[string]()
+			err := participantsForSorobanOp(tc.op, participants)
 
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantParticipants, participants)

--- a/internal/indexer/processors/contract_operations_test.go
+++ b/internal/indexer/processors/contract_operations_test.go
@@ -37,7 +37,7 @@ func Test_participantsForSorobanOp_nonSorobanOp(t *testing.T) {
 			Operation: xdr.Operation{
 				Body: xdr.OperationBody{Type: xdr.OperationTypePayment},
 			},
-			Transaction: ingest.LedgerTransaction{
+			Transaction: &ingest.LedgerTransaction{
 				Envelope: xdr.TransactionEnvelope{
 					Type: xdr.EnvelopeTypeEnvelopeTypeTx,
 					V1: &xdr.TransactionV1Envelope{
@@ -97,7 +97,7 @@ func Test_participantsForSorobanOp_footprintOps(t *testing.T) {
 			Network:      network.TestNetworkPassphrase,
 			LedgerClosed: time.Now(),
 			Operation:    xdr.Operation{},
-			Transaction: ingest.LedgerTransaction{
+			Transaction: &ingest.LedgerTransaction{
 				Envelope: xdr.TransactionEnvelope{
 					Type: xdr.EnvelopeTypeEnvelopeTypeTx,
 					V1: &xdr.TransactionV1Envelope{

--- a/internal/indexer/processors/contracts/sac.go
+++ b/internal/indexer/processors/contracts/sac.go
@@ -90,7 +90,7 @@ func (p *SACEventsProcessor) ProcessOperation(_ context.Context, opWrapper *proc
 	}
 
 	stateChanges := make([]types.StateChange, 0)
-	builder := processors.NewStateChangeBuilder(ledgerNumber, ledgerCloseTime, txID, p.metricsService).WithOperationID(opWrapper.ID())
+	builder := processors.NewStateChangeBuilder(ledgerNumber, ledgerCloseTime, txID).WithOperationID(opWrapper.ID())
 	for _, event := range contractEvents {
 		// Validate basic contract contractEvent structure
 		if event.Type != xdr.ContractEventTypeContract || event.ContractId == nil || event.Body.V != 0 {
@@ -201,11 +201,11 @@ func (p *SACEventsProcessor) ProcessOperation(_ context.Context, opWrapper *proc
 				// Contract authorization: handle AUTHORIZED state
 				if isAuthorized != wasAuthorized {
 					if isAuthorized {
-						flagChanges = append(flagChanges, scBuilder.Clone().
+						flagChanges = append(flagChanges, scBuilder.
 							WithReason(types.StateChangeReasonSet).
 							Build())
 					} else {
-						flagChanges = append(flagChanges, scBuilder.Clone().
+						flagChanges = append(flagChanges, scBuilder.
 							WithReason(types.StateChangeReasonClear).
 							Build())
 					}
@@ -214,14 +214,14 @@ func (p *SACEventsProcessor) ProcessOperation(_ context.Context, opWrapper *proc
 				if isAuthorized {
 					// Authorizing: should set AUTHORIZED_FLAG if it wasn't already set
 					if !wasAuthorized {
-						flagChanges = append(flagChanges, scBuilder.Clone().
+						flagChanges = append(flagChanges, scBuilder.
 							WithReason(types.StateChangeReasonSet).
 							WithFlags([]string{AuthorizedFlagName}).
 							Build())
 					}
 					// Should clear AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG if it was previously set
 					if wasMaintainLiabilities {
-						flagChanges = append(flagChanges, scBuilder.Clone().
+						flagChanges = append(flagChanges, scBuilder.
 							WithReason(types.StateChangeReasonClear).
 							WithFlags([]string{AuthorizedToMaintainLiabilitesFlagName}).
 							Build())
@@ -229,14 +229,14 @@ func (p *SACEventsProcessor) ProcessOperation(_ context.Context, opWrapper *proc
 				} else {
 					// Deauthorizing: should clear AUTHORIZED_FLAG if it was previously set
 					if wasAuthorized {
-						flagChanges = append(flagChanges, scBuilder.Clone().
+						flagChanges = append(flagChanges, scBuilder.
 							WithReason(types.StateChangeReasonClear).
 							WithFlags([]string{AuthorizedFlagName}).
 							Build())
 					}
 					// Should set AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG if it wasn't already set
 					if !wasMaintainLiabilities {
-						flagChanges = append(flagChanges, scBuilder.Clone().
+						flagChanges = append(flagChanges, scBuilder.
 							WithReason(types.StateChangeReasonSet).
 							WithFlags([]string{AuthorizedToMaintainLiabilitesFlagName}).
 							Build())

--- a/internal/indexer/processors/contracts/sac.go
+++ b/internal/indexer/processors/contracts/sac.go
@@ -55,6 +55,10 @@ func (p *SACEventsProcessor) StateChangeSubBase() int64 {
 
 // ProcessOperation processes contract events and converts them into state changes.
 func (p *SACEventsProcessor) ProcessOperation(_ context.Context, opWrapper *processors.TransactionOperationWrapper) ([]types.StateChange, error) {
+	if opWrapper.OperationType() != xdr.OperationTypeInvokeHostFunction {
+		return nil, processors.ErrInvalidOpType
+	}
+
 	startTime := time.Now()
 	defer func() {
 		if p.metricsService != nil {
@@ -63,13 +67,8 @@ func (p *SACEventsProcessor) ProcessOperation(_ context.Context, opWrapper *proc
 		}
 	}()
 
-	if opWrapper.OperationType() != xdr.OperationTypeInvokeHostFunction {
-		return nil, processors.ErrInvalidOpType
-	}
-
 	ledgerCloseTime := opWrapper.Transaction.Ledger.LedgerCloseTime()
 	ledgerNumber := opWrapper.Transaction.Ledger.LedgerSequence()
-	txHash := opWrapper.Transaction.Result.TransactionHash.HexString()
 	txID := opWrapper.Transaction.ID()
 
 	tx := opWrapper.Transaction
@@ -115,26 +114,26 @@ func (p *SACEventsProcessor) ProcessOperation(_ context.Context, opWrapper *proc
 			asset, err := p.extractAsset(topics, tx.UnsafeMeta.V)
 			if err != nil {
 				log.Debugf("processor: %s: extracting asset from tx meta: txHash=%s opID=%d contractId=%s error=%v",
-					p.Name(), txHash, opWrapper.ID(), contractID, err)
+					p.Name(), opWrapper.Transaction.Result.TransactionHash.HexString(), opWrapper.ID(), contractID, err)
 				continue
 			}
 
 			isSAC, err := p.isSACContract(asset, contractID)
 			if err != nil {
 				log.Debugf("processor: %s: validating SAC contract: txHash=%s opID=%d contractId=%s error=%v",
-					p.Name(), txHash, opWrapper.ID(), contractID, err)
+					p.Name(), opWrapper.Transaction.Result.TransactionHash.HexString(), opWrapper.ID(), contractID, err)
 				continue
 			}
 			if !isSAC {
 				log.Debugf("processor: %s: skipping event due to non-SAC contract: txHash=%s opID=%d contractId=%s",
-					p.Name(), txHash, opWrapper.ID(), contractID)
+					p.Name(), opWrapper.Transaction.Result.TransactionHash.HexString(), opWrapper.ID(), contractID)
 				continue
 			}
 
 			accountToAuthorize, err := p.extractAccount(topics, tx.UnsafeMeta.V)
 			if err != nil {
 				log.Debugf("processor: %s: extracting account from tx meta: txHash=%s opID=%d contractId=%s error=%v",
-					p.Name(), txHash, opWrapper.ID(), contractID, err)
+					p.Name(), opWrapper.Transaction.Result.TransactionHash.HexString(), opWrapper.ID(), contractID, err)
 				continue
 			}
 
@@ -142,7 +141,7 @@ func (p *SACEventsProcessor) ProcessOperation(_ context.Context, opWrapper *proc
 			isAuthorized, ok := value.GetB()
 			if !ok {
 				log.Debugf("processor: %s: extracting authorization value from event data: txHash=%s opID=%d contractId=%s",
-					p.Name(), txHash, opWrapper.ID(), contractID)
+					p.Name(), opWrapper.Transaction.Result.TransactionHash.HexString(), opWrapper.ID(), contractID)
 				continue
 			}
 
@@ -171,7 +170,7 @@ func (p *SACEventsProcessor) ProcessOperation(_ context.Context, opWrapper *proc
 					// We dont want to log errors for no contract data change found. We can simply skip processing.
 					if !errors.Is(err, errNoContractDataChangeFound) {
 						log.Debugf("processor: %s: extracting contract authorization changes: txHash=%s opID=%d contractId=%s contractAddress=%s error=%v",
-							p.Name(), txHash, opWrapper.ID(), contractID, accountToAuthorize, err)
+							p.Name(), opWrapper.Transaction.Result.TransactionHash.HexString(), opWrapper.ID(), contractID, accountToAuthorize, err)
 					}
 					continue
 				}
@@ -182,7 +181,7 @@ func (p *SACEventsProcessor) ProcessOperation(_ context.Context, opWrapper *proc
 					// We dont want to log errors for no trustline change found. We can simply skip processing.
 					if !errors.Is(err, errNoTrustlineChangeFound) {
 						log.Debugf("processor: %s: extracting trustline flag changes: txHash=%s opID=%d contractId=%s accountAddress=%s error=%v",
-							p.Name(), txHash, opWrapper.ID(), contractID, accountToAuthorize, err)
+							p.Name(), opWrapper.Transaction.Result.TransactionHash.HexString(), opWrapper.ID(), contractID, accountToAuthorize, err)
 					}
 					continue
 				}

--- a/internal/indexer/processors/contracts/sac.go
+++ b/internal/indexer/processors/contracts/sac.go
@@ -85,7 +85,7 @@ func (p *SACEventsProcessor) ProcessOperation(_ context.Context, opWrapper *proc
 	}
 
 	// Get operation changes to access previous trustline flag state
-	changes, err := tx.GetOperationChanges(opWrapper.Index)
+	changes, err := opWrapper.Changes()
 	if err != nil {
 		return nil, fmt.Errorf("getting operation changes for operation %d: %w", opWrapper.ID(), err)
 	}

--- a/internal/indexer/processors/contracts/sac.go
+++ b/internal/indexer/processors/contracts/sac.go
@@ -36,6 +36,7 @@ const (
 type SACEventsProcessor struct {
 	networkPassphrase string
 	metricsService    *metrics.IngestionMetrics
+	assetContractIDs  processors.AssetContractIDMemo
 }
 
 func NewSACEventsProcessor(networkPassphrase string, metricsService *metrics.IngestionMetrics) *SACEventsProcessor {
@@ -300,30 +301,23 @@ func (p *SACEventsProcessor) extractAccount(topics []xdr.ScVal, txMetaVersion in
 
 // isSACContract checks if a contract is an SAC contract
 func (p *SACEventsProcessor) isSACContract(asset xdr.Asset, contractID string) (bool, error) {
-	assetContractID, err := asset.ContractID(p.networkPassphrase)
+	assetContractID, err := p.assetContractIDs.FromAsset(p.networkPassphrase, asset)
 	if err != nil {
 		return false, fmt.Errorf("invalid asset contract ID: %w", err)
 	}
-	return strkey.MustEncode(strkey.VersionByteContract, assetContractID[:]) == contractID, nil
+	return assetContractID == contractID, nil
 }
 
 // extractTrustlineFlagChanges extracts the previous trustline flags for the given account.
-// The change scan now verifies the trustline belongs to the same SAC contract referenced by the event so
+// The change scan verifies the trustline belongs to the same SAC contract referenced by the event so
 // unrelated trustlines updated in the same operation are ignored.
 func (p *SACEventsProcessor) extractTrustlineFlagChanges(changes []ingest.Change, accountToAuthorize string, contractID string) (wasAuthorized bool, wasMaintainLiabilities bool, err error) {
-	contractIDBytes, err := strkey.Decode(strkey.VersionByteContract, contractID)
-	if err != nil {
-		return false, false, fmt.Errorf("invalid contract id %s: %w", contractID, err)
-	}
-	var expectedContract xdr.ContractId
-	copy(expectedContract[:], contractIDBytes)
-
 	for _, change := range changes {
 		if change.Type != xdr.LedgerEntryTypeTrustline {
 			continue
 		}
 
-		if !p.trustlineEntryMatches(change, accountToAuthorize, expectedContract) {
+		if !p.trustlineEntryMatches(change, accountToAuthorize, contractID) {
 			continue
 		}
 
@@ -437,7 +431,9 @@ func (p *SACEventsProcessor) extractAuthorizedFromBalanceMap(balanceVal xdr.ScVa
 }
 
 // trustlineEntryMatches verifies the ledger entry represents the SAC trustline for the target account.
-func (p *SACEventsProcessor) trustlineEntryMatches(change ingest.Change, account string, expectedContract xdr.ContractId) bool {
+// Both contract IDs are compared strkey-encoded, which is equivalent to comparing the raw 32 bytes
+// because the encoding is injective, and it lets the derivation come from the memo.
+func (p *SACEventsProcessor) trustlineEntryMatches(change ingest.Change, account string, expectedContractID string) bool {
 	var entry *xdr.LedgerEntry
 	if change.Pre != nil {
 		entry = change.Pre
@@ -459,12 +455,12 @@ func (p *SACEventsProcessor) trustlineEntryMatches(change ingest.Change, account
 		return false
 	}
 
-	contractID, err := asset.ContractID(p.networkPassphrase)
+	contractID, err := p.assetContractIDs.FromAsset(p.networkPassphrase, asset)
 	if err != nil {
 		return false
 	}
 
-	return xdr.ContractId(contractID) == expectedContract
+	return contractID == expectedContractID
 }
 
 // contractDataChangeMatches ensures the contract-data change belongs to the SAC token and target balance key.

--- a/internal/indexer/processors/contracts/sac_test.go
+++ b/internal/indexer/processors/contracts/sac_test.go
@@ -32,7 +32,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -67,7 +67,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -102,7 +102,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -136,7 +136,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -159,7 +159,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -188,7 +188,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -215,7 +215,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -238,7 +238,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -266,7 +266,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -286,7 +286,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -306,7 +306,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -325,7 +325,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -344,7 +344,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -368,7 +368,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -397,7 +397,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -424,7 +424,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -445,7 +445,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -465,7 +465,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -488,7 +488,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -514,7 +514,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -535,7 +535,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -556,7 +556,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        networkPassphrase,
-			Transaction:    tx,
+			Transaction:    &tx,
 			LedgerSequence: 12345,
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)

--- a/internal/indexer/processors/contracts_test_utils.go
+++ b/internal/indexer/processors/contracts_test_utils.go
@@ -57,7 +57,7 @@ func makeBasicSorobanOp() *TransactionOperationWrapper {
 		LedgerClosed:   closeTime,
 		LedgerSequence: 12345,
 		Operation:      xdr.Operation{},
-		Transaction: ingest.LedgerTransaction{
+		Transaction: &ingest.LedgerTransaction{
 			Envelope: xdr.TransactionEnvelope{
 				Type: xdr.EnvelopeTypeEnvelopeTypeTx,
 				V1: &xdr.TransactionV1Envelope{
@@ -136,6 +136,10 @@ func setFrom(op *TransactionOperationWrapper, hostFnType xdr.HostFunctionType, p
 // makeFeeBumpOp updates the envelope type to a fee bump envelope and sets the fee source account.
 func makeFeeBumpOp(feeBumpSourceAccount string, baseOp *TransactionOperationWrapper) *TransactionOperationWrapper {
 	op := *baseOp
+	// The wrapper copy shares baseOp's transaction, so the fee bump envelope is built on a
+	// copy of it: the InnerTx fields below read baseOp's envelope after these writes.
+	transaction := *baseOp.Transaction
+	op.Transaction = &transaction
 	op.Transaction.Envelope.V0 = nil
 	op.Transaction.Envelope.V1 = nil
 	op.Transaction.Envelope.Type = xdr.EnvelopeTypeEnvelopeTypeTxFeeBump

--- a/internal/indexer/processors/effects.go
+++ b/internal/indexer/processors/effects.go
@@ -77,7 +77,7 @@ var (
 type EffectsProcessor struct {
 	networkPassphrase string
 	metricsService    *metrics.IngestionMetrics
-	assetContractIDs  assetContractIDMemo
+	assetContractIDs  AssetContractIDMemo
 }
 
 // NewEffectsProcessor creates a new effects processor for the specified Stellar network.

--- a/internal/indexer/processors/effects.go
+++ b/internal/indexer/processors/effects.go
@@ -110,19 +110,22 @@ func (p *EffectsProcessor) ProcessOperation(_ context.Context, opWrapper *Transa
 
 	ledgerCloseTime := opWrapper.Transaction.Ledger.LedgerCloseTime()
 	ledgerNumber := opWrapper.Transaction.Ledger.LedgerSequence()
-	txHash := opWrapper.Transaction.Result.TransactionHash.HexString()
 	txID := opWrapper.Transaction.ID()
 
 	// Extract effects from the operation using Stellar SDK
 	effectOutputs, err := Effects(opWrapper)
 	if err != nil {
-		return nil, fmt.Errorf("getting effects for tx: %s, opID: %d, err: %w", txHash, opWrapper.ID(), err)
+		return nil, fmt.Errorf("getting effects for tx: %s, opID: %d, err: %w", opWrapper.Transaction.Result.TransactionHash.HexString(), opWrapper.ID(), err)
 	}
 
 	// Get operation changes to access old values when needed
 	changes, err := opWrapper.Changes()
 	if err != nil {
-		return nil, fmt.Errorf("getting operation changes for tx: %s, opID: %d, err: %w", txHash, opWrapper.ID(), err)
+		return nil, fmt.Errorf("getting operation changes for tx: %s, opID: %d, err: %w", opWrapper.Transaction.Result.TransactionHash.HexString(), opWrapper.ID(), err)
+	}
+
+	if len(effectOutputs) == 0 {
+		return nil, nil
 	}
 
 	var stateChanges []types.StateChange
@@ -142,7 +145,7 @@ func (p *EffectsProcessor) ProcessOperation(_ context.Context, opWrapper *Transa
 				WithReason(signerEffectToReasonMap[effect.Type])
 			signerChanges, err := p.parseSigners(changeBuilder, &effect, effectType, changes)
 			if err != nil {
-				log.Warnf("processor: %s: failed to parse signer effects: effectType: %s, address: %s, txHash: %s, opID: %d, err: %v", p.Name(), effect.TypeString, effect.Address, txHash, opWrapper.ID(), err)
+				log.Warnf("processor: %s: failed to parse signer effects: effectType: %s, address: %s, txHash: %s, opID: %d, err: %v", p.Name(), effect.TypeString, effect.Address, opWrapper.Transaction.Result.TransactionHash.HexString(), opWrapper.ID(), err)
 				continue
 			}
 			stateChanges = append(stateChanges, signerChanges...)
@@ -152,7 +155,7 @@ func (p *EffectsProcessor) ProcessOperation(_ context.Context, opWrapper *Transa
 			changeBuilder = changeBuilder.WithCategory(types.StateChangeCategorySignatureThreshold)
 			thresholdChanges, err := p.parseThresholds(changeBuilder, &effect, changes)
 			if err != nil {
-				log.Warnf("processor: %s: failed to parse threshold effects: effectType: %s, address: %s, txHash: %s, opID: %d, err: %v", p.Name(), effect.TypeString, effect.Address, txHash, opWrapper.ID(), err)
+				log.Warnf("processor: %s: failed to parse threshold effects: effectType: %s, address: %s, txHash: %s, opID: %d, err: %v", p.Name(), effect.TypeString, effect.Address, opWrapper.Transaction.Result.TransactionHash.HexString(), opWrapper.ID(), err)
 				continue
 			}
 			stateChanges = append(stateChanges, thresholdChanges...)
@@ -166,7 +169,7 @@ func (p *EffectsProcessor) ProcessOperation(_ context.Context, opWrapper *Transa
 		case EffectAccountHomeDomainUpdated:
 			oldDomain, newDomain, err := p.parseHomeDomain(&effect, changes)
 			if err != nil {
-				log.Warnf("processor: %s: failed to parse home domain effect: effectType: %s, address: %s, txHash: %s, opID: %d, err: %v", p.Name(), effect.TypeString, effect.Address, txHash, opWrapper.ID(), err)
+				log.Warnf("processor: %s: failed to parse home domain effect: effectType: %s, address: %s, txHash: %s, opID: %d, err: %v", p.Name(), effect.TypeString, effect.Address, opWrapper.Transaction.Result.TransactionHash.HexString(), opWrapper.ID(), err)
 				continue
 			}
 			reason, keyValueMap, changed := homeDomainChange(oldDomain, newDomain)
@@ -192,7 +195,7 @@ func (p *EffectsProcessor) ProcessOperation(_ context.Context, opWrapper *Transa
 			// Build the asset contract ID from the trustline effect
 			_, _, assetContractID, err := p.buildAssetContractIDFromTrustlineEffect(&effect)
 			if err != nil {
-				log.Warnf("processor: %s: failed to build asset contract ID from trustline effect: effectType: %s, address: %s, txHash: %s, opID: %d, err: %v", p.Name(), effect.TypeString, effect.Address, txHash, opWrapper.ID(), err)
+				log.Warnf("processor: %s: failed to build asset contract ID from trustline effect: effectType: %s, address: %s, txHash: %s, opID: %d, err: %v", p.Name(), effect.TypeString, effect.Address, opWrapper.Transaction.Result.TransactionHash.HexString(), opWrapper.ID(), err)
 				continue
 			}
 			changeBuilder = changeBuilder.WithToken(assetContractID)
@@ -203,7 +206,7 @@ func (p *EffectsProcessor) ProcessOperation(_ context.Context, opWrapper *Transa
 			changeBuilder = changeBuilder.WithCategory(types.StateChangeCategoryTrustline)
 			trustlineChange, err := p.parseTrustline(changeBuilder, &effect, effectType, changes)
 			if err != nil {
-				log.Warnf("processor: %s: failed to parse trustline effect: effectType: %s, address: %s, txHash: %s, opID: %d, err: %v", p.Name(), effect.TypeString, effect.Address, txHash, opWrapper.ID(), err)
+				log.Warnf("processor: %s: failed to parse trustline effect: effectType: %s, address: %s, txHash: %s, opID: %d, err: %v", p.Name(), effect.TypeString, effect.Address, opWrapper.Transaction.Result.TransactionHash.HexString(), opWrapper.ID(), err)
 				continue
 			}
 			stateChanges = append(stateChanges, trustlineChange)
@@ -213,7 +216,7 @@ func (p *EffectsProcessor) ProcessOperation(_ context.Context, opWrapper *Transa
 			if effectType == EffectTrustlineCreated {
 				authChanges, err := p.generateBalanceAuthorizationForNewTrustline(changeBuilder, &effect, changes)
 				if err != nil {
-					log.Warnf("processor: %s: failed to generate balance authorization for new trustline: effectType: %s, address: %s, txHash: %s, opID: %d, err: %v", p.Name(), effect.TypeString, effect.Address, txHash, opWrapper.ID(), err)
+					log.Warnf("processor: %s: failed to generate balance authorization for new trustline: effectType: %s, address: %s, txHash: %s, opID: %d, err: %v", p.Name(), effect.TypeString, effect.Address, opWrapper.Transaction.Result.TransactionHash.HexString(), opWrapper.ID(), err)
 					continue
 				}
 				stateChanges = append(stateChanges, authChanges)
@@ -223,7 +226,7 @@ func (p *EffectsProcessor) ProcessOperation(_ context.Context, opWrapper *Transa
 		case EffectDataCreated, EffectDataRemoved, EffectDataUpdated:
 			keyValueMap, err := p.parseDataEntryValues(&effect, effectType, changes)
 			if err != nil {
-				log.Warnf("processor: %s: failed to parse data entry effect: effectType: %s, address: %s, txHash: %s, opID: %d, err: %v", p.Name(), effect.TypeString, effect.Address, txHash, opWrapper.ID(), err)
+				log.Warnf("processor: %s: failed to parse data entry effect: effectType: %s, address: %s, txHash: %s, opID: %d, err: %v", p.Name(), effect.TypeString, effect.Address, opWrapper.Transaction.Result.TransactionHash.HexString(), opWrapper.ID(), err)
 				continue
 			}
 			stateChanges = append(stateChanges, changeBuilder.

--- a/internal/indexer/processors/effects.go
+++ b/internal/indexer/processors/effects.go
@@ -120,7 +120,7 @@ func (p *EffectsProcessor) ProcessOperation(_ context.Context, opWrapper *Transa
 	}
 
 	// Get operation changes to access old values when needed
-	changes, err := opWrapper.Transaction.GetOperationChanges(opWrapper.Index)
+	changes, err := opWrapper.Changes()
 	if err != nil {
 		return nil, fmt.Errorf("getting operation changes for tx: %s, opID: %d, err: %w", txHash, opWrapper.ID(), err)
 	}

--- a/internal/indexer/processors/effects.go
+++ b/internal/indexer/processors/effects.go
@@ -77,6 +77,7 @@ var (
 type EffectsProcessor struct {
 	networkPassphrase string
 	metricsService    *metrics.IngestionMetrics
+	assetContractIDs  assetContractIDMemo
 }
 
 // NewEffectsProcessor creates a new effects processor for the specified Stellar network.
@@ -268,7 +269,7 @@ func (p *EffectsProcessor) parseTrustline(baseBuilder *StateChangeBuilder, effec
 		if err != nil {
 			return types.StateChange{}, fmt.Errorf("extracting asset issuer from effect details: %w", err)
 		}
-		assetContractID, err := getContractIDFromAssetDetails(p.networkPassphrase, assetType, assetCode, assetIssuer)
+		assetContractID, err := p.assetContractIDs.fromDetails(p.networkPassphrase, assetType, assetCode, assetIssuer)
 		if err != nil {
 			return types.StateChange{}, fmt.Errorf("parsing asset: %w", err)
 		}
@@ -363,7 +364,7 @@ func (p *EffectsProcessor) buildAssetContractIDFromTrustlineEffect(effect *Effec
 	if err != nil {
 		return "", "", "", fmt.Errorf("extracting asset issuer from effect details: %w", err)
 	}
-	assetContractID, err := getContractIDFromAssetDetails(p.networkPassphrase, assetType, assetCode, assetIssuer)
+	assetContractID, err := p.assetContractIDs.fromDetails(p.networkPassphrase, assetType, assetCode, assetIssuer)
 	if err != nil {
 		return "", "", "", fmt.Errorf("getting asset contract ID: %w", err)
 	}

--- a/internal/indexer/processors/effects.go
+++ b/internal/indexer/processors/effects.go
@@ -130,10 +130,10 @@ func (p *EffectsProcessor) ProcessOperation(_ context.Context, opWrapper *Transa
 	}
 
 	var stateChanges []types.StateChange
-	masterBuilder := NewStateChangeBuilder(ledgerNumber, ledgerCloseTime, txID, p.metricsService).WithOperationID(opWrapper.ID())
+	masterBuilder := NewStateChangeBuilder(ledgerNumber, ledgerCloseTime, txID).WithOperationID(opWrapper.ID())
 	// Process each effect and convert to our internal state change representation
 	for _, effect := range effectOutputs {
-		changeBuilder := masterBuilder.Clone().WithAccount(effect.Address)
+		changeBuilder := masterBuilder.WithAccount(effect.Address)
 
 		effectType := EffectType(effect.Type)
 		// Process different types of effects based on what account property they modify
@@ -191,7 +191,7 @@ func (p *EffectsProcessor) ProcessOperation(_ context.Context, opWrapper *Transa
 			// but the trustline flags are actually being set on the trustor's account.
 			// We need to extract the trustor address from effect.Details instead.
 			if trustorAddr, err := safeStringFromDetails(effect.Details, "trustor"); err == nil {
-				changeBuilder = changeBuilder.Clone().WithAccount(trustorAddr)
+				changeBuilder = changeBuilder.WithAccount(trustorAddr)
 			}
 			// Build the asset contract ID from the trustline effect
 			_, _, assetContractID, err := p.buildAssetContractIDFromTrustlineEffect(&effect)
@@ -205,7 +205,7 @@ func (p *EffectsProcessor) ProcessOperation(_ context.Context, opWrapper *Transa
 		// Change trust effects
 		case EffectTrustlineCreated, EffectTrustlineRemoved, EffectTrustlineUpdated:
 			changeBuilder = changeBuilder.WithCategory(types.StateChangeCategoryTrustline)
-			trustlineChange, err := p.parseTrustline(changeBuilder, &effect, effectType, changes)
+			trustlineChange, trustlineBuilder, err := p.parseTrustline(changeBuilder, &effect, effectType, changes)
 			if err != nil {
 				log.Warnf("processor: %s: failed to parse trustline effect: effectType: %s, address: %s, txHash: %s, opID: %d, err: %v", p.Name(), effect.TypeString, effect.Address, opWrapper.Transaction.Result.TransactionHash.HexString(), opWrapper.ID(), err)
 				continue
@@ -215,7 +215,7 @@ func (p *EffectsProcessor) ProcessOperation(_ context.Context, opWrapper *Transa
 			// Generate balance authorization state change for new trustline.
 			// We will extract the authorization flags directly from the trustline entry in the changes.
 			if effectType == EffectTrustlineCreated {
-				authChanges, err := p.generateBalanceAuthorizationForNewTrustline(changeBuilder, &effect, changes)
+				authChanges, err := p.generateBalanceAuthorizationForNewTrustline(trustlineBuilder, &effect, changes)
 				if err != nil {
 					log.Warnf("processor: %s: failed to generate balance authorization for new trustline: effectType: %s, address: %s, txHash: %s, opID: %d, err: %v", p.Name(), effect.TypeString, effect.Address, opWrapper.Transaction.Result.TransactionHash.HexString(), opWrapper.ID(), err)
 					continue
@@ -246,32 +246,35 @@ func (p *EffectsProcessor) ProcessOperation(_ context.Context, opWrapper *Transa
 	return stateChanges, nil
 }
 
-func (p *EffectsProcessor) parseTrustline(baseBuilder *StateChangeBuilder, effect *EffectOutput, effectType EffectType, changes []ingest.Change) (types.StateChange, error) {
+// parseTrustline builds the trustline state change and returns the builder it was
+// built from: the asset (or pool) it resolved and the trustline limits it recorded
+// also belong to the balance-authorization change a trustline creation emits.
+func (p *EffectsProcessor) parseTrustline(baseBuilder StateChangeBuilder, effect *EffectOutput, effectType EffectType, changes []ingest.Change) (types.StateChange, StateChangeBuilder, error) {
 	var assetCode, assetIssuer string
 	assetType, err := safeStringFromDetails(effect.Details, "asset_type")
 	if err != nil {
-		return types.StateChange{}, fmt.Errorf("extracting asset type from effect details: %w", err)
+		return types.StateChange{}, baseBuilder, fmt.Errorf("extracting asset type from effect details: %w", err)
 	}
 	if assetType == "liquidity_pool_shares" {
 		var poolID string
 		poolID, err = safeStringFromDetails(effect.Details, "liquidity_pool_id")
 		if err != nil {
-			return types.StateChange{}, fmt.Errorf("extracting liquidity pool ID from effect details: %w", err)
+			return types.StateChange{}, baseBuilder, fmt.Errorf("extracting liquidity pool ID from effect details: %w", err)
 		}
 
 		baseBuilder = baseBuilder.WithLiquidityPoolID(poolID)
 	} else {
 		assetCode, err = safeStringFromDetails(effect.Details, "asset_code")
 		if err != nil {
-			return types.StateChange{}, fmt.Errorf("extracting asset code from effect details: %w", err)
+			return types.StateChange{}, baseBuilder, fmt.Errorf("extracting asset code from effect details: %w", err)
 		}
 		assetIssuer, err = safeStringFromDetails(effect.Details, "asset_issuer")
 		if err != nil {
-			return types.StateChange{}, fmt.Errorf("extracting asset issuer from effect details: %w", err)
+			return types.StateChange{}, baseBuilder, fmt.Errorf("extracting asset issuer from effect details: %w", err)
 		}
 		assetContractID, err := p.assetContractIDs.fromDetails(p.networkPassphrase, assetType, assetCode, assetIssuer)
 		if err != nil {
-			return types.StateChange{}, fmt.Errorf("parsing asset: %w", err)
+			return types.StateChange{}, baseBuilder, fmt.Errorf("parsing asset: %w", err)
 		}
 		baseBuilder = baseBuilder.WithToken(assetContractID)
 	}
@@ -282,34 +285,35 @@ func (p *EffectsProcessor) parseTrustline(baseBuilder *StateChangeBuilder, effec
 	switch effectType {
 	case EffectTrustlineCreated:
 		newLimit := fmt.Sprintf("%v", effect.Details["limit"])
-		stateChange = baseBuilder.WithReason(types.StateChangeReasonAdd).
-			WithTrustlineLimit(nil, &newLimit).
-			Build()
+		baseBuilder = baseBuilder.WithReason(types.StateChangeReasonAdd).
+			WithTrustlineLimit(nil, &newLimit)
+		stateChange = baseBuilder.Build()
 
 	case EffectTrustlineRemoved:
-		stateChange = baseBuilder.WithReason(types.StateChangeReasonRemove).Build()
+		baseBuilder = baseBuilder.WithReason(types.StateChangeReasonRemove)
+		stateChange = baseBuilder.Build()
 
 	case EffectTrustlineUpdated:
 		// The GraphQL schema declares oldLimit non-null, so the trustline
 		// pre-image is required; an update effect without one is malformed.
 		prevLedgerEntryState := p.getPrevLedgerEntryState(effect, xdr.LedgerEntryTypeTrustline, changes)
 		if prevLedgerEntryState == nil {
-			return types.StateChange{}, fmt.Errorf("no previous trustline state for trustline update on account %s (opID %d)", effect.Address, effect.OperationID)
+			return types.StateChange{}, baseBuilder, fmt.Errorf("no previous trustline state for trustline update on account %s (opID %d)", effect.Address, effect.OperationID)
 		}
 		prevTrustline := prevLedgerEntryState.Data.MustTrustLine()
 		oldLimit := strconv.FormatInt(int64(prevTrustline.Limit), 10)
 		newLimit := fmt.Sprintf("%v", effect.Details["limit"])
-		stateChange = baseBuilder.WithReason(types.StateChangeReasonUpdate).
-			WithTrustlineLimit(&oldLimit, &newLimit).
-			Build()
+		baseBuilder = baseBuilder.WithReason(types.StateChangeReasonUpdate).
+			WithTrustlineLimit(&oldLimit, &newLimit)
+		stateChange = baseBuilder.Build()
 	}
 
-	return stateChange, nil
+	return stateChange, baseBuilder, nil
 }
 
 // generateBalanceAuthorizationForNewTrustline generates balance authorization state changes
 // for newly created trustlines by reading the trustline flags directly from transaction changes
-func (p *EffectsProcessor) generateBalanceAuthorizationForNewTrustline(baseBuilder *StateChangeBuilder, effect *EffectOutput, changes []ingest.Change) (types.StateChange, error) {
+func (p *EffectsProcessor) generateBalanceAuthorizationForNewTrustline(baseBuilder StateChangeBuilder, effect *EffectOutput, changes []ingest.Change) (types.StateChange, error) {
 	// Skip native assets as they don't have authorization
 	assetType, err := safeStringFromDetails(effect.Details, "asset_type")
 	if err != nil {
@@ -344,7 +348,7 @@ func (p *EffectsProcessor) generateBalanceAuthorizationForNewTrustline(baseBuild
 	}
 
 	// Generate state changes for each flag that should be set
-	return baseBuilder.Clone().
+	return baseBuilder.
 		WithCategory(types.StateChangeCategoryBalanceAuthorization).
 		WithReason(types.StateChangeReasonSet).
 		WithFlags(defaultFlags).
@@ -524,7 +528,7 @@ func (p *EffectsProcessor) parseDataEntryValues(effect *EffectOutput, effectType
 
 // parseFlags processes flag-related effects and creates separate state changes for set and cleared flags.
 // Stellar flags can be either set (true) or cleared (false), and we track each change separately.
-func (p *EffectsProcessor) parseFlags(flags []string, changeBuilder *StateChangeBuilder, effect *EffectOutput) []types.StateChange {
+func (p *EffectsProcessor) parseFlags(flags []string, changeBuilder StateChangeBuilder, effect *EffectOutput) []types.StateChange {
 	var setFlags, clearFlags []string
 
 	for _, flag := range flags {
@@ -540,14 +544,12 @@ func (p *EffectsProcessor) parseFlags(flags []string, changeBuilder *StateChange
 	var changes []types.StateChange
 	if len(setFlags) > 0 {
 		changes = append(changes, changeBuilder.
-			Clone().
 			WithReason(types.StateChangeReasonSet).
 			WithFlags(setFlags).
 			Build())
 	}
 	if len(clearFlags) > 0 {
 		changes = append(changes, changeBuilder.
-			Clone().
 			WithReason(types.StateChangeReasonClear).
 			WithFlags(clearFlags).
 			Build())
@@ -556,7 +558,7 @@ func (p *EffectsProcessor) parseFlags(flags []string, changeBuilder *StateChange
 	return changes
 }
 
-func (p *EffectsProcessor) parseSigners(changeBuilder *StateChangeBuilder, effect *EffectOutput, effectType EffectType, changes []ingest.Change) ([]types.StateChange, error) {
+func (p *EffectsProcessor) parseSigners(changeBuilder StateChangeBuilder, effect *EffectOutput, effectType EffectType, changes []ingest.Change) ([]types.StateChange, error) {
 	signerPublicKey := effect.Details["public_key"].(string)
 	weight, err := convertToInt32(effect.Details["weight"])
 	if err != nil {
@@ -601,7 +603,7 @@ func (p *EffectsProcessor) parseSigners(changeBuilder *StateChangeBuilder, effec
 // parseThresholds processes threshold-related effects and creates state changes for each threshold type.
 // It extracts both old and new threshold values from the ledger entry changes. The GraphQL schema
 // declares oldThreshold non-null, so a threshold effect without an account pre-image is malformed.
-func (p *EffectsProcessor) parseThresholds(changeBuilder *StateChangeBuilder, effect *EffectOutput, changes []ingest.Change) ([]types.StateChange, error) {
+func (p *EffectsProcessor) parseThresholds(changeBuilder StateChangeBuilder, effect *EffectOutput, changes []ingest.Change) ([]types.StateChange, error) {
 	// Find the account entry change to get old threshold values
 	prevLedgerEntryState := p.getPrevLedgerEntryState(effect, xdr.LedgerEntryTypeAccount, changes)
 	if prevLedgerEntryState == nil {
@@ -629,7 +631,6 @@ func (p *EffectsProcessor) parseThresholds(changeBuilder *StateChangeBuilder, ef
 			}
 
 			thresholdChanges = append(thresholdChanges, changeBuilder.
-				Clone().
 				WithReason(types.StateChangeReasonUpdate).
 				WithThresholdLevel(level).
 				WithThreshold(&oldVal, &newValue).

--- a/internal/indexer/processors/effects_horizon.go
+++ b/internal/indexer/processors/effects_horizon.go
@@ -107,7 +107,7 @@ func Effects(operation *TransactionOperationWrapper) ([]EffectOutput, error) {
 		return []EffectOutput{}, nil
 	}
 
-	changes, err := operation.Transaction.GetOperationChanges(operation.Index)
+	changes, err := operation.Changes()
 	if err != nil {
 		return nil, fmt.Errorf("getting operation changes: %w", err)
 	}
@@ -418,7 +418,7 @@ func (e *effectsWrapper) addSetOptionsEffects() error {
 		e.addMuxed(source, EffectAccountFlagsUpdated, flagDetails)
 	}
 
-	changes, err := e.operation.Transaction.GetOperationChanges(e.operation.Index)
+	changes, err := e.operation.Changes()
 	if err != nil {
 		return fmt.Errorf("getting operation changes: %w", err)
 	}
@@ -490,7 +490,7 @@ func (e *effectsWrapper) addChangeTrustEffects() error {
 	source := e.operation.SourceAccount()
 
 	op := e.operation.Operation.Body.MustChangeTrustOp()
-	changes, err := e.operation.Transaction.GetOperationChanges(e.operation.Index)
+	changes, err := e.operation.Changes()
 	if err != nil {
 		return fmt.Errorf("getting operation changes: %w", err)
 	}
@@ -588,7 +588,7 @@ func (e *effectsWrapper) addManageDataEffects() error {
 	op := e.operation.Operation.Body.MustManageDataOp()
 	details := map[string]interface{}{"name": op.DataName}
 	effect := EffectType(0)
-	changes, err := e.operation.Transaction.GetOperationChanges(e.operation.Index)
+	changes, err := e.operation.Changes()
 	if err != nil {
 		return fmt.Errorf("getting operation changes: %w", err)
 	}

--- a/internal/indexer/processors/effects_horizon.go
+++ b/internal/indexer/processors/effects_horizon.go
@@ -338,10 +338,12 @@ func (e *effectsWrapper) addLedgerEntrySponsorshipEffects(change ingest.Change) 
 			details["asset"] = tl.Asset.ToAsset().StringCanonical()
 		}
 	case xdr.LedgerEntryTypeData:
-		muxedAccount = e.operation.SourceAccount()
+		sourceAccount := e.operation.SourceAccount()
+		muxedAccount = &sourceAccount
 		details["data_name"] = string(data.MustData().DataName)
 	case xdr.LedgerEntryTypeClaimableBalance:
-		muxedAccount = e.operation.SourceAccount()
+		sourceAccount := e.operation.SourceAccount()
+		muxedAccount = &sourceAccount
 		var err error
 		details["balance_id"], err = xdr.MarshalHex(data.MustClaimableBalance().BalanceId)
 		if err != nil {
@@ -381,7 +383,7 @@ func (e *effectsWrapper) addSetOptionsEffects() error {
 	op := e.operation.Operation.Body.MustSetOptionsOp()
 
 	if op.HomeDomain != nil {
-		e.addMuxed(source, EffectAccountHomeDomainUpdated,
+		e.addMuxed(&source, EffectAccountHomeDomainUpdated,
 			map[string]interface{}{
 				"home_domain": string(*op.HomeDomain),
 			},
@@ -403,7 +405,7 @@ func (e *effectsWrapper) addSetOptionsEffects() error {
 	}
 
 	if len(thresholdDetails) > 0 {
-		e.addMuxed(source, EffectAccountThresholdsUpdated, thresholdDetails)
+		e.addMuxed(&source, EffectAccountThresholdsUpdated, thresholdDetails)
 	}
 
 	flagDetails := map[string]interface{}{}
@@ -415,7 +417,7 @@ func (e *effectsWrapper) addSetOptionsEffects() error {
 	}
 
 	if len(flagDetails) > 0 {
-		e.addMuxed(source, EffectAccountFlagsUpdated, flagDetails)
+		e.addMuxed(&source, EffectAccountFlagsUpdated, flagDetails)
 	}
 
 	changes, err := e.operation.Changes()
@@ -448,14 +450,14 @@ func (e *effectsWrapper) addSetOptionsEffects() error {
 		for _, addy := range beforeSortedSigners {
 			weight, ok := after[addy]
 			if !ok {
-				e.addMuxed(source, EffectSignerRemoved, map[string]interface{}{
+				e.addMuxed(&source, EffectSignerRemoved, map[string]interface{}{
 					"public_key": addy,
 				})
 				continue
 			}
 
 			if weight != before[addy] {
-				e.addMuxed(source, EffectSignerUpdated, map[string]interface{}{
+				e.addMuxed(&source, EffectSignerUpdated, map[string]interface{}{
 					"public_key": addy,
 					"weight":     weight,
 				})
@@ -477,7 +479,7 @@ func (e *effectsWrapper) addSetOptionsEffects() error {
 				continue
 			}
 
-			e.addMuxed(source, EffectSignerCreated, map[string]interface{}{
+			e.addMuxed(&source, EffectSignerCreated, map[string]interface{}{
 				"public_key": addy,
 				"weight":     weight,
 			})
@@ -541,7 +543,7 @@ func (e *effectsWrapper) addChangeTrustEffects() error {
 			}
 		}
 
-		e.addMuxed(source, effect, details)
+		e.addMuxed(&source, effect, details)
 		break
 	}
 
@@ -562,24 +564,24 @@ func (e *effectsWrapper) addAllowTrustEffects() {
 
 	switch {
 	case xdr.TrustLineFlags(op.Authorize).IsAuthorized():
-		e.addMuxed(source, EffectTrustlineFlagsUpdated, details)
+		e.addMuxed(&source, EffectTrustlineFlagsUpdated, details)
 		// Forward compatibility
 		setFlags := xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag)
-		e.addTrustLineFlagsEffect(source, &op.Trustor, asset, &setFlags, nil)
+		e.addTrustLineFlagsEffect(&source, &op.Trustor, asset, &setFlags, nil)
 	case xdr.TrustLineFlags(op.Authorize).IsAuthorizedToMaintainLiabilitiesFlag():
 		e.addMuxed(
-			source,
+			&source,
 			EffectTrustlineFlagsUpdated,
 			details,
 		)
 		// Forward compatibility
 		setFlags := xdr.Uint32(xdr.TrustLineFlagsAuthorizedToMaintainLiabilitiesFlag)
-		e.addTrustLineFlagsEffect(source, &op.Trustor, asset, &setFlags, nil)
+		e.addTrustLineFlagsEffect(&source, &op.Trustor, asset, &setFlags, nil)
 	default:
-		e.addMuxed(source, EffectTrustlineFlagsUpdated, details)
+		e.addMuxed(&source, EffectTrustlineFlagsUpdated, details)
 		// Forward compatibility, show both as cleared
 		clearFlags := xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag | xdr.TrustLineFlagsAuthorizedToMaintainLiabilitiesFlag)
-		e.addTrustLineFlagsEffect(source, &op.Trustor, asset, nil, &clearFlags)
+		e.addTrustLineFlagsEffect(&source, &op.Trustor, asset, nil, &clearFlags)
 	}
 }
 
@@ -620,14 +622,14 @@ func (e *effectsWrapper) addManageDataEffects() error {
 		break
 	}
 
-	e.addMuxed(source, effect, details)
+	e.addMuxed(&source, effect, details)
 	return nil
 }
 
 func (e *effectsWrapper) addSetTrustLineFlagsEffects() {
 	source := e.operation.SourceAccount()
 	op := e.operation.Operation.Body.MustSetTrustLineFlagsOp()
-	e.addTrustLineFlagsEffect(source, &op.Trustor, op.Asset, &op.SetFlags, &op.ClearFlags)
+	e.addTrustLineFlagsEffect(&source, &op.Trustor, op.Asset, &op.SetFlags, &op.ClearFlags)
 }
 
 func (e *effectsWrapper) addTrustLineFlagsEffect(

--- a/internal/indexer/processors/effects_horizon.go
+++ b/internal/indexer/processors/effects_horizon.go
@@ -9,9 +9,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	"time"
 
-	"github.com/guregu/null"
 	"github.com/stellar/go-stellar-sdk/amount"
 	"github.com/stellar/go-stellar-sdk/ingest"
 	"github.com/stellar/go-stellar-sdk/keypair"
@@ -21,16 +19,11 @@ import (
 
 // EffectOutput is a representation of an operation that aligns with the BigQuery table history_effects
 type EffectOutput struct {
-	Address        string                 `json:"address"`
-	AddressMuxed   null.String            `json:"address_muxed,omitempty"`
-	OperationID    int64                  `json:"operation_id"`
-	Details        map[string]interface{} `json:"details"`
-	Type           int32                  `json:"type"`
-	TypeString     string                 `json:"type_string"`
-	LedgerClosed   time.Time              `json:"closed_at"`
-	LedgerSequence uint32                 `json:"ledger_sequence"`
-	EffectIndex    uint32                 `json:"index"`
-	EffectID       string                 `json:"id"`
+	Address     string                 `json:"address"`
+	OperationID int64                  `json:"operation_id"`
+	Details     map[string]interface{} `json:"details"`
+	Type        int32                  `json:"type"`
+	TypeString  string                 `json:"type_string"`
 }
 
 // EffectType is the numeric type for an effect
@@ -151,13 +144,6 @@ func Effects(operation *TransactionOperationWrapper) ([]EffectOutput, error) {
 		wrapper.addSignerSponsorshipEffects(change)
 	}
 
-	for i := range wrapper.effects {
-		wrapper.effects[i].LedgerClosed = operation.LedgerClosed
-		wrapper.effects[i].LedgerSequence = operation.LedgerSequence
-		wrapper.effects[i].EffectIndex = uint32(i)
-		wrapper.effects[i].EffectID = fmt.Sprintf("%d-%d", wrapper.effects[i].OperationID, wrapper.effects[i].EffectIndex)
-	}
-
 	return wrapper.effects, nil
 }
 
@@ -166,28 +152,23 @@ type effectsWrapper struct {
 	operation *TransactionOperationWrapper
 }
 
-func (e *effectsWrapper) add(address string, addressMuxed null.String, effectType EffectType, details map[string]interface{}) {
+func (e *effectsWrapper) add(address string, effectType EffectType, details map[string]interface{}) {
 	e.effects = append(e.effects, EffectOutput{
-		Address:      address,
-		AddressMuxed: addressMuxed,
-		OperationID:  e.operation.ID(),
-		TypeString:   EffectTypeNames[effectType],
-		Type:         int32(effectType),
-		Details:      details,
+		Address:     address,
+		OperationID: e.operation.ID(),
+		TypeString:  EffectTypeNames[effectType],
+		Type:        int32(effectType),
+		Details:     details,
 	})
 }
 
 func (e *effectsWrapper) addUnmuxed(address *xdr.AccountId, effectType EffectType, details map[string]interface{}) {
-	e.add(address.Address(), null.String{}, effectType, details)
+	e.add(address.Address(), effectType, details)
 }
 
 func (e *effectsWrapper) addMuxed(address *xdr.MuxedAccount, effectType EffectType, details map[string]interface{}) {
-	var addressMuxed null.String
-	if address.Type == xdr.CryptoKeyTypeKeyTypeMuxedEd25519 {
-		addressMuxed = null.StringFrom(address.Address())
-	}
 	accID := address.ToAccountId()
-	e.add(accID.Address(), addressMuxed, effectType, details)
+	e.add(accID.Address(), effectType, details)
 }
 
 var sponsoringEffectsTable = map[xdr.LedgerEntryType]struct {
@@ -218,8 +199,32 @@ var sponsoringEffectsTable = map[xdr.LedgerEntryType]struct {
 	// entries because we don't generate creation effects for them.
 }
 
+// accountHasSponsoredSigner reports whether any of the entry's signers carries a
+// sponsor. It reads the sponsoring IDs in place, where AccountEntry.SponsorPerSigner
+// builds a map, so an account with no sponsored signers costs nothing.
+func accountHasSponsoredSigner(entry *xdr.LedgerEntry) bool {
+	if entry == nil {
+		return false
+	}
+	account := entry.Data.Account
+	if account == nil || account.Ext.V1 == nil || account.Ext.V1.Ext.V2 == nil {
+		return false
+	}
+	for _, sponsoringID := range account.Ext.V1.Ext.V2.SignerSponsoringIDs {
+		if sponsoringID != nil {
+			return true
+		}
+	}
+	return false
+}
+
 func (e *effectsWrapper) addSignerSponsorshipEffects(change ingest.Change) {
 	if change.Type != xdr.LedgerEntryTypeAccount {
+		return
+	}
+
+	// Neither side sponsors a signer, so no transition can exist.
+	if !accountHasSponsoredSigner(change.Pre) && !accountHasSponsoredSigner(change.Post) {
 		return
 	}
 
@@ -249,21 +254,22 @@ func (e *effectsWrapper) addSignerSponsorshipEffects(change ingest.Change) {
 	for _, signer := range all {
 		pre, foundPre := preSigners[signer]
 		post, foundPost := postSigners[signer]
-		details := map[string]interface{}{}
 
 		switch {
 		case !foundPre && !foundPost:
 			continue
 		case !foundPre && foundPost:
-			details["sponsor"] = post.Address()
-			details["signer"] = signer
 			srcAccount := change.Post.Data.MustAccount().AccountId
-			e.addUnmuxed(&srcAccount, EffectSignerSponsorshipCreated, details)
+			e.addUnmuxed(&srcAccount, EffectSignerSponsorshipCreated, map[string]interface{}{
+				"sponsor": post.Address(),
+				"signer":  signer,
+			})
 		case !foundPost && foundPre:
-			details["former_sponsor"] = pre.Address()
-			details["signer"] = signer
 			srcAccount := change.Pre.Data.MustAccount().AccountId
-			e.addUnmuxed(&srcAccount, EffectSignerSponsorshipRemoved, details)
+			e.addUnmuxed(&srcAccount, EffectSignerSponsorshipRemoved, map[string]interface{}{
+				"former_sponsor": pre.Address(),
+				"signer":         signer,
+			})
 		case foundPre && foundPost:
 			formerSponsor := pre.Address()
 			newSponsor := post.Address()
@@ -271,11 +277,12 @@ func (e *effectsWrapper) addSignerSponsorshipEffects(change ingest.Change) {
 				continue
 			}
 
-			details["former_sponsor"] = formerSponsor
-			details["new_sponsor"] = newSponsor
-			details["signer"] = signer
 			srcAccount := change.Post.Data.MustAccount().AccountId
-			e.addUnmuxed(&srcAccount, EffectSignerSponsorshipUpdated, details)
+			e.addUnmuxed(&srcAccount, EffectSignerSponsorshipUpdated, map[string]interface{}{
+				"former_sponsor": formerSponsor,
+				"new_sponsor":    newSponsor,
+				"signer":         signer,
+			})
 		}
 	}
 }
@@ -286,18 +293,24 @@ func (e *effectsWrapper) addLedgerEntrySponsorshipEffects(change ingest.Change) 
 		return nil
 	}
 
-	details := map[string]interface{}{}
-	var effectType EffectType
+	var (
+		effectType EffectType
+		details    map[string]interface{}
+	)
 
 	switch {
 	case (change.Pre == nil || change.Pre.SponsoringID() == nil) &&
 		(change.Post != nil && change.Post.SponsoringID() != nil):
 		effectType = effectsForEntryType.created
-		details["sponsor"] = (*change.Post.SponsoringID()).Address()
+		details = map[string]interface{}{
+			"sponsor": (*change.Post.SponsoringID()).Address(),
+		}
 	case (change.Pre != nil && change.Pre.SponsoringID() != nil) &&
 		(change.Post == nil || change.Post.SponsoringID() == nil):
 		effectType = effectsForEntryType.removed
-		details["former_sponsor"] = (*change.Pre.SponsoringID()).Address()
+		details = map[string]interface{}{
+			"former_sponsor": (*change.Pre.SponsoringID()).Address(),
+		}
 	case (change.Pre != nil && change.Pre.SponsoringID() != nil) &&
 		(change.Post != nil && change.Post.SponsoringID() != nil):
 		preSponsor := (*change.Pre.SponsoringID()).Address()
@@ -306,8 +319,10 @@ func (e *effectsWrapper) addLedgerEntrySponsorshipEffects(change ingest.Change) 
 			return nil
 		}
 		effectType = effectsForEntryType.updated
-		details["new_sponsor"] = postSponsor
-		details["former_sponsor"] = preSponsor
+		details = map[string]interface{}{
+			"new_sponsor":    postSponsor,
+			"former_sponsor": preSponsor,
+		}
 	default:
 		return nil
 	}

--- a/internal/indexer/processors/effects_horizon_test.go
+++ b/internal/indexer/processors/effects_horizon_test.go
@@ -1,0 +1,583 @@
+package processors
+
+import (
+	"testing"
+
+	"github.com/stellar/go-stellar-sdk/ingest"
+	"github.com/stellar/go-stellar-sdk/network"
+	"github.com/stellar/go-stellar-sdk/toid"
+	"github.com/stellar/go-stellar-sdk/xdr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Addresses used by the sponsorship fixtures. They only need to be distinct, valid
+// strkeys; the signer constants are ordered so that sponsoredSigner sorts before
+// otherSigner, which pins the emission order asserted below.
+const (
+	sponsoredAccount = "GC4XF7RE3R4P77GY5XNGICM56IOKUURWAAANPXHFC7G5H6FCNQVVH3OH"
+	firstSponsor     = "GAQHWQYBBW272OOXNQMMLCA5WY2XAZPODGB7Q3S5OKKIXVESKO55ZQ7C"
+	secondSponsor    = "GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY"
+	sponsoredSigner  = "GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON"
+	otherSigner      = "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z"
+)
+
+// signerSponsor pairs a signer with the account sponsoring it. An empty sponsor
+// means the signer is unsponsored, which core encodes as a nil descriptor at the
+// signer's position.
+type signerSponsor struct {
+	signer  string
+	sponsor string
+}
+
+// sponsorshipAccountEntry builds a bare account ledger entry: no extensions on
+// either the ledger entry or the account, so neither sponsorship reader sees a
+// sponsor.
+func sponsorshipAccountEntry(accountID string) *xdr.LedgerEntry {
+	return &xdr.LedgerEntry{Data: xdr.LedgerEntryData{
+		Type: xdr.LedgerEntryTypeAccount,
+		Account: &xdr.AccountEntry{
+			AccountId: xdr.MustAddress(accountID),
+		},
+	}}
+}
+
+// signerSponsorshipEntry builds an account entry carrying the given signers and
+// their sponsors. SponsorPerSigner zips Signers against SignerSponsoringIDs by
+// position, so the two slices are written in lockstep.
+func signerSponsorshipEntry(accountID string, pairs ...signerSponsor) *xdr.LedgerEntry {
+	entry := sponsorshipAccountEntry(accountID)
+	if len(pairs) == 0 {
+		return entry
+	}
+
+	acct := entry.Data.Account
+	sponsoringIDs := make([]xdr.SponsorshipDescriptor, 0, len(pairs))
+	for _, pair := range pairs {
+		acct.Signers = append(acct.Signers, xdr.Signer{
+			Key:    xdr.MustSigner(pair.signer),
+			Weight: 1,
+		})
+		if pair.sponsor == "" {
+			sponsoringIDs = append(sponsoringIDs, nil)
+			continue
+		}
+		sponsor := xdr.MustAddress(pair.sponsor)
+		sponsoringIDs = append(sponsoringIDs, &sponsor)
+	}
+
+	acct.Ext = xdr.AccountEntryExt{
+		V: 1,
+		V1: &xdr.AccountEntryExtensionV1{
+			Ext: xdr.AccountEntryExtensionV1Ext{
+				V:  2,
+				V2: &xdr.AccountEntryExtensionV2{SignerSponsoringIDs: sponsoringIDs},
+			},
+		},
+	}
+	return entry
+}
+
+// withSponsoringID stamps the sponsor of the ledger entry itself. This is a
+// different extension chain from the per-signer sponsors: SponsoringID() reads
+// LedgerEntry.Ext.V1, while the signer sponsors live under AccountEntry.Ext.V1.Ext.V2.
+func withSponsoringID(entry *xdr.LedgerEntry, sponsor string) *xdr.LedgerEntry {
+	sponsorID := xdr.MustAddress(sponsor)
+	entry.Ext = xdr.LedgerEntryExt{
+		V:  1,
+		V1: &xdr.LedgerEntryExtensionV1{SponsoringId: &sponsorID},
+	}
+	return entry
+}
+
+// newSponsorshipEffectsWrapper returns an empty wrapper bound to a real operation,
+// which the effect appenders need for the operation ID they stamp on every effect.
+func newSponsorshipEffectsWrapper(t *testing.T) *effectsWrapper {
+	t.Helper()
+	transaction := createTx(setTrustlineFlagsOp(), nil, nil, false)
+	op, found := transaction.GetOperation(0)
+	require.True(t, found)
+	return &effectsWrapper{
+		effects: []EffectOutput{},
+		operation: &TransactionOperationWrapper{
+			Index:          0,
+			Operation:      op,
+			Network:        network.TestNetworkPassphrase,
+			Transaction:    &transaction,
+			LedgerSequence: 12345,
+		},
+	}
+}
+
+// TestEffects_SignerSponsorshipPredicate covers accountHasSponsoredSigner, the
+// early-out guard that spares addSignerSponsorshipEffects from building a
+// SponsorPerSigner map for the overwhelming majority of account changes, which
+// sponsor no signer at all. The guard must never report false for an entry that
+// actually carries a sponsor.
+func TestEffects_SignerSponsorshipPredicate(t *testing.T) {
+	// An account extended to V2 but with every sponsoring slot empty: two signers,
+	// neither sponsored.
+	unsponsored := signerSponsorshipEntry(sponsoredAccount,
+		signerSponsor{signer: sponsoredSigner},
+		signerSponsor{signer: otherSigner},
+	)
+
+	// V1 extension present, V2 absent: the reader must stop at the missing V2
+	// rather than dereference it.
+	v1Only := sponsorshipAccountEntry(sponsoredAccount)
+	v1Only.Data.Account.Ext = xdr.AccountEntryExt{V: 1, V1: &xdr.AccountEntryExtensionV1{}}
+
+	// A non-account entry reaches the predicate through the type switch in Effects,
+	// so the nil Account pointer must be handled rather than dereferenced.
+	nonAccount := &xdr.LedgerEntry{Data: xdr.LedgerEntryData{
+		Type: xdr.LedgerEntryTypeTrustline,
+		TrustLine: &xdr.TrustLineEntry{
+			AccountId: xdr.MustAddress(sponsoredAccount),
+			Asset:     usdcAsset.ToTrustLineAsset(),
+		},
+	}}
+
+	testCases := []struct {
+		name  string
+		entry *xdr.LedgerEntry
+		want  bool
+	}{
+		{
+			name:  "a missing entry side sponsors nothing",
+			entry: nil,
+			want:  false,
+		},
+		{
+			name:  "an entry that is not an account sponsors nothing",
+			entry: nonAccount,
+			want:  false,
+		},
+		{
+			name:  "an account with no extensions sponsors nothing",
+			entry: sponsorshipAccountEntry(sponsoredAccount),
+			want:  false,
+		},
+		{
+			name:  "an account extended to V1 only sponsors nothing",
+			entry: v1Only,
+			want:  false,
+		},
+		{
+			name:  "an account whose sponsoring IDs are all nil sponsors nothing",
+			entry: unsponsored,
+			want:  false,
+		},
+		{
+			name: "a single non-nil sponsoring ID is enough",
+			entry: signerSponsorshipEntry(sponsoredAccount,
+				signerSponsor{signer: sponsoredSigner},
+				signerSponsor{signer: otherSigner, sponsor: firstSponsor},
+			),
+			want: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, accountHasSponsoredSigner(tc.entry))
+		})
+	}
+}
+
+// TestEffects_AddSignerSponsorshipEffects covers the signer-sponsorship transitions
+// derived from an account change: which effect each pre/post pairing yields, whose
+// address it is attributed to, and the cases that must yield nothing at all.
+func TestEffects_AddSignerSponsorshipEffects(t *testing.T) {
+	t.Run("a change to a non-account entry yields no effects", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		wrapper.addSignerSponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeTrustline,
+			Pre:  signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
+			Post: signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner}),
+		})
+		assert.Empty(t, wrapper.effects)
+	})
+
+	t.Run("an account sponsoring no signer on either side yields no effects", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		wrapper.addSignerSponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeAccount,
+			Pre:  signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner}),
+			Post: signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner}, signerSponsor{signer: otherSigner}),
+		})
+		assert.Empty(t, wrapper.effects)
+	})
+
+	t.Run("an account created with an unsponsored signer yields no effects", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		wrapper.addSignerSponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeAccount,
+			Post: signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner}),
+		})
+		assert.Empty(t, wrapper.effects)
+	})
+
+	t.Run("a signer gaining a sponsor is a creation attributed to the account", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		wrapper.addSignerSponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeAccount,
+			Pre:  signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner}),
+			Post: signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
+		})
+
+		require.Len(t, wrapper.effects, 1)
+		effect := wrapper.effects[0]
+		assert.Equal(t, sponsoredAccount, effect.Address)
+		assert.Equal(t, int32(EffectSignerSponsorshipCreated), effect.Type)
+		assert.Equal(t, "signer_sponsorship_created", effect.TypeString)
+		assert.Equal(t, toid.New(12345, 1, 1).ToInt64(), effect.OperationID)
+		assert.Equal(t, map[string]interface{}{
+			"sponsor": firstSponsor,
+			"signer":  sponsoredSigner,
+		}, effect.Details)
+	})
+
+	t.Run("a signer losing its sponsor is a removal attributed to the pre-image account", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		wrapper.addSignerSponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeAccount,
+			Pre:  signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
+			Post: signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner}),
+		})
+
+		require.Len(t, wrapper.effects, 1)
+		effect := wrapper.effects[0]
+		assert.Equal(t, sponsoredAccount, effect.Address)
+		assert.Equal(t, int32(EffectSignerSponsorshipRemoved), effect.Type)
+		assert.Equal(t, "signer_sponsorship_removed", effect.TypeString)
+		assert.Equal(t, map[string]interface{}{
+			"former_sponsor": firstSponsor,
+			"signer":         sponsoredSigner,
+		}, effect.Details)
+	})
+
+	t.Run("removing the whole account removes its signer sponsorship", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		wrapper.addSignerSponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeAccount,
+			Pre:  signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
+		})
+
+		require.Len(t, wrapper.effects, 1)
+		assert.Equal(t, int32(EffectSignerSponsorshipRemoved), wrapper.effects[0].Type)
+		assert.Equal(t, map[string]interface{}{
+			"former_sponsor": firstSponsor,
+			"signer":         sponsoredSigner,
+		}, wrapper.effects[0].Details)
+	})
+
+	t.Run("a sponsor carried unchanged across the change yields no effects", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		wrapper.addSignerSponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeAccount,
+			Pre:  signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
+			Post: signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
+		})
+		assert.Empty(t, wrapper.effects)
+	})
+
+	t.Run("a signer changing sponsors is an update carrying both sponsors", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		wrapper.addSignerSponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeAccount,
+			Pre:  signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
+			Post: signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner, sponsor: secondSponsor}),
+		})
+
+		require.Len(t, wrapper.effects, 1)
+		assert.Equal(t, int32(EffectSignerSponsorshipUpdated), wrapper.effects[0].Type)
+		assert.Equal(t, map[string]interface{}{
+			"former_sponsor": firstSponsor,
+			"new_sponsor":    secondSponsor,
+			"signer":         sponsoredSigner,
+		}, wrapper.effects[0].Details)
+	})
+
+	// The guard only reads the sponsoring IDs, while SponsorPerSigner zips them
+	// against the signer list. An entry with a sponsoring ID but no matching signer
+	// therefore passes the guard and still yields nothing, which is the safe
+	// direction: the guard may over-admit, never over-reject.
+	t.Run("a sponsoring ID with no matching signer yields no effects", func(t *testing.T) {
+		post := sponsorshipAccountEntry(sponsoredAccount)
+		sponsorID := xdr.MustAddress(firstSponsor)
+		post.Data.Account.Ext = xdr.AccountEntryExt{
+			V: 1,
+			V1: &xdr.AccountEntryExtensionV1{
+				Ext: xdr.AccountEntryExtensionV1Ext{
+					V:  2,
+					V2: &xdr.AccountEntryExtensionV2{SignerSponsoringIDs: []xdr.SponsorshipDescriptor{&sponsorID}},
+				},
+			},
+		}
+		require.True(t, accountHasSponsoredSigner(post))
+
+		wrapper := newSponsorshipEffectsWrapper(t)
+		wrapper.addSignerSponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeAccount,
+			Pre:  sponsorshipAccountEntry(sponsoredAccount),
+			Post: post,
+		})
+		assert.Empty(t, wrapper.effects)
+	})
+
+	// Core delivers signers in an unordered map, so the effects are sorted by signer
+	// address to keep re-ingests of the same operation byte-identical.
+	t.Run("effects for several signers are emitted in signer address order", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		wrapper.addSignerSponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeAccount,
+			Pre: signerSponsorshipEntry(sponsoredAccount,
+				signerSponsor{signer: otherSigner, sponsor: firstSponsor},
+				signerSponsor{signer: sponsoredSigner},
+			),
+			Post: signerSponsorshipEntry(sponsoredAccount,
+				signerSponsor{signer: otherSigner},
+				signerSponsor{signer: sponsoredSigner, sponsor: secondSponsor},
+			),
+		})
+
+		require.Len(t, wrapper.effects, 2)
+		assert.Equal(t, sponsoredSigner, wrapper.effects[0].Details["signer"])
+		assert.Equal(t, int32(EffectSignerSponsorshipCreated), wrapper.effects[0].Type)
+		assert.Equal(t, otherSigner, wrapper.effects[1].Details["signer"])
+		assert.Equal(t, int32(EffectSignerSponsorshipRemoved), wrapper.effects[1].Type)
+	})
+}
+
+// TestEffects_AddLedgerEntrySponsorshipEffects covers the sponsorship of the ledger
+// entry itself, which is read from a different extension than the per-signer
+// sponsors and is attributed to the account owning the entry.
+func TestEffects_AddLedgerEntrySponsorshipEffects(t *testing.T) {
+	t.Run("an account gaining a sponsor is a creation", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		err := wrapper.addLedgerEntrySponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeAccount,
+			Pre:  sponsorshipAccountEntry(sponsoredAccount),
+			Post: withSponsoringID(sponsorshipAccountEntry(sponsoredAccount), firstSponsor),
+		})
+		require.NoError(t, err)
+
+		require.Len(t, wrapper.effects, 1)
+		effect := wrapper.effects[0]
+		assert.Equal(t, sponsoredAccount, effect.Address)
+		assert.Equal(t, int32(EffectAccountSponsorshipCreated), effect.Type)
+		assert.Equal(t, "account_sponsorship_created", effect.TypeString)
+		assert.Equal(t, toid.New(12345, 1, 1).ToInt64(), effect.OperationID)
+		assert.Equal(t, map[string]interface{}{"sponsor": firstSponsor}, effect.Details)
+	})
+
+	t.Run("a sponsored account created from nothing is a creation", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		err := wrapper.addLedgerEntrySponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeAccount,
+			Post: withSponsoringID(sponsorshipAccountEntry(sponsoredAccount), firstSponsor),
+		})
+		require.NoError(t, err)
+
+		require.Len(t, wrapper.effects, 1)
+		assert.Equal(t, int32(EffectAccountSponsorshipCreated), wrapper.effects[0].Type)
+		assert.Equal(t, map[string]interface{}{"sponsor": firstSponsor}, wrapper.effects[0].Details)
+	})
+
+	t.Run("an account losing its sponsor is a removal", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		err := wrapper.addLedgerEntrySponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeAccount,
+			Pre:  withSponsoringID(sponsorshipAccountEntry(sponsoredAccount), firstSponsor),
+			Post: sponsorshipAccountEntry(sponsoredAccount),
+		})
+		require.NoError(t, err)
+
+		require.Len(t, wrapper.effects, 1)
+		effect := wrapper.effects[0]
+		assert.Equal(t, sponsoredAccount, effect.Address)
+		assert.Equal(t, int32(EffectAccountSponsorshipRemoved), effect.Type)
+		assert.Equal(t, "account_sponsorship_removed", effect.TypeString)
+		assert.Equal(t, map[string]interface{}{"former_sponsor": firstSponsor}, effect.Details)
+	})
+
+	// A removed entry has no post-image, so the effect must be built from the
+	// pre-image alone.
+	t.Run("removing a sponsored account is a removal read from the pre-image", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		err := wrapper.addLedgerEntrySponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeAccount,
+			Pre:  withSponsoringID(sponsorshipAccountEntry(sponsoredAccount), firstSponsor),
+		})
+		require.NoError(t, err)
+
+		require.Len(t, wrapper.effects, 1)
+		assert.Equal(t, sponsoredAccount, wrapper.effects[0].Address)
+		assert.Equal(t, int32(EffectAccountSponsorshipRemoved), wrapper.effects[0].Type)
+		assert.Equal(t, map[string]interface{}{"former_sponsor": firstSponsor}, wrapper.effects[0].Details)
+	})
+
+	t.Run("an account changing sponsors is an update carrying both sponsors", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		err := wrapper.addLedgerEntrySponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeAccount,
+			Pre:  withSponsoringID(sponsorshipAccountEntry(sponsoredAccount), firstSponsor),
+			Post: withSponsoringID(sponsorshipAccountEntry(sponsoredAccount), secondSponsor),
+		})
+		require.NoError(t, err)
+
+		require.Len(t, wrapper.effects, 1)
+		assert.Equal(t, int32(EffectAccountSponsorshipUpdated), wrapper.effects[0].Type)
+		assert.Equal(t, map[string]interface{}{
+			"former_sponsor": firstSponsor,
+			"new_sponsor":    secondSponsor,
+		}, wrapper.effects[0].Details)
+	})
+
+	t.Run("an account keeping the same sponsor yields no effect", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		err := wrapper.addLedgerEntrySponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeAccount,
+			Pre:  withSponsoringID(sponsorshipAccountEntry(sponsoredAccount), firstSponsor),
+			Post: withSponsoringID(sponsorshipAccountEntry(sponsoredAccount), firstSponsor),
+		})
+		require.NoError(t, err)
+		assert.Empty(t, wrapper.effects)
+	})
+
+	t.Run("an unsponsored account yields no effect and no error", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		err := wrapper.addLedgerEntrySponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeAccount,
+			Pre:  sponsorshipAccountEntry(sponsoredAccount),
+			Post: sponsorshipAccountEntry(sponsoredAccount),
+		})
+		require.NoError(t, err)
+		assert.Empty(t, wrapper.effects)
+	})
+
+	t.Run("a sponsored trustline names the asset and belongs to the trustor", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		trustline := &xdr.LedgerEntry{Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeTrustline,
+			TrustLine: &xdr.TrustLineEntry{
+				AccountId: xdr.MustAddress(sponsoredAccount),
+				Asset:     usdcAsset.ToTrustLineAsset(),
+			},
+		}}
+		err := wrapper.addLedgerEntrySponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeTrustline,
+			Post: withSponsoringID(trustline, firstSponsor),
+		})
+		require.NoError(t, err)
+
+		require.Len(t, wrapper.effects, 1)
+		effect := wrapper.effects[0]
+		assert.Equal(t, sponsoredAccount, effect.Address)
+		assert.Equal(t, int32(EffectTrustlineSponsorshipCreated), effect.Type)
+		assert.Equal(t, map[string]interface{}{
+			"sponsor": firstSponsor,
+			"asset":   "USDC:" + usdcIssuer,
+		}, effect.Details)
+	})
+
+	// A pool-share trustline has no issuer to render, so it is described by the pool
+	// it holds shares in instead of by a canonical asset string.
+	t.Run("a sponsored pool share trustline names the liquidity pool", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		poolShare := &xdr.LedgerEntry{Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeTrustline,
+			TrustLine: &xdr.TrustLineEntry{
+				AccountId: xdr.MustAddress(sponsoredAccount),
+				Asset: xdr.TrustLineAsset{
+					Type:            xdr.AssetTypeAssetTypePoolShare,
+					LiquidityPoolId: &lpBtcEthID,
+				},
+			},
+		}}
+		err := wrapper.addLedgerEntrySponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeTrustline,
+			Pre:  withSponsoringID(poolShare, firstSponsor),
+		})
+		require.NoError(t, err)
+
+		require.Len(t, wrapper.effects, 1)
+		effect := wrapper.effects[0]
+		assert.Equal(t, sponsoredAccount, effect.Address)
+		assert.Equal(t, int32(EffectTrustlineSponsorshipRemoved), effect.Type)
+		assert.Equal(t, map[string]interface{}{
+			"former_sponsor":    firstSponsor,
+			"asset_type":        "liquidity_pool",
+			"liquidity_pool_id": PoolIDToString(lpBtcEthID),
+		}, effect.Details)
+	})
+
+	// Data entries and claimable balances are attributed to the operation source
+	// rather than to an account read off the entry, so the effect can land on a
+	// muxed address.
+	t.Run("a sponsored data entry is attributed to the operation source", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		dataEntry := &xdr.LedgerEntry{Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeData,
+			Data: &xdr.DataEntry{
+				AccountId: xdr.MustAddress(sponsoredAccount),
+				DataName:  xdr.String64("config_a"),
+				DataValue: xdr.DataValue("v1"),
+			},
+		}}
+		err := wrapper.addLedgerEntrySponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeData,
+			Post: withSponsoringID(dataEntry, firstSponsor),
+		})
+		require.NoError(t, err)
+
+		require.Len(t, wrapper.effects, 1)
+		effect := wrapper.effects[0]
+		source := wrapper.operation.SourceAccount()
+		sourceID := source.ToAccountId()
+		assert.Equal(t, sourceID.Address(), effect.Address)
+		assert.NotEqual(t, sponsoredAccount, effect.Address)
+		assert.Equal(t, int32(EffectDataSponsorshipCreated), effect.Type)
+		assert.Equal(t, map[string]interface{}{
+			"sponsor":   firstSponsor,
+			"data_name": "config_a",
+		}, effect.Details)
+	})
+
+	t.Run("a sponsored claimable balance carries its hex balance id", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		cbEntry := cbLedgerEntry(someBalanceID, xlmAsset, 100)
+		err := wrapper.addLedgerEntrySponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeClaimableBalance,
+			Post: withSponsoringID(&cbEntry, firstSponsor),
+		})
+		require.NoError(t, err)
+
+		require.Len(t, wrapper.effects, 1)
+		effect := wrapper.effects[0]
+		source := wrapper.operation.SourceAccount()
+		sourceID := source.ToAccountId()
+		assert.Equal(t, sourceID.Address(), effect.Address)
+		assert.Equal(t, int32(EffectClaimableBalanceSponsorshipCreated), effect.Type)
+		// The discriminant of the V0 balance-id union followed by its 32-byte hash.
+		assert.Equal(t, map[string]interface{}{
+			"sponsor":    firstSponsor,
+			"balance_id": "000000000102030405000000000000000000000000000000000000000000000000000000",
+		}, effect.Details)
+	})
+
+	// Liquidity pools cannot be sponsored, so they are absent from the effect table
+	// and must be dropped before the entry-type switch, which would reject them.
+	t.Run("an entry type that cannot be sponsored yields no effect and no error", func(t *testing.T) {
+		wrapper := newSponsorshipEffectsWrapper(t)
+		err := wrapper.addLedgerEntrySponsorshipEffects(ingest.Change{
+			Type: xdr.LedgerEntryTypeLiquidityPool,
+			Post: &xdr.LedgerEntry{Data: xdr.LedgerEntryData{
+				Type:          xdr.LedgerEntryTypeLiquidityPool,
+				LiquidityPool: &xdr.LiquidityPoolEntry{LiquidityPoolId: lpBtcEthID},
+			}},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, wrapper.effects)
+	})
+}

--- a/internal/indexer/processors/effects_horizon_test.go
+++ b/internal/indexer/processors/effects_horizon_test.go
@@ -30,23 +30,23 @@ type signerSponsor struct {
 	sponsor string
 }
 
-// sponsorshipAccountEntry builds a bare account ledger entry: no extensions on
+// sponsorshipAccountEntry builds a bare sponsoredAccount ledger entry: no extensions on
 // either the ledger entry or the account, so neither sponsorship reader sees a
 // sponsor.
-func sponsorshipAccountEntry(accountID string) *xdr.LedgerEntry {
+func sponsorshipAccountEntry() *xdr.LedgerEntry {
 	return &xdr.LedgerEntry{Data: xdr.LedgerEntryData{
 		Type: xdr.LedgerEntryTypeAccount,
 		Account: &xdr.AccountEntry{
-			AccountId: xdr.MustAddress(accountID),
+			AccountId: xdr.MustAddress(sponsoredAccount),
 		},
 	}}
 }
 
-// signerSponsorshipEntry builds an account entry carrying the given signers and
-// their sponsors. SponsorPerSigner zips Signers against SignerSponsoringIDs by
-// position, so the two slices are written in lockstep.
-func signerSponsorshipEntry(accountID string, pairs ...signerSponsor) *xdr.LedgerEntry {
-	entry := sponsorshipAccountEntry(accountID)
+// signerSponsorshipEntry builds a sponsoredAccount entry carrying the given
+// signers and their sponsors. SponsorPerSigner zips Signers against
+// SignerSponsoringIDs by position, so the two slices are written in lockstep.
+func signerSponsorshipEntry(pairs ...signerSponsor) *xdr.LedgerEntry {
+	entry := sponsorshipAccountEntry()
 	if len(pairs) == 0 {
 		return entry
 	}
@@ -117,14 +117,13 @@ func newSponsorshipEffectsWrapper(t *testing.T) *effectsWrapper {
 func TestEffects_SignerSponsorshipPredicate(t *testing.T) {
 	// An account extended to V2 but with every sponsoring slot empty: two signers,
 	// neither sponsored.
-	unsponsored := signerSponsorshipEntry(sponsoredAccount,
-		signerSponsor{signer: sponsoredSigner},
+	unsponsored := signerSponsorshipEntry(signerSponsor{signer: sponsoredSigner},
 		signerSponsor{signer: otherSigner},
 	)
 
 	// V1 extension present, V2 absent: the reader must stop at the missing V2
 	// rather than dereference it.
-	v1Only := sponsorshipAccountEntry(sponsoredAccount)
+	v1Only := sponsorshipAccountEntry()
 	v1Only.Data.Account.Ext = xdr.AccountEntryExt{V: 1, V1: &xdr.AccountEntryExtensionV1{}}
 
 	// A non-account entry reaches the predicate through the type switch in Effects,
@@ -154,7 +153,7 @@ func TestEffects_SignerSponsorshipPredicate(t *testing.T) {
 		},
 		{
 			name:  "an account with no extensions sponsors nothing",
-			entry: sponsorshipAccountEntry(sponsoredAccount),
+			entry: sponsorshipAccountEntry(),
 			want:  false,
 		},
 		{
@@ -169,8 +168,7 @@ func TestEffects_SignerSponsorshipPredicate(t *testing.T) {
 		},
 		{
 			name: "a single non-nil sponsoring ID is enough",
-			entry: signerSponsorshipEntry(sponsoredAccount,
-				signerSponsor{signer: sponsoredSigner},
+			entry: signerSponsorshipEntry(signerSponsor{signer: sponsoredSigner},
 				signerSponsor{signer: otherSigner, sponsor: firstSponsor},
 			),
 			want: true,
@@ -192,8 +190,8 @@ func TestEffects_AddSignerSponsorshipEffects(t *testing.T) {
 		wrapper := newSponsorshipEffectsWrapper(t)
 		wrapper.addSignerSponsorshipEffects(ingest.Change{
 			Type: xdr.LedgerEntryTypeTrustline,
-			Pre:  signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
-			Post: signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner}),
+			Pre:  signerSponsorshipEntry(signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
+			Post: signerSponsorshipEntry(signerSponsor{signer: sponsoredSigner}),
 		})
 		assert.Empty(t, wrapper.effects)
 	})
@@ -202,8 +200,8 @@ func TestEffects_AddSignerSponsorshipEffects(t *testing.T) {
 		wrapper := newSponsorshipEffectsWrapper(t)
 		wrapper.addSignerSponsorshipEffects(ingest.Change{
 			Type: xdr.LedgerEntryTypeAccount,
-			Pre:  signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner}),
-			Post: signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner}, signerSponsor{signer: otherSigner}),
+			Pre:  signerSponsorshipEntry(signerSponsor{signer: sponsoredSigner}),
+			Post: signerSponsorshipEntry(signerSponsor{signer: sponsoredSigner}, signerSponsor{signer: otherSigner}),
 		})
 		assert.Empty(t, wrapper.effects)
 	})
@@ -212,7 +210,7 @@ func TestEffects_AddSignerSponsorshipEffects(t *testing.T) {
 		wrapper := newSponsorshipEffectsWrapper(t)
 		wrapper.addSignerSponsorshipEffects(ingest.Change{
 			Type: xdr.LedgerEntryTypeAccount,
-			Post: signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner}),
+			Post: signerSponsorshipEntry(signerSponsor{signer: sponsoredSigner}),
 		})
 		assert.Empty(t, wrapper.effects)
 	})
@@ -221,8 +219,8 @@ func TestEffects_AddSignerSponsorshipEffects(t *testing.T) {
 		wrapper := newSponsorshipEffectsWrapper(t)
 		wrapper.addSignerSponsorshipEffects(ingest.Change{
 			Type: xdr.LedgerEntryTypeAccount,
-			Pre:  signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner}),
-			Post: signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
+			Pre:  signerSponsorshipEntry(signerSponsor{signer: sponsoredSigner}),
+			Post: signerSponsorshipEntry(signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
 		})
 
 		require.Len(t, wrapper.effects, 1)
@@ -241,8 +239,8 @@ func TestEffects_AddSignerSponsorshipEffects(t *testing.T) {
 		wrapper := newSponsorshipEffectsWrapper(t)
 		wrapper.addSignerSponsorshipEffects(ingest.Change{
 			Type: xdr.LedgerEntryTypeAccount,
-			Pre:  signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
-			Post: signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner}),
+			Pre:  signerSponsorshipEntry(signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
+			Post: signerSponsorshipEntry(signerSponsor{signer: sponsoredSigner}),
 		})
 
 		require.Len(t, wrapper.effects, 1)
@@ -260,7 +258,7 @@ func TestEffects_AddSignerSponsorshipEffects(t *testing.T) {
 		wrapper := newSponsorshipEffectsWrapper(t)
 		wrapper.addSignerSponsorshipEffects(ingest.Change{
 			Type: xdr.LedgerEntryTypeAccount,
-			Pre:  signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
+			Pre:  signerSponsorshipEntry(signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
 		})
 
 		require.Len(t, wrapper.effects, 1)
@@ -275,8 +273,8 @@ func TestEffects_AddSignerSponsorshipEffects(t *testing.T) {
 		wrapper := newSponsorshipEffectsWrapper(t)
 		wrapper.addSignerSponsorshipEffects(ingest.Change{
 			Type: xdr.LedgerEntryTypeAccount,
-			Pre:  signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
-			Post: signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
+			Pre:  signerSponsorshipEntry(signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
+			Post: signerSponsorshipEntry(signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
 		})
 		assert.Empty(t, wrapper.effects)
 	})
@@ -285,8 +283,8 @@ func TestEffects_AddSignerSponsorshipEffects(t *testing.T) {
 		wrapper := newSponsorshipEffectsWrapper(t)
 		wrapper.addSignerSponsorshipEffects(ingest.Change{
 			Type: xdr.LedgerEntryTypeAccount,
-			Pre:  signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
-			Post: signerSponsorshipEntry(sponsoredAccount, signerSponsor{signer: sponsoredSigner, sponsor: secondSponsor}),
+			Pre:  signerSponsorshipEntry(signerSponsor{signer: sponsoredSigner, sponsor: firstSponsor}),
+			Post: signerSponsorshipEntry(signerSponsor{signer: sponsoredSigner, sponsor: secondSponsor}),
 		})
 
 		require.Len(t, wrapper.effects, 1)
@@ -303,7 +301,7 @@ func TestEffects_AddSignerSponsorshipEffects(t *testing.T) {
 	// therefore passes the guard and still yields nothing, which is the safe
 	// direction: the guard may over-admit, never over-reject.
 	t.Run("a sponsoring ID with no matching signer yields no effects", func(t *testing.T) {
-		post := sponsorshipAccountEntry(sponsoredAccount)
+		post := sponsorshipAccountEntry()
 		sponsorID := xdr.MustAddress(firstSponsor)
 		post.Data.Account.Ext = xdr.AccountEntryExt{
 			V: 1,
@@ -319,7 +317,7 @@ func TestEffects_AddSignerSponsorshipEffects(t *testing.T) {
 		wrapper := newSponsorshipEffectsWrapper(t)
 		wrapper.addSignerSponsorshipEffects(ingest.Change{
 			Type: xdr.LedgerEntryTypeAccount,
-			Pre:  sponsorshipAccountEntry(sponsoredAccount),
+			Pre:  sponsorshipAccountEntry(),
 			Post: post,
 		})
 		assert.Empty(t, wrapper.effects)
@@ -331,12 +329,10 @@ func TestEffects_AddSignerSponsorshipEffects(t *testing.T) {
 		wrapper := newSponsorshipEffectsWrapper(t)
 		wrapper.addSignerSponsorshipEffects(ingest.Change{
 			Type: xdr.LedgerEntryTypeAccount,
-			Pre: signerSponsorshipEntry(sponsoredAccount,
-				signerSponsor{signer: otherSigner, sponsor: firstSponsor},
+			Pre: signerSponsorshipEntry(signerSponsor{signer: otherSigner, sponsor: firstSponsor},
 				signerSponsor{signer: sponsoredSigner},
 			),
-			Post: signerSponsorshipEntry(sponsoredAccount,
-				signerSponsor{signer: otherSigner},
+			Post: signerSponsorshipEntry(signerSponsor{signer: otherSigner},
 				signerSponsor{signer: sponsoredSigner, sponsor: secondSponsor},
 			),
 		})
@@ -357,8 +353,8 @@ func TestEffects_AddLedgerEntrySponsorshipEffects(t *testing.T) {
 		wrapper := newSponsorshipEffectsWrapper(t)
 		err := wrapper.addLedgerEntrySponsorshipEffects(ingest.Change{
 			Type: xdr.LedgerEntryTypeAccount,
-			Pre:  sponsorshipAccountEntry(sponsoredAccount),
-			Post: withSponsoringID(sponsorshipAccountEntry(sponsoredAccount), firstSponsor),
+			Pre:  sponsorshipAccountEntry(),
+			Post: withSponsoringID(sponsorshipAccountEntry(), firstSponsor),
 		})
 		require.NoError(t, err)
 
@@ -375,7 +371,7 @@ func TestEffects_AddLedgerEntrySponsorshipEffects(t *testing.T) {
 		wrapper := newSponsorshipEffectsWrapper(t)
 		err := wrapper.addLedgerEntrySponsorshipEffects(ingest.Change{
 			Type: xdr.LedgerEntryTypeAccount,
-			Post: withSponsoringID(sponsorshipAccountEntry(sponsoredAccount), firstSponsor),
+			Post: withSponsoringID(sponsorshipAccountEntry(), firstSponsor),
 		})
 		require.NoError(t, err)
 
@@ -388,8 +384,8 @@ func TestEffects_AddLedgerEntrySponsorshipEffects(t *testing.T) {
 		wrapper := newSponsorshipEffectsWrapper(t)
 		err := wrapper.addLedgerEntrySponsorshipEffects(ingest.Change{
 			Type: xdr.LedgerEntryTypeAccount,
-			Pre:  withSponsoringID(sponsorshipAccountEntry(sponsoredAccount), firstSponsor),
-			Post: sponsorshipAccountEntry(sponsoredAccount),
+			Pre:  withSponsoringID(sponsorshipAccountEntry(), firstSponsor),
+			Post: sponsorshipAccountEntry(),
 		})
 		require.NoError(t, err)
 
@@ -407,7 +403,7 @@ func TestEffects_AddLedgerEntrySponsorshipEffects(t *testing.T) {
 		wrapper := newSponsorshipEffectsWrapper(t)
 		err := wrapper.addLedgerEntrySponsorshipEffects(ingest.Change{
 			Type: xdr.LedgerEntryTypeAccount,
-			Pre:  withSponsoringID(sponsorshipAccountEntry(sponsoredAccount), firstSponsor),
+			Pre:  withSponsoringID(sponsorshipAccountEntry(), firstSponsor),
 		})
 		require.NoError(t, err)
 
@@ -421,8 +417,8 @@ func TestEffects_AddLedgerEntrySponsorshipEffects(t *testing.T) {
 		wrapper := newSponsorshipEffectsWrapper(t)
 		err := wrapper.addLedgerEntrySponsorshipEffects(ingest.Change{
 			Type: xdr.LedgerEntryTypeAccount,
-			Pre:  withSponsoringID(sponsorshipAccountEntry(sponsoredAccount), firstSponsor),
-			Post: withSponsoringID(sponsorshipAccountEntry(sponsoredAccount), secondSponsor),
+			Pre:  withSponsoringID(sponsorshipAccountEntry(), firstSponsor),
+			Post: withSponsoringID(sponsorshipAccountEntry(), secondSponsor),
 		})
 		require.NoError(t, err)
 
@@ -438,8 +434,8 @@ func TestEffects_AddLedgerEntrySponsorshipEffects(t *testing.T) {
 		wrapper := newSponsorshipEffectsWrapper(t)
 		err := wrapper.addLedgerEntrySponsorshipEffects(ingest.Change{
 			Type: xdr.LedgerEntryTypeAccount,
-			Pre:  withSponsoringID(sponsorshipAccountEntry(sponsoredAccount), firstSponsor),
-			Post: withSponsoringID(sponsorshipAccountEntry(sponsoredAccount), firstSponsor),
+			Pre:  withSponsoringID(sponsorshipAccountEntry(), firstSponsor),
+			Post: withSponsoringID(sponsorshipAccountEntry(), firstSponsor),
 		})
 		require.NoError(t, err)
 		assert.Empty(t, wrapper.effects)
@@ -449,8 +445,8 @@ func TestEffects_AddLedgerEntrySponsorshipEffects(t *testing.T) {
 		wrapper := newSponsorshipEffectsWrapper(t)
 		err := wrapper.addLedgerEntrySponsorshipEffects(ingest.Change{
 			Type: xdr.LedgerEntryTypeAccount,
-			Pre:  sponsorshipAccountEntry(sponsoredAccount),
-			Post: sponsorshipAccountEntry(sponsoredAccount),
+			Pre:  sponsorshipAccountEntry(),
+			Post: sponsorshipAccountEntry(),
 		})
 		require.NoError(t, err)
 		assert.Empty(t, wrapper.effects)

--- a/internal/indexer/processors/effects_test.go
+++ b/internal/indexer/processors/effects_test.go
@@ -43,7 +43,7 @@ func TestEffects_ProcessTransaction(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        network.TestNetworkPassphrase,
-			Transaction:    transaction,
+			Transaction:    &transaction,
 			LedgerSequence: 12345,
 		}
 		changes, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -112,7 +112,7 @@ func TestEffects_ProcessTransaction(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        network.TestNetworkPassphrase,
-			Transaction:    transaction,
+			Transaction:    &transaction,
 			LedgerSequence: 12345,
 		}
 		changes, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -157,7 +157,7 @@ func TestEffects_ProcessTransaction(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        network.TestNetworkPassphrase,
-			Transaction:    transaction,
+			Transaction:    &transaction,
 			LedgerSequence: 12345,
 		}
 		changes, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -202,7 +202,7 @@ func TestEffects_ProcessTransaction(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        network.TestNetworkPassphrase,
-			Transaction:    transaction,
+			Transaction:    &transaction,
 			LedgerSequence: 12345,
 		}
 		changes, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -242,7 +242,7 @@ func TestEffects_ProcessTransaction(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        network.TestNetworkPassphrase,
-			Transaction:    transaction,
+			Transaction:    &transaction,
 			LedgerSequence: 12345,
 		}
 		changes, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -285,7 +285,7 @@ func TestEffects_ProcessTransaction(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        network.TestNetworkPassphrase,
-			Transaction:    transaction,
+			Transaction:    &transaction,
 			LedgerSequence: 12345,
 		}
 		changes, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -324,7 +324,7 @@ func TestEffects_ProcessTransaction(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        network.TestNetworkPassphrase,
-			Transaction:    transaction,
+			Transaction:    &transaction,
 			LedgerSequence: 12345,
 		}
 		changes, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -367,7 +367,7 @@ func TestEffects_ProcessTransaction(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        network.TestNetworkPassphrase,
-			Transaction:    transaction,
+			Transaction:    &transaction,
 			LedgerSequence: 12345,
 		}
 		changes, err := processor.ProcessOperation(context.Background(), opWrapper)
@@ -406,7 +406,7 @@ func TestEffects_ProcessTransaction(t *testing.T) {
 			Index:          0,
 			Operation:      op,
 			Network:        network.TestNetworkPassphrase,
-			Transaction:    transaction,
+			Transaction:    &transaction,
 			LedgerSequence: 12345,
 		}
 		changes, err := processor.ProcessOperation(context.Background(), opWrapper)

--- a/internal/indexer/processors/effects_test.go
+++ b/internal/indexer/processors/effects_test.go
@@ -429,7 +429,7 @@ func TestEffects_ProcessTransaction(t *testing.T) {
 func TestEffects_ParseThresholds_DeterministicOrder(t *testing.T) {
 	const address = "GC4XF7RE3R4P77GY5XNGICM56IOKUURWAAANPXHFC7G5H6FCNQVVH3OH"
 	processor := NewEffectsProcessor(networkPassphrase, nil)
-	changeBuilder := NewStateChangeBuilder(12345, 12345*100, toid.New(12345, 1, 1).ToInt64(), nil).
+	changeBuilder := NewStateChangeBuilder(12345, 12345*100, toid.New(12345, 1, 1).ToInt64()).
 		WithAccount(address).
 		WithCategory(types.StateChangeCategorySignatureThreshold)
 	effect := &EffectOutput{

--- a/internal/indexer/processors/liquidity_pools.go
+++ b/internal/indexer/processors/liquidity_pools.go
@@ -46,7 +46,7 @@ func (p *LiquidityPoolSharesProcessor) ProcessOperation(ctx context.Context, opW
 		}
 	}()
 
-	changes, err := opWrapper.Transaction.GetOperationChanges(opWrapper.Index)
+	changes, err := opWrapper.Changes()
 	if err != nil {
 		return nil, fmt.Errorf("getting operation changes: %w", err)
 	}
@@ -129,7 +129,7 @@ func (p *LiquidityPoolsProcessor) ProcessOperation(ctx context.Context, opWrappe
 		}
 	}()
 
-	changes, err := opWrapper.Transaction.GetOperationChanges(opWrapper.Index)
+	changes, err := opWrapper.Changes()
 	if err != nil {
 		return nil, fmt.Errorf("getting operation changes: %w", err)
 	}

--- a/internal/indexer/processors/liquidity_pools_test.go
+++ b/internal/indexer/processors/liquidity_pools_test.go
@@ -118,7 +118,7 @@ func TestLiquidityPoolSharesProcessor_ProcessOperation(t *testing.T) {
 			tx := createTx(op, tc.changes, nil, false)
 			wrapper := &TransactionOperationWrapper{
 				Index:          0,
-				Transaction:    tx,
+				Transaction:    &tx,
 				Operation:      op,
 				LedgerSequence: 12345,
 				Network:        networkPassphrase,
@@ -212,7 +212,7 @@ func TestLiquidityPoolsProcessor_ProcessOperation(t *testing.T) {
 			tx := createTx(op, tc.changes, nil, false)
 			wrapper := &TransactionOperationWrapper{
 				Index:          0,
-				Transaction:    tx,
+				Transaction:    &tx,
 				Operation:      op,
 				LedgerSequence: 12345,
 				Network:        networkPassphrase,

--- a/internal/indexer/processors/participants.go
+++ b/internal/indexer/processors/participants.go
@@ -128,11 +128,14 @@ func (p *ParticipantsProcessor) GetOperationsParticipants(transaction ingest.Led
 	ops := transaction.Envelope.Operations()
 	operationsParticipants := make(map[int64]OperationParticipants, len(ops))
 
+	// Every operation's wrapper points at the one transaction rather than copying it.
+	tx := &transaction
+
 	for opi, xdrOp := range ops {
 		// 1. Build op wrapper, so we can use its methods
 		op := &TransactionOperationWrapper{
 			Index:          uint32(opi),
-			Transaction:    transaction,
+			Transaction:    tx,
 			Operation:      xdrOp,
 			LedgerSequence: ledgerSequence,
 			Network:        p.networkPassphrase,

--- a/internal/indexer/processors/participants.go
+++ b/internal/indexer/processors/participants.go
@@ -182,16 +182,11 @@ func (p *ParticipantsProcessor) GetOperationParticipants(op *TransactionOperatio
 		return participants, nil
 	}
 
-	// 2. Get Soroban participants
-	sorobanParticipants, err := participantsForSorobanOp(op)
-	if err != nil {
+	// 2. Add Soroban participants into the same accumulator: the entire Soroban path
+	// folds into this one set instead of allocating and merging its own.
+	if err := participantsForSorobanOp(op, participants); err != nil {
 		return nil, fmt.Errorf("getting soroban participants: %w", err)
 	}
 
-	// Merged element-wise rather than with Union, which would allocate a third set.
-	sorobanParticipants.Each(func(participant string) bool {
-		participants.Add(participant)
-		return false
-	})
 	return participants, nil
 }

--- a/internal/indexer/processors/participants.go
+++ b/internal/indexer/processors/participants.go
@@ -124,9 +124,11 @@ type OperationParticipants struct {
 // This function processes ALL operations regardless of transaction success.
 func (p *ParticipantsProcessor) GetOperationsParticipants(transaction ingest.LedgerTransaction) (map[int64]OperationParticipants, error) {
 	ledgerSequence := transaction.Ledger.LedgerSequence()
-	operationsParticipants := map[int64]OperationParticipants{}
+	ledgerClosed := transaction.Ledger.ClosedAt()
+	ops := transaction.Envelope.Operations()
+	operationsParticipants := make(map[int64]OperationParticipants, len(ops))
 
-	for opi, xdrOp := range transaction.Envelope.Operations() {
+	for opi, xdrOp := range ops {
 		// 1. Build op wrapper, so we can use its methods
 		op := &TransactionOperationWrapper{
 			Index:          uint32(opi),
@@ -134,7 +136,7 @@ func (p *ParticipantsProcessor) GetOperationsParticipants(transaction ingest.Led
 			Operation:      xdrOp,
 			LedgerSequence: ledgerSequence,
 			Network:        p.networkPassphrase,
-			LedgerClosed:   transaction.Ledger.ClosedAt(),
+			LedgerClosed:   ledgerClosed,
 		}
 		opID := op.ID()
 
@@ -146,14 +148,11 @@ func (p *ParticipantsProcessor) GetOperationsParticipants(transaction ingest.Led
 			continue
 		}
 
-		// 3. Add participants to the map
-		if _, ok := operationsParticipants[opID]; !ok {
-			operationsParticipants[opID] = OperationParticipants{
-				OpWrapper:    op,
-				Participants: participants,
-			}
-		} else {
-			operationsParticipants[opID].Participants.Append(participants.ToSlice()...)
+		// 3. Add participants to the map. opID embeds the operation index, so every iteration
+		// writes a distinct key and no merge with an existing entry is possible.
+		operationsParticipants[opID] = OperationParticipants{
+			OpWrapper:    op,
+			Participants: participants,
 		}
 	}
 
@@ -168,7 +167,7 @@ func (p *ParticipantsProcessor) GetOperationParticipants(op *TransactionOperatio
 	if err != nil {
 		return nil, fmt.Errorf("reading operation %d participants: %w", op.ID(), err)
 	}
-	participants := set.NewThreadUnsafeSet[string]()
+	participants := set.NewThreadUnsafeSetWithSize[string](len(participantsAccountIDs))
 	for _, accountID := range participantsAccountIDs {
 		participants.Add(accountID.Address())
 	}

--- a/internal/indexer/processors/participants_test.go
+++ b/internal/indexer/processors/participants_test.go
@@ -613,7 +613,7 @@ func TestParticipantsProcessor_GetOperationsParticipants(t *testing.T) {
 				Index:          0,
 				Operation:      op,
 				Network:        network.TestNetworkPassphrase,
-				Transaction:    ingestTx,
+				Transaction:    &ingestTx,
 				LedgerSequence: 4873,
 				LedgerClosed:   ingestTx.Ledger.ClosedAt(),
 			}

--- a/internal/indexer/processors/participants_test.go
+++ b/internal/indexer/processors/participants_test.go
@@ -617,6 +617,16 @@ func TestParticipantsProcessor_GetOperationsParticipants(t *testing.T) {
 				LedgerSequence: 4873,
 				LedgerClosed:   ingestTx.Ledger.ClosedAt(),
 			}
+			// The change memo is derived state that participant extraction populates
+			// on the wrapper it builds, so resolve it on both sides to keep the
+			// comparison on the operation itself.
+			_, err = opWrapper.Changes()
+			require.NoError(t, err)
+			for _, got := range gotParticipants {
+				_, err = got.OpWrapper.Changes()
+				require.NoError(t, err)
+			}
+
 			assert.Equal(t, tc.wantParticipantsFn(t, opWrapper), gotParticipants)
 		})
 	}

--- a/internal/indexer/processors/protocol_contracts.go
+++ b/internal/indexer/processors/protocol_contracts.go
@@ -42,7 +42,7 @@ func (p *ProtocolContractsProcessor) ProcessOperation(ctx context.Context, opWra
 		}
 	}()
 
-	changes, err := opWrapper.Transaction.GetOperationChanges(opWrapper.Index)
+	changes, err := opWrapper.Changes()
 	if err != nil {
 		return nil, fmt.Errorf("getting operation changes: %w", err)
 	}

--- a/internal/indexer/processors/protocol_contracts_test.go
+++ b/internal/indexer/processors/protocol_contracts_test.go
@@ -201,7 +201,7 @@ func TestProtocolContractsProcessor_ProcessOperation(t *testing.T) {
 			tx := createTx(op, tc.changes, nil, false)
 			wrapper := &TransactionOperationWrapper{
 				Index:          0,
-				Transaction:    tx,
+				Transaction:    &tx,
 				Operation:      op,
 				LedgerSequence: 12345,
 				Network:        networkPassphrase,

--- a/internal/indexer/processors/protocol_wasms.go
+++ b/internal/indexer/processors/protocol_wasms.go
@@ -53,7 +53,7 @@ func (p *ProtocolWasmProcessor) ProcessOperation(_ context.Context, opWrapper *T
 		}
 	}()
 
-	changes, err := opWrapper.Transaction.GetOperationChanges(opWrapper.Index)
+	changes, err := opWrapper.Changes()
 	if err != nil {
 		return nil, fmt.Errorf("getting operation changes: %w", err)
 	}

--- a/internal/indexer/processors/protocol_wasms_test.go
+++ b/internal/indexer/processors/protocol_wasms_test.go
@@ -117,7 +117,7 @@ func TestProtocolWasmProcessor_ProcessOperation(t *testing.T) {
 			tx := createTx(op, tc.changes, nil, false)
 			wrapper := &TransactionOperationWrapper{
 				Index:          0,
-				Transaction:    tx,
+				Transaction:    &tx,
 				Operation:      op,
 				LedgerSequence: 12345,
 				Network:        networkPassphrase,

--- a/internal/indexer/processors/sac_balances.go
+++ b/internal/indexer/processors/sac_balances.go
@@ -42,7 +42,7 @@ func (p *SACBalancesProcessor) Name() string {
 // Returns SACBalanceChange structs with absolute balance values for database upsert.
 // Only processes changes for contract addresses (C...) since G-addresses use trustlines.
 func (p *SACBalancesProcessor) ProcessOperation(ctx context.Context, opWrapper *TransactionOperationWrapper) ([]types.SACBalanceChange, error) {
-	changes, err := opWrapper.Transaction.GetOperationChanges(opWrapper.Index)
+	changes, err := opWrapper.Changes()
 	if err != nil {
 		return nil, fmt.Errorf("getting operation changes: %w", err)
 	}

--- a/internal/indexer/processors/sac_balances_test.go
+++ b/internal/indexer/processors/sac_balances_test.go
@@ -177,7 +177,7 @@ func TestSACBalancesProcessor_ProcessOperation(t *testing.T) {
 			tx := createTx(op, tc.changes, nil, false)
 			wrapper := &TransactionOperationWrapper{
 				Index:          0,
-				Transaction:    tx,
+				Transaction:    &tx,
 				Operation:      op,
 				LedgerSequence: 12345,
 				Network:        networkPassphrase,
@@ -231,7 +231,7 @@ func TestSACBalancesProcessor_ProcessOperation_WithInt128Balance(t *testing.T) {
 	tx := createTx(op, changes, nil, false)
 	wrapper := &TransactionOperationWrapper{
 		Index:          0,
-		Transaction:    tx,
+		Transaction:    &tx,
 		Operation:      op,
 		LedgerSequence: 12345,
 		Network:        networkPassphrase,
@@ -300,7 +300,7 @@ func TestSACBalancesProcessor_SkipsGAddressHolders(t *testing.T) {
 	tx := createTx(op, changes, nil, false)
 	wrapper := &TransactionOperationWrapper{
 		Index:          0,
-		Transaction:    tx,
+		Transaction:    &tx,
 		Operation:      op,
 		LedgerSequence: 12345,
 		Network:        networkPassphrase,

--- a/internal/indexer/processors/sac_instances.go
+++ b/internal/indexer/processors/sac_instances.go
@@ -38,7 +38,7 @@ func (p *SACInstanceProcessor) Name() string {
 // Returns Contract structs with asset code and issuer for database insertion.
 // Only processes contract instance entries that represent SAC tokens.
 func (p *SACInstanceProcessor) ProcessOperation(ctx context.Context, opWrapper *TransactionOperationWrapper) ([]*data.Contract, error) {
-	changes, err := opWrapper.Transaction.GetOperationChanges(opWrapper.Index)
+	changes, err := opWrapper.Changes()
 	if err != nil {
 		return nil, fmt.Errorf("getting operation changes: %w", err)
 	}

--- a/internal/indexer/processors/sac_instances_test.go
+++ b/internal/indexer/processors/sac_instances_test.go
@@ -183,7 +183,7 @@ func TestSACInstanceProcessor_ProcessOperation(t *testing.T) {
 			tx := createTx(op, tc.changes, nil, false)
 			wrapper := &TransactionOperationWrapper{
 				Index:          0,
-				Transaction:    tx,
+				Transaction:    &tx,
 				Operation:      op,
 				LedgerSequence: 12345,
 				Network:        networkPassphrase,
@@ -235,7 +235,7 @@ func TestSACInstanceProcessor_ProcessOperation_AlphaNum12(t *testing.T) {
 	tx := createTx(op, changes, nil, false)
 	wrapper := &TransactionOperationWrapper{
 		Index:          0,
-		Transaction:    tx,
+		Transaction:    &tx,
 		Operation:      op,
 		LedgerSequence: 12345,
 		Network:        networkPassphrase,

--- a/internal/indexer/processors/state_change_builder.go
+++ b/internal/indexer/processors/state_change_builder.go
@@ -8,54 +8,53 @@ import (
 	"time"
 
 	"github.com/stellar/wallet-backend/internal/indexer/types"
-	"github.com/stellar/wallet-backend/internal/metrics"
 	"github.com/stellar/wallet-backend/internal/utils"
 )
 
-// StateChangeBuilder provides a fluent interface for creating state changes
+// StateChangeBuilder provides a fluent interface for creating state changes.
+// It is used by value: every With* method mutates its own copy and returns it,
+// so a builder can be branched by plain assignment and stays on the stack.
 type StateChangeBuilder struct {
-	base           types.StateChange
-	metricsService *metrics.IngestionMetrics
+	base types.StateChange
 }
 
 // NewStateChangeBuilder creates a new builder with base state change fields
-func NewStateChangeBuilder(ledgerNumber uint32, ledgerCloseTime int64, txID int64, metricsService *metrics.IngestionMetrics) *StateChangeBuilder {
-	return &StateChangeBuilder{
+func NewStateChangeBuilder(ledgerNumber uint32, ledgerCloseTime int64, txID int64) StateChangeBuilder {
+	return StateChangeBuilder{
 		base: types.StateChange{
 			LedgerNumber:    ledgerNumber,
 			LedgerCreatedAt: time.Unix(ledgerCloseTime, 0),
 			ToID:            txID,
 		},
-		metricsService: metricsService,
 	}
 }
 
 // WithCategory sets the state change category
-func (b *StateChangeBuilder) WithCategory(category types.StateChangeCategory) *StateChangeBuilder {
+func (b StateChangeBuilder) WithCategory(category types.StateChangeCategory) StateChangeBuilder {
 	b.base.StateChangeCategory = category
 	return b
 }
 
 // WithReason sets the state change reason
-func (b *StateChangeBuilder) WithReason(reason types.StateChangeReason) *StateChangeBuilder {
+func (b StateChangeBuilder) WithReason(reason types.StateChangeReason) StateChangeBuilder {
 	b.base.StateChangeReason = reason
 	return b
 }
 
 // WithDataEntryName sets the name of the changed data entry
-func (b *StateChangeBuilder) WithDataEntryName(name string) *StateChangeBuilder {
+func (b StateChangeBuilder) WithDataEntryName(name string) StateChangeBuilder {
 	b.base.DataEntryName = sql.NullString{String: name, Valid: true}
 	return b
 }
 
 // WithThresholdLevel records which of the account's signature thresholds this change refers to
-func (b *StateChangeBuilder) WithThresholdLevel(level types.ThresholdLevel) *StateChangeBuilder {
+func (b StateChangeBuilder) WithThresholdLevel(level types.ThresholdLevel) StateChangeBuilder {
 	b.base.Threshold = sql.NullString{String: string(level), Valid: true}
 	return b
 }
 
 // WithThreshold sets the threshold old and new values directly
-func (b *StateChangeBuilder) WithThreshold(oldValue, newValue *int16) *StateChangeBuilder {
+func (b StateChangeBuilder) WithThreshold(oldValue, newValue *int16) StateChangeBuilder {
 	if oldValue != nil {
 		b.base.ThresholdOld = sql.NullInt16{Int16: *oldValue, Valid: true}
 	}
@@ -66,7 +65,7 @@ func (b *StateChangeBuilder) WithThreshold(oldValue, newValue *int16) *StateChan
 }
 
 // WithTrustlineLimit sets the trustline limit old and new values directly
-func (b *StateChangeBuilder) WithTrustlineLimit(oldValue, newValue *string) *StateChangeBuilder {
+func (b StateChangeBuilder) WithTrustlineLimit(oldValue, newValue *string) StateChangeBuilder {
 	if oldValue != nil {
 		b.base.TrustlineLimitOld = utils.SQLNullString(*oldValue)
 	}
@@ -77,7 +76,7 @@ func (b *StateChangeBuilder) WithTrustlineLimit(oldValue, newValue *string) *Sta
 }
 
 // WithFlags sets the flags as a bitmask from a slice of flag names
-func (b *StateChangeBuilder) WithFlags(flags []string) *StateChangeBuilder {
+func (b StateChangeBuilder) WithFlags(flags []string) StateChangeBuilder {
 	if len(flags) > 0 {
 		bitmask := types.EncodeFlagsToBitmask(flags)
 		b.base.Flags = sql.NullInt16{Int16: bitmask, Valid: true}
@@ -86,13 +85,13 @@ func (b *StateChangeBuilder) WithFlags(flags []string) *StateChangeBuilder {
 }
 
 // WithAccount sets the account ID
-func (b *StateChangeBuilder) WithAccount(accountID string) *StateChangeBuilder {
+func (b StateChangeBuilder) WithAccount(accountID string) StateChangeBuilder {
 	b.base.AccountID = types.AddressBytea(accountID)
 	return b
 }
 
 // WithSigner sets the signer account ID and the weights directly
-func (b *StateChangeBuilder) WithSigner(signer string, oldWeight, newWeight *int16) *StateChangeBuilder {
+func (b StateChangeBuilder) WithSigner(signer string, oldWeight, newWeight *int16) StateChangeBuilder {
 	b.base.SignerAccountID = utils.NullAddressBytea(signer)
 	if oldWeight != nil {
 		b.base.SignerWeightOld = sql.NullInt16{Int16: *oldWeight, Valid: true}
@@ -105,56 +104,56 @@ func (b *StateChangeBuilder) WithSigner(signer string, oldWeight, newWeight *int
 
 // WithCreator sets the creator account ID: the account that funded a classic
 // account creation, or the address that deployed a contract.
-func (b *StateChangeBuilder) WithCreator(creator string) *StateChangeBuilder {
+func (b StateChangeBuilder) WithCreator(creator string) StateChangeBuilder {
 	b.base.CreatorAccountID = utils.NullAddressBytea(creator)
 	return b
 }
 
 // WithDestination sets the destination account ID, the account a merged account was merged into.
-func (b *StateChangeBuilder) WithDestination(destination string) *StateChangeBuilder {
+func (b StateChangeBuilder) WithDestination(destination string) StateChangeBuilder {
 	b.base.DestinationAccountID = utils.NullAddressBytea(destination)
 	return b
 }
 
 // WithSpender sets the spender account ID, the account granted an allowance to spend on the owner's behalf.
-func (b *StateChangeBuilder) WithSpender(spender string) *StateChangeBuilder {
+func (b StateChangeBuilder) WithSpender(spender string) StateChangeBuilder {
 	b.base.SpenderAccountID = utils.NullAddressBytea(spender)
 	return b
 }
 
 // WithKeyValue sets the key value JSONB field for truly variable data (data entries, home domain)
-func (b *StateChangeBuilder) WithKeyValue(valueMap map[string]any) *StateChangeBuilder {
+func (b StateChangeBuilder) WithKeyValue(valueMap map[string]any) StateChangeBuilder {
 	b.base.KeyValue = types.NullableJSONB(valueMap)
 	return b
 }
 
 // WithAmount sets the amount
-func (b *StateChangeBuilder) WithAmount(amount string) *StateChangeBuilder {
+func (b StateChangeBuilder) WithAmount(amount string) StateChangeBuilder {
 	b.base.Amount = utils.SQLNullString(amount)
 	return b
 }
 
 // WithToMuxedID sets the CAP-67 destination memo (u64) on the state change.
 // Stored as a decimal string so values above 2^63-1 round-trip without overflow.
-func (b *StateChangeBuilder) WithToMuxedID(muxedID uint64) *StateChangeBuilder {
+func (b StateChangeBuilder) WithToMuxedID(muxedID uint64) StateChangeBuilder {
 	b.base.ToMuxedID = sql.NullString{String: strconv.FormatUint(muxedID, 10), Valid: true}
 	return b
 }
 
 // WithToken sets the token ID using the contract address
-func (b *StateChangeBuilder) WithToken(contractAddress string) *StateChangeBuilder {
+func (b StateChangeBuilder) WithToken(contractAddress string) StateChangeBuilder {
 	b.base.TokenID = utils.NullAddressBytea(contractAddress)
 	return b
 }
 
 // WithOperationID sets the operation ID
-func (b *StateChangeBuilder) WithOperationID(operationID int64) *StateChangeBuilder {
+func (b StateChangeBuilder) WithOperationID(operationID int64) StateChangeBuilder {
 	b.base.OperationID = operationID
 	return b
 }
 
 // WithLiquidityPoolID sets the liquidity pool ID for trustline state changes
-func (b *StateChangeBuilder) WithLiquidityPoolID(poolID string) *StateChangeBuilder {
+func (b StateChangeBuilder) WithLiquidityPoolID(poolID string) StateChangeBuilder {
 	b.base.LiquidityPoolID = utils.SQLNullString(poolID)
 	return b
 }
@@ -163,14 +162,6 @@ func (b *StateChangeBuilder) WithLiquidityPoolID(poolID string) *StateChangeBuil
 // Note: StateChangeID is left zero here — the emitter assigns it afterward via
 // types.AssignStateChangeOrdinals, numbering each transaction's or window's
 // state changes in deterministic emission order before persisting.
-func (b *StateChangeBuilder) Build() types.StateChange {
+func (b StateChangeBuilder) Build() types.StateChange {
 	return b.base
-}
-
-// Clone returns a shallow copy of the builder, sharing the same metrics service.
-func (b *StateChangeBuilder) Clone() *StateChangeBuilder {
-	return &StateChangeBuilder{
-		base:           b.base,
-		metricsService: b.metricsService,
-	}
 }

--- a/internal/indexer/processors/state_change_builder_test.go
+++ b/internal/indexer/processors/state_change_builder_test.go
@@ -3,40 +3,63 @@ package processors
 import (
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/wallet-backend/internal/indexer/types"
-	"github.com/stellar/wallet-backend/internal/metrics"
 )
 
 func int16Ptr(v int16) *int16 { return &v }
 
 func TestStateChangeBuilder_FluentAPI(t *testing.T) {
-	ingestionMetrics := metrics.NewMetrics(prometheus.NewRegistry()).Ingestion
+	t.Run("branching copies the builder", func(t *testing.T) {
+		base := NewStateChangeBuilder(1, 1000, 42).WithCategory(types.StateChangeCategoryBalance)
+
+		// Processors branch one operation-level builder into many state changes by
+		// plain assignment, so a With* call must leave the builder it was called on
+		// untouched and the branches independent of each other.
+		credit := base.WithReason(types.StateChangeReasonCredit).WithAccount("GCREDIT")
+		debit := base.WithReason(types.StateChangeReasonDebit).WithAccount("GDEBIT")
+
+		assert.Equal(t, types.StateChangeReasonCredit, credit.Build().StateChangeReason)
+		assert.Equal(t, types.AddressBytea("GCREDIT"), credit.Build().AccountID)
+		assert.Equal(t, types.StateChangeReasonDebit, debit.Build().StateChangeReason)
+		assert.Equal(t, types.AddressBytea("GDEBIT"), debit.Build().AccountID)
+
+		assert.Empty(t, base.Build().StateChangeReason)
+		assert.Empty(t, base.Build().AccountID)
+		assert.Equal(t, types.StateChangeCategoryBalance, base.Build().StateChangeCategory)
+	})
 
 	t.Run("chainable", func(t *testing.T) {
-		b := NewStateChangeBuilder(1, 1000, 42, ingestionMetrics)
+		sc := NewStateChangeBuilder(1, 1000, 42).
+			WithCategory(types.StateChangeCategoryBalance).
+			WithReason(types.StateChangeReasonCredit).
+			WithAccount("GABC").
+			WithOperationID(1).
+			WithToken("CTOKEN").
+			WithAmount("100").
+			WithSigner("GSIGNER", int16Ptr(1), int16Ptr(2)).
+			WithThreshold(int16Ptr(10), int16Ptr(20)).
+			WithTrustlineLimit(strPtr("500"), strPtr("1000")).
+			WithFlags([]string{"auth_required"}).
+			WithKeyValue(map[string]any{"k": "v"}).
+			WithCreator("GCREATOR").
+			WithLiquidityPoolID("lp").
+			Build()
 
-		// Each With* method should return the same builder pointer.
-		require.Same(t, b, b.WithCategory(types.StateChangeCategoryBalance))
-		require.Same(t, b, b.WithReason(types.StateChangeReasonCredit))
-		require.Same(t, b, b.WithAccount("GABC"))
-		require.Same(t, b, b.WithOperationID(1))
-		require.Same(t, b, b.WithToken("CTOKEN"))
-		require.Same(t, b, b.WithAmount("100"))
-		require.Same(t, b, b.WithSigner("GSIGNER", int16Ptr(1), int16Ptr(2)))
-		require.Same(t, b, b.WithThreshold(int16Ptr(10), int16Ptr(20)))
-		require.Same(t, b, b.WithTrustlineLimit(strPtr("500"), strPtr("1000")))
-		require.Same(t, b, b.WithFlags([]string{"auth_required"}))
-		require.Same(t, b, b.WithKeyValue(map[string]any{"k": "v"}))
-		require.Same(t, b, b.WithCreator("GCREATOR"))
-		require.Same(t, b, b.WithLiquidityPoolID("lp"))
+		assert.Equal(t, types.AddressBytea("GSIGNER"), sc.SignerAccountID.AddressBytea)
+		assert.Equal(t, int16(1), sc.SignerWeightOld.Int16)
+		assert.Equal(t, int16(2), sc.SignerWeightNew.Int16)
+		assert.Equal(t, int16(10), sc.ThresholdOld.Int16)
+		assert.Equal(t, int16(20), sc.ThresholdNew.Int16)
+		assert.Equal(t, "500", sc.TrustlineLimitOld.String)
+		assert.Equal(t, "1000", sc.TrustlineLimitNew.String)
+		assert.Equal(t, types.EncodeFlagsToBitmask([]string{"auth_required"}), sc.Flags.Int16)
+		assert.Equal(t, types.NullableJSONB{"k": "v"}, sc.KeyValue)
 	})
 
 	t.Run("field values", func(t *testing.T) {
-		sc := NewStateChangeBuilder(5, 2000, 77, ingestionMetrics).
+		sc := NewStateChangeBuilder(5, 2000, 77).
 			WithCategory(types.StateChangeCategorySigner).
 			WithReason(types.StateChangeReasonAdd).
 			WithAccount("GACC").

--- a/internal/indexer/processors/token_transfer.go
+++ b/internal/indexer/processors/token_transfer.go
@@ -5,13 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/stellar/go-stellar-sdk/asset"
 	"github.com/stellar/go-stellar-sdk/ingest"
 	ttp "github.com/stellar/go-stellar-sdk/processors/token_transfer"
-	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/toid"
 	"github.com/stellar/go-stellar-sdk/xdr"
@@ -34,27 +32,14 @@ func (p *TokenTransferProcessor) getContractType(asset *asset.Asset, contractAdd
 		return types.ContractTypeNative
 	}
 
-	// The SAC contract ID is a SHA-256 over the asset's contract-ID preimage
-	// plus a strkey encode, recomputed for the same few assets on every event,
-	// so it is memoized by asset identity. sacContractIDs is a sync.Map
-	// because one processor instance serves every pool worker concurrently.
 	issued := asset.GetIssuedAsset()
-	memoKey := issued.GetAssetCode() + "\x00" + issued.GetIssuer()
-
-	var sacContractIDStr string
-	if cached, ok := p.sacContractIDs.Load(memoKey); ok {
-		sacContractIDStr = cached.(string)
-	} else {
-		sacContractID, err := asset.ToXdrAsset().ContractID(p.networkPassphrase)
-		if err != nil {
-			return types.ContractTypeUnknown
-		}
-		sacContractIDStr = strkey.MustEncode(strkey.VersionByteContract, sacContractID[:])
-		p.sacContractIDs.Store(memoKey, sacContractIDStr)
+	sacContractID, err := p.assetContractIDs.fromCreditAsset(p.networkPassphrase, issued.GetAssetCode(), issued.GetIssuer())
+	if err != nil {
+		return types.ContractTypeUnknown
 	}
 
 	// Compare with the actual contract address
-	if sacContractIDStr == contractAddress {
+	if sacContractID == contractAddress {
 		return types.ContractTypeSAC
 	}
 	return types.ContractTypeUnknown
@@ -66,7 +51,7 @@ type TokenTransferProcessor struct {
 	eventsProcessor   *ttp.EventsProcessor
 	networkPassphrase string
 	metricsService    *metrics.IngestionMetrics
-	sacContractIDs    sync.Map // asset "<code>\x00<issuer>" → strkey-encoded SAC contract ID
+	assetContractIDs  AssetContractIDMemo
 }
 
 // NewTokenTransferProcessor creates a new token transfer processor for the specified Stellar network.

--- a/internal/indexer/processors/token_transfer.go
+++ b/internal/indexer/processors/token_transfer.go
@@ -83,13 +83,12 @@ func (p *TokenTransferProcessor) ProcessTransaction(ctx context.Context, tx inge
 
 	ledgerCloseTime := tx.Ledger.LedgerCloseTime()
 	ledgerNumber := tx.Ledger.LedgerSequence()
-	txHash := tx.Result.TransactionHash.HexString()
 	txID := tx.ID()
 
 	// Extract token transfer events from the transaction using Stellar SDK
 	txEvents, err := p.eventsProcessor.EventsFromTransaction(tx)
 	if err != nil {
-		return nil, fmt.Errorf("processing token transfer events for transaction hash: %s, err: %w", txHash, err)
+		return nil, fmt.Errorf("processing token transfer events for transaction hash: %s, err: %w", tx.Result.TransactionHash.HexString(), err)
 	}
 
 	stateChanges := make([]types.StateChange, 0, len(txEvents.OperationEvents)+1)
@@ -98,7 +97,7 @@ func (p *TokenTransferProcessor) ProcessTransaction(ctx context.Context, tx inge
 	// Process fee events
 	feeChange, err := p.processFeeEvents(builder.Clone(), txEvents.FeeEvents)
 	if err != nil {
-		return nil, fmt.Errorf("processing fee events for transaction hash: %s, err: %w", txHash, err)
+		return nil, fmt.Errorf("processing fee events for transaction hash: %s, err: %w", tx.Result.TransactionHash.HexString(), err)
 	}
 	if feeChange.AccountID != "" {
 		stateChanges = append(stateChanges, feeChange)

--- a/internal/indexer/processors/token_transfer.go
+++ b/internal/indexer/processors/token_transfer.go
@@ -101,10 +101,10 @@ func (p *TokenTransferProcessor) ProcessTransaction(ctx context.Context, tx inge
 	}
 
 	stateChanges := make([]types.StateChange, 0, len(txEvents.OperationEvents)+1)
-	builder := NewStateChangeBuilder(ledgerNumber, ledgerCloseTime, txID, p.metricsService)
+	builder := NewStateChangeBuilder(ledgerNumber, ledgerCloseTime, txID)
 
 	// Process fee events
-	feeChange, err := p.processFeeEvents(builder.Clone(), txEvents.FeeEvents)
+	feeChange, err := p.processFeeEvents(builder, txEvents.FeeEvents)
 	if err != nil {
 		return nil, fmt.Errorf("processing fee events for transaction hash: %s, err: %w", tx.Result.TransactionHash.HexString(), err)
 	}
@@ -123,7 +123,7 @@ func (p *TokenTransferProcessor) ProcessTransaction(ctx context.Context, tx inge
 
 		// For non-fee events, we need operation details to determine the correct state change type
 		opID, opType, opSourceAccount := p.parseOperationDetails(tx, ledgerNumber, tx.Index, opIdx)
-		changes := p.processNonFeeEvent(event, contractAddress, builder.Clone(), opID, opType, opSourceAccount)
+		changes := p.processNonFeeEvent(event, contractAddress, builder, opID, opType, opSourceAccount)
 		stateChanges = append(stateChanges, changes...)
 	}
 
@@ -147,7 +147,7 @@ func (p *TokenTransferProcessor) parseOperationDetails(tx ingest.LedgerTransacti
 // recognized SAC: SEP-41-classified contracts are owned end-to-end by sep41.Processor, and truly
 // unclassified contracts intentionally produce no state changes. SAC contracts continue to flow
 // through this processor unchanged.
-func (p *TokenTransferProcessor) processNonFeeEvent(event any, contractAddress string, builder *StateChangeBuilder, opID int64, operationType *xdr.OperationType, opSourceAccount string) []types.StateChange {
+func (p *TokenTransferProcessor) processNonFeeEvent(event any, contractAddress string, builder StateChangeBuilder, opID int64, operationType *xdr.OperationType, opSourceAccount string) []types.StateChange {
 	if operationType != nil && *operationType == xdr.OperationTypeInvokeHostFunction &&
 		p.getContractType(eventAsset(event), contractAddress) == types.ContractTypeUnknown {
 		return nil
@@ -187,7 +187,7 @@ func eventAsset(event any) *asset.Asset {
 }
 
 // processFeeEvents processes both fee and refund events and calculates a state change with the net fee per transaction.
-func (p *TokenTransferProcessor) processFeeEvents(builder *StateChangeBuilder, feeEvents []*ttp.TokenTransferEvent) (types.StateChange, error) {
+func (p *TokenTransferProcessor) processFeeEvents(builder StateChangeBuilder, feeEvents []*ttp.TokenTransferEvent) (types.StateChange, error) {
 	if len(feeEvents) == 0 {
 		return types.StateChange{}, nil
 	}
@@ -227,7 +227,7 @@ func (p *TokenTransferProcessor) processFeeEvents(builder *StateChangeBuilder, f
 }
 
 // createStateChange creates a basic state change with the common fields.
-func createStateChange(category types.StateChangeCategory, reason types.StateChangeReason, account, amount, contractAddress string, builder *StateChangeBuilder) types.StateChange {
+func createStateChange(category types.StateChangeCategory, reason types.StateChangeReason, account, amount, contractAddress string, builder StateChangeBuilder) types.StateChange {
 	b := builder.WithCategory(category).
 		WithReason(reason).
 		WithAccount(account).
@@ -242,13 +242,13 @@ func createStateChange(category types.StateChangeCategory, reason types.StateCha
 
 // createDebitCreditPair creates a pair of debit and credit state changes for normal transfers.
 // Used for regular payments between two accounts (e.g., Alice sends 100 USDC to Bob).
-func createDebitCreditPair(from, to, amount string, contractAddress string, builder *StateChangeBuilder) []types.StateChange {
+func createDebitCreditPair(from, to, amount string, contractAddress string, builder StateChangeBuilder) []types.StateChange {
 	change := builder.
 		WithToken(contractAddress).
 		WithAmount(amount)
 
-	debitChange := change.Clone().WithCategory(types.StateChangeCategoryBalance).WithReason(types.StateChangeReasonDebit).WithAccount(from).Build()
-	creditChange := change.Clone().WithCategory(types.StateChangeCategoryBalance).WithReason(types.StateChangeReasonCredit).WithAccount(to).Build()
+	debitChange := change.WithCategory(types.StateChangeCategoryBalance).WithReason(types.StateChangeReasonDebit).WithAccount(from).Build()
+	creditChange := change.WithCategory(types.StateChangeCategoryBalance).WithReason(types.StateChangeReasonCredit).WithAccount(to).Build()
 
 	return []types.StateChange{debitChange, creditChange}
 }
@@ -258,7 +258,7 @@ func createDebitCreditPair(from, to, amount string, contractAddress string, buil
 // - Claimable balances: single debit/credit since we dont record claimable balance IDs as accounts
 // - Liquidity pools: single debit/credit since we dont record liquidity pool IDs as accounts
 // - Regular transfers: debit/credit pair between accounts
-func (p *TokenTransferProcessor) handleTransfer(transfer *ttp.Transfer, contractAddress string, builder *StateChangeBuilder, operationType *xdr.OperationType) []types.StateChange {
+func (p *TokenTransferProcessor) handleTransfer(transfer *ttp.Transfer, contractAddress string, builder StateChangeBuilder, operationType *xdr.OperationType) []types.StateChange {
 	switch *operationType {
 	case xdr.OperationTypeCreateClaimableBalance, xdr.OperationTypeLiquidityPoolDeposit:
 		// When creating a claimable balance, record debit from creator with CB ID
@@ -290,9 +290,9 @@ func (p *TokenTransferProcessor) handleTransfer(transfer *ttp.Transfer, contract
 		switch *operationType {
 		case xdr.OperationTypeCreateAccount:
 			funder := transfer.GetFrom()
-			stateChanges = append(stateChanges, createStateChange(types.StateChangeCategoryAccount, types.StateChangeReasonCreate, transfer.GetTo(), "", "", builder.Clone().WithCreator(funder)))
+			stateChanges = append(stateChanges, createStateChange(types.StateChangeCategoryAccount, types.StateChangeReasonCreate, transfer.GetTo(), "", "", builder.WithCreator(funder)))
 		case xdr.OperationTypeAccountMerge:
-			stateChanges = append(stateChanges, createStateChange(types.StateChangeCategoryAccount, types.StateChangeReasonMerge, transfer.GetFrom(), "", "", builder.Clone().WithDestination(transfer.GetTo())))
+			stateChanges = append(stateChanges, createStateChange(types.StateChangeCategoryAccount, types.StateChangeReasonMerge, transfer.GetFrom(), "", "", builder.WithDestination(transfer.GetTo())))
 		}
 
 		// Normal transfer between two accounts
@@ -303,7 +303,7 @@ func (p *TokenTransferProcessor) handleTransfer(transfer *ttp.Transfer, contract
 
 // handleTransfersWithLiquidityPool handles transfers between liquidity pools and accounts.
 // This is a special case where a liquidity pool is the source or destination account which could occur when path payments go through liquidity pools.
-func handleTransfersWithLiquidityPool(transfer *ttp.Transfer, contractAddress string, builder *StateChangeBuilder) []types.StateChange {
+func handleTransfersWithLiquidityPool(transfer *ttp.Transfer, contractAddress string, builder StateChangeBuilder) []types.StateChange {
 	from := transfer.GetFrom()
 	to := transfer.GetTo()
 	amount := transfer.GetAmount()
@@ -321,7 +321,7 @@ func handleTransfersWithLiquidityPool(transfer *ttp.Transfer, contractAddress st
 
 // handleMint processes mint events that occur when asset issuers create new tokens.
 // This happens when an issuer sends their own asset to another account (e.g., USDC payment from USDC issuer).
-func (p *TokenTransferProcessor) handleMint(mint *ttp.Mint, contractAddress string, builder *StateChangeBuilder) []types.StateChange {
+func (p *TokenTransferProcessor) handleMint(mint *ttp.Mint, contractAddress string, builder StateChangeBuilder) []types.StateChange {
 	asset := mint.GetAsset()
 	var changes []types.StateChange
 
@@ -342,7 +342,7 @@ func (p *TokenTransferProcessor) handleMint(mint *ttp.Mint, contractAddress stri
 
 // handleBurn processes burn events that occur when tokens are destroyed.
 // Burns happen when: 1) tokens are sent to their issuer, 2) issuer claims claimable balance, 3) issuer withdraws from LP.
-func (p *TokenTransferProcessor) handleBurn(burn *ttp.Burn, contractAddress string, builder *StateChangeBuilder, operationType *xdr.OperationType, opSourceAccount string) []types.StateChange {
+func (p *TokenTransferProcessor) handleBurn(burn *ttp.Burn, contractAddress string, builder StateChangeBuilder, operationType *xdr.OperationType, opSourceAccount string) []types.StateChange {
 	asset := burn.GetAsset()
 
 	switch *operationType {
@@ -358,7 +358,7 @@ func (p *TokenTransferProcessor) handleBurn(burn *ttp.Burn, contractAddress stri
 
 // handleClawback processes clawback events where an asset issuer forcibly reclaims tokens.
 // Similar to burns but initiated by issuer rather than voluntary transfer to issuer.
-func (p *TokenTransferProcessor) handleClawback(clawback *ttp.Clawback, contractAddress string, builder *StateChangeBuilder, operationType *xdr.OperationType, opSourceAccount string) []types.StateChange {
+func (p *TokenTransferProcessor) handleClawback(clawback *ttp.Clawback, contractAddress string, builder StateChangeBuilder, operationType *xdr.OperationType, opSourceAccount string) []types.StateChange {
 	asset := clawback.GetAsset()
 
 	switch *operationType {
@@ -375,7 +375,7 @@ func (p *TokenTransferProcessor) handleClawback(clawback *ttp.Clawback, contract
 // handleDefaultBurnOrClawback creates state changes for regular burns and clawbacks.
 // For non-native assets: creates burn (issuer receives) + debit (sender loses) pair.
 // For native XLM: only creates debit since there's no issuer to burn from.
-func (p *TokenTransferProcessor) handleDefaultBurnOrClawback(from string, amount string, asset *asset.Asset, contractAddress string, builder *StateChangeBuilder) []types.StateChange {
+func (p *TokenTransferProcessor) handleDefaultBurnOrClawback(from string, amount string, asset *asset.Asset, contractAddress string, builder StateChangeBuilder) []types.StateChange {
 	var changes []types.StateChange
 
 	// For issued assets, record burn at the issuer account

--- a/internal/indexer/processors/token_transfer.go
+++ b/internal/indexer/processors/token_transfer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/stellar/go-stellar-sdk/asset"
@@ -33,17 +34,24 @@ func (p *TokenTransferProcessor) getContractType(asset *asset.Asset, contractAdd
 		return types.ContractTypeNative
 	}
 
-	// Convert to XDR asset
-	xdrAsset := asset.ToXdrAsset()
+	// The SAC contract ID is a SHA-256 over the asset's contract-ID preimage
+	// plus a strkey encode, recomputed for the same few assets on every event,
+	// so it is memoized by asset identity. sacContractIDs is a sync.Map
+	// because one processor instance serves every pool worker concurrently.
+	issued := asset.GetIssuedAsset()
+	memoKey := issued.GetAssetCode() + "\x00" + issued.GetIssuer()
 
-	// Compute the SAC contract ID for this asset
-	sacContractID, err := xdrAsset.ContractID(p.networkPassphrase)
-	if err != nil {
-		return types.ContractTypeUnknown
+	var sacContractIDStr string
+	if cached, ok := p.sacContractIDs.Load(memoKey); ok {
+		sacContractIDStr = cached.(string)
+	} else {
+		sacContractID, err := asset.ToXdrAsset().ContractID(p.networkPassphrase)
+		if err != nil {
+			return types.ContractTypeUnknown
+		}
+		sacContractIDStr = strkey.MustEncode(strkey.VersionByteContract, sacContractID[:])
+		p.sacContractIDs.Store(memoKey, sacContractIDStr)
 	}
-
-	// Encode as Stellar contract address (C...)
-	sacContractIDStr := strkey.MustEncode(strkey.VersionByteContract, sacContractID[:])
 
 	// Compare with the actual contract address
 	if sacContractIDStr == contractAddress {
@@ -58,6 +66,7 @@ type TokenTransferProcessor struct {
 	eventsProcessor   *ttp.EventsProcessor
 	networkPassphrase string
 	metricsService    *metrics.IngestionMetrics
+	sacContractIDs    sync.Map // asset "<code>\x00<issuer>" → strkey-encoded SAC contract ID
 }
 
 // NewTokenTransferProcessor creates a new token transfer processor for the specified Stellar network.

--- a/internal/indexer/processors/transaction_operation_wrapper.go
+++ b/internal/indexer/processors/transaction_operation_wrapper.go
@@ -627,17 +627,29 @@ func (operation *TransactionOperationWrapper) Participants() ([]xdr.AccountId, e
 	return dedupeParticipants(participants), nil
 }
 
-// dedupeParticipants remove any duplicate ids from `in`
-func dedupeParticipants(in []xdr.AccountId) (out []xdr.AccountId) {
-	set := map[string]xdr.AccountId{}
-	for _, id := range in {
-		set[id.Address()] = id
+// dedupeParticipants removes duplicate ids from `in`, comparing raw ed25519 keys and
+// keeping first-seen order. An operation carries a handful of participants at most,
+// so a linear scan over the kept prefix beats a map — and by filtering in place it
+// allocates nothing. Callers hand over ownership of `in`.
+func dedupeParticipants(in []xdr.AccountId) []xdr.AccountId {
+	if len(in) <= 1 {
+		return in
 	}
 
-	for _, id := range set {
-		out = append(out, id)
+	out := in[:1]
+	for _, id := range in[1:] {
+		isDuplicate := false
+		for _, kept := range out {
+			if *kept.Ed25519 == *id.Ed25519 {
+				isDuplicate = true
+				break
+			}
+		}
+		if !isDuplicate {
+			out = append(out, id)
+		}
 	}
-	return
+	return out
 }
 
 func serializeParameters(args []xdr.ScVal) ([]map[string]string, []map[string]string) {

--- a/internal/indexer/processors/transaction_operation_wrapper.go
+++ b/internal/indexer/processors/transaction_operation_wrapper.go
@@ -31,6 +31,30 @@ type TransactionOperationWrapper struct {
 	LedgerSequence uint32
 	Network        string
 	LedgerClosed   time.Time
+
+	// Memo backing Changes, valid only for Index.
+	changes    []ingest.Change
+	changesErr error
+	changesSet bool
+}
+
+// Changes returns the ledger entry changes the operation produced, decoding them on
+// the first call and serving the memo on every later one. All of an operation's
+// processors share a single wrapper, so the decode, the allocations, and the sort
+// the SDK accessor performs happen once per operation rather than once per processor.
+//
+// The wrapper is used from a single goroutine — the per-transaction worker walks its
+// operations sequentially — so the memo needs no synchronization.
+//
+// Callers must not mutate the returned slice or the entries it points at: sorting it,
+// filtering it in place, or writing through a change's Pre/Post would corrupt every
+// other processor's view of the operation.
+func (operation *TransactionOperationWrapper) Changes() ([]ingest.Change, error) {
+	if !operation.changesSet {
+		operation.changes, operation.changesErr = operation.Transaction.GetOperationChanges(operation.Index)
+		operation.changesSet = true
+	}
+	return operation.changes, operation.changesErr
 }
 
 // ID returns the ID for the operation.
@@ -101,7 +125,7 @@ func (operation *TransactionOperationWrapper) getSignerSponsorInChange(signerKey
 }
 
 func (operation *TransactionOperationWrapper) getSponsor() (*xdr.AccountId, error) {
-	changes, err := operation.Transaction.GetOperationChanges(operation.Index)
+	changes, err := operation.Changes()
 	if err != nil {
 		return nil, fmt.Errorf("getting operation changes: %w", err)
 	}
@@ -154,6 +178,9 @@ func (operation *TransactionOperationWrapper) findInitatingBeginSponsoringOp() *
 			result := *operation
 			result.Index = uint32(i)
 			result.Operation = operations[i]
+			// The copy describes a different operation, so it starts with an empty
+			// change memo instead of inheriting one keyed to the source's index.
+			result.changes, result.changesErr, result.changesSet = nil, nil, false
 			return &result
 		}
 	}

--- a/internal/indexer/processors/transaction_operation_wrapper.go
+++ b/internal/indexer/processors/transaction_operation_wrapper.go
@@ -26,7 +26,7 @@ var ErrLiquidityPoolChangeNotFound = errors.New("liquidity pool change not found
 // TransactionOperationWrapper represents the data for a single operation within a transaction
 type TransactionOperationWrapper struct {
 	Index          uint32
-	Transaction    ingest.LedgerTransaction
+	Transaction    *ingest.LedgerTransaction
 	Operation      xdr.Operation
 	LedgerSequence uint32
 	Network        string

--- a/internal/indexer/processors/transaction_operation_wrapper.go
+++ b/internal/indexer/processors/transaction_operation_wrapper.go
@@ -77,14 +77,11 @@ func (operation *TransactionOperationWrapper) TransactionID() int64 {
 }
 
 // SourceAccount returns the operation's source account.
-func (operation *TransactionOperationWrapper) SourceAccount() *xdr.MuxedAccount {
-	sourceAccount := operation.Operation.SourceAccount
-	if sourceAccount != nil {
-		return sourceAccount
-	} else {
-		ret := operation.Transaction.Envelope.SourceAccount()
-		return &ret
+func (operation *TransactionOperationWrapper) SourceAccount() xdr.MuxedAccount {
+	if sourceAccount := operation.Operation.SourceAccount; sourceAccount != nil {
+		return *sourceAccount
 	}
+	return operation.Transaction.Envelope.SourceAccount()
 }
 
 // OperationType returns the operation type.
@@ -243,7 +240,7 @@ func (operation *TransactionOperationWrapper) Details() (map[string]interface{},
 			}
 			details["trustee"] = details["asset_issuer"]
 		}
-		if err := AddAccountAndMuxedAccountDetails(details, *source, "trustor"); err != nil {
+		if err := AddAccountAndMuxedAccountDetails(details, source, "trustor"); err != nil {
 			return nil, err
 		}
 		details["limit"] = amount.String(op.Limit)
@@ -252,7 +249,7 @@ func (operation *TransactionOperationWrapper) Details() (map[string]interface{},
 		if err := AddAssetDetails(details, op.Asset.ToAsset(source.ToAccountId()), ""); err != nil {
 			return nil, err
 		}
-		if err := AddAccountAndMuxedAccountDetails(details, *source, "trustee"); err != nil {
+		if err := AddAccountAndMuxedAccountDetails(details, source, "trustee"); err != nil {
 			return nil, err
 		}
 		details["trustor"] = op.Trustor.Address()
@@ -280,7 +277,7 @@ func (operation *TransactionOperationWrapper) Details() (map[string]interface{},
 		beginSponsorshipOp := operation.findInitatingBeginSponsoringOp()
 		if beginSponsorshipOp != nil {
 			beginSponsorshipSource := beginSponsorshipOp.SourceAccount()
-			if err := AddAccountAndMuxedAccountDetails(details, *beginSponsorshipSource, "begin_sponsor"); err != nil {
+			if err := AddAccountAndMuxedAccountDetails(details, beginSponsorshipSource, "begin_sponsor"); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/indexer/processors/transaction_operation_wrapper_test.go
+++ b/internal/indexer/processors/transaction_operation_wrapper_test.go
@@ -1,0 +1,74 @@
+package processors
+
+import (
+	"testing"
+
+	"github.com/stellar/go-stellar-sdk/xdr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dedupeParticipantsReference is the map-based implementation dedupeParticipants
+// replaced, kept as a differential oracle: both must always keep the same set of
+// account IDs, whatever order each returns them in.
+func dedupeParticipantsReference(in []xdr.AccountId) (out []xdr.AccountId) {
+	set := map[string]xdr.AccountId{}
+	for _, id := range in {
+		set[id.Address()] = id
+	}
+
+	for _, id := range set {
+		out = append(out, id)
+	}
+	return
+}
+
+// testAccountID builds a deterministic AccountId whose ed25519 key starts with seed.
+func testAccountID(seed byte) xdr.AccountId {
+	key := xdr.Uint256{seed}
+	return xdr.AccountId{Type: xdr.PublicKeyTypePublicKeyTypeEd25519, Ed25519: &key}
+}
+
+func Test_dedupeParticipants(t *testing.T) {
+	a, b, c := testAccountID(1), testAccountID(2), testAccountID(3)
+	// aClone shares a's key bytes through a distinct pointer: duplicates in real
+	// input are separate xdr decodes of the same account, never shared pointers.
+	aKey := *a.Ed25519
+	aClone := xdr.AccountId{Type: xdr.PublicKeyTypePublicKeyTypeEd25519, Ed25519: &aKey}
+
+	testCases := []struct {
+		name string
+		in   []xdr.AccountId
+		want []xdr.AccountId
+	}{
+		{name: "🟢empty", in: []xdr.AccountId{}, want: []xdr.AccountId{}},
+		{name: "🟢single", in: []xdr.AccountId{a}, want: []xdr.AccountId{a}},
+		{name: "🟢no duplicates", in: []xdr.AccountId{a, b, c}, want: []xdr.AccountId{a, b, c}},
+		{name: "🟢adjacent duplicate", in: []xdr.AccountId{a, aClone, b}, want: []xdr.AccountId{a, b}},
+		{name: "🟢non-adjacent duplicate keeps first", in: []xdr.AccountId{b, a, c, aClone}, want: []xdr.AccountId{b, a, c}},
+		{name: "🟢all the same", in: []xdr.AccountId{a, aClone, a}, want: []xdr.AccountId{a}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The oracle runs on its own copy: dedupeParticipants may reuse its
+			// input's backing array.
+			oracle := dedupeParticipantsReference(append([]xdr.AccountId{}, tc.in...))
+
+			got := dedupeParticipants(tc.in)
+
+			require.ElementsMatch(t, oracle, got, "diverged from the reference implementation")
+			assert.Equal(t, tc.want, got, "expected first-seen order")
+		})
+	}
+}
+
+func Test_dedupeParticipants_zeroAllocationsOnTypicalInput(t *testing.T) {
+	a, b := testAccountID(1), testAccountID(2)
+	in := []xdr.AccountId{a, b, a}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		dedupeParticipants(in)
+	})
+	assert.Zero(t, allocs)
+}

--- a/internal/indexer/processors/trustlines.go
+++ b/internal/indexer/processors/trustlines.go
@@ -44,7 +44,7 @@ func (p *TrustlinesProcessor) ProcessOperation(ctx context.Context, opWrapper *T
 		}
 	}()
 
-	changes, err := opWrapper.Transaction.GetOperationChanges(opWrapper.Index)
+	changes, err := opWrapper.Changes()
 	if err != nil {
 		return nil, fmt.Errorf("getting operation changes: %w", err)
 	}

--- a/internal/indexer/processors/trustlines_test.go
+++ b/internal/indexer/processors/trustlines_test.go
@@ -180,7 +180,7 @@ func TestTrustlinesProcessor_ProcessOperation(t *testing.T) {
 			tx := createTx(op, tc.changes, nil, false)
 			wrapper := &TransactionOperationWrapper{
 				Index:          0,
-				Transaction:    tx,
+				Transaction:    &tx,
 				Operation:      op,
 				LedgerSequence: 12345,
 				Network:        networkPassphrase,

--- a/internal/indexer/processors/utils.go
+++ b/internal/indexer/processors/utils.go
@@ -178,8 +178,22 @@ func getContractIDFromAssetDetails(networkPassphrase string, assetType, assetCod
 	return strkey.MustEncode(strkey.VersionByteContract, contractID[:]), nil
 }
 
+// Every strkey version byte is a multiple of 8, so its top five bits — which
+// are exactly what the first base32 character encodes — determine it. A strkey
+// that does not start with these characters cannot decode to the corresponding
+// version byte, which lets the checks below skip a base32 decode and a CRC
+// validation for the account and contract addresses that make up nearly every
+// transfer endpoint.
+const (
+	liquidityPoolStrkeyPrefix    = 'L' // strkey.VersionByteLiquidityPool
+	claimableBalanceStrkeyPrefix = 'B' // strkey.VersionByteClaimableBalance
+)
+
 // isLiquidityPool checks if the given account ID is a liquidity pool
 func isLiquidityPool(accountID string) bool {
+	if len(accountID) == 0 || accountID[0] != liquidityPoolStrkeyPrefix {
+		return false
+	}
 	// Try to decode the account ID as a strkey
 	versionByte, _, err := strkey.DecodeAny(accountID)
 	if err != nil {
@@ -191,6 +205,9 @@ func isLiquidityPool(accountID string) bool {
 
 // isClaimableBalance checks if the given ID is a claimable balance
 func isClaimableBalance(id string) bool {
+	if len(id) == 0 || id[0] != claimableBalanceStrkeyPrefix {
+		return false
+	}
 	versionByte, _, err := strkey.DecodeAny(id)
 	if err != nil {
 		return false

--- a/internal/indexer/processors/utils.go
+++ b/internal/indexer/processors/utils.go
@@ -5,6 +5,7 @@ package processors
 import (
 	"encoding/hex"
 	"fmt"
+	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/stellar/go-stellar-sdk/hash"
@@ -154,6 +155,31 @@ func addTrustLineFlagDetails(result map[string]interface{}, f xdr.TrustLineFlags
 
 	result[prefix+"_flags"] = n
 	result[prefix+"_flags_s"] = s
+}
+
+// assetContractIDMemo caches asset→contract-ID derivations — each one a
+// SHA-256 over the asset's contract-ID preimage plus a strkey encode —
+// which processors otherwise recompute for the same few assets on every
+// event. Results are content-derived (the processor's network passphrase is
+// fixed at construction), so entries never invalidate and the memo is
+// bounded by the distinct assets a process sees. sync.Map because one
+// processor instance serves every indexer pool worker concurrently, and the
+// workload is read-mostly once warm.
+type assetContractIDMemo struct {
+	m sync.Map // "<type>\x00<code>\x00<issuer>" → strkey-encoded contract ID
+}
+
+func (memo *assetContractIDMemo) fromDetails(networkPassphrase string, assetType, assetCode, assetIssuer string) (string, error) {
+	key := assetType + "\x00" + assetCode + "\x00" + assetIssuer
+	if id, ok := memo.m.Load(key); ok {
+		return id.(string), nil
+	}
+	id, err := getContractIDFromAssetDetails(networkPassphrase, assetType, assetCode, assetIssuer)
+	if err != nil {
+		return "", err
+	}
+	memo.m.Store(key, id)
+	return id, nil
 }
 
 func getContractIDFromAssetDetails(networkPassphrase string, assetType, assetCode, assetIssuer string) (string, error) {

--- a/internal/indexer/processors/utils.go
+++ b/internal/indexer/processors/utils.go
@@ -157,7 +157,7 @@ func addTrustLineFlagDetails(result map[string]interface{}, f xdr.TrustLineFlags
 	result[prefix+"_flags_s"] = s
 }
 
-// assetContractIDMemo caches asset→contract-ID derivations — each one a
+// AssetContractIDMemo caches asset→contract-ID derivations — each one a
 // SHA-256 over the asset's contract-ID preimage plus a strkey encode —
 // which processors otherwise recompute for the same few assets on every
 // event. Results are content-derived (the processor's network passphrase is
@@ -165,15 +165,25 @@ func addTrustLineFlagDetails(result map[string]interface{}, f xdr.TrustLineFlags
 // bounded by the distinct assets a process sees. sync.Map because one
 // processor instance serves every indexer pool worker concurrently, and the
 // workload is read-mostly once warm.
-type assetContractIDMemo struct {
+//
+// Entries are keyed by "<type>\x00<code>\x00<issuer>", which is the complete
+// identity of a Stellar asset: native is the only type with an empty code and
+// issuer, and the two credit widths are separated both by their type and by the
+// code length that implies it. The NUL delimiter is unambiguous because an
+// asset code is alphanumeric with its padding trimmed and an issuer is base32
+// strkey, so neither component can contain a NUL. No two distinct assets can
+// therefore share a key. Every accessor normalizes to the same three
+// components — the type spelled exactly as xdr.Asset.Extract spells it — so an
+// asset reaching the memo through different accessors lands on one entry.
+//
+// The zero value is ready to use.
+type AssetContractIDMemo struct {
 	m sync.Map // "<type>\x00<code>\x00<issuer>" → strkey-encoded contract ID
 }
 
-// operationXDRBuffers recycles XDR encoding buffers across ConvertOperation
-// calls, which run on every indexer pool worker concurrently.
-var operationXDRBuffers = sync.Pool{New: func() any { return xdr.NewEncodingBuffer() }}
-
-func (memo *assetContractIDMemo) fromDetails(networkPassphrase string, assetType, assetCode, assetIssuer string) (string, error) {
+// fromDetails returns the contract ID of the asset described by the extracted
+// asset detail strings.
+func (memo *AssetContractIDMemo) fromDetails(networkPassphrase string, assetType, assetCode, assetIssuer string) (string, error) {
 	key := assetType + "\x00" + assetCode + "\x00" + assetIssuer
 	if id, ok := memo.m.Load(key); ok {
 		return id.(string), nil
@@ -185,6 +195,33 @@ func (memo *assetContractIDMemo) fromDetails(networkPassphrase string, assetType
 	memo.m.Store(key, id)
 	return id, nil
 }
+
+// FromAsset returns the contract ID of an asset held as XDR. Extracting the
+// key components costs a strkey encode of the issuer on every call, hit or
+// miss, which is why callers already holding the code and issuer as strings go
+// through fromCreditAsset instead.
+func (memo *AssetContractIDMemo) FromAsset(networkPassphrase string, asset xdr.Asset) (string, error) {
+	var assetType, assetCode, assetIssuer string
+	if err := asset.Extract(&assetType, &assetCode, &assetIssuer); err != nil {
+		return "", fmt.Errorf("extracting asset details: %w", err)
+	}
+	return memo.fromDetails(networkPassphrase, assetType, assetCode, assetIssuer)
+}
+
+// fromCreditAsset returns the contract ID of an issued asset held as its code
+// and issuer, the shape token transfer events carry. The code length fixes the
+// asset type, the same way xdr.MustNewCreditAsset derives it from the code.
+func (memo *AssetContractIDMemo) fromCreditAsset(networkPassphrase string, assetCode, assetIssuer string) (string, error) {
+	assetType := "credit_alphanum4"
+	if len(assetCode) > 4 {
+		assetType = "credit_alphanum12"
+	}
+	return memo.fromDetails(networkPassphrase, assetType, assetCode, assetIssuer)
+}
+
+// operationXDRBuffers recycles XDR encoding buffers across ConvertOperation
+// calls, which run on every indexer pool worker concurrently.
+var operationXDRBuffers = sync.Pool{New: func() any { return xdr.NewEncodingBuffer() }}
 
 func getContractIDFromAssetDetails(networkPassphrase string, assetType, assetCode, assetIssuer string) (string, error) {
 	var asset xdr.Asset

--- a/internal/indexer/processors/utils.go
+++ b/internal/indexer/processors/utils.go
@@ -169,6 +169,10 @@ type assetContractIDMemo struct {
 	m sync.Map // "<type>\x00<code>\x00<issuer>" → strkey-encoded contract ID
 }
 
+// operationXDRBuffers recycles XDR encoding buffers across ConvertOperation
+// calls, which run on every indexer pool worker concurrently.
+var operationXDRBuffers = sync.Pool{New: func() any { return xdr.NewEncodingBuffer() }}
+
 func (memo *assetContractIDMemo) fromDetails(networkPassphrase string, assetType, assetCode, assetIssuer string) (string, error) {
 	key := assetType + "\x00" + assetCode + "\x00" + assetIssuer
 	if id, ok := memo.m.Load(key); ok {
@@ -308,7 +312,13 @@ func ConvertOperation(
 	opIndex uint32,
 	opResults []xdr.OperationResult,
 ) (*types.Operation, error) {
-	xdrBytes, err := op.MarshalBinary()
+	// The operation's XDR bytes are retained by the returned row, so one
+	// exact-size allocation is unavoidable — but the encoder and its growth
+	// copies are not: a pooled EncodingBuffer reuses the scratch across calls
+	// and pool workers, and MarshalBinary returns the owned copy.
+	buf := operationXDRBuffers.Get().(*xdr.EncodingBuffer)
+	xdrBytes, err := buf.MarshalBinary(op)
+	operationXDRBuffers.Put(buf)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling operation %d: %w", opID, err)
 	}

--- a/internal/indexer/processors/utils_test.go
+++ b/internal/indexer/processors/utils_test.go
@@ -177,3 +177,90 @@ func Test_strkeyPrefixMatchesVersionByte(t *testing.T) {
 		}
 	}
 }
+
+// memoAssetIssuerAlt is a second issuer, used to show the issuer participates in
+// the memo key.
+const memoAssetIssuerAlt = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+
+// memoEntryCount reports how many distinct assets the memo has cached.
+func memoEntryCount(memo *AssetContractIDMemo) int {
+	count := 0
+	memo.m.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	return count
+}
+
+// Test_AssetContractIDMemo pins the property the memo rests on: a cached lookup
+// returns exactly what an uncached derivation returns, for every asset shape,
+// and each distinct asset gets its own entry. The asset set separates the two
+// credit widths under one issuer (including the 4-vs-5 character boundary where
+// the width flips), one code under two issuers, and the native asset.
+func Test_AssetContractIDMemo(t *testing.T) {
+	assets := []struct {
+		name  string
+		asset xdr.Asset
+	}{
+		{name: "native", asset: xdr.MustNewNativeAsset()},
+		{name: "alphanum4", asset: xdr.MustNewCreditAsset(testAssetCode, testAssetIssuer)},
+		{name: "alphanum12 at the width boundary", asset: xdr.MustNewCreditAsset(testAssetCode+"X", testAssetIssuer)},
+		{name: "alphanum12 at full width", asset: xdr.MustNewCreditAsset("USDCOIN12345", testAssetIssuer)},
+		{name: "alphanum4 under another issuer", asset: xdr.MustNewCreditAsset(testAssetCode, memoAssetIssuerAlt)},
+	}
+
+	var memo AssetContractIDMemo
+	for _, tc := range assets {
+		t.Run(tc.name, func(t *testing.T) {
+			rawContractID, err := tc.asset.ContractID(networkPassphrase)
+			require.NoError(t, err)
+			want := strkey.MustEncode(strkey.VersionByteContract, rawContractID[:])
+
+			// The miss and the hit must both agree with the uncached derivation.
+			// A key that collided with an asset cached by an earlier subtest
+			// would surface here as the other asset's contract ID.
+			missed, err := memo.FromAsset(networkPassphrase, tc.asset)
+			require.NoError(t, err)
+			assert.Equal(t, want, missed)
+
+			hit, err := memo.FromAsset(networkPassphrase, tc.asset)
+			require.NoError(t, err)
+			assert.Equal(t, want, hit)
+		})
+	}
+	assert.Equal(t, len(assets), memoEntryCount(&memo), "each distinct asset must occupy its own entry")
+}
+
+// Test_AssetContractIDMemoAccessorsAgree pins that the accessors are one
+// mechanism and not three: the same asset arriving as XDR, as extracted detail
+// strings, or as a bare code and issuer resolves to one contract ID and shares
+// one entry.
+func Test_AssetContractIDMemoAccessorsAgree(t *testing.T) {
+	tests := []struct {
+		name      string
+		assetType string
+		code      string
+	}{
+		{name: "alphanum4", assetType: "credit_alphanum4", code: testAssetCode},
+		{name: "alphanum12", assetType: "credit_alphanum12", code: testAssetCode + "X"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var memo AssetContractIDMemo
+
+			fromAsset, err := memo.FromAsset(networkPassphrase, xdr.MustNewCreditAsset(tc.code, testAssetIssuer))
+			require.NoError(t, err)
+
+			fromDetails, err := memo.fromDetails(networkPassphrase, tc.assetType, tc.code, testAssetIssuer)
+			require.NoError(t, err)
+			assert.Equal(t, fromAsset, fromDetails)
+
+			fromCredit, err := memo.fromCreditAsset(networkPassphrase, tc.code, testAssetIssuer)
+			require.NoError(t, err)
+			assert.Equal(t, fromAsset, fromCredit)
+
+			assert.Equal(t, 1, memoEntryCount(&memo), "all three accessors must key the asset identically")
+		})
+	}
+}

--- a/internal/indexer/processors/utils_test.go
+++ b/internal/indexer/processors/utils_test.go
@@ -1,12 +1,15 @@
 package processors
 
 import (
+	"bytes"
 	"encoding/base64"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stellar/go-stellar-sdk/ingest"
 	"github.com/stellar/go-stellar-sdk/network"
+	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stellar/go-stellar-sdk/toid"
 	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/assert"
@@ -118,5 +121,59 @@ func Test_isClaimableBalance(t *testing.T) {
 			result := isClaimableBalance(tt.id)
 			assert.Equal(t, tt.expected, result)
 		})
+	}
+}
+
+func Test_isLiquidityPool(t *testing.T) {
+	poolID, err := strkey.Encode(strkey.VersionByteLiquidityPool, make([]byte, 32))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		id       string
+		expected bool
+	}{
+		{name: "valid liquidity pool ID", id: poolID, expected: true},
+		{name: "regular account ID starting with G", id: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H", expected: false},
+		{name: "claimable balance ID starting with B", id: "BAAFK3PZYCD4YKOLFNOCJVG2JIHWOBE5NHU5FHY3ESAHMAO3C5RIYGTBDI", expected: false},
+		{name: "L prefix but not a valid strkey", id: "L" + poolID[1:len(poolID)-1] + "A", expected: false},
+		{name: "invalid string", id: "invalid-id", expected: false},
+		{name: "empty string", id: "", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isLiquidityPool(tt.id))
+		})
+	}
+}
+
+// Test_strkeyPrefixMatchesVersionByte pins the invariant the prefix gates in
+// isLiquidityPool and isClaimableBalance rest on: a strkey's first character is
+// fixed by its version byte and never by its payload, so a string that does not
+// start with that character cannot decode to that version byte. Both an
+// all-zero and an all-ones payload are encoded to show the payload does not
+// reach the leading character.
+func Test_strkeyPrefixMatchesVersionByte(t *testing.T) {
+	payloads := map[string][]byte{
+		"zero": make([]byte, 64),
+		"ones": bytes.Repeat([]byte{0xFF}, 64),
+	}
+	versionBytes := map[byte]struct {
+		versionByte strkey.VersionByte
+		payloadLen  int
+	}{
+		liquidityPoolStrkeyPrefix:    {strkey.VersionByteLiquidityPool, 32},
+		claimableBalanceStrkeyPrefix: {strkey.VersionByteClaimableBalance, 33},
+	}
+
+	for name, payload := range payloads {
+		for wantPrefix, v := range versionBytes {
+			t.Run(fmt.Sprintf("%s/%c", name, wantPrefix), func(t *testing.T) {
+				encoded, err := strkey.Encode(v.versionByte, payload[:v.payloadLen])
+				require.NoError(t, err)
+				assert.Equal(t, wantPrefix, encoded[0])
+			})
+		}
 	}
 }

--- a/internal/indexer/types/types.go
+++ b/internal/indexer/types/types.go
@@ -885,12 +885,17 @@ const (
 // actually handed to BatchCopy — so ordinals come out contiguous (1..N, no
 // gaps) per group within the stream's namespace.
 func AssignStateChangeOrdinals(changes []StateChange, base int64) {
-	type ordinalKey struct{ toID, opID int64 }
-	next := make(map[ordinalKey]int64, len(changes))
+	// A change's ordinal is the count of earlier same-group changes plus one.
+	// Streams are a handful of changes per transaction, so a quadratic scan is
+	// cheaper than a per-call map and allocates nothing.
 	for i := range changes {
-		k := ordinalKey{changes[i].ToID, changes[i].OperationID}
-		next[k]++
-		changes[i].StateChangeID = base + next[k]
+		ordinal := int64(1)
+		for j := range i {
+			if changes[j].ToID == changes[i].ToID && changes[j].OperationID == changes[i].OperationID {
+				ordinal++
+			}
+		}
+		changes[i].StateChangeID = base + ordinal
 	}
 }
 

--- a/internal/indexer/types/types.go
+++ b/internal/indexer/types/types.go
@@ -81,6 +81,11 @@ func (a AddressBytea) Value() (driver.Value, error) {
 	if err != nil {
 		return nil, fmt.Errorf("decoding stellar address %s: %w", a, err)
 	}
+	// The 33-byte storage format fits exactly one 32-byte key. Larger payloads exist
+	// (an M-address decodes to 40 bytes) and must fail here rather than truncate.
+	if len(rawBytes) != 32 {
+		return nil, fmt.Errorf("decoding stellar address %s: expected 32-byte payload, got %d", a, len(rawBytes))
+	}
 	result := make([]byte, 33)
 	result[0] = byte(versionByte)
 	copy(result[1:], rawBytes)
@@ -123,6 +128,44 @@ func (n NullAddressBytea) Value() (driver.Value, error) {
 // String returns the Stellar address as a string (convenience accessor).
 func (n NullAddressBytea) String() string {
 	return string(n.AddressBytea)
+}
+
+// AddressByteaMemo caches strkey→BYTEA conversions across the rows of one batch
+// build. Addresses repeat heavily within a single COPY — every transfer of a token
+// shares its token_id, an account's rows share its account_id — so a hit skips the
+// whole strkey decode (base32 + CRC16) and the 33-byte allocation.
+//
+// The memo is a plain map for use by exactly one goroutine, and hits return the
+// SAME []byte every time: callers must treat the slice as read-only. Both contracts
+// hold in the persist COPY builders, which are single-goroutine per call and hand
+// the slices to pgx, which only reads them while encoding its own buffer.
+type AddressByteaMemo map[string][]byte
+
+// Bytes returns the 33-byte BYTEA form of a, converting on the first sight of an
+// address and serving the shared slice afterwards. Output and errors match
+// AddressBytea.Value exactly ("" → nil, invalid → error); failures are not cached.
+func (m AddressByteaMemo) Bytes(a AddressBytea) ([]byte, error) {
+	if a == "" {
+		return nil, nil
+	}
+	if cached, ok := m[string(a)]; ok {
+		return cached, nil
+	}
+	val, err := a.Value()
+	if err != nil {
+		return nil, err
+	}
+	bytes := val.([]byte)
+	m[string(a)] = bytes
+	return bytes, nil
+}
+
+// NullBytes is Bytes for the nullable wrapper: NULL → (nil, nil).
+func (m AddressByteaMemo) NullBytes(n NullAddressBytea) ([]byte, error) {
+	if !n.Valid {
+		return nil, nil
+	}
+	return m.Bytes(n.AddressBytea)
 }
 
 // HashBytea represents a transaction hash stored as BYTEA in the database.

--- a/internal/indexer/types/types.go
+++ b/internal/indexer/types/types.go
@@ -885,17 +885,20 @@ const (
 // actually handed to BatchCopy — so ordinals come out contiguous (1..N, no
 // gaps) per group within the stream's namespace.
 func AssignStateChangeOrdinals(changes []StateChange, base int64) {
-	// A change's ordinal is the count of earlier same-group changes plus one.
-	// Streams are a handful of changes per transaction, so a quadratic scan is
-	// cheaper than a per-call map and allocates nothing.
+	// A counting map keeps the assignment linear in the slice: the indexer
+	// passes per-transaction streams of a handful of changes, but protocol
+	// processors pass a whole staged migration window at persist time, bounded
+	// only by the window, and that call runs inside the window's CAS-guarded
+	// transaction.
+	type ordinalKey struct {
+		toID        int64
+		operationID int64
+	}
+	counts := make(map[ordinalKey]int64, len(changes))
 	for i := range changes {
-		ordinal := int64(1)
-		for j := range i {
-			if changes[j].ToID == changes[i].ToID && changes[j].OperationID == changes[i].OperationID {
-				ordinal++
-			}
-		}
-		changes[i].StateChangeID = base + ordinal
+		key := ordinalKey{toID: changes[i].ToID, operationID: changes[i].OperationID}
+		counts[key]++
+		changes[i].StateChangeID = base + counts[key]
 	}
 }
 

--- a/internal/indexer/types/types_test.go
+++ b/internal/indexer/types/types_test.go
@@ -205,6 +205,144 @@ func TestAddressBytea_String(t *testing.T) {
 	}
 }
 
+func TestAddressBytea_Value_rejectsNon32BytePayloads(t *testing.T) {
+	// An M-address (muxed account) decodes to a 40-byte payload; the 33-byte storage
+	// format only fits 32, so Value must reject it loudly rather than truncate.
+	muxedPayload := make([]byte, 40)
+	for i := range muxedPayload {
+		muxedPayload[i] = byte(i)
+	}
+	muxedAddress, err := strkey.Encode(strkey.VersionByteMuxedAccount, muxedPayload)
+	require.NoError(t, err)
+
+	_, err = AddressBytea(muxedAddress).Value()
+	assert.ErrorContains(t, err, "expected 32-byte payload")
+}
+
+func TestAddressByteaMemo_Bytes_matchesValue(t *testing.T) {
+	kp := keypair.MustRandom()
+
+	testCases := []struct {
+		name  string
+		input AddressBytea
+	}{
+		{name: "🟢valid G address", input: AddressBytea(kp.Address())},
+		{name: "🟢valid C address", input: AddressBytea("CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC")},
+		{name: "🟢empty string", input: ""},
+		{name: "🔴invalid address", input: "not-a-valid-address"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			memo := make(AddressByteaMemo)
+			wantVal, wantErr := tc.input.Value()
+
+			// Repeated calls must keep matching Value exactly, hit or miss.
+			for range 2 {
+				got, err := memo.Bytes(tc.input)
+				if wantErr != nil {
+					require.Error(t, err)
+					assert.Equal(t, wantErr.Error(), err.Error())
+					assert.Nil(t, got)
+				} else {
+					require.NoError(t, err)
+					if wantVal == nil {
+						assert.Nil(t, got)
+					} else {
+						assert.Equal(t, wantVal, driver.Value(got))
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestAddressByteaMemo_Bytes_sharesTheSliceAcrossHits(t *testing.T) {
+	kp := keypair.MustRandom()
+	memo := make(AddressByteaMemo)
+
+	first, err := memo.Bytes(AddressBytea(kp.Address()))
+	require.NoError(t, err)
+	second, err := memo.Bytes(AddressBytea(kp.Address()))
+	require.NoError(t, err)
+
+	// The memo's whole point is skipping the decode and the 33-byte allocation on a
+	// hit, so both calls must return the same backing array.
+	assert.Same(t, &first[0], &second[0])
+}
+
+func TestAddressByteaMemo_Bytes_cachesOnlySuccesses(t *testing.T) {
+	memo := make(AddressByteaMemo)
+
+	_, err := memo.Bytes("not-a-valid-address")
+	assert.Error(t, err)
+
+	_, err = memo.Bytes("")
+	assert.NoError(t, err)
+
+	assert.Empty(t, memo)
+}
+
+func TestAddressByteaMemo_NullBytes(t *testing.T) {
+	kp := keypair.MustRandom()
+	validAddress := AddressBytea(kp.Address())
+	wantBytes, err := validAddress.Value()
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name  string
+		input NullAddressBytea
+		want  []byte
+	}{
+		{name: "🟢invalid (NULL)", input: NullAddressBytea{Valid: false}, want: nil},
+		{name: "🟢valid address", input: NullAddressBytea{AddressBytea: validAddress, Valid: true}, want: wantBytes.([]byte)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			memo := make(AddressByteaMemo)
+			got, err := memo.NullBytes(tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func BenchmarkAddressBytea_Value(b *testing.B) {
+	addresses := benchmarkAddresses()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		_, err := addresses[i%len(addresses)].Value()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkAddressByteaMemo_Bytes(b *testing.B) {
+	addresses := benchmarkAddresses()
+	memo := make(AddressByteaMemo)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		_, err := memo.Bytes(addresses[i%len(addresses)])
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// benchmarkAddresses mirrors the repetition the persist COPY builds see: a small
+// working set of unique addresses converted over and over within one batch.
+func benchmarkAddresses() []AddressBytea {
+	addresses := make([]AddressBytea, 8)
+	for i := range addresses {
+		addresses[i] = AddressBytea(keypair.MustRandom().Address())
+	}
+	return addresses
+}
+
 func TestNullableJSONB_Value(t *testing.T) {
 	testCases := []struct {
 		name            string

--- a/internal/indexer/types/types_test.go
+++ b/internal/indexer/types/types_test.go
@@ -614,6 +614,24 @@ func TestAssignStateChangeOrdinals_Deterministic(t *testing.T) {
 	}
 }
 
+func TestAssignStateChangeOrdinals_LargeInterleavedGroups(t *testing.T) {
+	// Window-sized input: protocol processors assign ordinals over a whole
+	// staged migration window, not a per-transaction stream. Three
+	// (to_id, operation_id) groups interleaved round-robin — element i is the
+	// (i/3 + 1)-th member of its group, so each group must come out numbered
+	// 1..N contiguously in slice order.
+	changes := make([]StateChange, 3*100)
+	for i := range changes {
+		changes[i] = StateChange{ToID: 1, OperationID: int64(10 * (i%3 + 1))}
+	}
+
+	AssignStateChangeOrdinals(changes, StateChangeOrdinalBaseIndexer)
+
+	for i := range changes {
+		assert.Equal(t, StateChangeOrdinalBaseIndexer+int64(i/3)+1, changes[i].StateChangeID, "index %d", i)
+	}
+}
+
 func TestAssignStateChangeOrdinals_DifferentEmittersNeverCollide(t *testing.T) {
 	indexerChanges := []StateChange{{ToID: 1, OperationID: 42}}
 	sep41Changes := []StateChange{{ToID: 1, OperationID: 42}}

--- a/internal/ingest/streaming_loadtest_corpus_test.go
+++ b/internal/ingest/streaming_loadtest_corpus_test.go
@@ -3,10 +3,12 @@ package ingest
 import (
 	"context"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/alitto/pond/v2"
 	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,6 +44,7 @@ func TestStreamingLoadtestBackendRealCorpus(t *testing.T) {
 		MetaSources: paths,
 	})
 	require.NoError(t, err)
+	pool := pond.NewPool(runtime.NumCPU())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
@@ -65,7 +68,9 @@ func TestStreamingLoadtestBackendRealCorpus(t *testing.T) {
 
 		// The production read path: this is what live ingestion runs on every
 		// ledger, so a merged ledger it cannot parse would fail here first.
-		txs, err := indexer.GetLedgerTransactions(ctx, passphrase, lcm)
+		// Merged ledgers can repeat a transaction, which is the case the
+		// envelope↔meta pairing has to survive.
+		txs, err := indexer.GetLedgerTransactions(ctx, passphrase, lcm, pool)
 		require.NoError(t, err, "reading transactions of ledger %d", seq)
 		totalTxs += len(txs)
 	}

--- a/internal/services/blend/processor.go
+++ b/internal/services/blend/processor.go
@@ -328,7 +328,7 @@ func (p *processor) ProcessLedger(_ context.Context, input services.ProtocolProc
 		// tx walk would have produced (mirrors sep41's processor).
 		txID := toid.New(int32(input.LedgerSequence), int32(key.TxIdx), 0).ToInt64()
 		opID := toid.New(int32(input.LedgerSequence), int32(key.TxIdx), int32(key.OpIdx+1)).ToInt64()
-		opBuilder := processors.NewStateChangeBuilder(input.LedgerSequence, input.LedgerCloseTime, txID, nil).
+		opBuilder := processors.NewStateChangeBuilder(input.LedgerSequence, input.LedgerCloseTime, txID).
 			WithOperationID(opID)
 
 		for _, event := range events {
@@ -354,7 +354,7 @@ func (p *processor) ProcessLedger(_ context.Context, input services.ProtocolProc
 // processEvent decodes one contract event and stages its Blend history
 // rows and/or cost-basis folds per mode. Events from contracts this run
 // doesn't track are silently skipped (not an error).
-func (p *processor) processEvent(event xdr.ContractEvent, opBuilder *processors.StateChangeBuilder, mode services.StagingMode, blndToken string) error {
+func (p *processor) processEvent(event xdr.ContractEvent, opBuilder processors.StateChangeBuilder, mode services.StagingMode, blndToken string) error {
 	contractStr, ok := contractIDAddress(event)
 	if !ok {
 		return fmt.Errorf("event has no resolvable contract id")
@@ -429,8 +429,8 @@ func (p *processor) isTracked(addr string) bool {
 // stageHistoryRow appends one Blend state-change row built from row onto
 // the staged history set. row.Token == "" and row.Amount == "" leave their
 // respective columns NULL; row.PoolID == "" omits the poolId key_value entry.
-func (p *processor) stageHistoryRow(opBuilder *processors.StateChangeBuilder, row EventRow) {
-	b := opBuilder.Clone().
+func (p *processor) stageHistoryRow(opBuilder processors.StateChangeBuilder, row EventRow) {
+	b := opBuilder.
 		WithCategory(row.Category).
 		WithReason(row.Reason).
 		WithAccount(row.Account)

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -11,7 +11,6 @@ import (
 	"github.com/alitto/pond/v2"
 	"github.com/jackc/pgx/v5"
 	"github.com/stellar/go-stellar-sdk/historyarchive"
-	"github.com/stellar/go-stellar-sdk/ingest"
 	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
 	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/xdr"
@@ -265,16 +264,15 @@ func (m *ingestService) Close() {
 }
 
 // processLedger processes a single ledger - gets the transactions and
-// processes them using indexer processors. The materialized transactions are
-// returned so the live path can reuse them for ContractData extraction
-// instead of building a second LedgerTransactionReader for the same ledger.
-func (m *ingestService) processLedger(ctx context.Context, ledgerMeta xdr.LedgerCloseMeta, buffer *indexer.IndexerBuffer) ([]ingest.LedgerTransaction, error) {
-	participantCount, transactions, err := indexer.ProcessLedger(ctx, m.networkPassphrase, ledgerMeta, m.ledgerIndexer, buffer)
+// processes them using indexer processors. Everything downstream stages need,
+// including the ledger's ContractData changes, lands in the buffer.
+func (m *ingestService) processLedger(ctx context.Context, ledgerMeta xdr.LedgerCloseMeta, buffer *indexer.IndexerBuffer) error {
+	participantCount, err := indexer.ProcessLedger(ctx, m.networkPassphrase, ledgerMeta, m.ledgerIndexer, buffer)
 	if err != nil {
-		return nil, fmt.Errorf("processing ledger %d: %w", ledgerMeta.LedgerSequence(), err)
+		return fmt.Errorf("processing ledger %d: %w", ledgerMeta.LedgerSequence(), err)
 	}
 	m.appMetrics.Ingestion.ParticipantsCount.Observe(float64(participantCount))
-	return transactions, nil
+	return nil
 }
 
 // insertIntoDB persists the processed data from the buffer to the database.

--- a/internal/services/ingest_backfill.go
+++ b/internal/services/ingest_backfill.go
@@ -342,7 +342,7 @@ func (m *ingestService) processLedgersInBatch(
 		}
 		endTime = ledgerTime
 
-		if _, err := m.processLedger(ctx, ledgerMeta, batchBuffer); err != nil {
+		if err := m.processLedger(ctx, ledgerMeta, batchBuffer); err != nil {
 			return ledgersProcessed, startTime, endTime, fmt.Errorf("processing ledger %d: %w", ledgerSeq, err)
 		}
 		ledgersProcessed++

--- a/internal/services/ingest_live.go
+++ b/internal/services/ingest_live.go
@@ -35,40 +35,6 @@ const (
 	advisoryUnlockTimeout = 10 * time.Second
 )
 
-// contractDataMemo lazily extracts ContractData changes from a ledger's
-// already-materialized transactions (from the processLedger staging pass) and
-// memoizes the result. Extraction is pure over (transactions, ledgerSeq), so
-// one memo shared across persistLedgerDataWithRetry's attempts means the
-// extraction walk runs at most once per ledger — never inside a retried
-// attempt's open transaction — and only when a CAS-winning processor
-// requires it, so a protocol still backfilling costs nothing extra.
-type contractDataMemo struct {
-	transactions []ingest.LedgerTransaction
-	ledgerSeq    uint32
-	changes      map[string][]ingest.Change
-	extracted    bool
-}
-
-func newContractDataMemo(transactions []ingest.LedgerTransaction, ledgerSeq uint32) *contractDataMemo {
-	return &contractDataMemo{transactions: transactions, ledgerSeq: ledgerSeq}
-}
-
-// get returns the memoized extraction, running it on first use. The result is
-// always non-nil, including over zero transactions, because a
-// RequiresContractData processor must receive a ContractDataChanges map it can
-// range over unconditionally.
-func (c *contractDataMemo) get() (map[string][]ingest.Change, error) {
-	if !c.extracted {
-		changes, err := indexer.ExtractContractDataChangesFromTransactions(c.transactions, c.ledgerSeq)
-		if err != nil {
-			return nil, fmt.Errorf("extracting contract data changes for ledger %d: %w", c.ledgerSeq, err)
-		}
-		c.changes = changes
-		c.extracted = true
-	}
-	return c.changes, nil
-}
-
 // ErrPartialPersist marks a persist failure that occurred after the first
 // sibling commit succeeded: some of the ledger's tables are durable and the
 // rest are not, the transaction set can no longer roll back atomically, and no
@@ -81,16 +47,16 @@ var ErrPartialPersist = errors.New("ledger persist partially committed")
 // persistItem is one ledger's persist payload: its classification plan
 // (computed by prepareClassificationPlan before any transaction opens, RPC
 // calls already resolved; nil when the ledger had nothing to classify) and
-// its ContractData extraction memo. Both are shared verbatim across
+// its buffer, which carries the ledger's ContractData changes collected by
+// the process stage. Both are shared verbatim across
 // persistLedgerDataWithRetry's attempts, so a retry never re-issues RPC
-// calls or re-runs the extraction walk. transactions and operations hold the
+// calls or re-collects changes. transactions and operations hold the
 // buffer's rows materialized by persistLedgerData, so the two siblings that
 // each need them share one slice.
 type persistItem struct {
 	seq          uint32
 	closeTime    int64
 	plan         *ClassificationPlan
-	contractData *contractDataMemo
 	buffer       *indexer.IndexerBuffer
 	transactions []*types.Transaction
 	operations   []*types.Operation
@@ -306,7 +272,7 @@ func (m *ingestService) persistLedgerData(ctx context.Context, items []persistIt
 	g.Go(func() error {
 		for j := range items {
 			it := &items[j]
-			if stageErr := m.stageCoordinatedWrites(gctx, coordTx, history, it.seq, it.closeTime, it.plan, it.contractData, it.buffer); stageErr != nil {
+			if stageErr := m.stageCoordinatedWrites(gctx, coordTx, history, it.seq, it.closeTime, it.plan, it.buffer); stageErr != nil {
 				return fmt.Errorf("staging coordinated writes for ledger %d: %w", it.seq, stageErr)
 			}
 		}
@@ -377,7 +343,6 @@ func (m *ingestService) stageCoordinatedWrites(
 	ledgerSeq uint32,
 	ledgerCloseTime int64,
 	plan *ClassificationPlan,
-	contractData *contractDataMemo,
 	buffer *indexer.IndexerBuffer,
 ) error {
 	// 1. Insert new SAC contract tokens (filter existing, insert)
@@ -505,11 +470,7 @@ func (m *ingestService) stageCoordinatedWrites(
 
 			committed := committedByProtocol[protocolID]
 			if processor.RequiresContractData() {
-				var cdErr error
-				contractDataChanges, cdErr = contractData.get()
-				if cdErr != nil {
-					return cdErr
-				}
+				contractDataChanges = buffer.GetContractDataChanges()
 
 				// ContractData-driven processors need the protocol's FULL committed
 				// membership, not just this ledger's event emitters: entries can
@@ -794,16 +755,15 @@ type fetchedLedger struct {
 	meta xdr.LedgerCloseMeta
 }
 
-// processedLedger is the process→persist handoff. The close time and the
-// ContractData memo over the staging pass's materialized transactions are
-// both derived at the end of that pass, so the decoded close meta itself
-// never rides the queue. processDuration rides along so the per-ledger
-// Duration metric can sum the ledger's stage times instead of counting the
-// time it sat queued between stages.
+// processedLedger is the process→persist handoff. The buffer carries
+// everything the persist stage consumes, including the ledger's ContractData
+// changes, and the close time is extracted at the end of the staging pass,
+// so the decoded close meta itself never rides the queue. processDuration
+// rides along so the per-ledger Duration metric can sum the ledger's stage
+// times instead of counting the time it sat queued between stages.
 type processedLedger struct {
 	seq             uint32
 	closeTime       int64
-	contractData    *contractDataMemo
 	buffer          *indexer.IndexerBuffer
 	processDuration time.Duration
 }
@@ -953,8 +913,7 @@ func (m *ingestService) processFetchedLedgers(ctx context.Context, fetched <-cha
 		buffer.Clear()
 
 		processStart := time.Now()
-		transactions, err := m.processLedger(ctx, fl.meta, buffer)
-		if err != nil {
+		if err := m.processLedger(ctx, fl.meta, buffer); err != nil {
 			m.appMetrics.Ingestion.ErrorsTotal.WithLabelValues("ingest_live").Inc()
 			return fmt.Errorf("processing ledger %d: %w", fl.seq, err)
 		}
@@ -965,7 +924,6 @@ func (m *ingestService) processFetchedLedgers(ctx context.Context, fetched <-cha
 		case processed <- processedLedger{
 			seq:             fl.seq,
 			closeTime:       fl.meta.LedgerCloseTime(),
-			contractData:    newContractDataMemo(transactions, fl.seq),
 			buffer:          buffer,
 			processDuration: processDuration,
 		}:
@@ -1134,10 +1092,9 @@ func (m *ingestService) persistProcessedLedgers(ctx context.Context, processed <
 		items := make([]persistItem, len(batch))
 		for i, pl := range batch {
 			items[i] = persistItem{
-				seq:          pl.seq,
-				closeTime:    pl.closeTime,
-				contractData: pl.contractData,
-				buffer:       pl.buffer,
+				seq:       pl.seq,
+				closeTime: pl.closeTime,
+				buffer:    pl.buffer,
 			}
 		}
 		items[0].plan = plan

--- a/internal/services/ingest_live_test.go
+++ b/internal/services/ingest_live_test.go
@@ -147,28 +147,3 @@ func Test_isPermanentPersistError(t *testing.T) {
 		})
 	}
 }
-
-// Test_contractDataMemo_get covers the memo's two guarantees. The result is
-// always non-nil: a RequiresContractData processor ranges over the map
-// unconditionally, so even a ledger with zero transactions has to yield an
-// empty map rather than nil. And the extraction walk runs at most once no
-// matter how often get() is called, which is what makes one memo safe to
-// share across every persistLedgerDataWithRetry attempt for a ledger.
-func Test_contractDataMemo_get(t *testing.T) {
-	memo := newContractDataMemo(nil, 100)
-
-	first, err := memo.get()
-	require.NoError(t, err)
-	require.NotNil(t, first, "a zero-transaction ledger still needs a rangeable map")
-	assert.Empty(t, first)
-
-	// Marking the first result is what makes the second call's map
-	// identifiable: a second extraction builds a fresh map and could not carry
-	// the marker, so finding it proves the walk did not run again.
-	const marker = "extracted-once"
-	first[marker] = nil
-
-	second, err := memo.get()
-	require.NoError(t, err)
-	assert.Contains(t, second, marker, "get should serve the memoized map instead of extracting again")
-}

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -1660,8 +1660,8 @@ func Test_ingestLiveLedgers_batchReachesConfiguredCap(t *testing.T) {
 
 // oneLedger wraps a single ledger's persist payload as the batch slice
 // persistLedgerData and persistLedgerDataWithRetry consume.
-func oneLedger(seq uint32, plan *ClassificationPlan, contractData *contractDataMemo, buffer *indexer.IndexerBuffer) []persistItem {
-	return []persistItem{{seq: seq, plan: plan, contractData: contractData, buffer: buffer}}
+func oneLedger(seq uint32, plan *ClassificationPlan, buffer *indexer.IndexerBuffer) []persistItem {
+	return []persistItem{{seq: seq, plan: plan, buffer: buffer}}
 }
 
 // Test_persistLedgerData_rejectsLedgerZero pins the batch entry guard. Ledger
@@ -1763,7 +1763,7 @@ func Test_persistLedgerDataWithRetry(t *testing.T) {
 
 		// Call persistLedgerDataWithRetry - should succeed
 		// Note: assetIDMap and contractIDMap are no longer passed - operations use direct DB queries
-		err = svc.persistLedgerDataWithRetry(ctx, oneLedger(100, nil, newContractDataMemo(nil, 100), buffer))
+		err = svc.persistLedgerDataWithRetry(ctx, oneLedger(100, nil, buffer))
 
 		// Verify success
 		require.NoError(t, err)
@@ -1850,7 +1850,7 @@ func Test_persistLedgerDataWithRetry(t *testing.T) {
 
 		// Call persistLedgerDataWithRetry - should fail after retries due to DB error
 		// Note: assetIDMap and contractIDMap are no longer passed - operations use direct DB queries
-		err = svc.persistLedgerDataWithRetry(ctx, oneLedger(100, nil, newContractDataMemo(nil, 100), buffer))
+		err = svc.persistLedgerDataWithRetry(ctx, oneLedger(100, nil, buffer))
 
 		// Verify error propagates with retry failure message
 		require.Error(t, err)
@@ -1942,7 +1942,7 @@ func Test_persistLedgerDataWithRetry(t *testing.T) {
 
 		// Call persistLedgerDataWithRetry - should succeed after retry
 		// Note: assetIDMap and contractIDMap are no longer passed - operations use direct DB queries
-		err = svc.persistLedgerDataWithRetry(ctx, oneLedger(100, nil, newContractDataMemo(nil, 100), buffer))
+		err = svc.persistLedgerDataWithRetry(ctx, oneLedger(100, nil, buffer))
 
 		// Verify success after retry
 		require.NoError(t, err)
@@ -2150,7 +2150,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		require.NoError(t, svc.snapshotProtocolCursors(ctx))
 
 		buffer := indexer.NewIndexerBuffer()
-		err := svc.persistLedgerData(ctx, oneLedger(100, nil, newContractDataMemo(nil, 100), buffer))
+		err := svc.persistLedgerData(ctx, oneLedger(100, nil, buffer))
 		require.NoError(t, err)
 
 		// Both protocol cursors should advance to 100
@@ -2182,7 +2182,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		require.NoError(t, svc.snapshotProtocolCursors(ctx))
 
 		buffer := indexer.NewIndexerBuffer()
-		err := svc.persistLedgerData(ctx, oneLedger(100, nil, newContractDataMemo(nil, 100), buffer))
+		err := svc.persistLedgerData(ctx, oneLedger(100, nil, buffer))
 		require.NoError(t, err)
 
 		// Cursors should stay at 100 (CAS expected 99 but found 100)
@@ -2214,7 +2214,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		require.NoError(t, svc.snapshotProtocolCursors(ctx))
 
 		buffer := indexer.NewIndexerBuffer()
-		err := svc.persistLedgerData(ctx, oneLedger(100, nil, newContractDataMemo(nil, 100), buffer))
+		err := svc.persistLedgerData(ctx, oneLedger(100, nil, buffer))
 		require.NoError(t, err)
 
 		// Cursors should stay at 98 (behind, so entire block is skipped)
@@ -2250,7 +2250,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		// No protocol cursors inserted.
 
 		buffer := indexer.NewIndexerBuffer()
-		err := svc.persistLedgerData(ctx, oneLedger(100, nil, newContractDataMemo(nil, 100), buffer))
+		err := svc.persistLedgerData(ctx, oneLedger(100, nil, buffer))
 		require.NoError(t, err)
 
 		// Main cursor advances; protocol persist methods were not called and
@@ -2287,7 +2287,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, svc.snapshotProtocolCursors(ctx))
 
-		err = svc.persistLedgerData(ctx, oneLedger(100, nil, newContractDataMemo(nil, 100), indexer.NewIndexerBuffer()))
+		err = svc.persistLedgerData(ctx, oneLedger(100, nil, indexer.NewIndexerBuffer()))
 		require.NoError(t, err)
 
 		// History CAS succeeded.
@@ -2326,7 +2326,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, svc.snapshotProtocolCursors(ctx))
 
-		err = svc.persistLedgerData(ctx, oneLedger(100, nil, newContractDataMemo(nil, 100), indexer.NewIndexerBuffer()))
+		err = svc.persistLedgerData(ctx, oneLedger(100, nil, indexer.NewIndexerBuffer()))
 		require.NoError(t, err)
 
 		// Current-state CAS succeeded.
@@ -2354,7 +2354,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		setupDBCursors(t, ctx, pool, 99, 99)
 
 		buffer := indexer.NewIndexerBuffer()
-		err := svc.persistLedgerData(ctx, oneLedger(100, nil, newContractDataMemo(nil, 100), buffer))
+		err := svc.persistLedgerData(ctx, oneLedger(100, nil, buffer))
 		require.NoError(t, err)
 
 		// Main cursor should advance
@@ -2373,13 +2373,13 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		// First ledger succeeds and advances the current-state cursor to 100.
 		processor.processedLedger = 100
-		err := svc.persistLedgerData(ctx, oneLedger(100, nil, newContractDataMemo(nil, 100), indexer.NewIndexerBuffer()))
+		err := svc.persistLedgerData(ctx, oneLedger(100, nil, indexer.NewIndexerBuffer()))
 		require.NoError(t, err)
 
 		// Next ledger fails inside PersistCurrentState, rolling back the whole
 		// transaction — the current-state cursor must stay at 100.
 		processor.processedLedger = 101
-		err = svc.persistLedgerData(ctx, oneLedger(101, nil, newContractDataMemo(nil, 101), indexer.NewIndexerBuffer()))
+		err = svc.persistLedgerData(ctx, oneLedger(101, nil, indexer.NewIndexerBuffer()))
 		require.Error(t, err)
 
 		currentStateCursor, err := models.IngestStore.Get(ctx, "protocol_testproto_current_state_cursor")
@@ -2389,7 +2389,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		// Retrying the same ledger succeeds and advances the cursor.
 		processor.failPersistCurrentStateAt = 0
 		processor.processedLedger = 101
-		err = svc.persistLedgerData(ctx, oneLedger(101, nil, newContractDataMemo(nil, 101), indexer.NewIndexerBuffer()))
+		err = svc.persistLedgerData(ctx, oneLedger(101, nil, indexer.NewIndexerBuffer()))
 		require.NoError(t, err)
 
 		currentStateCursor, err = models.IngestStore.Get(ctx, "protocol_testproto_current_state_cursor")
@@ -2420,7 +2420,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		require.NoError(t, delErr)
 
 		buffer := indexer.NewIndexerBuffer()
-		err := svc.persistLedgerData(ctx, oneLedger(100, nil, newContractDataMemo(nil, 100), buffer))
+		err := svc.persistLedgerData(ctx, oneLedger(100, nil, buffer))
 		require.Error(t, err)
 		assert.ErrorIs(t, err, data.ErrCASCursorMissing)
 
@@ -2455,7 +2455,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		// Production is now enabled: a ledger processed after the re-probe actually CASes.
 		processor.processedLedger = 100
 		buffer := indexer.NewIndexerBuffer()
-		err := svc.persistLedgerData(ctx, oneLedger(100, nil, newContractDataMemo(nil, 100), buffer))
+		err := svc.persistLedgerData(ctx, oneLedger(100, nil, buffer))
 		require.NoError(t, err)
 
 		histCursor, getErr := models.IngestStore.Get(ctx, "protocol_testproto_history_cursor")
@@ -2480,7 +2480,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		require.NoError(t, svc.snapshotProtocolCursors(ctx))
 
 		buffer := indexer.NewIndexerBuffer()
-		err := svc.persistLedgerData(ctx, oneLedger(100, nil, newContractDataMemo(nil, 100), buffer))
+		err := svc.persistLedgerData(ctx, oneLedger(100, nil, buffer))
 		require.NoError(t, err)
 	})
 
@@ -2501,7 +2501,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		require.NoError(t, svc.snapshotProtocolCursors(ctx))
 
 		buffer := indexer.NewIndexerBuffer()
-		err := svc.persistLedgerData(ctx, oneLedger(100, nil, newContractDataMemo(nil, 100), buffer))
+		err := svc.persistLedgerData(ctx, oneLedger(100, nil, buffer))
 		require.NoError(t, err)
 	})
 
@@ -2561,7 +2561,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		require.NoError(t, err)
 
 		buffer := indexer.NewIndexerBuffer()
-		err = svc.persistLedgerData(ctx, oneLedger(100, nil, newContractDataMemo(nil, 100), buffer))
+		err = svc.persistLedgerData(ctx, oneLedger(100, nil, buffer))
 		require.NoError(t, err)
 	})
 
@@ -2588,7 +2588,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 			[]xdr.ContractEvent{{Type: xdr.ContractEventTypeContract, ContractId: &contractID}},
 		)
 
-		err := svc.persistLedgerData(ctx, oneLedger(100, nil, newContractDataMemo(nil, 100), buffer))
+		err := svc.persistLedgerData(ctx, oneLedger(100, nil, buffer))
 		require.ErrorContains(t, err, "resolving protocol contracts for ledger 100")
 
 		// The transaction rolled back: the protocol history cursor stayed at 99.
@@ -2906,7 +2906,7 @@ func Test_persistLedgerData_ClassificationPlan(t *testing.T) {
 			}},
 		}
 
-		err = svc.persistLedgerData(ctx, oneLedger(100, plan, newContractDataMemo(nil, 100), buffer))
+		err = svc.persistLedgerData(ctx, oneLedger(100, plan, buffer))
 		require.NoError(t, err)
 
 		// The validator's Apply ran inside the transaction.
@@ -2970,7 +2970,7 @@ func Test_persistLedgerData_ClassificationPlan(t *testing.T) {
 
 		plan := &ClassificationPlan{Matches: map[types.HashBytea]string{w2: "otherproto"}}
 
-		err = svc.persistLedgerData(ctx, oneLedger(100, plan, newContractDataMemo(nil, 100), buffer))
+		err = svc.persistLedgerData(ctx, oneLedger(100, plan, buffer))
 		require.NoError(t, err)
 
 		// The processor staged the ledger but saw no testproto contracts: the
@@ -3032,8 +3032,8 @@ func Test_persistLedgerData_ClassificationPlan(t *testing.T) {
 		)
 
 		items := []persistItem{
-			{seq: 100, contractData: newContractDataMemo(nil, 100), buffer: headBuffer},
-			{seq: 101, contractData: newContractDataMemo(nil, 101), buffer: midBuffer},
+			{seq: 100, buffer: headBuffer},
+			{seq: 101, buffer: midBuffer},
 		}
 		require.NoError(t, svc.persistLedgerData(ctx, items))
 
@@ -3336,7 +3336,7 @@ func Test_persistLedgerData_Batch(t *testing.T) {
 		buffer := indexer.NewIndexerBuffer()
 		buffer.PushTransaction(testAddr1, &tx)
 		buffer.PushOperation(testAddr1, &op, &tx)
-		return persistItem{seq: seq, contractData: newContractDataMemo(nil, seq), buffer: buffer}
+		return persistItem{seq: seq, buffer: buffer}
 	}
 
 	t.Run("one commit set persists every ledger and the cursor lands on the last", func(t *testing.T) {
@@ -3489,7 +3489,7 @@ func Test_persistLedgerData_SiblingFailureRollsBackEverything(t *testing.T) {
 		[]byte("preexisting-hash"), tx.ToID, ledgerSeq, tx.LedgerCreatedAt)
 	require.NoError(t, err)
 
-	err = ingestSvc.persistLedgerData(ctx, oneLedger(ledgerSeq, nil, newContractDataMemo(nil, ledgerSeq), buffer))
+	err = ingestSvc.persistLedgerData(ctx, oneLedger(ledgerSeq, nil, buffer))
 	require.Error(t, err)
 
 	var txCount, opCount int

--- a/internal/services/sep41/processor.go
+++ b/internal/services/sep41/processor.go
@@ -126,7 +126,7 @@ func (p *processor) ProcessLedger(_ context.Context, input services.ProtocolProc
 		// tx walk would have produced.
 		txID := toid.New(int32(input.LedgerSequence), int32(key.TxIdx), 0).ToInt64()
 		opID := toid.New(int32(input.LedgerSequence), int32(key.TxIdx), int32(key.OpIdx+1)).ToInt64()
-		opBuilder := processors.NewStateChangeBuilder(input.LedgerSequence, input.LedgerCloseTime, txID, nil).
+		opBuilder := processors.NewStateChangeBuilder(input.LedgerSequence, input.LedgerCloseTime, txID).
 			WithOperationID(opID)
 
 		for _, event := range events {
@@ -142,7 +142,7 @@ func (p *processor) ProcessLedger(_ context.Context, input services.ProtocolProc
 	return nil
 }
 
-func (p *processor) processEvent(event xdr.ContractEvent, opBuilder *processors.StateChangeBuilder, mode services.StagingMode) error {
+func (p *processor) processEvent(event xdr.ContractEvent, opBuilder processors.StateChangeBuilder, mode services.StagingMode) error {
 	if event.Type != xdr.ContractEventTypeContract || event.ContractId == nil || event.Body.V != 0 {
 		return fmt.Errorf("unsupported event shape")
 	}
@@ -163,7 +163,7 @@ func (p *processor) processEvent(event xdr.ContractEvent, opBuilder *processors.
 		return fmt.Errorf("topic[0] not a symbol")
 	}
 
-	scBuilder := opBuilder.Clone().
+	scBuilder := opBuilder.
 		WithCategory(types.StateChangeCategoryBalance).
 		WithToken(contractStr)
 
@@ -178,13 +178,13 @@ func (p *processor) processEvent(event xdr.ContractEvent, opBuilder *processors.
 			p.applyBalanceDelta(types.AddressBytea(decoded.To), contractStr, decoded.Amount)
 		}
 		if mode.NeedsHistory() {
-			creditBuilder := scBuilder.Clone().WithReason(types.StateChangeReasonCredit).
+			creditBuilder := scBuilder.WithReason(types.StateChangeReasonCredit).
 				WithAccount(decoded.To).WithAmount(decoded.Amount.String())
 			if decoded.ToMuxedID != nil {
 				creditBuilder = creditBuilder.WithToMuxedID(*decoded.ToMuxedID)
 			}
 			p.stagedStateChanges = append(p.stagedStateChanges,
-				scBuilder.Clone().WithReason(types.StateChangeReasonDebit).
+				scBuilder.WithReason(types.StateChangeReasonDebit).
 					WithAccount(decoded.From).WithAmount(decoded.Amount.String()).Build(),
 				creditBuilder.Build(),
 			)
@@ -199,7 +199,7 @@ func (p *processor) processEvent(event xdr.ContractEvent, opBuilder *processors.
 			p.applyBalanceDelta(types.AddressBytea(decoded.To), contractStr, decoded.Amount)
 		}
 		if mode.NeedsHistory() {
-			mintBuilder := scBuilder.Clone().WithReason(types.StateChangeReasonMint).
+			mintBuilder := scBuilder.WithReason(types.StateChangeReasonMint).
 				WithAccount(decoded.To).WithAmount(decoded.Amount.String())
 			if decoded.ToMuxedID != nil {
 				mintBuilder = mintBuilder.WithToMuxedID(*decoded.ToMuxedID)
@@ -217,7 +217,7 @@ func (p *processor) processEvent(event xdr.ContractEvent, opBuilder *processors.
 		}
 		if mode.NeedsHistory() {
 			p.stagedStateChanges = append(p.stagedStateChanges,
-				scBuilder.Clone().WithReason(types.StateChangeReasonBurn).
+				scBuilder.WithReason(types.StateChangeReasonBurn).
 					WithAccount(decoded.From).WithAmount(decoded.Amount.String()).Build(),
 			)
 		}
@@ -233,7 +233,7 @@ func (p *processor) processEvent(event xdr.ContractEvent, opBuilder *processors.
 		if mode.NeedsHistory() {
 			// Reason=BURN reflects supply reduction — no dedicated CLAWBACK reason in the schema enum.
 			p.stagedStateChanges = append(p.stagedStateChanges,
-				scBuilder.Clone().WithReason(types.StateChangeReasonBurn).
+				scBuilder.WithReason(types.StateChangeReasonBurn).
 					WithAccount(decoded.From).WithAmount(decoded.Amount.String()).Build(),
 			)
 		}
@@ -257,7 +257,7 @@ func (p *processor) processEvent(event xdr.ContractEvent, opBuilder *processors.
 			// column (spender_account_id) and amount flows through WithAmount; key_value carries
 			// only live_until_ledger, which expirationLedger is read from.
 			p.stagedStateChanges = append(p.stagedStateChanges,
-				scBuilder.Clone().
+				scBuilder.
 					WithCategory(types.StateChangeCategoryAllowance).
 					WithReason(types.StateChangeReasonUpdate).
 					WithAccount(decoded.From).

--- a/internal/services/sep41/processor_test.go
+++ b/internal/services/sep41/processor_test.go
@@ -37,8 +37,8 @@ func newTestProcessorWithStateChanges(sc data.StateChangeWriter) *processor {
 	}
 }
 
-func newTestOpBuilder() *processors.StateChangeBuilder {
-	return processors.NewStateChangeBuilder(42, 0, 1, nil).WithOperationID(100)
+func newTestOpBuilder() processors.StateChangeBuilder {
+	return processors.NewStateChangeBuilder(42, 0, 1).WithOperationID(100)
 }
 
 func TestProcessor_NeedsResetGuard(t *testing.T) {


### PR DESCRIPTION
**Review commit-by-commit, in order. ~1 hour. No schema changes, no new flags, no behavior changes. Every risky rewrite has a differential test against the implementation it replaced.**

## Why

After #684, the process stage was the bottleneck for the p99 ≤ block-time target, and GC was 20–28% of ingest CPU. This PR only cuts CPU and allocations on that stage.

## What changed

1. **Each operation's ledger changes are decoded once and shared.** Before, every processor re-decoded them through the SDK. This is the biggest win: 40–50% less wall time per ledger in the process benchmark. The shared decode also feeds ContractData collection, which moved off the serial persist goroutine and now skips classic transactions entirely (only Soroban transactions can write ContractData).
2. **Transaction envelopes are hashed in parallel** instead of single-threaded inside the SDK reader. ~3× faster ledger loading.
3. **State changes are built with less garbage.** The builder is by-value instead of heap-allocated, account comparison stopped XDR-marshaling both entries, the XDR encoder is pooled, and dead output fields are deleted.
4. **Participants are deduped on raw ed25519 keys** and the Soroban walk fills one accumulator instead of allocating a set per tree node.
5. **Hot conversions are memoized**: one shared asset→contract-ID memo serves all processors, and address→BYTEA conversion is cached per COPY batch. Riding along: an oversized address payload now errors instead of silently truncating.

State-change ordinals are assigned with a counting map — linear even for the migration path, which passes a whole window at once.

## How it's verified

| Rewrite | Gate |
|---|---|
| Parallel hashing | Differential vs the SDK reader over every committed fixture |
| ContractData at process time | Differential vs reader-based extraction on real ledgers |
| Participant dedupe | Old implementation kept in the test file as oracle |
| Field-wise account comparison | 28-case differential vs the SDK function |
| By-value builder, ordinals | Existing exact-output suites; byte-identical IDs |

Plus 583 lines of new sponsorship-effects coverage (previously none).

## Numbers

Combined loadtest rig result for the campaign: **18,458 tx/s, process p99 0.992 s** — this PR took process p99 under the 1 s bar. Individual PRs were not re-benchmarked.

## Stack

Third of four PRs from the loadtest campaign (replaces #682). Review order: #679 → #684 → this. #686 is independent.

**Follow-up, decided separately:** the BALANCE_AUTHORIZATION change for a new trustline inherits `trustline_limit_new` from its sibling trustline change. Preserved byte-identically here; the field arguably doesn't belong there.
