### PR TITLE
sep41: fold contract events in apply order so approves are deterministic

### DIFF
--- a/internal/services/sep41/processor.go
+++ b/internal/services/sep41/processor.go
@@ -1,10 +1,12 @@
 package sep41
 
 import (
+	"cmp"
 	"context"
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"slices"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/stellar/go-stellar-sdk/strkey"
@@ -14,6 +16,7 @@ import (
 
 	"github.com/stellar/wallet-backend/internal/data"
 	sep41data "github.com/stellar/wallet-backend/internal/data/sep41"
+	"github.com/stellar/wallet-backend/internal/indexer"
 	"github.com/stellar/wallet-backend/internal/indexer/processors"
 	"github.com/stellar/wallet-backend/internal/indexer/types"
 	"github.com/stellar/wallet-backend/internal/services"
@@ -116,7 +119,8 @@ func (p *processor) ProcessLedger(_ context.Context, input services.ProtocolProc
 		return nil
 	}
 
-	for key, events := range input.ContractEvents {
+	for _, key := range sortedEventKeys(input.ContractEvents) {
+		events := input.ContractEvents[key]
 		// tx.ID() in stellar/go is toid.New(ledgerSeq, txIdx, 0); recompute it
 		// here so PersistHistory's state-change rows carry the same txID a full
 		// tx walk would have produced.
@@ -136,6 +140,37 @@ func (p *processor) ProcessLedger(_ context.Context, input services.ProtocolProc
 	}
 
 	return nil
+}
+
+// sortedEventKeys returns the contract-event keys in canonical apply order —
+// ascending (TxIdx, OpIdx), which is the order Stellar Core executed them in.
+//
+// Iterating the map directly would visit keys in Go's randomized order. Balance
+// deltas are commutative and so are unaffected, but approve() is a last-write-wins
+// *replacement*: when two approves for the same (owner, spender, contract) land in
+// one ledger — e.g. a grant at TxIdx=1 followed by a revoke at TxIdx=2 — random
+// order lets the superseded grant overwrite the revoke, leaving the allowance row
+// disagreeing with the chain until the row expires or is next touched. Folding in
+// apply order makes the surviving value the chronologically last one, and makes
+// re-ingesting a ledger reproduce the same result.
+//
+// OpIdx is always 0 today — events are keyed only for InvokeHostFunction operations and
+// Soroban transactions carry exactly one operation — so TxIdx alone would order the keys
+// we actually see. It stays in the comparison to keep it a total order over the key type:
+// slices.SortFunc is not stable, so any two keys comparing equal would sort in unspecified
+// order, reintroducing exactly this bug.
+func sortedEventKeys(events map[indexer.ContractEventKey][]xdr.ContractEvent) []indexer.ContractEventKey {
+	keys := make([]indexer.ContractEventKey, 0, len(events))
+	for key := range events {
+		keys = append(keys, key)
+	}
+	slices.SortFunc(keys, func(a, b indexer.ContractEventKey) int {
+		return cmp.Or(
+			cmp.Compare(a.TxIdx, b.TxIdx),
+			cmp.Compare(a.OpIdx, b.OpIdx),
+		)
+	})
+	return keys
 }
 
 func (p *processor) processEvent(event xdr.ContractEvent, opBuilder *processors.StateChangeBuilder, mode services.StagingMode) error {

--- a/internal/services/sep41/processor_test.go
+++ b/internal/services/sep41/processor_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stellar/wallet-backend/internal/data"
 	sep41data "github.com/stellar/wallet-backend/internal/data/sep41"
+	"github.com/stellar/wallet-backend/internal/indexer"
 	"github.com/stellar/wallet-backend/internal/indexer/processors"
 	"github.com/stellar/wallet-backend/internal/indexer/types"
 	"github.com/stellar/wallet-backend/internal/services"
@@ -401,6 +402,78 @@ func TestProcessor_StampsPerRowLastModifiedLedgerAcrossWindow(t *testing.T) {
 		"B was last touched at ledger 100, not the window end 199")
 	assert.Equal(t, uint32(100), p.stagedAllowances[allowanceKey{Owner: testAccountA, Spender: testAccountB, ContractID: contractID}].LedgerNumber,
 		"the allowance was last modified at ledger 100, not the window end 199")
+}
+
+func TestProcessor_SameLedgerApprovesFoldInApplyOrder(t *testing.T) {
+	// Regression test: ProcessLedger must fold contract events in canonical apply order
+	// (ascending TxIdx, OpIdx), not Go's randomized map order. approve() is a last-write-wins
+	// replacement, so when a grant and a revoke for the same (owner, spender, contract) land
+	// in the same ledger, map order let the superseded grant win at random — leaving the
+	// allowance row disagreeing with the chain. The surviving value must always be the
+	// chronologically last approve, on every run.
+	contractID := "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA"
+	// Hex of the strkey above; indexContracts decodes it and re-encodes to the same address.
+	contractHex := types.HashBytea("25b4fcd859aec2fa6348438c489b3c3c10c98b6d21be4fd3cb30cb68953ef977")
+
+	newApprove := func(amount int64, liveUntil uint32) xdr.ContractEvent {
+		return buildEventForContract(t, contractID, []xdr.ScVal{
+			symScVal(EventApprove),
+			mustAddressScVal(t, testAccountA),
+			mustAddressScVal(t, testAccountB),
+		}, vecScVal(i128ScVal(amount), u32ScVal(liveUntil)))
+	}
+
+	input := services.ProtocolProcessorInput{
+		LedgerSequence: 42,
+		ContractEvents: map[indexer.ContractEventKey][]xdr.ContractEvent{
+			// Grant 1000 at TxIdx=1, then revoke to 0 at TxIdx=2. On-chain, the revoke wins.
+			{TxIdx: 1, OpIdx: 0}: {newApprove(1000, 9000)},
+			{TxIdx: 2, OpIdx: 0}: {newApprove(0, 0)},
+		},
+		ProtocolContracts: []data.ProtocolContracts{{ContractID: contractHex}},
+		StagingMode:       services.StagingModeCurrentState,
+	}
+	key := allowanceKey{Owner: testAccountA, Spender: testAccountB, ContractID: contractID}
+
+	// Go randomizes map iteration per range, so a single pass can pass by luck. Repeat
+	// enough that an unordered fold would almost surely surface the superseded grant.
+	for i := range 200 {
+		p := newTestProcessor()
+		p.Reset()
+		require.NoError(t, p.ProcessLedger(context.Background(), input))
+
+		staged, ok := p.stagedAllowances[key]
+		require.True(t, ok, "iteration %d: expected a staged allowance", i)
+		assert.Equal(t, "0", staged.Amount.String(),
+			"iteration %d: the revoke at TxIdx=2 is chronologically last and must win", i)
+		assert.Equal(t, uint32(0), staged.ExpirationLedger,
+			"iteration %d: the revoke's live_until_ledger must win too", i)
+	}
+}
+
+func TestSortedEventKeys_OrdersByTxThenOp(t *testing.T) {
+	// Unit test of the comparator itself, not a reachable ledger shape: contract events are
+	// only keyed for InvokeHostFunction operations, and Soroban transactions carry exactly one
+	// operation, so OpIdx is always 0 in practice. The tiebreak exists so the comparator is a
+	// total order over the key type — slices.SortFunc is not stable, so keys comparing equal
+	// would land in unspecified order, which is the bug class this fix is closing.
+	events := map[indexer.ContractEventKey][]xdr.ContractEvent{
+		{TxIdx: 2, OpIdx: 1}:  nil,
+		{TxIdx: 1, OpIdx: 3}:  nil,
+		{TxIdx: 2, OpIdx: 0}:  nil,
+		{TxIdx: 1, OpIdx: 0}:  nil,
+		{TxIdx: 10, OpIdx: 0}: nil,
+	}
+	assert.Equal(t, []indexer.ContractEventKey{
+		{TxIdx: 1, OpIdx: 0},
+		{TxIdx: 1, OpIdx: 3},
+		{TxIdx: 2, OpIdx: 0},
+		{TxIdx: 2, OpIdx: 1},
+		{TxIdx: 10, OpIdx: 0},
+	}, sortedEventKeys(events))
+
+	assert.Empty(t, sortedEventKeys(map[indexer.ContractEventKey][]xdr.ContractEvent{}))
+	assert.Empty(t, sortedEventKeys(nil))
 }
 
 // ---- helpers ----


### PR DESCRIPTION
### What

`ProcessLedger` sorts contract-event keys by `(TxIdx, OpIdx)` before folding, instead of ranging over `input.ContractEvents` directly.

### Why

See stellar/wallet-eng-monorepo#65.

### Known limitations

Existing rows are not backfilled. See the issue above.

### Issue that this PR addresses

resolves https://github.com/stellar/wallet-eng-monorepo/issues/65

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one). — N/A, no query changes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production. — N/A, a correctness fix on an existing path.
