### PR TITLE
Stream bulk COPYs on sibling connections and coalesce persist backlogs

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -69,6 +69,14 @@ func (c *ingestCmd) Command() *cobra.Command {
 			Required:    false,
 		},
 		{
+			Name:        "live-persist-max-batch-size",
+			Usage:       "Maximum consecutive ledgers coalesced into one persist commit when live ingestion falls behind. 1 persists every ledger in its own commit; larger values amortize inserts across a backlog at the cost of coarser crash recovery and visibility latency under load.",
+			OptType:     types.Int,
+			ConfigKey:   &cfg.LivePersistMaxBatchSize,
+			FlagDefault: 5,
+			Required:    false,
+		},
+		{
 			Name:        "archive-url",
 			Usage:       "Archive URL for history archives",
 			OptType:     types.String,

--- a/internal/data/ingest_store.go
+++ b/internal/data/ingest_store.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stellar/go-stellar-sdk/support/log"
+	"github.com/stellar/go-stellar-sdk/toid"
 
 	"github.com/stellar/wallet-backend/internal/db"
 	"github.com/stellar/wallet-backend/internal/metrics"
@@ -264,4 +266,48 @@ func (m *IngestStoreModel) GetOldestLedger(ctx context.Context) (uint32, error) 
 	}
 	m.Metrics.QueriesTotal.WithLabelValues("GetOldestLedger", "transactions").Inc()
 	return oldest, nil
+}
+
+// DeleteRowsAboveLedger removes every row belonging to a ledger past the given
+// one from the five bulk-COPY tables, in one transaction. It is live
+// ingestion's startup reconciliation: sibling COPY transactions commit before
+// the coordinating transaction that carries the cursor, so a crash between
+// those commits leaves orphaned bulk rows for (at most) the single ledger past
+// the committed cursor — and they must be cleared before that ledger is
+// re-ingested, because COPY has no ON CONFLICT and would collide on the
+// primary keys. Rows of ledgers > ledger are exactly rows whose TOID column is
+// >= the first TOID of ledger+1; each table has chunk skipping on its TOID
+// column, so the deletes stay bounded to the newest chunks.
+func (m *IngestStoreModel) DeleteRowsAboveLedger(ctx context.Context, ledger uint32) error {
+	minTOID := toid.New(int32(ledger+1), 0, 0).ToInt64()
+	targets := []struct {
+		table  string
+		column string
+	}{
+		{"transactions", "to_id"},
+		{"transactions_accounts", "tx_to_id"},
+		{"operations", "id"},
+		{"operations_accounts", "operation_id"},
+		{"state_changes", "to_id"},
+	}
+	err := db.RunInTransaction(ctx, m.DB, func(dbTx pgx.Tx) error {
+		for _, target := range targets {
+			start := time.Now()
+			tag, execErr := dbTx.Exec(ctx, fmt.Sprintf(`DELETE FROM %s WHERE %s >= $1`, target.table, target.column), minTOID)
+			m.Metrics.QueryDuration.WithLabelValues("DeleteRowsAboveLedger", target.table).Observe(time.Since(start).Seconds())
+			m.Metrics.QueriesTotal.WithLabelValues("DeleteRowsAboveLedger", target.table).Inc()
+			if execErr != nil {
+				m.Metrics.QueryErrors.WithLabelValues("DeleteRowsAboveLedger", target.table, utils.GetDBErrorType(execErr)).Inc()
+				return fmt.Errorf("deleting %s rows above ledger %d: %w", target.table, ledger, execErr)
+			}
+			if tag.RowsAffected() > 0 {
+				log.Ctx(ctx).Infof("startup reconciliation: deleted %d orphaned %s row(s) above cursor ledger %d", tag.RowsAffected(), target.table, ledger)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("reconciling rows above ledger %d: %w", ledger, err)
+	}
+	return nil
 }

--- a/internal/data/ingest_store_test.go
+++ b/internal/data/ingest_store_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go-stellar-sdk/toid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -697,5 +698,88 @@ func Test_IngestStoreModel_GetOldestLedger(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedLedger, oldest)
 		})
+	}
+}
+
+// Test_IngestStoreModel_DeleteRowsAboveLedger seeds two consecutive ledgers across all five
+// bulk-COPY tables and verifies the startup reconciliation removes exactly the rows above the
+// cursor ledger — the shape a crash between persistLedgerData's sibling commits and its
+// coordinating commit leaves behind — and is a no-op when run again.
+func Test_IngestStoreModel_DeleteRowsAboveLedger(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	ctx := context.Background()
+	dbConnectionPool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	m := &IngestStoreModel{
+		DB:      dbConnectionPool,
+		Metrics: metrics.NewMetrics(prometheus.NewRegistry()).DB,
+	}
+
+	const cursorLedger = uint32(100)
+	seedLedger := func(t *testing.T, ledger uint32, closedAt string) {
+		txTOID := toid.New(int32(ledger), 1, 0).ToInt64()
+		opTOID := toid.New(int32(ledger), 1, 1).ToInt64()
+		_, seedErr := dbConnectionPool.Exec(ctx,
+			`INSERT INTO transactions (hash, to_id, fee_charged, result_code, ledger_number, ledger_created_at)
+			 VALUES ($1, $2, 100, 'TransactionResultCodeTxSuccess', $3, $4::timestamptz)`,
+			fmt.Appendf(nil, "hash-%d", ledger), txTOID, ledger, closedAt)
+		require.NoError(t, seedErr)
+		_, seedErr = dbConnectionPool.Exec(ctx,
+			`INSERT INTO transactions_accounts (ledger_created_at, tx_to_id, account_id)
+			 VALUES ($1::timestamptz, $2, $3)`, closedAt, txTOID, []byte{1})
+		require.NoError(t, seedErr)
+		_, seedErr = dbConnectionPool.Exec(ctx,
+			`INSERT INTO operations (id, operation_type, operation_xdr, result_code, successful, ledger_number, ledger_created_at)
+			 VALUES ($1, 'PAYMENT', $2, 'op_success', true, $3, $4::timestamptz)`,
+			opTOID, []byte{0}, ledger, closedAt)
+		require.NoError(t, seedErr)
+		_, seedErr = dbConnectionPool.Exec(ctx,
+			`INSERT INTO operations_accounts (ledger_created_at, operation_id, account_id)
+			 VALUES ($1::timestamptz, $2, $3)`, closedAt, opTOID, []byte{1})
+		require.NoError(t, seedErr)
+		_, seedErr = dbConnectionPool.Exec(ctx,
+			`INSERT INTO state_changes (to_id, operation_id, state_change_id, state_change_category, state_change_reason, ledger_number, account_id, ledger_created_at)
+			 VALUES ($1, $2, 1, 'BALANCE', 'CREDIT', $3, $4, $5::timestamptz)`,
+			txTOID, opTOID, ledger, []byte{1}, closedAt)
+		require.NoError(t, seedErr)
+	}
+	seedLedger(t, cursorLedger, "2026-01-01T00:00:00Z")
+	seedLedger(t, cursorLedger+1, "2026-01-01T00:00:05Z")
+
+	countRows := func(t *testing.T) map[string][2]int {
+		counts := make(map[string][2]int)
+		for table, column := range map[string]string{
+			"transactions":          "to_id",
+			"transactions_accounts": "tx_to_id",
+			"operations":            "id",
+			"operations_accounts":   "operation_id",
+			"state_changes":         "to_id",
+		} {
+			var atCursor, aboveCursor int
+			boundary := toid.New(int32(cursorLedger+1), 0, 0).ToInt64()
+			require.NoError(t, dbConnectionPool.QueryRow(ctx,
+				fmt.Sprintf(`SELECT count(*) FILTER (WHERE %[1]s < $1), count(*) FILTER (WHERE %[1]s >= $1) FROM %[2]s`, column, table),
+				boundary).Scan(&atCursor, &aboveCursor))
+			counts[table] = [2]int{atCursor, aboveCursor}
+		}
+		return counts
+	}
+
+	for table, c := range countRows(t) {
+		require.Equal(t, [2]int{1, 1}, c, "seed should place one row per ledger in %s", table)
+	}
+
+	require.NoError(t, m.DeleteRowsAboveLedger(ctx, cursorLedger))
+	for table, c := range countRows(t) {
+		assert.Equal(t, [2]int{1, 0}, c, "%s must keep the cursor ledger's row and lose the orphan", table)
+	}
+
+	// Idempotent: nothing above the cursor remains, so a second run changes nothing.
+	require.NoError(t, m.DeleteRowsAboveLedger(ctx, cursorLedger))
+	for table, c := range countRows(t) {
+		assert.Equal(t, [2]int{1, 0}, c, "%s must be unchanged by a reconciliation no-op", table)
 	}
 }

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -75,6 +75,10 @@ type Configs struct {
 	// BackfillDBInsertBatchSize is the number of ledgers to process before flushing to DB.
 	// Defaults to 50. Lower values reduce RAM usage at cost of more DB transactions.
 	BackfillDBInsertBatchSize int
+	// LivePersistMaxBatchSize caps how many consecutive ledgers live
+	// ingestion coalesces into one persist commit when persist falls behind.
+	// 1 persists every ledger in its own commit.
+	LivePersistMaxBatchSize int
 	// ChunkInterval sets the TimescaleDB chunk time interval for hypertables.
 	// Only affects future chunks. Uses PostgreSQL INTERVAL syntax (e.g., "1 day", "7 days").
 	ChunkInterval string
@@ -323,6 +327,7 @@ func setupDeps(ctx context.Context, cfg Configs) (services.IngestService, func()
 		BackfillWorkers:           cfg.BackfillWorkers,
 		BackfillBatchSize:         cfg.BackfillBatchSize,
 		BackfillDBInsertBatchSize: cfg.BackfillDBInsertBatchSize,
+		LivePersistMaxBatchSize:   cfg.LivePersistMaxBatchSize,
 		ProtocolProcessors:        protocolProcessors,
 		ProtocolValidators:        protocolValidators,
 		WasmSpecExtractor:         wasmExtractor,

--- a/internal/metrics/ingestion.go
+++ b/internal/metrics/ingestion.go
@@ -22,6 +22,11 @@ type IngestionMetrics struct {
 	// LedgersProcessed counts total ledgers ingested.
 	// PromQL: rate(wallet_ingestion_ledgers_total[5m])
 	LedgersProcessed prometheus.Counter
+	// PersistBatchSize observes how many ledgers each persist commit coalesced.
+	// Sits at 1 while the pipeline keeps pace; larger values mean the persist
+	// stage found a backlog and amortized it into one commit.
+	// PromQL: histogram_quantile(0.5, rate(wallet_ingestion_persist_batch_size_bucket[5m]))
+	PersistBatchSize prometheus.Histogram
 	// TransactionsTotal counts total transactions ingested.
 	// PromQL: rate(wallet_ingestion_transactions_total[5m])
 	TransactionsTotal prometheus.Counter
@@ -105,6 +110,11 @@ func newIngestionMetrics(reg prometheus.Registerer) *IngestionMetrics {
 			Name: "wallet_ingestion_ledgers_total",
 			Help: "Total number of ledgers processed during ingestion.",
 		}),
+		PersistBatchSize: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "wallet_ingestion_persist_batch_size",
+			Help:    "Ledgers coalesced into one persist commit. 1 while the pipeline keeps pace; larger under backlog.",
+			Buckets: []float64{1, 2, 3, 4, 5, 8, 12, 16},
+		}),
 		TransactionsTotal: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "wallet_ingestion_transactions_total",
 			Help: "Total number of transactions processed during ingestion.",
