### PR TITLE
fix(indexer): reduce muxed addresses to their base account

### DIFF
--- a/internal/data/sep41/balances_test.go
+++ b/internal/data/sep41/balances_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/strkey"
+	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -188,4 +190,53 @@ func TestBalanceModel_BatchApplyDeltas(t *testing.T) {
 		// Must not fail when no deltas are staged.
 		require.NoError(t, m.BatchApplyDeltas(ctx, nil, nil))
 	})
+}
+
+// muxedOver builds the M... strkey for a muxed account over baseG with the given sub-id.
+func muxedOver(t *testing.T, baseG string, id uint64) string {
+	t.Helper()
+	var ed xdr.Uint256
+	copy(ed[:], strkey.MustDecode(strkey.VersionByteAccountID, baseG))
+	m := xdr.MuxedAccount{
+		Type:     xdr.CryptoKeyTypeKeyTypeMuxedEd25519,
+		Med25519: &xdr.MuxedAccountMed25519{Id: xdr.Uint64(id), Ed25519: ed},
+	}
+	addr, err := m.GetAddress()
+	require.NoError(t, err)
+	return addr
+}
+
+// TestBatchApplyDeltas_MuxedWritesLandOnBaseAccount checks that two credits to different
+// muxed addresses over the same base account accumulate on one base-account row
+// (1000 + 2000 = 3000). Applied in separate calls, since the processor dedups a window to
+// one delta per account before this layer sees it.
+func TestBatchApplyDeltas_MuxedWritesLandOnBaseAccount(t *testing.T) {
+	ctx, pool, m, cleanup := newBalancesFixture(t)
+	defer cleanup()
+
+	contract := "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA"
+	cid := insertContractToken(t, ctx, pool, contract)
+
+	base := keypair.MustRandom().Address()
+	mA := muxedOver(t, base, 1)
+	mB := muxedOver(t, base, 2)
+	require.NotEqual(t, mA, mB)
+
+	// A credit under muxed #1, then a credit under muxed #2 (separate ledgers/windows).
+	runInTx(t, ctx, pool, func(tx pgx.Tx) {
+		require.NoError(t, m.BatchApplyDeltas(ctx, tx, []sep41.Balance{
+			{AccountID: types.AddressBytea(mA), ContractID: cid, Balance: "1000", LedgerNumber: 42},
+		}))
+	})
+	runInTx(t, ctx, pool, func(tx pgx.Tx) {
+		require.NoError(t, m.BatchApplyDeltas(ctx, tx, []sep41.Balance{
+			{AccountID: types.AddressBytea(mB), ContractID: cid, Balance: "2000", LedgerNumber: 43},
+		}))
+	})
+
+	// Both credits accumulated onto the single base-account row, readable by the base G address.
+	balances, err := m.GetByAccount(ctx, base, nil, nil, sep41.SortASC)
+	require.NoError(t, err)
+	require.Len(t, balances, 1, "muxed credits must not fragment into per-id rows")
+	assert.Equal(t, "3000", balances[0].Balance)
 }

--- a/internal/indexer/types/types.go
+++ b/internal/indexer/types/types.go
@@ -90,6 +90,12 @@ func (a AddressBytea) Value() (driver.Value, error) {
 		return nil, fmt.Errorf("decoding stellar address %s: %w", a, err)
 	}
 	if versionByte == strkey.VersionByteMuxedAccount {
+		// strkey.DecodeAny validates the checksum and version byte but not the
+		// version-specific payload length, so guard it before slicing: a muxed payload
+		// must be exactly 40 bytes (32-byte ed25519 key + 8-byte id).
+		if len(rawBytes) != 40 {
+			return nil, fmt.Errorf("stellar muxed address %s has a %d-byte payload; expected 40 bytes", a, len(rawBytes))
+		}
 		versionByte = strkey.VersionByteAccountID
 		rawBytes = rawBytes[:32] // keep the ed25519 key; drop the trailing 8-byte id
 	}

--- a/internal/indexer/types/types.go
+++ b/internal/indexer/types/types.go
@@ -72,7 +72,15 @@ func (a *AddressBytea) Scan(value any) error {
 	return nil
 }
 
-// Value implements driver.Valuer - converts StrKey string to 33-byte []byte
+// Value implements driver.Valuer - converts StrKey string to 33-byte []byte.
+//
+// Muxed addresses (M...) carry a 40-byte payload — a 32-byte ed25519 key followed by an
+// 8-byte multiplexing id (SEP-23). They are reduced to their base account here: the id is
+// off-chain routing metadata, not part of the stored key. This is a storage-layer backstop;
+// ingestion is expected to normalize muxed addresses to their base account before this point
+// (see the SEP-41 processor and the classic path's MuxedAccount.ToAccountId()). Any other
+// payload length is rejected rather than silently truncated, so a malformed address surfaces
+// as an error instead of corrupt data.
 func (a AddressBytea) Value() (driver.Value, error) {
 	if a == "" {
 		return nil, nil
@@ -80,6 +88,13 @@ func (a AddressBytea) Value() (driver.Value, error) {
 	versionByte, rawBytes, err := strkey.DecodeAny(string(a))
 	if err != nil {
 		return nil, fmt.Errorf("decoding stellar address %s: %w", a, err)
+	}
+	if versionByte == strkey.VersionByteMuxedAccount {
+		versionByte = strkey.VersionByteAccountID
+		rawBytes = rawBytes[:32] // keep the ed25519 key; drop the trailing 8-byte id
+	}
+	if len(rawBytes) != 32 {
+		return nil, fmt.Errorf("stellar address %s has a %d-byte key payload; the account_id column stores only 32-byte account/contract keys", a, len(rawBytes))
 	}
 	result := make([]byte, 33)
 	result[0] = byte(versionByte)

--- a/internal/indexer/types/types_test.go
+++ b/internal/indexer/types/types_test.go
@@ -560,7 +560,8 @@ func TestMuxedAddressBytea_NormalizesToBaseAccount(t *testing.T) {
 
 	// Distinct base accounts still stay distinct — normalization only strips the id.
 	gOther := keypair.MustRandom().Address()
-	vOther, _ := AddressBytea(gOther).Value()
+	vOther, err := AddressBytea(gOther).Value()
+	require.NoError(t, err)
 	assert.NotEqual(t, baseBytes, vOther)
 }
 
@@ -575,6 +576,17 @@ func TestAddressBytea_RejectsMalformedPayload(t *testing.T) {
 	_, err = AddressBytea(bogus).Value()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "5-byte")
+
+	// A checksum-valid muxed strkey with a short (<32-byte) payload must be rejected,
+	// not panic: strkey.DecodeAny does not enforce the version-specific payload length,
+	// so Value must guard before slicing the ed25519 key out of it.
+	shortMuxed, err := strkey.Encode(strkey.VersionByteMuxedAccount, []byte{1, 2, 3, 4, 5})
+	require.NoError(t, err)
+	require.NotPanics(t, func() {
+		_, err = AddressBytea(shortMuxed).Value()
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected 40 bytes")
 
 	// Control: a normal contract address still encodes fine.
 	_, err = AddressBytea("CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA").Value()

--- a/internal/indexer/types/types_test.go
+++ b/internal/indexer/types/types_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/strkey"
+	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -517,4 +518,65 @@ func TestAssignStateChangeOrdinals_GroupsByToIDAndOperationID(t *testing.T) {
 		changes[0].StateChangeID, changes[1].StateChangeID,
 		changes[2].StateChangeID, changes[3].StateChangeID,
 	})
+}
+
+// muxedOver builds the M... strkey for a muxed account over baseG with the given sub-id.
+func muxedOver(t *testing.T, baseG string, id uint64) string {
+	t.Helper()
+	var ed xdr.Uint256
+	copy(ed[:], strkey.MustDecode(strkey.VersionByteAccountID, baseG))
+	m := xdr.MuxedAccount{
+		Type:     xdr.CryptoKeyTypeKeyTypeMuxedEd25519,
+		Med25519: &xdr.MuxedAccountMed25519{Id: xdr.Uint64(id), Ed25519: ed},
+	}
+	addr, err := m.GetAddress()
+	require.NoError(t, err)
+	return addr
+}
+
+// TestMuxedAddressBytea_NormalizesToBaseAccount verifies that a muxed address and its base
+// account, and two muxed addresses over the same base, all encode to the same 33-byte
+// base-account key — the 8-byte multiplexing id is not part of the stored key.
+func TestMuxedAddressBytea_NormalizesToBaseAccount(t *testing.T) {
+	base := keypair.MustRandom().Address() // one base G... account
+
+	mA := muxedOver(t, base, 1) // customer #1
+	mB := muxedOver(t, base, 2) // customer #2
+	require.NotEqual(t, mA, mB, "the two muxed strkeys must differ as strings")
+	require.Equal(t, byte('M'), mA[0], "sanity: these are M-addresses")
+
+	baseBytes, err := AddressBytea(base).Value()
+	require.NoError(t, err)
+	vA, err := AddressBytea(mA).Value()
+	require.NoError(t, err)
+	vB, err := AddressBytea(mB).Value()
+	require.NoError(t, err)
+
+	require.Len(t, baseBytes.([]byte), 33)
+	assert.Equal(t, baseBytes, vA, "muxed #1 must store as its base account")
+	assert.Equal(t, baseBytes, vB, "muxed #2 must store as its base account")
+	assert.Equal(t, byte(strkey.VersionByteAccountID), vA.([]byte)[0],
+		"stored version byte must be the base-account (G) byte, not the muxed (M) byte")
+
+	// Distinct base accounts still stay distinct — normalization only strips the id.
+	gOther := keypair.MustRandom().Address()
+	vOther, _ := AddressBytea(gOther).Value()
+	assert.NotEqual(t, baseBytes, vOther)
+}
+
+// TestAddressBytea_RejectsMalformedPayload verifies that Value rejects a well-formed
+// strkey whose payload is neither 32 bytes (account/contract) nor a muxed account,
+// rather than truncating it. (Contract C... and account G... still pass.)
+func TestAddressBytea_RejectsMalformedPayload(t *testing.T) {
+	// A 5-byte-payload strkey encoded under the account version byte: not a real key.
+	bogus, err := strkey.Encode(strkey.VersionByteAccountID, []byte{1, 2, 3, 4, 5})
+	require.NoError(t, err)
+
+	_, err = AddressBytea(bogus).Value()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "5-byte")
+
+	// Control: a normal contract address still encodes fine.
+	_, err = AddressBytea("CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA").Value()
+	require.NoError(t, err)
 }

--- a/internal/services/sep41/events.go
+++ b/internal/services/sep41/events.go
@@ -299,10 +299,26 @@ func extractAmountAndMuxedID(val xdr.ScVal) (*big.Int, *uint64, error) {
 }
 
 // extractAddressFromScVal decodes an address ScVal to its strkey-encoded form.
+//
+// A muxed address (SC_ADDRESS_TYPE_MUXED_ACCOUNT) is reduced to its base account: the
+// multiplexing id is off-chain routing metadata rather than account identity, so a
+// balance or allowance belongs to the underlying G-account. This mirrors the classic
+// ingestion path (MuxedAccount.ToAccountId()) and keeps every downstream key on the base
+// account. When a token carries a muxed id it travels separately in the event's
+// to_muxed_id data field (see extractAmountAndMuxedID), which is where it is surfaced for
+// history.
 func extractAddressFromScVal(val xdr.ScVal) (string, error) {
 	addr, ok := val.GetAddress()
 	if !ok {
 		return "", fmt.Errorf("invalid address")
+	}
+	if addr.Type == xdr.ScAddressTypeScAddressTypeMuxedAccount {
+		muxed := addr.MustMuxedAccount()
+		s, err := strkey.Encode(strkey.VersionByteAccountID, muxed.Ed25519[:])
+		if err != nil {
+			return "", fmt.Errorf("encoding muxed account base address: %w", err)
+		}
+		return s, nil
 	}
 	s, err := addr.String()
 	if err != nil {

--- a/internal/services/sep41/events_test.go
+++ b/internal/services/sep41/events_test.go
@@ -294,3 +294,45 @@ func TestContractIDString(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, want, got)
 }
+
+// mustMuxedAddressScVal builds an ScVal holding a muxed ScAddress over baseG with the
+// given sub-id, as it appears in a transfer to/from topic.
+func mustMuxedAddressScVal(t *testing.T, baseG string, id uint64) xdr.ScVal {
+	t.Helper()
+	var ed xdr.Uint256
+	copy(ed[:], strkey.MustDecode(strkey.VersionByteAccountID, baseG))
+	scAddr := xdr.ScAddress{
+		Type:         xdr.ScAddressTypeScAddressTypeMuxedAccount,
+		MuxedAccount: &xdr.MuxedEd25519Account{Id: xdr.Uint64(id), Ed25519: ed},
+	}
+	return xdr.ScVal{Type: xdr.ScValTypeScvAddress, Address: &scAddr}
+}
+
+// TestParseTransferEvent_MuxedTopicNormalizedToBase verifies that a muxed address in a
+// transfer topic is decoded to its base account rather than its full M-strkey.
+func TestParseTransferEvent_MuxedTopicNormalizedToBase(t *testing.T) {
+	base := testAccountA
+	muxed := muxedStrkey(t, base, 9)
+	require.Equal(t, byte('M'), muxed[0])
+
+	event := contractEvent(
+		[]xdr.ScVal{symScVal(EventTransfer), mustAddressScVal(t, testAccountB), mustMuxedAddressScVal(t, base, 9)},
+		i128ScVal(500),
+	)
+
+	got, err := ParseTransferEvent(event)
+	require.NoError(t, err)
+	assert.Equal(t, base, got.To, "muxed `to` topic must decode to its base account")
+	assert.NotEqual(t, muxed, got.To, "the full M-strkey must not survive into the key")
+}
+
+// muxedStrkey returns the M... strkey for a muxed account over baseG with the given sub-id.
+func muxedStrkey(t *testing.T, baseG string, id uint64) string {
+	t.Helper()
+	var ed xdr.Uint256
+	copy(ed[:], strkey.MustDecode(strkey.VersionByteAccountID, baseG))
+	m := xdr.MuxedAccount{Type: xdr.CryptoKeyTypeKeyTypeMuxedEd25519, Med25519: &xdr.MuxedAccountMed25519{Id: xdr.Uint64(id), Ed25519: ed}}
+	addr, err := m.GetAddress()
+	require.NoError(t, err)
+	return addr
+}

--- a/internal/services/sep41/processor_test.go
+++ b/internal/services/sep41/processor_test.go
@@ -421,3 +421,35 @@ func buildEventForContract(t *testing.T, contractAddr string, topics []xdr.ScVal
 		},
 	}
 }
+
+// TestProcessor_MuxedTransfersOverSameBaseDoNotCollide verifies that two transfers
+// crediting two different muxed addresses over the same base account stage a single
+// balance key (the base account) holding the summed amount.
+func TestProcessor_MuxedTransfersOverSameBaseDoNotCollide(t *testing.T) {
+	p := newTestProcessor()
+	p.Reset()
+
+	contractID := "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA"
+	p.sep41Contracts[contractID] = struct{}{}
+
+	base := testAccountA // both muxed destinations share this base account
+
+	// Two transfers: to = muxed(base, 1) and to = muxed(base, 2).
+	ev1 := buildEventForContract(t, contractID, []xdr.ScVal{
+		symScVal(EventTransfer), mustAddressScVal(t, testAccountB), mustMuxedAddressScVal(t, base, 1),
+	}, i128ScVal(1000))
+	ev2 := buildEventForContract(t, contractID, []xdr.ScVal{
+		symScVal(EventTransfer), mustAddressScVal(t, testAccountB), mustMuxedAddressScVal(t, base, 2),
+	}, i128ScVal(2000))
+
+	require.NoError(t, p.processEvent(ev1, newTestOpBuilder(), services.StagingModeCurrentState))
+	require.NoError(t, p.processEvent(ev2, newTestOpBuilder(), services.StagingModeCurrentState))
+
+	// The base account must be a single staged key holding 1000+2000 credit.
+	credit := p.stagedBalanceDelta[balanceKey{Account: types.AddressBytea(base), ContractID: contractID}]
+	require.NotNil(t, credit, "both muxed credits must fold into the base-account key")
+	assert.Equal(t, big.NewInt(3000), credit)
+
+	// Exactly two keys total: the shared base-account credit and testAccountB's debit.
+	assert.Len(t, p.stagedBalanceDelta, 2, "no per-id fragmentation of the base account")
+}


### PR DESCRIPTION
### What

Normalize muxed addresses to their base account, mirroring what the classic ingestion path already does via `MuxedAccount.ToAccountId()`

### Why

`AddressBytea` stores addresses as a fixed 33-byte key (1 version byte + 32-byte key). A muxed address (`M...`) instead carries a 40-byte payload, so the 8-byte multiplexing id was silently dropped on write. 

Because the SEP-41 event decoder kept the full `M...` strkey as the balance/allowance key, two muxed addresses over the same base account became two distinct in-memory keys that encoded to the **same** database key. When both landed in one batch, the `INSERT … ON CONFLICT` upsert hit a primary-key collision.

### Known limitations

The classic/SAC ingestion path (`token_transfer.go`) receives the muxed memo from the SDK (`EventMeta.ToMuxedInfo`) but doesn't persist it, so `to_muxed_id` is never populated for SAC transfers (unlike the SEP-41 path). Balances are unaffected; only per-deposit attribution metadata is missing. Worth a separate change.

### Issue that this PR addresses

https://hackerone.com/reports/3953551

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [ ] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [ ] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