@@ -168,6 +178,7 @@ func newIngestionMetrics(reg prometheus.Registerer) *IngestionMetrics {
 		m.Duration,
 		m.PhaseDuration,
 		m.LedgersProcessed,
+		m.PersistBatchSize,
 		m.TransactionsTotal,
 		m.OperationsTotal,
 		m.ParticipantsCount,

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -136,9 +136,16 @@ type ingestService struct {
 	backfillBatchSize         uint32
 	backfillDBInsertBatchSize uint32
 	livePersistMaxBatchSize   int
-	protocolProcessors        map[string]ProtocolProcessor
-	protocolValidators        []ProtocolValidator
-	wasmSpecExtractor         WasmSpecExtractor
+	// classifiedWasms / classifiedContracts are the persist batch cut's
+	// seen-sets: classification inputs already applied by a COMMITTED batch
+	// this process. Owned exclusively by the persist goroutine
+	// (persistProcessedLedgers) — no synchronization. See
+	// hasUnclassifiedInputs in ingest_live.go.
+	classifiedWasms     map[string]struct{}
+	classifiedContracts map[string]struct{}
+	protocolProcessors  map[string]ProtocolProcessor
+	protocolValidators  []ProtocolValidator
+	wasmSpecExtractor   WasmSpecExtractor
 	// protocolCursors tracks, per protocol, whether its history/current-state
 	// ingest_store cursor rows exist. See casProtocolCursor and
 	// snapshotProtocolCursors in ingest_live.go. Always non-nil; empty maps
@@ -209,6 +216,8 @@ func NewIngestService(cfg IngestServiceConfig) (*ingestService, error) {
 		backfillBatchSize:         uint32(cfg.BackfillBatchSize),
 		backfillDBInsertBatchSize: uint32(cfg.BackfillDBInsertBatchSize),
 		livePersistMaxBatchSize:   livePersistMaxBatchSize,
+		classifiedWasms:           make(map[string]struct{}),
+		classifiedContracts:       make(map[string]struct{}),
 		protocolProcessors:        ppMap,
 		protocolCursors: &protocolCursorSnapshot{
 			historyExists:      make(map[string]bool, len(ppMap)),

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -95,6 +95,7 @@ type IngestServiceConfig struct {
 	BackfillWorkers           int
 	BackfillBatchSize         int
 	BackfillDBInsertBatchSize int
+	LivePersistMaxBatchSize   int
 }
 
 // generateAdvisoryLockID creates a deterministic advisory lock ID based on the network name.
@@ -134,6 +135,7 @@ type ingestService struct {
 	backfillPool              pond.Pool
 	backfillBatchSize         uint32
 	backfillDBInsertBatchSize uint32
+	livePersistMaxBatchSize   int
 	protocolProcessors        map[string]ProtocolProcessor
 	protocolValidators        []ProtocolValidator
 	wasmSpecExtractor         WasmSpecExtractor
@@ -160,6 +162,10 @@ func NewIngestService(cfg IngestServiceConfig) (*ingestService, error) {
 	if backfillWorkers <= 0 {
 		backfillWorkers = runtime.NumCPU()
 	}
+
+	// A batch cap below 1 cannot hold even a single ledger; clamp so the
+	// zero value means unbatched persists.
+	livePersistMaxBatchSize := max(1, cfg.LivePersistMaxBatchSize)
 	backfillPool := pond.NewPool(backfillWorkers)
 	cfg.Metrics.RegisterPoolMetrics("backfill", backfillPool)
 
@@ -202,6 +208,7 @@ func NewIngestService(cfg IngestServiceConfig) (*ingestService, error) {
 		backfillPool:              backfillPool,
 		backfillBatchSize:         uint32(cfg.BackfillBatchSize),
 		backfillDBInsertBatchSize: uint32(cfg.BackfillDBInsertBatchSize),
+		livePersistMaxBatchSize:   livePersistMaxBatchSize,
 		protocolProcessors:        ppMap,
 		protocolCursors: &protocolCursorSnapshot{
 			historyExists:      make(map[string]bool, len(ppMap)),

--- a/internal/services/ingest_live.go
+++ b/internal/services/ingest_live.go
@@ -780,23 +780,60 @@ func (m *ingestService) processFetchedLedgers(ctx context.Context, fetched <-cha
 	}
 }
 
-// hasClassificationInputs reports whether the ledger staged anything the
-// classification plan would act on. A ledger for which this is false gets a
-// nil plan from prepareClassificationPlan, so it can ride behind other
-// ledgers in a persist batch.
-func hasClassificationInputs(buffer *indexer.IndexerBuffer) bool {
-	return len(buffer.GetProtocolWasms()) > 0 ||
-		len(buffer.GetProtocolWasmBytecodes()) > 0 ||
-		len(buffer.GetProtocolContracts()) > 0
+// hasUnclassifiedInputs reports whether the ledger staged classification
+// inputs this process has not yet seen COMMIT. Only such a ledger needs to
+// open its own persist batch: the classification plan's pool reads are sound
+// for anything a committed batch already classified, and re-observations of
+// known wasms/contracts are the overwhelmingly common case — synthetic
+// loadtest traffic re-observes the same token contracts every single ledger,
+// which would otherwise cut every batch to size one and disable batching
+// entirely.
+func (m *ingestService) hasUnclassifiedInputs(buffer *indexer.IndexerBuffer) bool {
+	for hash := range buffer.GetProtocolWasms() {
+		if _, seen := m.classifiedWasms[hash]; !seen {
+			return true
+		}
+	}
+	for hash := range buffer.GetProtocolWasmBytecodes() {
+		if _, seen := m.classifiedWasms[hash]; !seen {
+			return true
+		}
+	}
+	for contractID := range buffer.GetProtocolContracts() {
+		if _, seen := m.classifiedContracts[contractID]; !seen {
+			return true
+		}
+	}
+	return false
+}
+
+// markClassificationInputsSeen folds a successfully COMMITTED batch's
+// classification inputs into the seen-sets consulted by the batch cut. Only
+// committed inputs count: a rolled-back batch must keep cutting until its
+// classification actually lands. The sets are owned by the persist goroutine
+// and start empty each process — a restart just cuts conservatively until
+// re-warmed.
+func (m *ingestService) markClassificationInputsSeen(batch []processedLedger) {
+	for _, pl := range batch {
+		for hash := range pl.buffer.GetProtocolWasms() {
+			m.classifiedWasms[hash] = struct{}{}
+		}
+		for hash := range pl.buffer.GetProtocolWasmBytecodes() {
+			m.classifiedWasms[hash] = struct{}{}
+		}
+		for contractID := range pl.buffer.GetProtocolContracts() {
+			m.classifiedContracts[contractID] = struct{}{}
+		}
+	}
 }
 
 // persistBatchCut returns how many leading pending ledgers form the next
 // persist batch: everything before the first non-head ledger carrying
-// classification inputs, which must instead open the following batch — its
-// plan's pool reads are only sound once this batch has committed.
-func persistBatchCut(pending []processedLedger) int {
+// UNSEEN classification inputs, which must instead open the following batch —
+// its plan's pool reads are only sound once this batch has committed.
+func (m *ingestService) persistBatchCut(pending []processedLedger) int {
 	for i := 1; i < len(pending); i++ {
-		if hasClassificationInputs(pending[i].buffer) {
+		if m.hasUnclassifiedInputs(pending[i].buffer) {
 			return i
 		}
 	}
@@ -844,7 +881,7 @@ func (m *ingestService) persistProcessedLedgers(ctx context.Context, processed <
 				break drain
 			}
 		}
-		cut := persistBatchCut(pending)
+		cut := m.persistBatchCut(pending)
 		batch := pending[:cut]
 
 		if probeErr := checkLockSession(ctx); probeErr != nil {
@@ -855,7 +892,10 @@ func (m *ingestService) persistProcessedLedgers(ctx context.Context, processed <
 		// Classification runs on this stage, not the process stage: its
 		// known-hash lookup is a non-transactional pool read of protocol_wasms
 		// whose correctness depends on the previous batch's persist having
-		// committed. Only the batch head can need a plan (the cut above), and
+		// committed. Only the batch head can need a plan: the cut opens a new
+		// batch for any ledger with unseen inputs, while a ledger whose inputs
+		// were all classified by an earlier committed batch rides mid-batch —
+		// its re-observations were already applied then, so it needs no plan.
 		// RPC prefetch still happens before any transaction opens; the plan is
 		// reused verbatim across every retry attempt below.
 		classifyStart := time.Now()
@@ -887,6 +927,7 @@ func (m *ingestService) persistProcessedLedgers(ctx context.Context, processed <
 		}
 		persistDuration := time.Since(dbStart)
 		m.appMetrics.Ingestion.PersistBatchSize.Observe(float64(len(batch)))
+		m.markClassificationInputsSeen(batch)
 
 		// Per-ledger phase observations record each ledger's amortized share
 		// of the batch, so the histograms keep per-ledger semantics and stay

--- a/internal/services/ingest_live.go
+++ b/internal/services/ingest_live.go
@@ -168,6 +168,16 @@ func (m *ingestService) persistLedgerData(ctx context.Context, items []persistIt
 				log.Ctx(ctx).Warnf("rolling back %s transaction for %s: %v", name, label, rbErr)
 			}
 		}(s.name, tx)
+		// Sibling commits skip the WAL-flush wait. Durability is untouched:
+		// the coordinating transaction commits synchronously and strictly
+		// last, and its flush covers all earlier WAL — including these
+		// commit records — so a durable cursor implies durable siblings. A
+		// crash inside the window can only lose rows the cursor never
+		// acknowledged, exactly what startup reconciliation
+		// (DeleteRowsAboveLedger) removes anyway.
+		if _, setErr := tx.Exec(ctx, "SET LOCAL synchronous_commit = off"); setErr != nil {
+			return fmt.Errorf("disabling synchronous commit on %s for %s: %w", s.name, label, setErr)
+		}
 	}
 
 	// Stream the COPY families and stage the coordinated writes concurrently.

--- a/internal/services/ingest_live.go
+++ b/internal/services/ingest_live.go
@@ -77,101 +77,127 @@ func (c *contractDataMemo) get() (map[string][]ingest.Change, error) {
 // orphaned rows above the committed cursor before ingestion resumes.
 var ErrPartialPersist = errors.New("ledger persist partially committed")
 
-// persistLedgerData persists one ledger. The three bulk COPY families —
-// transactions(+accounts), operations(+accounts), state_changes — stream
-// concurrently on sibling connections, each in its own transaction, while the
-// coordinating transaction stages everything else (assets, contracts,
-// classification, protocol state, token changes, cursor). All the slow work
-// happens uncommitted and invisible; only after every stream and the
-// coordinator succeed do the commits fire, siblings first and the
-// coordinating transaction strictly last. The cursor it carries is the
-// authority: the only crash state this ordering can produce is orphaned bulk
-// rows above the committed cursor, which DeleteRowsAboveLedger removes at
-// startup. A failure before the first commit rolls everything back and is
-// retryable as before; a failure after it wraps ErrPartialPersist and is
-// fatal.
+// persistItem is one ledger's persist payload: its classification plan
+// (computed by prepareClassificationPlan before any transaction opens, RPC
+// calls already resolved; nil when the ledger had nothing to classify) and
+// its ContractData extraction memo. Both are shared verbatim across
+// persistLedgerDataWithRetry's attempts, so a retry never re-issues RPC
+// calls or re-runs the extraction walk.
+type persistItem struct {
+	seq          uint32
+	meta         xdr.LedgerCloseMeta
+	plan         *ClassificationPlan
+	contractData *contractDataMemo
+	buffer       *indexer.IndexerBuffer
+}
+
+// batchLabel names a batch in errors and logs: "ledger N" for a single
+// ledger, "ledgers N-M" for a coalesced batch.
+func batchLabel(items []persistItem) string {
+	if len(items) == 1 {
+		return fmt.Sprintf("ledger %d", items[0].seq)
+	}
+	return fmt.Sprintf("ledgers %d-%d", items[0].seq, items[len(items)-1].seq)
+}
+
+// persistLedgerData persists a batch of consecutive ledgers in one commit
+// set. The three bulk COPY families — transactions(+accounts),
+// operations(+accounts), state_changes — stream concurrently on sibling
+// connections, each in its own transaction covering every ledger in the
+// batch, while the coordinating transaction stages everything else (assets,
+// contracts, classification, protocol state, token changes, cursor) ledger
+// by ledger in order — the per-protocol CAS chain advances N-1 → N inside
+// the transaction, and the guarded cursor's final value is the batch's last
+// ledger. All the slow work happens uncommitted and invisible; only after
+// every stream and the coordinator succeed do the commits fire, siblings
+// first and the coordinating transaction strictly last. The cursor it
+// carries is the authority: the only crash state this ordering can produce
+// is orphaned bulk rows above the committed cursor, which
+// DeleteRowsAboveLedger removes at startup. A failure before the first
+// commit rolls everything back and the whole batch is cleanly retryable; a
+// failure after it wraps ErrPartialPersist and is fatal.
 //
-// plan is this ledger's classification plan, computed by
-// prepareClassificationPlan before any transaction opens (RPC calls already
-// resolved); pass the same plan across persistLedgerDataWithRetry's retry
-// attempts so a retry never re-issues RPC calls. plan may be nil when there
-// was nothing to classify this ledger. contractData carries the ledger's
-// ContractData extraction memo; like plan, the same memo is shared across
-// retry attempts so a retry never re-runs the extraction walk.
-func (m *ingestService) persistLedgerData(
-	ctx context.Context,
-	ledgerSeq uint32,
-	ledgerMeta xdr.LedgerCloseMeta,
-	plan *ClassificationPlan,
-	contractData *contractDataMemo,
-	buffer *indexer.IndexerBuffer,
-) error {
+// Only the first ledger of a batch may carry a classification plan: a
+// plan's pool reads see exactly the state the previous batch committed (see
+// the batch cut in persistProcessedLedgers).
+func (m *ingestService) persistLedgerData(ctx context.Context, items []persistItem) error {
+	label := batchLabel(items)
+
 	// The sibling transactions and the coordinating transaction are all opened
 	// up front on this goroutine, so ownership at the commit barrier below is
 	// deterministic; the deferred rollbacks tolerate ErrTxClosed and so are
 	// no-ops for whatever committed.
 	coordTx, err := m.models.DB.Begin(ctx)
 	if err != nil {
-		return fmt.Errorf("beginning coordinating transaction for ledger %d: %w", ledgerSeq, err)
+		return fmt.Errorf("beginning coordinating transaction for %s: %w", label, err)
 	}
 	defer func() {
 		if rbErr := coordTx.Rollback(ctx); rbErr != nil && !errors.Is(rbErr, pgx.ErrTxClosed) {
-			log.Ctx(ctx).Warnf("rolling back coordinating transaction for ledger %d: %v", ledgerSeq, rbErr)
+			log.Ctx(ctx).Warnf("rolling back coordinating transaction for %s: %v", label, rbErr)
 		}
 	}()
 
 	siblings := []struct {
 		name string
-		run  func(ctx context.Context, dbTx pgx.Tx) error
+		run  func(ctx context.Context, dbTx pgx.Tx, it *persistItem) error
 	}{
-		{"transactions", func(ctx context.Context, dbTx pgx.Tx) error {
-			return m.insertTransactions(ctx, dbTx, buffer.GetTransactions(), buffer.GetTransactionsParticipants())
+		{"transactions", func(ctx context.Context, dbTx pgx.Tx, it *persistItem) error {
+			return m.insertTransactions(ctx, dbTx, it.buffer.GetTransactions(), it.buffer.GetTransactionsParticipants())
 		}},
-		{"operations", func(ctx context.Context, dbTx pgx.Tx) error {
-			return m.insertOperations(ctx, dbTx, buffer.GetOperations(), buffer.GetOperationsParticipants())
+		{"operations", func(ctx context.Context, dbTx pgx.Tx, it *persistItem) error {
+			return m.insertOperations(ctx, dbTx, it.buffer.GetOperations(), it.buffer.GetOperationsParticipants())
 		}},
-		{"state_changes", func(ctx context.Context, dbTx pgx.Tx) error {
-			return m.insertStateChanges(ctx, dbTx, buffer.GetStateChanges())
+		{"state_changes", func(ctx context.Context, dbTx pgx.Tx, it *persistItem) error {
+			return m.insertStateChanges(ctx, dbTx, it.buffer.GetStateChanges())
 		}},
 	}
 	siblingTxs := make([]pgx.Tx, len(siblings))
 	for i, s := range siblings {
 		conn, acquireErr := m.models.DB.Acquire(ctx)
 		if acquireErr != nil {
-			return fmt.Errorf("acquiring %s connection for ledger %d: %w", s.name, ledgerSeq, acquireErr)
+			return fmt.Errorf("acquiring %s connection for %s: %w", s.name, label, acquireErr)
 		}
 		defer conn.Release()
 		tx, beginErr := conn.Begin(ctx)
 		if beginErr != nil {
-			return fmt.Errorf("beginning %s transaction for ledger %d: %w", s.name, ledgerSeq, beginErr)
+			return fmt.Errorf("beginning %s transaction for %s: %w", s.name, label, beginErr)
 		}
 		siblingTxs[i] = tx
 		defer func(name string, tx pgx.Tx) {
 			if rbErr := tx.Rollback(ctx); rbErr != nil && !errors.Is(rbErr, pgx.ErrTxClosed) {
-				log.Ctx(ctx).Warnf("rolling back %s transaction for ledger %d: %v", name, ledgerSeq, rbErr)
+				log.Ctx(ctx).Warnf("rolling back %s transaction for %s: %v", name, label, rbErr)
 			}
 		}(s.name, tx)
 	}
 
 	// Stream the COPY families and stage the coordinated writes concurrently.
 	// The table sets are disjoint (no FKs among them), and the goroutines only
-	// read the quiescent buffer, so the four transactions never contend.
+	// read the quiescent buffers, so the four transactions never contend.
+	// Within each transaction the batch's ledgers run in order.
 	g, gctx := errgroup.WithContext(ctx)
 	for i, s := range siblings {
 		g.Go(func() error {
-			if runErr := s.run(gctx, siblingTxs[i]); runErr != nil {
-				return fmt.Errorf("streaming %s for ledger %d: %w", s.name, ledgerSeq, runErr)
+			for j := range items {
+				if runErr := s.run(gctx, siblingTxs[i], &items[j]); runErr != nil {
+					return fmt.Errorf("streaming %s for ledger %d: %w", s.name, items[j].seq, runErr)
+				}
 			}
 			return nil
 		})
 	}
 	g.Go(func() error {
-		return m.stageCoordinatedWrites(gctx, coordTx, ledgerSeq, ledgerMeta, plan, contractData, buffer)
+		for j := range items {
+			it := &items[j]
+			if stageErr := m.stageCoordinatedWrites(gctx, coordTx, it.seq, it.meta, it.plan, it.contractData, it.buffer); stageErr != nil {
+				return fmt.Errorf("staging coordinated writes for ledger %d: %w", it.seq, stageErr)
+			}
+		}
+		return nil
 	})
 	if err = g.Wait(); err != nil {
 		// Nothing has committed: the deferred rollbacks discard all four
-		// transactions and the ledger is cleanly retryable.
-		return fmt.Errorf("persisting ledger data for ledger %d: %w", ledgerSeq, err)
+		// transactions and the batch is cleanly retryable.
+		return fmt.Errorf("persisting ledger data for %s: %w", label, err)
 	}
 
 	// Commit barrier. A failed FIRST commit still leaves nothing durable
@@ -184,15 +210,15 @@ func (m *ingestService) persistLedgerData(
 	for i, s := range siblings {
 		if commitErr := siblingTxs[i].Commit(ctx); commitErr != nil {
 			if i > 0 {
-				return fmt.Errorf("committing %s for ledger %d: %w: %w", s.name, ledgerSeq, ErrPartialPersist, commitErr)
+				return fmt.Errorf("committing %s for %s: %w: %w", s.name, label, ErrPartialPersist, commitErr)
 			}
-			return fmt.Errorf("committing %s for ledger %d: %w", s.name, ledgerSeq, commitErr)
+			return fmt.Errorf("committing %s for %s: %w", s.name, label, commitErr)
 		}
 	}
 	// The coordinating transaction commits strictly last: it carries the
-	// cursor, so its commit is the point at which the ledger exists.
+	// cursor, so its commit is the point at which the batch's ledgers exist.
 	if commitErr := coordTx.Commit(ctx); commitErr != nil {
-		return fmt.Errorf("committing coordinating transaction for ledger %d: %w: %w", ledgerSeq, ErrPartialPersist, commitErr)
+		return fmt.Errorf("committing coordinating transaction for %s: %w: %w", label, ErrPartialPersist, commitErr)
 	}
 	return nil
 }
@@ -590,10 +616,12 @@ type processedLedger struct {
 }
 
 // ingestLiveLedgers runs live ingestion as a three-stage pipeline — fetch ‖
-// process ‖ persist — over consecutive ledgers, connected by depth-1
-// channels: while ledger N persists, N+1 processes and N+2 is fetched. The
-// ledger time is therefore the slowest stage, not the sum of stages. Persist
-// is strictly sequential in ledger order (the guarded cursor and the
+// process ‖ persist — over consecutive ledgers: while ledger N persists, N+1
+// processes and N+2 is fetched. The ledger time is therefore the slowest
+// stage, not the sum of stages. The processed channel's depth lets the
+// process stage run ahead when persist falls behind; the persist stage
+// coalesces that backlog into batched commits (see persistProcessedLedgers).
+// Persist is strictly sequential in ledger order (the guarded cursor and the
 // per-protocol CAS chain both advance N-1 → N), and any stage error cancels
 // the whole pipeline and returns: the process exits and re-acquires the
 // advisory lock cleanly on restart, resuming from the cursor.
@@ -634,15 +662,24 @@ func (m *ingestService) ingestLiveLedgers(ctx context.Context, startLedger uint3
 
 	g, gctx := errgroup.WithContext(ctx)
 	fetched := make(chan fetchedLedger, 1)
-	processed := make(chan processedLedger, 1)
+	// NewIngestService clamps the batch cap to ≥1; the max here keeps the
+	// channel math valid for a zero-valued service constructed directly.
+	batchCap := max(1, m.livePersistMaxBatchSize)
+	// The processed channel is where a persist backlog queues, so its depth
+	// caps how large a persist batch can form: the batch cap minus the one
+	// ledger the persist stage blocks on.
+	processed := make(chan processedLedger, batchCap-1)
 
-	// Two buffers rotate between the process and persist stages: process fills
-	// one while persist drains the other, and reuse keeps the asset-parse memo
-	// warm and the maps' backing arrays allocated across ledgers. Capacity 2
-	// means handing a buffer back never blocks.
-	freeBuffers := make(chan *indexer.IndexerBuffer, 2)
-	freeBuffers <- indexer.NewIndexerBuffer()
-	freeBuffers <- indexer.NewIndexerBuffer()
+	// Buffers rotate between the process and persist stages: process fills
+	// one while persist drains the others, and reuse keeps the asset-parse
+	// memo warm and the maps' backing arrays allocated across ledgers. The
+	// rotation holds one more buffer than the persist batch cap — a full
+	// batch in flight still leaves one for process to fill — and the
+	// channel's capacity matches, so handing a buffer back never blocks.
+	freeBuffers := make(chan *indexer.IndexerBuffer, batchCap+1)
+	for range batchCap + 1 {
+		freeBuffers <- indexer.NewIndexerBuffer()
+	}
 
 	g.Go(func() error { return m.fetchLedgers(gctx, startLedger, fetched) })
 	g.Go(func() error { return m.processFetchedLedgers(gctx, fetched, freeBuffers, processed) })
@@ -733,22 +770,72 @@ func (m *ingestService) processFetchedLedgers(ctx context.Context, fetched <-cha
 	}
 }
 
-// persistProcessedLedgers is the pipeline's persist stage and the only stage
-// that writes to the database. It runs strictly sequentially in ledger order,
-// probes the advisory-lock session before each ledger, and returns each
-// buffer to the rotation once its ledger is fully persisted.
-func (m *ingestService) persistProcessedLedgers(ctx context.Context, processed <-chan processedLedger, freeBuffers chan<- *indexer.IndexerBuffer, checkLockSession func(ctx context.Context) error, latestIngested *atomic.Uint32) error {
-	for {
-		var pl processedLedger
-		select {
-		case p, ok := <-processed:
-			if !ok {
-				return nil
-			}
-			pl = p
-		case <-ctx.Done():
-			return fmt.Errorf("pipeline cancelled: %w", ctx.Err())
+// hasClassificationInputs reports whether the ledger staged anything the
+// classification plan would act on. A ledger for which this is false gets a
+// nil plan from prepareClassificationPlan, so it can ride behind other
+// ledgers in a persist batch.
+func hasClassificationInputs(buffer *indexer.IndexerBuffer) bool {
+	return len(buffer.GetProtocolWasms()) > 0 ||
+		len(buffer.GetProtocolWasmBytecodes()) > 0 ||
+		len(buffer.GetProtocolContracts()) > 0
+}
+
+// persistBatchCut returns how many leading pending ledgers form the next
+// persist batch: everything before the first non-head ledger carrying
+// classification inputs, which must instead open the following batch — its
+// plan's pool reads are only sound once this batch has committed.
+func persistBatchCut(pending []processedLedger) int {
+	for i := 1; i < len(pending); i++ {
+		if hasClassificationInputs(pending[i].buffer) {
+			return i
 		}
+	}
+	return len(pending)
+}
+
+// persistProcessedLedgers is the pipeline's persist stage and the only stage
+// that writes to the database. It runs strictly sequentially in ledger
+// order. When the process stage has finished ledgers faster than persist
+// drains them, up to livePersistMaxBatchSize consecutive ledgers coalesce
+// into one persist commit, amortizing the COPY streams and the commit
+// barrier across the backlog; while the pipeline keeps pace every batch has
+// size 1 and behavior is exactly the unbatched persist. A ledger with
+// classification inputs always opens its own batch: its plan's pool reads
+// (prepareClassificationPlan) see exactly what the previous batch committed
+// — a contract deployed in ledger N+1 pointing at a wasm uploaded in N must
+// see N's row — so it can never ride behind N in the same commit. The
+// advisory-lock session is probed once per batch, and buffers return to the
+// rotation only after their batch is fully persisted.
+func (m *ingestService) persistProcessedLedgers(ctx context.Context, processed <-chan processedLedger, freeBuffers chan<- *indexer.IndexerBuffer, checkLockSession func(ctx context.Context) error, latestIngested *atomic.Uint32) error {
+	var pending []processedLedger
+	for {
+		if len(pending) == 0 {
+			select {
+			case p, ok := <-processed:
+				if !ok {
+					return nil
+				}
+				pending = append(pending, p)
+			case <-ctx.Done():
+				return fmt.Errorf("pipeline cancelled: %w", ctx.Err())
+			}
+		}
+		// Greedily take whatever the process stage has already finished, up
+		// to the batch cap — never wait for more.
+	drain:
+		for len(pending) < m.livePersistMaxBatchSize {
+			select {
+			case p, ok := <-processed:
+				if !ok {
+					break drain
+				}
+				pending = append(pending, p)
+			default:
+				break drain
+			}
+		}
+		cut := persistBatchCut(pending)
+		batch := pending[:cut]
 
 		if probeErr := checkLockSession(ctx); probeErr != nil {
 			m.appMetrics.Ingestion.ErrorsTotal.WithLabelValues("ingest_live").Inc()
@@ -757,53 +844,79 @@ func (m *ingestService) persistProcessedLedgers(ctx context.Context, processed <
 
 		// Classification runs on this stage, not the process stage: its
 		// known-hash lookup is a non-transactional pool read of protocol_wasms
-		// whose correctness depends on the previous ledger's persist having
-		// committed — a contract deployed in ledger N+1 pointing at a wasm
-		// uploaded in N must see N's row. RPC prefetch still happens before
-		// any transaction opens, and the plan is reused verbatim across every
-		// retry attempt below.
+		// whose correctness depends on the previous batch's persist having
+		// committed. Only the batch head can need a plan (the cut above), and
+		// RPC prefetch still happens before any transaction opens; the plan is
+		// reused verbatim across every retry attempt below.
 		classifyStart := time.Now()
-		plan, err := m.prepareClassificationPlan(ctx, pl.buffer.GetProtocolWasms(), pl.buffer.GetProtocolWasmBytecodes(), pl.buffer.GetProtocolContracts())
+		head := batch[0]
+		plan, err := m.prepareClassificationPlan(ctx, head.buffer.GetProtocolWasms(), head.buffer.GetProtocolWasmBytecodes(), head.buffer.GetProtocolContracts())
 		if err != nil {
 			m.appMetrics.Ingestion.ErrorsTotal.WithLabelValues("ingest_live").Inc()
-			return fmt.Errorf("preparing classification plan for ledger %d: %w", pl.seq, err)
+			return fmt.Errorf("preparing classification plan for ledger %d: %w", head.seq, err)
 		}
 		classifyDuration := time.Since(classifyStart)
 		m.appMetrics.Ingestion.PhaseDuration.WithLabelValues("prepare_classification").Observe(classifyDuration.Seconds())
 
-		// All DB operations in a single atomic transaction with retry
+		items := make([]persistItem, len(batch))
+		for i, pl := range batch {
+			items[i] = persistItem{
+				seq:          pl.seq,
+				meta:         pl.meta,
+				contractData: newContractDataMemo(pl.transactions, pl.seq),
+				buffer:       pl.buffer,
+			}
+		}
+		items[0].plan = plan
+
+		// All DB operations in a single atomic commit set with retry.
 		dbStart := time.Now()
-		if err := m.persistLedgerDataWithRetry(ctx, pl.seq, pl.meta, plan, pl.transactions, pl.buffer); err != nil {
+		if err := m.persistLedgerDataWithRetry(ctx, items); err != nil {
 			m.appMetrics.Ingestion.ErrorsTotal.WithLabelValues("ingest_live").Inc()
-			return fmt.Errorf("persisting ledger %d: %w", pl.seq, err)
+			return fmt.Errorf("persisting %s: %w", batchLabel(items), err)
 		}
 		persistDuration := time.Since(dbStart)
-		m.appMetrics.Ingestion.PhaseDuration.WithLabelValues("insert_into_db").Observe(persistDuration.Seconds())
+		m.appMetrics.Ingestion.PersistBatchSize.Observe(float64(len(batch)))
 
-		ledgerDuration := pl.processDuration + classifyDuration + persistDuration
-		m.appMetrics.Ingestion.Duration.Observe(ledgerDuration.Seconds())
-		m.appMetrics.Ingestion.TransactionsTotal.Add(float64(pl.buffer.GetNumberOfTransactions()))
-		m.appMetrics.Ingestion.OperationsTotal.Add(float64(pl.buffer.GetNumberOfOperations()))
-		m.appMetrics.Ingestion.LedgersProcessed.Add(float64(1))
-		m.appMetrics.Ingestion.LatestLedger.Set(float64(pl.seq))
+		// Per-ledger phase observations record each ledger's amortized share
+		// of the batch, so the histograms keep per-ledger semantics and stay
+		// comparable across batch sizes.
+		classifyShare := classifyDuration / time.Duration(len(batch))
+		persistShare := persistDuration / time.Duration(len(batch))
+		for _, pl := range batch {
+			m.appMetrics.Ingestion.PhaseDuration.WithLabelValues("insert_into_db").Observe(persistShare.Seconds())
 
-		// Publish the just-ingested ledger for the lag updater goroutine.
-		latestIngested.Store(pl.seq)
+			ledgerDuration := pl.processDuration + classifyShare + persistShare
+			m.appMetrics.Ingestion.Duration.Observe(ledgerDuration.Seconds())
+			m.appMetrics.Ingestion.TransactionsTotal.Add(float64(pl.buffer.GetNumberOfTransactions()))
+			m.appMetrics.Ingestion.OperationsTotal.Add(float64(pl.buffer.GetNumberOfOperations()))
+			m.appMetrics.Ingestion.LedgersProcessed.Add(float64(1))
+			m.appMetrics.Ingestion.LatestLedger.Set(float64(pl.seq))
 
-		// Periodically sync oldest ledger metric from DB (picks up changes from backfill jobs),
-		// and re-probe protocol cursors that were missing at the last snapshot/re-probe (picks
-		// up a protocol-setup/migrate run that has initialized one since — see
-		// reprobeProtocolCursors).
-		if pl.seq%oldestLedgerSyncInterval == 0 {
-			if oldest, syncErr := m.models.IngestStore.Get(ctx, data.OldestLedgerCursorName); syncErr == nil {
-				m.appMetrics.Ingestion.OldestLedger.Set(float64(oldest))
+			// Publish the just-ingested ledger for the lag updater goroutine.
+			latestIngested.Store(pl.seq)
+
+			// Periodically sync oldest ledger metric from DB (picks up changes from backfill jobs),
+			// and re-probe protocol cursors that were missing at the last snapshot/re-probe (picks
+			// up a protocol-setup/migrate run that has initialized one since — see
+			// reprobeProtocolCursors).
+			if pl.seq%oldestLedgerSyncInterval == 0 {
+				if oldest, syncErr := m.models.IngestStore.Get(ctx, data.OldestLedgerCursorName); syncErr == nil {
+					m.appMetrics.Ingestion.OldestLedger.Set(float64(oldest))
+				}
+				m.reprobeProtocolCursors(ctx)
 			}
-			m.reprobeProtocolCursors(ctx)
+
+			log.Ctx(ctx).Infof("Ingested ledger %d in %.4fs", pl.seq, ledgerDuration.Seconds())
+
+			freeBuffers <- pl.buffer
 		}
 
-		log.Ctx(ctx).Infof("Ingested ledger %d in %.4fs", pl.seq, ledgerDuration.Seconds())
-
-		freeBuffers <- pl.buffer
+		// Shift the uncommitted remainder (at most the next batch's head plus
+		// what drained behind it) to the front; the overlapping forward copy
+		// is safe.
+		n := copy(pending, pending[cut:])
+		pending = pending[:n]
 	}
 }
 
@@ -969,30 +1082,23 @@ func getEffectiveProtocolContracts(
 	return out
 }
 
-// persistLedgerDataWithRetry wraps persistLedgerData with retry logic.
-// plan was computed once by the caller before this call and is reused
-// verbatim across every attempt, so a retried attempt never re-issues the
-// classification RPC calls plan already resolved. The ContractData extraction
-// memo is built here, outside the retried function, so it too is shared across
-// attempts and a retry never re-runs the extraction walk over the ledger's
-// transactions.
-func (m *ingestService) persistLedgerDataWithRetry(
-	ctx context.Context,
-	currentLedger uint32,
-	ledgerMeta xdr.LedgerCloseMeta,
-	plan *ClassificationPlan,
-	transactions []ingest.LedgerTransaction,
-	buffer *indexer.IndexerBuffer,
-) error {
-	contractData := newContractDataMemo(transactions, currentLedger)
+// persistLedgerDataWithRetry wraps persistLedgerData with retry logic. The
+// items' plans were computed once by the caller before this call and are
+// reused verbatim across every attempt, so a retried attempt never re-issues
+// the classification RPC calls a plan already resolved; the ContractData
+// extraction memos likewise ride along unchanged, so a retry never re-runs
+// the extraction walk over a ledger's transactions. A failed attempt rolled
+// everything back, so the retry replays the whole batch.
+func (m *ingestService) persistLedgerDataWithRetry(ctx context.Context, items []persistItem) error {
+	label := batchLabel(items)
 	_, err := utils.RetryWithBackoff(ctx, maxIngestProcessedDataRetries, maxIngestProcessedDataRetryBackoff,
 		func(ctx context.Context) (struct{}, error) {
-			return struct{}{}, m.persistLedgerData(ctx, currentLedger, ledgerMeta, plan, contractData, buffer)
+			return struct{}{}, m.persistLedgerData(ctx, items)
 		},
 		func(attempt int, err error, backoff time.Duration) {
 			m.appMetrics.Ingestion.RetriesTotal.WithLabelValues("db_persist").Inc()
-			log.Ctx(ctx).Warnf("Error ingesting data for ledger %d (attempt %d/%d): %v, retrying in %v...",
-				currentLedger, attempt+1, maxIngestProcessedDataRetries, err, backoff)
+			log.Ctx(ctx).Warnf("Error ingesting data for %s (attempt %d/%d): %v, retrying in %v...",
+				label, attempt+1, maxIngestProcessedDataRetries, err, backoff)
 		},
 		isPermanentPersistError,
 	)
@@ -1005,11 +1111,11 @@ func (m *ingestService) persistLedgerDataWithRetry(
 		m.appMetrics.Ingestion.ErrorsTotal.WithLabelValues("db_persist").Inc()
 	case isPermanentPersistError(err):
 		m.appMetrics.Ingestion.ErrorsTotal.WithLabelValues("db_persist").Inc()
-		return fmt.Errorf("ingesting processed data for ledger %d failed with a permanent error: %w", currentLedger, err)
+		return fmt.Errorf("ingesting processed data for %s failed with a permanent error: %w", label, err)
 	}
 	// The remaining exit is context cancellation — a shutdown, not an ingestion fault, so it
 	// counts against neither counter.
-	return fmt.Errorf("ingesting processed data for ledger %d: %w", currentLedger, err)
+	return fmt.Errorf("ingesting processed data for %s: %w", label, err)
 }
 
 // isPermanentPersistError classifies a persistLedgerData failure using its PostgreSQL SQLSTATE,

--- a/internal/services/ingest_live.go
+++ b/internal/services/ingest_live.go
@@ -68,16 +68,36 @@ func (c *contractDataMemo) get() (map[string][]ingest.Change, error) {
 	return c.changes, nil
 }
 
-// persistLedgerData persists processed ledger data to the database in a single
-// atomic transaction. It handles: trustline assets, contract tokens, filtered
-// data insertion, token changes, and cursor update. plan is this ledger's
-// classification plan, computed by prepareClassificationPlan before any
-// transaction opens (RPC calls already resolved); pass the same plan across
-// persistLedgerDataWithRetry's retry attempts so a retry never re-issues
-// RPC calls. plan may be nil when there was nothing to classify this ledger.
-// contractData carries the ledger's ContractData extraction memo; like plan,
-// the same memo is shared across retry attempts so a retry never re-runs the
-// extraction walk.
+// ErrPartialPersist marks a persist failure that occurred after the first
+// sibling commit succeeded: some of the ledger's tables are durable and the
+// rest are not, the transaction set can no longer roll back atomically, and no
+// in-process retry can fix it (COPY has no ON CONFLICT, so re-running the
+// ledger would collide on primary keys). It is classified permanent so the
+// process exits; startup reconciliation (DeleteRowsAboveLedger) removes the
+// orphaned rows above the committed cursor before ingestion resumes.
+var ErrPartialPersist = errors.New("ledger persist partially committed")
+
+// persistLedgerData persists one ledger. The three bulk COPY families —
+// transactions(+accounts), operations(+accounts), state_changes — stream
+// concurrently on sibling connections, each in its own transaction, while the
+// coordinating transaction stages everything else (assets, contracts,
+// classification, protocol state, token changes, cursor). All the slow work
+// happens uncommitted and invisible; only after every stream and the
+// coordinator succeed do the commits fire, siblings first and the
+// coordinating transaction strictly last. The cursor it carries is the
+// authority: the only crash state this ordering can produce is orphaned bulk
+// rows above the committed cursor, which DeleteRowsAboveLedger removes at
+// startup. A failure before the first commit rolls everything back and is
+// retryable as before; a failure after it wraps ErrPartialPersist and is
+// fatal.
+//
+// plan is this ledger's classification plan, computed by
+// prepareClassificationPlan before any transaction opens (RPC calls already
+// resolved); pass the same plan across persistLedgerDataWithRetry's retry
+// attempts so a retry never re-issues RPC calls. plan may be nil when there
+// was nothing to classify this ledger. contractData carries the ledger's
+// ContractData extraction memo; like plan, the same memo is shared across
+// retry attempts so a retry never re-runs the extraction walk.
 func (m *ingestService) persistLedgerData(
 	ctx context.Context,
 	ledgerSeq uint32,
@@ -86,229 +106,321 @@ func (m *ingestService) persistLedgerData(
 	contractData *contractDataMemo,
 	buffer *indexer.IndexerBuffer,
 ) error {
-	err := db.RunInTransaction(ctx, m.models.DB, func(dbTx pgx.Tx) error {
-		// 1. Insert unique trustline assets (FK prerequisite for trustline balances)
-		uniqueAssets := buffer.GetUniqueTrustlineAssets()
-		if len(uniqueAssets) > 0 {
-			if txErr := m.models.TrustlineAsset.BatchInsert(ctx, dbTx, uniqueAssets); txErr != nil {
-				return fmt.Errorf("inserting trustline assets for ledger %d: %w", ledgerSeq, txErr)
-			}
-		}
-
-		// 2. Insert new SAC contract tokens (filter existing, insert)
-		contracts, txErr := m.prepareNewSACContracts(ctx, dbTx, buffer.GetSACContracts())
-		if txErr != nil {
-			return fmt.Errorf("preparing contract tokens for ledger %d: %w", ledgerSeq, txErr)
-		}
-		if len(contracts) > 0 {
-			if txErr = m.models.Contract.BatchInsert(ctx, dbTx, contracts); txErr != nil {
-				return fmt.Errorf("inserting contracts for ledger %d: %w", ledgerSeq, txErr)
-			}
-			log.Ctx(ctx).Infof("inserted %d SAC contract tokens", len(contracts))
-		}
-
-		// 3. Apply protocol classification (black-box per protocol). plan was
-		// computed by prepareClassificationPlan before this transaction opened,
-		// so any RPC calls (e.g. SEP-41 metadata) already happened;
-		// ApplyClassificationPlan only performs each validator's DB writes
-		// here, atomically with the classification verdict and wasm/contract
-		// rows below. Wasm rows are persisted next, then live protocol
-		// processors stage ledger state from the classification result, and
-		// the generic protocol_contracts rows are persisted after them so a
-		// processor's name-enriched row lands first (the generic insert's
-		// COALESCE preserves it).
-		bufferedWasms := buffer.GetProtocolWasms()
-		bufferedContracts := buffer.GetProtocolContracts()
-
-		contractSlice := make([]data.ProtocolContracts, 0, len(bufferedContracts))
-		for _, c := range bufferedContracts {
-			contractSlice = append(contractSlice, c)
-		}
-
-		var classification map[types.HashBytea]string
-		if plan != nil {
-			classification = plan.Matches
-		}
-		if txErr = ApplyClassificationPlan(ctx, dbTx, m.models, plan, m.appMetrics.Ingestion.WasmClassificationFailuresTotal); txErr != nil {
-			return fmt.Errorf("applying classification for ledger %d: %w", ledgerSeq, txErr)
-		}
-
-		// Persist this ledger's wasm rows BEFORE processors run: a processor
-		// enriching protocol_contracts (e.g. contract names decoded from
-		// instance storage) inserts rows that are FK-filtered against
-		// protocol_wasms, so a contract deployed in the same ledger as its
-		// wasm upload would otherwise be silently dropped.
-		if len(bufferedWasms) > 0 {
-			wasmSlice := make([]data.ProtocolWasms, 0, len(bufferedWasms))
-			for hash, wasm := range bufferedWasms {
-				if pid, ok := classification[types.HashBytea(hash)]; ok {
-					stamped := pid
-					wasm.ProtocolID = &stamped
-				}
-				wasmSlice = append(wasmSlice, wasm)
-			}
-			if txErr = m.models.ProtocolWasms.BatchInsert(ctx, dbTx, wasmSlice); txErr != nil {
-				return fmt.Errorf("inserting protocol wasms for ledger %d: %w", ledgerSeq, txErr)
-			}
-		}
-
-		// 4. Per-protocol CAS-gated state production. The compare-and-swap on each
-		// protocol cursor is the authoritative gate — exactly one of live ingestion or
-		// protocol-migrate wins a given ledger. Staging (ProcessLedger) and persistence
-		// run only for cursors that win the swap, so a protocol still backfilling (its
-		// cursor behind tip) costs a single CAS and a continue.
-		if len(m.protocolProcessors) > 0 {
-			ledgerCloseTime := ledgerMeta.LedgerCloseTime()
-			contractEvents := buffer.GetContractEvents()
-			expected := strconv.FormatUint(uint64(ledgerSeq-1), 10)
-			next := strconv.FormatUint(uint64(ledgerSeq), 10)
-
-			// Resolve protocol membership once for the contracts that emitted events
-			// this ledger. One bounded query serves every protocol; ledgers with no
-			// contract events skip it entirely. The buffered overlay (below) covers
-			// contracts deployed or upgraded this ledger, which are not yet committed.
-			var committedByProtocol map[string][]data.ProtocolContracts
-			if eventContractIDs := distinctEventContractIDs(contractEvents); len(eventContractIDs) > 0 {
-				var lookupErr error
-				committedByProtocol, lookupErr = m.models.ProtocolContracts.BatchGetByContractIDs(ctx, eventContractIDs)
-				if lookupErr != nil {
-					return fmt.Errorf("resolving protocol contracts for ledger %d: %w", ledgerSeq, lookupErr)
-				}
-			}
-
-			var contractDataChanges map[string][]ingest.Change
-
-			for protocolID, processor := range m.protocolProcessors {
-				// Only attempt the CAS for a cursor m.protocolCursors believes exists (see
-				// snapshotProtocolCursors/reprobeProtocolCursors): a cursor known not yet
-				// initialized is skipped entirely — no DB round trip, no metric — since
-				// there is nothing to CAS against. This also means casProtocolCursor only
-				// ever sees ErrCASCursorMissing for a cursor that existed as of the last
-				// snapshot/re-probe, i.e. a genuine incident, not the operationally normal
-				// not-yet-initialized case.
-				var historySwapped, currentStateSwapped bool
-				if m.protocolCursors.historyExists[protocolID] {
-					var casErr error
-					historyCursor := utils.ProtocolHistoryCursorName(protocolID)
-					historySwapped, casErr = m.casProtocolCursor(ctx, dbTx, historyCursor, expected, next)
-					if casErr != nil {
-						return casErr
-					}
-				}
-				if m.protocolCursors.currentStateExists[protocolID] {
-					var casErr error
-					currentStateCursor := utils.ProtocolCurrentStateCursorName(protocolID)
-					currentStateSwapped, casErr = m.casProtocolCursor(ctx, dbTx, currentStateCursor, expected, next)
-					if casErr != nil {
-						return casErr
-					}
-				}
-				if !historySwapped && !currentStateSwapped {
-					// Behind tip (value mismatch), not yet set up (both cursors known
-					// missing), or the value mismatch a live CAS returns when another
-					// process already owns this ledger: nothing to stage. Skipping is
-					// lossless: the migrate engine folds a ledger only after this
-					// cursor's transaction commits (its frontier gate), so a ledger
-					// lost here is folded later by a winner that sees every
-					// classification this transaction commits — including contracts
-					// classified this very ledger.
-					continue
-				}
-
-				committed := committedByProtocol[protocolID]
-				if processor.RequiresContractData() {
-					var cdErr error
-					contractDataChanges, cdErr = contractData.get()
-					if cdErr != nil {
-						return cdErr
-					}
-
-					// ContractData-driven processors need the protocol's FULL committed
-					// membership, not just this ledger's event emitters: entries can
-					// change on a contract that emitted no event this ledger, and event
-					// decoding may disambiguate against tracked contracts that appear
-					// only in another contract's topics. Protocols requiring contract
-					// data have bounded membership, so the per-ledger query stays cheap.
-					var fullErr error
-					committed, fullErr = m.models.ProtocolContracts.GetByProtocolID(ctx, dbTx, protocolID)
-					if fullErr != nil {
-						return fmt.Errorf("resolving full protocol contracts for ledger %d protocol %s: %w", ledgerSeq, protocolID, fullErr)
-					}
-				}
-
-				contracts := getEffectiveProtocolContracts(protocolID, committed, bufferedContracts, classification)
-				input := ProtocolProcessorInput{
-					LedgerSequence:      ledgerSeq,
-					LedgerCloseTime:     ledgerCloseTime,
-					ContractEvents:      contractEvents,
-					ProtocolContracts:   contracts,
-					StagingMode:         StagingModeBoth,
-					ContractDataChanges: contractDataChanges,
-				}
-				// Reset before staging so a retried transaction (ingestProcessedDataWithRetry)
-				// re-stages cleanly; the processor is long-lived and accumulates across
-				// ProcessLedger calls.
-				processor.Reset()
-				start := time.Now()
-				processErr := processor.ProcessLedger(ctx, input)
-				m.appMetrics.Ingestion.ProtocolStateProcessingDuration.WithLabelValues(protocolID, "process_ledger").Observe(time.Since(start).Seconds())
-				if processErr != nil {
-					return fmt.Errorf("processing ledger %d for protocol %s: %w", ledgerSeq, protocolID, processErr)
-				}
-
-				if historySwapped {
-					persistStart := time.Now()
-					persistErr := processor.PersistHistory(ctx, dbTx)
-					m.appMetrics.Ingestion.ProtocolStateProcessingDuration.WithLabelValues(protocolID, "persist_history").Observe(time.Since(persistStart).Seconds())
-					if persistErr != nil {
-						return fmt.Errorf("persisting history for %s at ledger %d: %w", protocolID, ledgerSeq, persistErr)
-					}
-				}
-				if currentStateSwapped {
-					persistStart := time.Now()
-					persistErr := processor.PersistCurrentState(ctx, dbTx)
-					m.appMetrics.Ingestion.ProtocolStateProcessingDuration.WithLabelValues(protocolID, "persist_current_state").Observe(time.Since(persistStart).Seconds())
-					if persistErr != nil {
-						return fmt.Errorf("persisting current state for %s at ledger %d: %w", protocolID, ledgerSeq, persistErr)
-					}
-				}
-			}
-		}
-
-		if len(contractSlice) > 0 {
-			if txErr = m.models.ProtocolContracts.BatchInsert(ctx, dbTx, contractSlice); txErr != nil {
-				return fmt.Errorf("inserting protocol contracts for ledger %d: %w", ledgerSeq, txErr)
-			}
-		}
-
-		// 5. Insert transactions/operations/state_changes
-		if txErr = m.insertIntoDB(ctx, dbTx, buffer); txErr != nil {
-			return fmt.Errorf("inserting processed data into db for ledger %d: %w", ledgerSeq, txErr)
-		}
-
-		// 6. Process token changes (trustline add/remove/update, native balance, SAC balance)
-		if txErr = m.tokenIngestionService.ProcessTokenChanges(ctx, dbTx,
-			buffer.GetTrustlineChanges(),
-			buffer.GetAccountChanges(),
-			buffer.GetSACBalanceChanges(),
-			buffer.GetLiquidityPoolShareChanges(),
-			buffer.GetLiquidityPoolChanges(),
-		); txErr != nil {
-			return fmt.Errorf("processing token changes for ledger %d: %w", ledgerSeq, txErr)
-		}
-
-		// 7. Advance the latest-ledger cursor. The update is guarded: a session that
-		// silently lost its advisory lock (server-side failover, see startLiveIngestion's
-		// checkLockSession) must not blindly overwrite a value a second instance already
-		// advanced, or the cursor could regress.
-		if txErr = m.models.IngestStore.UpdateGuarded(ctx, dbTx, data.LatestLedgerCursorName, ledgerSeq); txErr != nil {
-			return fmt.Errorf("updating cursor for ledger %d: %w", ledgerSeq, txErr)
-		}
-
-		return nil
-	})
+	// The sibling transactions and the coordinating transaction are all opened
+	// up front on this goroutine, so ownership at the commit barrier below is
+	// deterministic; the deferred rollbacks tolerate ErrTxClosed and so are
+	// no-ops for whatever committed.
+	coordTx, err := m.models.DB.Begin(ctx)
 	if err != nil {
+		return fmt.Errorf("beginning coordinating transaction for ledger %d: %w", ledgerSeq, err)
+	}
+	defer func() {
+		if rbErr := coordTx.Rollback(ctx); rbErr != nil && !errors.Is(rbErr, pgx.ErrTxClosed) {
+			log.Ctx(ctx).Warnf("rolling back coordinating transaction for ledger %d: %v", ledgerSeq, rbErr)
+		}
+	}()
+
+	siblings := []struct {
+		name string
+		run  func(ctx context.Context, dbTx pgx.Tx) error
+	}{
+		{"transactions", func(ctx context.Context, dbTx pgx.Tx) error {
+			return m.insertTransactions(ctx, dbTx, buffer.GetTransactions(), buffer.GetTransactionsParticipants())
+		}},
+		{"operations", func(ctx context.Context, dbTx pgx.Tx) error {
+			return m.insertOperations(ctx, dbTx, buffer.GetOperations(), buffer.GetOperationsParticipants())
+		}},
+		{"state_changes", func(ctx context.Context, dbTx pgx.Tx) error {
+			return m.insertStateChanges(ctx, dbTx, buffer.GetStateChanges())
+		}},
+	}
+	siblingTxs := make([]pgx.Tx, len(siblings))
+	for i, s := range siblings {
+		conn, acquireErr := m.models.DB.Acquire(ctx)
+		if acquireErr != nil {
+			return fmt.Errorf("acquiring %s connection for ledger %d: %w", s.name, ledgerSeq, acquireErr)
+		}
+		defer conn.Release()
+		tx, beginErr := conn.Begin(ctx)
+		if beginErr != nil {
+			return fmt.Errorf("beginning %s transaction for ledger %d: %w", s.name, ledgerSeq, beginErr)
+		}
+		siblingTxs[i] = tx
+		defer func(name string, tx pgx.Tx) {
+			if rbErr := tx.Rollback(ctx); rbErr != nil && !errors.Is(rbErr, pgx.ErrTxClosed) {
+				log.Ctx(ctx).Warnf("rolling back %s transaction for ledger %d: %v", name, ledgerSeq, rbErr)
+			}
+		}(s.name, tx)
+	}
+
+	// Stream the COPY families and stage the coordinated writes concurrently.
+	// The table sets are disjoint (no FKs among them), and the goroutines only
+	// read the quiescent buffer, so the four transactions never contend.
+	g, gctx := errgroup.WithContext(ctx)
+	for i, s := range siblings {
+		g.Go(func() error {
+			if runErr := s.run(gctx, siblingTxs[i]); runErr != nil {
+				return fmt.Errorf("streaming %s for ledger %d: %w", s.name, ledgerSeq, runErr)
+			}
+			return nil
+		})
+	}
+	g.Go(func() error {
+		return m.stageCoordinatedWrites(gctx, coordTx, ledgerSeq, ledgerMeta, plan, contractData, buffer)
+	})
+	if err = g.Wait(); err != nil {
+		// Nothing has committed: the deferred rollbacks discard all four
+		// transactions and the ledger is cleanly retryable.
 		return fmt.Errorf("persisting ledger data for ledger %d: %w", ledgerSeq, err)
+	}
+
+	// Commit barrier. A failed FIRST commit still leaves nothing durable
+	// (its transaction aborts, the others roll back), so it stays retryable;
+	// once any commit has succeeded the set can no longer roll back
+	// atomically and every subsequent failure is ErrPartialPersist. The one
+	// indeterminate case — a first-commit error whose commit actually
+	// reached the server — self-heals: the retry collides on primary keys,
+	// which is permanent, and startup reconciliation repairs after restart.
+	for i, s := range siblings {
+		if commitErr := siblingTxs[i].Commit(ctx); commitErr != nil {
+			if i > 0 {
+				return fmt.Errorf("committing %s for ledger %d: %w: %w", s.name, ledgerSeq, ErrPartialPersist, commitErr)
+			}
+			return fmt.Errorf("committing %s for ledger %d: %w", s.name, ledgerSeq, commitErr)
+		}
+	}
+	// The coordinating transaction commits strictly last: it carries the
+	// cursor, so its commit is the point at which the ledger exists.
+	if commitErr := coordTx.Commit(ctx); commitErr != nil {
+		return fmt.Errorf("committing coordinating transaction for ledger %d: %w: %w", ledgerSeq, ErrPartialPersist, commitErr)
+	}
+	return nil
+}
+
+// stageCoordinatedWrites runs every per-ledger write except the three bulk
+// COPY families on the coordinating transaction: trustline assets, SAC
+// contract tokens, protocol classification and wasm/contract rows,
+// CAS-gated protocol state, token changes, and finally the guarded cursor.
+func (m *ingestService) stageCoordinatedWrites(
+	ctx context.Context,
+	dbTx pgx.Tx,
+	ledgerSeq uint32,
+	ledgerMeta xdr.LedgerCloseMeta,
+	plan *ClassificationPlan,
+	contractData *contractDataMemo,
+	buffer *indexer.IndexerBuffer,
+) error {
+	// 1. Insert unique trustline assets (FK prerequisite for trustline balances)
+	uniqueAssets := buffer.GetUniqueTrustlineAssets()
+	if len(uniqueAssets) > 0 {
+		if txErr := m.models.TrustlineAsset.BatchInsert(ctx, dbTx, uniqueAssets); txErr != nil {
+			return fmt.Errorf("inserting trustline assets for ledger %d: %w", ledgerSeq, txErr)
+		}
+	}
+
+	// 2. Insert new SAC contract tokens (filter existing, insert)
+	contracts, txErr := m.prepareNewSACContracts(ctx, dbTx, buffer.GetSACContracts())
+	if txErr != nil {
+		return fmt.Errorf("preparing contract tokens for ledger %d: %w", ledgerSeq, txErr)
+	}
+	if len(contracts) > 0 {
+		if txErr = m.models.Contract.BatchInsert(ctx, dbTx, contracts); txErr != nil {
+			return fmt.Errorf("inserting contracts for ledger %d: %w", ledgerSeq, txErr)
+		}
+		log.Ctx(ctx).Infof("inserted %d SAC contract tokens", len(contracts))
+	}
+
+	// 3. Apply protocol classification (black-box per protocol). plan was
+	// computed by prepareClassificationPlan before this transaction opened,
+	// so any RPC calls (e.g. SEP-41 metadata) already happened;
+	// ApplyClassificationPlan only performs each validator's DB writes
+	// here, atomically with the classification verdict and wasm/contract
+	// rows below. Wasm rows are persisted next, then live protocol
+	// processors stage ledger state from the classification result, and
+	// the generic protocol_contracts rows are persisted after them so a
+	// processor's name-enriched row lands first (the generic insert's
+	// COALESCE preserves it).
+	bufferedWasms := buffer.GetProtocolWasms()
+	bufferedContracts := buffer.GetProtocolContracts()
+
+	contractSlice := make([]data.ProtocolContracts, 0, len(bufferedContracts))
+	for _, c := range bufferedContracts {
+		contractSlice = append(contractSlice, c)
+	}
+
+	var classification map[types.HashBytea]string
+	if plan != nil {
+		classification = plan.Matches
+	}
+	if txErr = ApplyClassificationPlan(ctx, dbTx, m.models, plan, m.appMetrics.Ingestion.WasmClassificationFailuresTotal); txErr != nil {
+		return fmt.Errorf("applying classification for ledger %d: %w", ledgerSeq, txErr)
+	}
+
+	// Persist this ledger's wasm rows BEFORE processors run: a processor
+	// enriching protocol_contracts (e.g. contract names decoded from
+	// instance storage) inserts rows that are FK-filtered against
+	// protocol_wasms, so a contract deployed in the same ledger as its
+	// wasm upload would otherwise be silently dropped.
+	if len(bufferedWasms) > 0 {
+		wasmSlice := make([]data.ProtocolWasms, 0, len(bufferedWasms))
+		for hash, wasm := range bufferedWasms {
+			if pid, ok := classification[types.HashBytea(hash)]; ok {
+				stamped := pid
+				wasm.ProtocolID = &stamped
+			}
+			wasmSlice = append(wasmSlice, wasm)
+		}
+		if txErr = m.models.ProtocolWasms.BatchInsert(ctx, dbTx, wasmSlice); txErr != nil {
+			return fmt.Errorf("inserting protocol wasms for ledger %d: %w", ledgerSeq, txErr)
+		}
+	}
+
+	// 4. Per-protocol CAS-gated state production. The compare-and-swap on each
+	// protocol cursor is the authoritative gate — exactly one of live ingestion or
+	// protocol-migrate wins a given ledger. Staging (ProcessLedger) and persistence
+	// run only for cursors that win the swap, so a protocol still backfilling (its
+	// cursor behind tip) costs a single CAS and a continue.
+	if len(m.protocolProcessors) > 0 {
+		ledgerCloseTime := ledgerMeta.LedgerCloseTime()
+		contractEvents := buffer.GetContractEvents()
+		expected := strconv.FormatUint(uint64(ledgerSeq-1), 10)
+		next := strconv.FormatUint(uint64(ledgerSeq), 10)
+
+		// Resolve protocol membership once for the contracts that emitted events
+		// this ledger. One bounded query serves every protocol; ledgers with no
+		// contract events skip it entirely. The buffered overlay (below) covers
+		// contracts deployed or upgraded this ledger, which are not yet committed.
+		var committedByProtocol map[string][]data.ProtocolContracts
+		if eventContractIDs := distinctEventContractIDs(contractEvents); len(eventContractIDs) > 0 {
+			var lookupErr error
+			committedByProtocol, lookupErr = m.models.ProtocolContracts.BatchGetByContractIDs(ctx, eventContractIDs)
+			if lookupErr != nil {
+				return fmt.Errorf("resolving protocol contracts for ledger %d: %w", ledgerSeq, lookupErr)
+			}
+		}
+
+		var contractDataChanges map[string][]ingest.Change
+
+		for protocolID, processor := range m.protocolProcessors {
+			// Only attempt the CAS for a cursor m.protocolCursors believes exists (see
+			// snapshotProtocolCursors/reprobeProtocolCursors): a cursor known not yet
+			// initialized is skipped entirely — no DB round trip, no metric — since
+			// there is nothing to CAS against. This also means casProtocolCursor only
+			// ever sees ErrCASCursorMissing for a cursor that existed as of the last
+			// snapshot/re-probe, i.e. a genuine incident, not the operationally normal
+			// not-yet-initialized case.
+			var historySwapped, currentStateSwapped bool
+			if m.protocolCursors.historyExists[protocolID] {
+				var casErr error
+				historyCursor := utils.ProtocolHistoryCursorName(protocolID)
+				historySwapped, casErr = m.casProtocolCursor(ctx, dbTx, historyCursor, expected, next)
+				if casErr != nil {
+					return casErr
+				}
+			}
+			if m.protocolCursors.currentStateExists[protocolID] {
+				var casErr error
+				currentStateCursor := utils.ProtocolCurrentStateCursorName(protocolID)
+				currentStateSwapped, casErr = m.casProtocolCursor(ctx, dbTx, currentStateCursor, expected, next)
+				if casErr != nil {
+					return casErr
+				}
+			}
+			if !historySwapped && !currentStateSwapped {
+				// Behind tip (value mismatch), not yet set up (both cursors known
+				// missing), or the value mismatch a live CAS returns when another
+				// process already owns this ledger: nothing to stage. Skipping is
+				// lossless: the migrate engine folds a ledger only after this
+				// cursor's transaction commits (its frontier gate), so a ledger
+				// lost here is folded later by a winner that sees every
+				// classification this transaction commits — including contracts
+				// classified this very ledger.
+				continue
+			}
+
+			committed := committedByProtocol[protocolID]
+			if processor.RequiresContractData() {
+				var cdErr error
+				contractDataChanges, cdErr = contractData.get()
+				if cdErr != nil {
+					return cdErr
+				}
+
+				// ContractData-driven processors need the protocol's FULL committed
+				// membership, not just this ledger's event emitters: entries can
+				// change on a contract that emitted no event this ledger, and event
+				// decoding may disambiguate against tracked contracts that appear
+				// only in another contract's topics. Protocols requiring contract
+				// data have bounded membership, so the per-ledger query stays cheap.
+				var fullErr error
+				committed, fullErr = m.models.ProtocolContracts.GetByProtocolID(ctx, dbTx, protocolID)
+				if fullErr != nil {
+					return fmt.Errorf("resolving full protocol contracts for ledger %d protocol %s: %w", ledgerSeq, protocolID, fullErr)
+				}
+			}
+
+			contracts := getEffectiveProtocolContracts(protocolID, committed, bufferedContracts, classification)
+			input := ProtocolProcessorInput{
+				LedgerSequence:      ledgerSeq,
+				LedgerCloseTime:     ledgerCloseTime,
+				ContractEvents:      contractEvents,
+				ProtocolContracts:   contracts,
+				StagingMode:         StagingModeBoth,
+				ContractDataChanges: contractDataChanges,
+			}
+			// Reset before staging so a retried transaction (persistLedgerDataWithRetry)
+			// re-stages cleanly; the processor is long-lived and accumulates across
+			// ProcessLedger calls.
+			processor.Reset()
+			start := time.Now()
+			processErr := processor.ProcessLedger(ctx, input)
+			m.appMetrics.Ingestion.ProtocolStateProcessingDuration.WithLabelValues(protocolID, "process_ledger").Observe(time.Since(start).Seconds())
+			if processErr != nil {
+				return fmt.Errorf("processing ledger %d for protocol %s: %w", ledgerSeq, protocolID, processErr)
+			}
+
+			if historySwapped {
+				persistStart := time.Now()
+				persistErr := processor.PersistHistory(ctx, dbTx)
+				m.appMetrics.Ingestion.ProtocolStateProcessingDuration.WithLabelValues(protocolID, "persist_history").Observe(time.Since(persistStart).Seconds())
+				if persistErr != nil {
+					return fmt.Errorf("persisting history for %s at ledger %d: %w", protocolID, ledgerSeq, persistErr)
+				}
+			}
+			if currentStateSwapped {
+				persistStart := time.Now()
+				persistErr := processor.PersistCurrentState(ctx, dbTx)
+				m.appMetrics.Ingestion.ProtocolStateProcessingDuration.WithLabelValues(protocolID, "persist_current_state").Observe(time.Since(persistStart).Seconds())
+				if persistErr != nil {
+					return fmt.Errorf("persisting current state for %s at ledger %d: %w", protocolID, ledgerSeq, persistErr)
+				}
+			}
+		}
+	}
+
+	if len(contractSlice) > 0 {
+		if txErr = m.models.ProtocolContracts.BatchInsert(ctx, dbTx, contractSlice); txErr != nil {
+			return fmt.Errorf("inserting protocol contracts for ledger %d: %w", ledgerSeq, txErr)
+		}
+	}
+
+	// 5. Process token changes (trustline add/remove/update, native balance, SAC balance)
+	if txErr = m.tokenIngestionService.ProcessTokenChanges(ctx, dbTx,
+		buffer.GetTrustlineChanges(),
+		buffer.GetAccountChanges(),
+		buffer.GetSACBalanceChanges(),
+		buffer.GetLiquidityPoolShareChanges(),
+		buffer.GetLiquidityPoolChanges(),
+	); txErr != nil {
+		return fmt.Errorf("processing token changes for ledger %d: %w", ledgerSeq, txErr)
+	}
+
+	// 6. Advance the latest-ledger cursor. The update is guarded: a session that
+	// silently lost its advisory lock (server-side failover, see startLiveIngestion's
+	// checkLockSession) must not blindly overwrite a value a second instance already
+	// advanced, or the cursor could regress.
+	if txErr = m.models.IngestStore.UpdateGuarded(ctx, dbTx, data.LatestLedgerCursorName, ledgerSeq); txErr != nil {
+		return fmt.Errorf("updating cursor for ledger %d: %w", ledgerSeq, txErr)
 	}
 
 	return nil
@@ -388,6 +500,16 @@ func (m *ingestService) startLiveIngestion(ctx context.Context) error {
 		m.appMetrics.Ingestion.LatestLedger.Set(float64(startLedger))
 		m.appMetrics.Ingestion.OldestLedger.Set(float64(startLedger))
 	} else {
+		// Remove any bulk rows a crashed run left above the cursor before that
+		// ledger is re-ingested: persistLedgerData commits the sibling COPY
+		// transactions before the coordinating transaction that carries the
+		// cursor, so a crash between those commits orphans (at most) the single
+		// ledger past the cursor. Fatal on failure — ingesting over the orphans
+		// would collide on the bulk tables' primary keys anyway.
+		if err := m.models.IngestStore.DeleteRowsAboveLedger(ctx, latestIngestedLedger); err != nil {
+			return fmt.Errorf("reconciling bulk rows above cursor ledger %d: %w", latestIngestedLedger, err)
+		}
+
 		// Initialize metrics from DB state so Prometheus reflects backfill progress after restart
 		oldestIngestedLedger, oldestErr := m.models.IngestStore.Get(ctx, data.OldestLedgerCursorName)
 		if oldestErr != nil {
@@ -903,8 +1025,11 @@ func (m *ingestService) persistLedgerDataWithRetry(
 // ErrCASCursorMissing (see IngestStoreModel.CompareAndSwap) is likewise permanent: the cursor row
 // this ledger's protocol CAS targets is gone, and no retry of the same transaction can recreate
 // it — failing fast surfaces the incident instead of burning the whole retry ladder.
+// ErrPartialPersist (see persistLedgerData) is permanent by definition: part of the ledger is
+// already durable, so re-running it collides on primary keys; the process must exit and let
+// startup reconciliation repair.
 func isPermanentPersistError(err error) bool {
-	if errors.Is(err, data.ErrCursorGuardFailed) || errors.Is(err, data.ErrCASCursorMissing) {
+	if errors.Is(err, data.ErrCursorGuardFailed) || errors.Is(err, data.ErrCASCursorMissing) || errors.Is(err, ErrPartialPersist) {
 		return true
 	}
 	var pgErr *pgconn.PgError

--- a/internal/services/ingest_live_test.go
+++ b/internal/services/ingest_live_test.go
@@ -132,6 +132,12 @@ func Test_isPermanentPersistError(t *testing.T) {
 			err:           fmt.Errorf("persisting ledger data for ledger 100: comparing and swapping protocol cursor blend: %w", data.ErrCASCursorMissing),
 			wantPermanent: true,
 		},
+		{name: "partial_persist_is_permanent", err: ErrPartialPersist, wantPermanent: true},
+		{
+			name:          "wrapped_partial_persist_is_permanent",
+			err:           fmt.Errorf("committing operations for ledger 100: %w: connection reset", ErrPartialPersist),
+			wantPermanent: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -1504,6 +1504,43 @@ func Test_ingestService_startBackfilling_HistoricalMode_AllBatchesFail_CursorUnc
 }
 
 // Test_persistLedgerDataWithRetry tests the persistLedgerDataWithRetry function covering success, failure, and retry scenarios.
+// Test_persistBatchCut verifies the classification-safety cut only isolates
+// ledgers carrying UNSEEN classification inputs: re-observations of contracts
+// a committed batch already classified ride mid-batch (synthetic loadtest
+// traffic re-observes the same contracts every ledger, which must not
+// degrade every batch to size one), while a genuinely new contract still
+// opens its own batch.
+func Test_persistBatchCut(t *testing.T) {
+	bufferWithContract := func(contractID string) *indexer.IndexerBuffer {
+		b := indexer.NewIndexerBuffer()
+		b.PushProtocolContracts(data.ProtocolContracts{ContractID: types.HashBytea(contractID)})
+		return b
+	}
+	plain := indexer.NewIndexerBuffer()
+
+	svc := &ingestService{
+		classifiedWasms:     map[string]struct{}{},
+		classifiedContracts: map[string]struct{}{},
+	}
+
+	pending := []processedLedger{
+		{seq: 1, buffer: plain},
+		{seq: 2, buffer: bufferWithContract("cafe01")},
+		{seq: 3, buffer: plain},
+	}
+
+	// Unseen contract at index 1 opens its own batch.
+	assert.Equal(t, 1, svc.persistBatchCut(pending))
+
+	// Once its batch commits, the same contract rides mid-batch.
+	svc.markClassificationInputsSeen(pending[1:2])
+	assert.Equal(t, 3, svc.persistBatchCut(pending))
+
+	// A different, unseen contract still cuts.
+	pending[2] = processedLedger{seq: 3, buffer: bufferWithContract("cafe02")}
+	assert.Equal(t, 2, svc.persistBatchCut(pending))
+}
+
 // oneLedger wraps a single ledger's persist payload as the batch slice
 // persistLedgerData and persistLedgerDataWithRetry consume.
 func oneLedger(seq uint32, meta xdr.LedgerCloseMeta, plan *ClassificationPlan, contractData *contractDataMemo, buffer *indexer.IndexerBuffer) []persistItem {

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -1504,6 +1504,12 @@ func Test_ingestService_startBackfilling_HistoricalMode_AllBatchesFail_CursorUnc
 }
 
 // Test_persistLedgerDataWithRetry tests the persistLedgerDataWithRetry function covering success, failure, and retry scenarios.
+// oneLedger wraps a single ledger's persist payload as the batch slice
+// persistLedgerData and persistLedgerDataWithRetry consume.
+func oneLedger(seq uint32, meta xdr.LedgerCloseMeta, plan *ClassificationPlan, contractData *contractDataMemo, buffer *indexer.IndexerBuffer) []persistItem {
+	return []persistItem{{seq: seq, meta: meta, plan: plan, contractData: contractData, buffer: buffer}}
+}
+
 func Test_persistLedgerDataWithRetry(t *testing.T) {
 	t.Run("success - processes data and updates cursor", func(t *testing.T) {
 		dbt := dbtest.Open(t)
@@ -1568,7 +1574,7 @@ func Test_persistLedgerDataWithRetry(t *testing.T) {
 
 		// Call persistLedgerDataWithRetry - should succeed
 		// Note: assetIDMap and contractIDMap are no longer passed - operations use direct DB queries
-		err = svc.persistLedgerDataWithRetry(ctx, 100, xdr.LedgerCloseMeta{}, nil, nil, buffer)
+		err = svc.persistLedgerDataWithRetry(ctx, oneLedger(100, xdr.LedgerCloseMeta{}, nil, newContractDataMemo(nil, 100), buffer))
 
 		// Verify success
 		require.NoError(t, err)
@@ -1646,7 +1652,7 @@ func Test_persistLedgerDataWithRetry(t *testing.T) {
 
 		// Call persistLedgerDataWithRetry - should fail after retries due to DB error
 		// Note: assetIDMap and contractIDMap are no longer passed - operations use direct DB queries
-		err = svc.persistLedgerDataWithRetry(ctx, 100, xdr.LedgerCloseMeta{}, nil, nil, buffer)
+		err = svc.persistLedgerDataWithRetry(ctx, oneLedger(100, xdr.LedgerCloseMeta{}, nil, newContractDataMemo(nil, 100), buffer))
 
 		// Verify error propagates with retry failure message
 		require.Error(t, err)
@@ -1733,7 +1739,7 @@ func Test_persistLedgerDataWithRetry(t *testing.T) {
 
 		// Call persistLedgerDataWithRetry - should succeed after retry
 		// Note: assetIDMap and contractIDMap are no longer passed - operations use direct DB queries
-		err = svc.persistLedgerDataWithRetry(ctx, 100, xdr.LedgerCloseMeta{}, nil, nil, buffer)
+		err = svc.persistLedgerDataWithRetry(ctx, oneLedger(100, xdr.LedgerCloseMeta{}, nil, newContractDataMemo(nil, 100), buffer))
 
 		// Verify success after retry
 		require.NoError(t, err)
@@ -1936,7 +1942,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		err := svc.persistLedgerData(ctx, 100, meta, nil, newContractDataMemo(nil, 100), buffer)
+		err := svc.persistLedgerData(ctx, oneLedger(100, meta, nil, newContractDataMemo(nil, 100), buffer))
 		require.NoError(t, err)
 
 		// Both protocol cursors should advance to 100
@@ -1969,7 +1975,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		err := svc.persistLedgerData(ctx, 100, meta, nil, newContractDataMemo(nil, 100), buffer)
+		err := svc.persistLedgerData(ctx, oneLedger(100, meta, nil, newContractDataMemo(nil, 100), buffer))
 		require.NoError(t, err)
 
 		// Cursors should stay at 100 (CAS expected 99 but found 100)
@@ -2002,7 +2008,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		err := svc.persistLedgerData(ctx, 100, meta, nil, newContractDataMemo(nil, 100), buffer)
+		err := svc.persistLedgerData(ctx, oneLedger(100, meta, nil, newContractDataMemo(nil, 100), buffer))
 		require.NoError(t, err)
 
 		// Cursors should stay at 98 (behind, so entire block is skipped)
@@ -2039,7 +2045,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		err := svc.persistLedgerData(ctx, 100, meta, nil, newContractDataMemo(nil, 100), buffer)
+		err := svc.persistLedgerData(ctx, oneLedger(100, meta, nil, newContractDataMemo(nil, 100), buffer))
 		require.NoError(t, err)
 
 		// Main cursor advances; protocol persist methods were not called and
@@ -2077,7 +2083,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		require.NoError(t, svc.snapshotProtocolCursors(ctx))
 
 		meta := dummyLedgerMeta(100)
-		err = svc.persistLedgerData(ctx, 100, meta, nil, newContractDataMemo(nil, 100), indexer.NewIndexerBuffer())
+		err = svc.persistLedgerData(ctx, oneLedger(100, meta, nil, newContractDataMemo(nil, 100), indexer.NewIndexerBuffer()))
 		require.NoError(t, err)
 
 		// History CAS succeeded.
@@ -2117,7 +2123,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		require.NoError(t, svc.snapshotProtocolCursors(ctx))
 
 		meta := dummyLedgerMeta(100)
-		err = svc.persistLedgerData(ctx, 100, meta, nil, newContractDataMemo(nil, 100), indexer.NewIndexerBuffer())
+		err = svc.persistLedgerData(ctx, oneLedger(100, meta, nil, newContractDataMemo(nil, 100), indexer.NewIndexerBuffer()))
 		require.NoError(t, err)
 
 		// Current-state CAS succeeded.
@@ -2146,7 +2152,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		err := svc.persistLedgerData(ctx, 100, meta, nil, newContractDataMemo(nil, 100), buffer)
+		err := svc.persistLedgerData(ctx, oneLedger(100, meta, nil, newContractDataMemo(nil, 100), buffer))
 		require.NoError(t, err)
 
 		// Main cursor should advance
@@ -2166,14 +2172,14 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		// First ledger succeeds and advances the current-state cursor to 100.
 		processor.processedLedger = 100
 		meta100 := dummyLedgerMeta(100)
-		err := svc.persistLedgerData(ctx, 100, meta100, nil, newContractDataMemo(nil, 100), indexer.NewIndexerBuffer())
+		err := svc.persistLedgerData(ctx, oneLedger(100, meta100, nil, newContractDataMemo(nil, 100), indexer.NewIndexerBuffer()))
 		require.NoError(t, err)
 
 		// Next ledger fails inside PersistCurrentState, rolling back the whole
 		// transaction — the current-state cursor must stay at 100.
 		processor.processedLedger = 101
 		meta101 := dummyLedgerMeta(101)
-		err = svc.persistLedgerData(ctx, 101, meta101, nil, newContractDataMemo(nil, 101), indexer.NewIndexerBuffer())
+		err = svc.persistLedgerData(ctx, oneLedger(101, meta101, nil, newContractDataMemo(nil, 101), indexer.NewIndexerBuffer()))
 		require.Error(t, err)
 
 		currentStateCursor, err := models.IngestStore.Get(ctx, "protocol_testproto_current_state_cursor")
@@ -2183,7 +2189,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		// Retrying the same ledger succeeds and advances the cursor.
 		processor.failPersistCurrentStateAt = 0
 		processor.processedLedger = 101
-		err = svc.persistLedgerData(ctx, 101, meta101, nil, newContractDataMemo(nil, 101), indexer.NewIndexerBuffer())
+		err = svc.persistLedgerData(ctx, oneLedger(101, meta101, nil, newContractDataMemo(nil, 101), indexer.NewIndexerBuffer()))
 		require.NoError(t, err)
 
 		currentStateCursor, err = models.IngestStore.Get(ctx, "protocol_testproto_current_state_cursor")
@@ -2215,7 +2221,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		err := svc.persistLedgerData(ctx, 100, meta, nil, newContractDataMemo(nil, 100), buffer)
+		err := svc.persistLedgerData(ctx, oneLedger(100, meta, nil, newContractDataMemo(nil, 100), buffer))
 		require.Error(t, err)
 		assert.ErrorIs(t, err, data.ErrCASCursorMissing)
 
@@ -2251,7 +2257,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		processor.processedLedger = 100
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		err := svc.persistLedgerData(ctx, 100, meta, nil, newContractDataMemo(nil, 100), buffer)
+		err := svc.persistLedgerData(ctx, oneLedger(100, meta, nil, newContractDataMemo(nil, 100), buffer))
 		require.NoError(t, err)
 
 		histCursor, getErr := models.IngestStore.Get(ctx, "protocol_testproto_history_cursor")
@@ -2277,7 +2283,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		err := svc.persistLedgerData(ctx, 100, meta, nil, newContractDataMemo(nil, 100), buffer)
+		err := svc.persistLedgerData(ctx, oneLedger(100, meta, nil, newContractDataMemo(nil, 100), buffer))
 		require.NoError(t, err)
 	})
 
@@ -2299,7 +2305,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		err := svc.persistLedgerData(ctx, 100, meta, nil, newContractDataMemo(nil, 100), buffer)
+		err := svc.persistLedgerData(ctx, oneLedger(100, meta, nil, newContractDataMemo(nil, 100), buffer))
 		require.NoError(t, err)
 	})
 
@@ -2360,7 +2366,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 
 		buffer := indexer.NewIndexerBuffer()
 		meta := dummyLedgerMeta(100)
-		err = svc.persistLedgerData(ctx, 100, meta, nil, newContractDataMemo(nil, 100), buffer)
+		err = svc.persistLedgerData(ctx, oneLedger(100, meta, nil, newContractDataMemo(nil, 100), buffer))
 		require.NoError(t, err)
 	})
 
@@ -2388,7 +2394,7 @@ func Test_persistLedgerData_ProtocolCASGating(t *testing.T) {
 		)
 
 		meta := dummyLedgerMeta(100)
-		err := svc.persistLedgerData(ctx, 100, meta, nil, newContractDataMemo(nil, 100), buffer)
+		err := svc.persistLedgerData(ctx, oneLedger(100, meta, nil, newContractDataMemo(nil, 100), buffer))
 		require.ErrorContains(t, err, "resolving protocol contracts for ledger 100")
 
 		// The transaction rolled back: the protocol history cursor stayed at 99.
@@ -2679,7 +2685,7 @@ func Test_persistLedgerData_ClassificationPlan(t *testing.T) {
 		}
 
 		meta := dummyLedgerMeta(100)
-		err = svc.persistLedgerData(ctx, 100, meta, plan, newContractDataMemo(nil, 100), buffer)
+		err = svc.persistLedgerData(ctx, oneLedger(100, meta, plan, newContractDataMemo(nil, 100), buffer))
 		require.NoError(t, err)
 
 		// The validator's Apply ran inside the transaction.
@@ -2744,7 +2750,7 @@ func Test_persistLedgerData_ClassificationPlan(t *testing.T) {
 		plan := &ClassificationPlan{Matches: map[types.HashBytea]string{w2: "otherproto"}}
 
 		meta := dummyLedgerMeta(100)
-		err = svc.persistLedgerData(ctx, 100, meta, plan, newContractDataMemo(nil, 100), buffer)
+		err = svc.persistLedgerData(ctx, oneLedger(100, meta, plan, newContractDataMemo(nil, 100), buffer))
 		require.NoError(t, err)
 
 		// The processor staged the ledger but saw no testproto contracts: the
@@ -2990,6 +2996,104 @@ func Test_ingestService_ingestLiveLedgers_StageErrorStopsPipeline(t *testing.T) 
 // sibling and no coordinated write may be durable — commits are held until every stream
 // succeeds, so a pre-commit failure leaves the database exactly as it was and the ledger fully
 // retryable.
+func Test_persistLedgerData_Batch(t *testing.T) {
+	setupTest := func(t *testing.T) (context.Context, *ingestService, *pgxpool.Pool) {
+		t.Helper()
+		dbt := dbtest.Open(t)
+		t.Cleanup(func() { dbt.Close() })
+		ctx := context.Background()
+		pool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+		require.NoError(t, err)
+		t.Cleanup(func() { pool.Close() })
+
+		m := metrics.NewMetrics(prometheus.NewRegistry())
+		models, err := data.NewModels(pool, m.DB)
+		require.NoError(t, err)
+
+		mockTokenIngestionService := NewTokenIngestionServiceMock(t)
+		mockTokenIngestionService.On("ProcessTokenChanges",
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		).Return(nil).Maybe()
+
+		svc, err := NewIngestService(IngestServiceConfig{
+			IngestionMode:         IngestionModeLive,
+			Models:                models,
+			RPCService:            &RPCServiceMock{},
+			LedgerBackend:         &LedgerBackendMock{},
+			TokenIngestionService: mockTokenIngestionService,
+			Metrics:               m,
+			Network:               network.TestNetworkPassphrase,
+			NetworkPassphrase:     network.TestNetworkPassphrase,
+			Archive:               &HistoryArchiveMock{},
+		})
+		require.NoError(t, err)
+		return ctx, svc, pool
+	}
+
+	// batchItem builds one ledger's persist payload carrying a transaction
+	// and an operation with ledger-derived TOIDs, so PKs never collide
+	// across the batch.
+	batchItem := func(seq uint32) persistItem {
+		toID := int64(seq) << 32
+		tx := createTestTransaction(fmt.Sprintf("%064x", seq), toID)
+		op := createTestOperation(toID + 1)
+		buffer := indexer.NewIndexerBuffer()
+		buffer.PushTransaction(testAddr1, &tx)
+		buffer.PushOperation(testAddr1, &op, &tx)
+		return persistItem{seq: seq, meta: dummyLedgerMeta(seq), contractData: newContractDataMemo(nil, seq), buffer: buffer}
+	}
+
+	t.Run("one commit set persists every ledger and the cursor lands on the last", func(t *testing.T) {
+		ctx, svc, pool := setupTest(t)
+		setupDBCursors(t, ctx, pool, 99, 99)
+
+		err := svc.persistLedgerData(ctx, []persistItem{batchItem(100), batchItem(101), batchItem(102)})
+		require.NoError(t, err)
+
+		var txCount, opCount int
+		require.NoError(t, pool.QueryRow(ctx, `SELECT count(*) FROM transactions`).Scan(&txCount))
+		require.NoError(t, pool.QueryRow(ctx, `SELECT count(*) FROM operations`).Scan(&opCount))
+		assert.Equal(t, 3, txCount)
+		assert.Equal(t, 3, opCount)
+
+		var cursor string
+		require.NoError(t, pool.QueryRow(ctx,
+			`SELECT value FROM ingest_store WHERE key = $1`, data.LatestLedgerCursorName).Scan(&cursor))
+		assert.Equal(t, "102", cursor, "the cursor must land on the batch's last ledger")
+	})
+
+	t.Run("a failure in any ledger rolls back the whole batch", func(t *testing.T) {
+		ctx, svc, pool := setupTest(t)
+		setupDBCursors(t, ctx, pool, 99, 99)
+
+		items := []persistItem{batchItem(100), batchItem(101), batchItem(102)}
+
+		// Pre-insert a row with ledger 102's transaction PK so the
+		// transactions sibling fails only on the batch's last ledger, after
+		// the earlier ledgers streamed successfully.
+		last := items[2].buffer.GetTransactions()[0]
+		_, err := pool.Exec(ctx,
+			`INSERT INTO transactions (hash, to_id, fee_charged, result_code, ledger_number, ledger_created_at)
+			 VALUES ($1, $2, 1, 'TransactionResultCodeTxSuccess', $3, $4)`,
+			[]byte("preexisting-hash"), last.ToID, 102, last.LedgerCreatedAt)
+		require.NoError(t, err)
+
+		err = svc.persistLedgerData(ctx, items)
+		require.Error(t, err)
+
+		var txCount, opCount int
+		require.NoError(t, pool.QueryRow(ctx, `SELECT count(*) FROM transactions`).Scan(&txCount))
+		require.NoError(t, pool.QueryRow(ctx, `SELECT count(*) FROM operations`).Scan(&opCount))
+		assert.Equal(t, 1, txCount, "only the pre-existing row may remain — no ledger of the batch may be durable")
+		assert.Equal(t, 0, opCount, "the operations sibling streamed successfully but must not have committed")
+
+		var cursor string
+		require.NoError(t, pool.QueryRow(ctx,
+			`SELECT value FROM ingest_store WHERE key = $1`, data.LatestLedgerCursorName).Scan(&cursor))
+		assert.Equal(t, "99", cursor, "the cursor must stay below the whole batch")
+	})
+}
+
 func Test_persistLedgerData_SiblingFailureRollsBackEverything(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()
@@ -3039,7 +3143,7 @@ func Test_persistLedgerData_SiblingFailureRollsBackEverything(t *testing.T) {
 		[]byte("preexisting-hash"), tx.ToID, ledgerSeq, tx.LedgerCreatedAt)
 	require.NoError(t, err)
 
-	err = ingestSvc.persistLedgerData(ctx, ledgerSeq, dummyLedgerMeta(1), nil, newContractDataMemo(nil, ledgerSeq), buffer)
+	err = ingestSvc.persistLedgerData(ctx, oneLedger(ledgerSeq, dummyLedgerMeta(1), nil, newContractDataMemo(nil, ledgerSeq), buffer))
 	require.Error(t, err)
 
 	var txCount, opCount int

--- a/internal/services/ingest_test.go
+++ b/internal/services/ingest_test.go
@@ -2984,3 +2984,73 @@ func Test_ingestService_ingestLiveLedgers_StageErrorStopsPipeline(t *testing.T) 
 	assert.Equal(t, strconv.FormatUint(uint64(startLedger+1), 10), cursor,
 		"the cursor must rest on the last fully persisted ledger")
 }
+
+// Test_persistLedgerData_SiblingFailureRollsBackEverything pins the commit barrier's pre-commit
+// contract: when one sibling COPY fails (here: a primary-key collision on transactions), no
+// sibling and no coordinated write may be durable — commits are held until every stream
+// succeeds, so a pre-commit failure leaves the database exactly as it was and the ledger fully
+// retryable.
+func Test_persistLedgerData_SiblingFailureRollsBackEverything(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	ctx := context.Background()
+
+	pool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	const ledgerSeq = uint32(100)
+	setupDBCursors(t, ctx, pool, ledgerSeq-1, ledgerSeq-1)
+
+	m := metrics.NewMetrics(prometheus.NewRegistry())
+	models, err := data.NewModels(pool, m.DB)
+	require.NoError(t, err)
+
+	mockTokenIngestionService := NewTokenIngestionServiceMock(t)
+	mockTokenIngestionService.On("ProcessTokenChanges",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return(nil).Maybe()
+
+	svc, err := NewIngestService(IngestServiceConfig{
+		IngestionMode:         IngestionModeLive,
+		Models:                models,
+		RPCService:            &RPCServiceMock{},
+		LedgerBackend:         &LedgerBackendMock{},
+		TokenIngestionService: mockTokenIngestionService,
+		Metrics:               m,
+		Network:               network.TestNetworkPassphrase,
+		NetworkPassphrase:     network.TestNetworkPassphrase,
+		Archive:               &HistoryArchiveMock{},
+	})
+	require.NoError(t, err)
+	ingestSvc := svc
+
+	tx := createTestTransaction("collision-hash", 100)
+	op := createTestOperation(101)
+	buffer := indexer.NewIndexerBuffer()
+	buffer.PushTransaction(testAddr1, &tx)
+	buffer.PushOperation(testAddr1, &op, &tx)
+
+	// Pre-insert a row with the transaction's exact primary key (to_id, ledger_created_at) so
+	// the transactions sibling's COPY fails after the other siblings have streamed their rows.
+	_, err = pool.Exec(ctx,
+		`INSERT INTO transactions (hash, to_id, fee_charged, result_code, ledger_number, ledger_created_at)
+		 VALUES ($1, $2, 1, 'TransactionResultCodeTxSuccess', $3, $4)`,
+		[]byte("preexisting-hash"), tx.ToID, ledgerSeq, tx.LedgerCreatedAt)
+	require.NoError(t, err)
+
+	err = ingestSvc.persistLedgerData(ctx, ledgerSeq, dummyLedgerMeta(1), nil, newContractDataMemo(nil, ledgerSeq), buffer)
+	require.Error(t, err)
+
+	var txCount, opCount int
+	require.NoError(t, pool.QueryRow(ctx, `SELECT count(*) FROM transactions`).Scan(&txCount))
+	require.NoError(t, pool.QueryRow(ctx, `SELECT count(*) FROM operations`).Scan(&opCount))
+	assert.Equal(t, 1, txCount, "only the pre-existing row may remain — the failed COPY must not be durable")
+	assert.Equal(t, 0, opCount, "the operations sibling streamed successfully but must not have committed")
+
+	var cursor string
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT value FROM ingest_store WHERE key = $1`, data.LatestLedgerCursorName).Scan(&cursor))
+	assert.Equal(t, strconv.FormatUint(uint64(ledgerSeq-1), 10), cursor,
+		"the coordinating transaction (and its cursor update) must roll back with the siblings")
+}


### PR DESCRIPTION
**Start with:** the doc comment on `persistLedgerData` in `internal/services/ingest_live.go`. Its commit-ordering rules are the contract for everything here.

### 1. Bulk COPYs stream on sibling connections

The three COPY families ran sequentially in one transaction on one connection, so the insert phase cost their sum and one Postgres backend did all the index maintenance.

They now stream concurrently on three sibling connections, each in its own transaction, while a coordinating transaction stages everything else. Table sets are disjoint with no FKs between them.

**Commits are the visibility point.** Siblings commit first, the coordinating transaction — whose cursor decides which ledgers exist — strictly last.

- Fail *before* the first commit → everything rolls back, retryable as before.
- Fail *after* → wraps `ErrPartialPersist`, fatal. COPY has no `ON CONFLICT`, so a retry would collide on PKs.

The only crash state this produces is orphaned rows above the cursor, which `DeleteRowsAboveLedger` clears at startup.

### 2. Backlogs coalesce into batched commits

When process outruns persist, up to `--live-persist-max-batch-size` consecutive ledgers fold into one commit set. At normal cadence every batch is size 1 and nothing changes.

### 3 and 4

Siblings commit with `synchronous_commit = off` (durability unchanged — the coordinator's synchronous commit covers their WAL). And batches only cut on *unseen* classification inputs, not any observation — the old rule cut every batch to size 1 and disabled batching entirely.

No performance numbers yet — review on design and correctness.

---
4 of 6 splitting #684. schema → fixes → pipeline → **seams** → write families → hardening
