### PR TITLE
feat(services): Phase 1 Implement Soroban state-change simulation 

### DIFF
--- a/internal/serve/graphql/resolvers/queries.resolvers.go
+++ b/internal/serve/graphql/resolvers/queries.resolvers.go
@@ -73,6 +73,11 @@ func (r *queryResolver) SimulateStateChanges(ctx context.Context, transactionXdr
 				Message:    err.Error(),
 				Extensions: map[string]interface{}{"code": "UNSUPPORTED_TRANSACTION"},
 			}
+		case errors.Is(err, services.ErrSimulationFailed):
+			return nil, &gqlerror.Error{
+				Message:    err.Error(),
+				Extensions: map[string]interface{}{"code": "SIMULATION_FAILED"},
+			}
 		default:
 			return nil, fmt.Errorf("simulating state changes: %w", err)
 		}

--- a/internal/serve/graphql/utils.go
+++ b/internal/serve/graphql/utils.go
@@ -36,6 +36,9 @@ var clientSafeErrorCodes = map[string]bool{
 	"UNAUTHENTICATED":           true,
 	"FORBIDDEN":                 true,
 	"PERSISTED_QUERY_NOT_FOUND": true, // gqlgen extension.AutomaticPersistedQuery: hash-only cache miss; the client must receive it verbatim to retry with the full query
+	"INVALID_TRANSACTION_XDR":   true, // simulateStateChanges: the transaction envelope failed to decode
+	"UNSUPPORTED_TRANSACTION":   true, // simulateStateChanges: the transaction/operation type is not simulatable
+	"SIMULATION_FAILED":         true, // simulateStateChanges: RPC simulateTransaction reported an error (e.g. a contract trap)
 }
 
 // CustomErrorPresenter provides more detailed error messages for GraphQL validation errors, and

--- a/internal/services/transaction_simulation.go
+++ b/internal/services/transaction_simulation.go
@@ -39,9 +39,9 @@ type SimulatedStateChanges struct {
 // TransactionSimulationService previews the state changes an unsubmitted
 // transaction would produce. It rebuilds the transaction's ledger-entry changes
 // (Soroban transactions via RPC simulateTransaction) and runs them through the
-// very same processors that build the history API's state changes — all in
-// memory, nothing written to the database. The point is for a preview to look
-// exactly like history.
+// very same processors that build the history API's state changes, all in
+// memory, with nothing written to the database. The point is for a preview to
+// look exactly like history.
 type TransactionSimulationService interface {
 	SimulateStateChanges(ctx context.Context, transactionXDR string) (*SimulatedStateChanges, error)
 }
@@ -116,12 +116,54 @@ func (s *transactionSimulationService) ledgerTransactionFromContract(transaction
 	if result.Error != "" {
 		return ingest.LedgerTransaction{}, 0, fmt.Errorf("%w: %s", ErrSimulationFailed, result.Error)
 	}
+	// A non-empty RestorePreamble means the transaction reads archived entries and
+	// would fail unless they are restored first. The recorded results/changes are
+	// not what the network would produce for the transaction as submitted, so we
+	// treat this as a simulation failure rather than returning a misleading preview.
+	if result.RestorePreamble.TransactionData.Resources.Footprint.ReadOnly != nil ||
+		result.RestorePreamble.TransactionData.Resources.Footprint.ReadWrite != nil {
+		return ingest.LedgerTransaction{}, 0, fmt.Errorf("%w: transaction requires restoring archived entries before it can succeed", ErrSimulationFailed)
+	}
+
+	// RPC records the auth entries an unsigned InvokeHostFunction would need to
+	// execute. The indexer reads operation auth to detect nested contract
+	// deployments and to collect participants, so we copy the recorded auth onto
+	// the operation before synthesizing. Without it, those changes are missed.
+	injectSimulatedAuth(&envelope, result)
 
 	tx, err := buildSimulatedLedgerTransaction(envelope, result)
 	if err != nil {
 		return ingest.LedgerTransaction{}, 0, fmt.Errorf("synthesizing ledger transaction: %w", err)
 	}
 	return tx, uint32(result.LatestLedger), nil
+}
+
+// injectSimulatedAuth copies the auth entries RPC recorded for the (unsigned)
+// invocation onto the InvokeHostFunction operation, so the synthesized
+// transaction carries the same auth a real submission would. Soroban
+// transactions have a single operation, so at most one result applies.
+func injectSimulatedAuth(envelope *xdr.TransactionEnvelope, result entities.RPCSimulateTransactionResult) {
+	if len(result.Results) == 0 {
+		return
+	}
+	var ops []xdr.Operation
+	switch envelope.Type {
+	case xdr.EnvelopeTypeEnvelopeTypeTx:
+		if envelope.V1 != nil {
+			ops = envelope.V1.Tx.Operations
+		}
+	case xdr.EnvelopeTypeEnvelopeTypeTxFeeBump:
+		if envelope.FeeBump != nil && envelope.FeeBump.Tx.InnerTx.V1 != nil {
+			ops = envelope.FeeBump.Tx.InnerTx.V1.Tx.Operations
+		}
+	default:
+		return
+	}
+	for i := range ops {
+		if ops[i].Body.Type == xdr.OperationTypeInvokeHostFunction && ops[i].Body.InvokeHostFunctionOp != nil {
+			ops[i].Body.InvokeHostFunctionOp.Auth = result.Results[0].Auth
+		}
+	}
 }
 
 // ledgerTransactionFromClassic will build the simulated ledger transaction for a
@@ -191,11 +233,12 @@ func buildSimulatedLedgerTransaction(envelope xdr.TransactionEnvelope, result en
 				},
 			},
 		},
+		// Protocol 23+ networks emit TransactionMetaV4, and processors branch on
+		// UnsafeMeta.V.
 		UnsafeMeta: xdr.TransactionMeta{
-			V: 3,
-			V3: &xdr.TransactionMetaV3{
-				Operations:  []xdr.OperationMeta{{Changes: changes}},
-				SorobanMeta: &xdr.SorobanTransactionMeta{Events: events},
+			V: 4,
+			V4: &xdr.TransactionMetaV4{
+				Operations: []xdr.OperationMetaV2{{Changes: changes, Events: events}},
 			},
 		},
 	}, nil
@@ -348,8 +391,14 @@ func isSorobanTransaction(envelope xdr.TransactionEnvelope) bool {
 }
 
 // stateChangesForTransaction runs a synthesized ledger transaction through the
-// ingestion pipeline into an in-memory buffer — the same processors real
-// ingestion uses, with no persistence — and returns the resulting state changes.
+// ingestion pipeline into an in-memory buffer. It uses the same processors real
+// ingestion uses, with no persistence, and returns the resulting state changes.
+//
+// Known limitation: this only runs the core Indexer processors, not the separate
+// protocol processors. SEP-41 custom tokens are handled by internal/services/sep41,
+// which the Indexer's token_transfer processor skips, and that processor is not
+// wired in here yet. So previews for SEP-41 tokens miss their balance changes.
+// Native and SAC token changes are covered.
 func (s *transactionSimulationService) stateChangesForTransaction(ctx context.Context, tx ingest.LedgerTransaction) ([]types.StateChange, error) {
 	buffer := indexer.NewIndexerBuffer()
 	if _, err := s.ledgerIndexer.ProcessLedgerTransactions(ctx, []ingest.LedgerTransaction{tx}, buffer); err != nil {

--- a/internal/services/transaction_simulation.go
+++ b/internal/services/transaction_simulation.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"strconv"
 
 	"github.com/alitto/pond/v2"
 	"github.com/stellar/go-stellar-sdk/ingest"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
+	"github.com/stellar/wallet-backend/internal/entities"
 	"github.com/stellar/wallet-backend/internal/indexer"
 	"github.com/stellar/wallet-backend/internal/indexer/types"
 )
@@ -21,21 +23,25 @@ var (
 	// ErrUnsupportedTransaction means the transaction (or one of its operations)
 	// is not supported by the implemented simulation sources.
 	ErrUnsupportedTransaction = errors.New("unsupported transaction")
+	// ErrSimulationFailed means RPC simulateTransaction ran but reported an error,
+	// for example the contract call would trap.
+	ErrSimulationFailed = errors.New("simulation failed")
 )
 
-// SimulatedStateChanges is the result of simulating an unsubmitted transaction:
-// the state changes the indexer would produce if it were submitted, evaluated
-// against LatestLedger.
+// SimulatedStateChanges is what a simulation returns: the state changes the
+// indexer would produce if this transaction were actually submitted, evaluated
+// against the ledger in LatestLedger.
 type SimulatedStateChanges struct {
 	LatestLedger uint32
 	StateChanges []types.StateChange
 }
 
 // TransactionSimulationService previews the state changes an unsubmitted
-// transaction would produce, by rebuilding the transaction's ledger-entry
-// changes (contract transactions via RPC simulateTransaction) and running them
-// through the same ingestion processors that produce the history API's state
-// changes — in memory, without persisting.
+// transaction would produce. It rebuilds the transaction's ledger-entry changes
+// (Soroban transactions via RPC simulateTransaction) and runs them through the
+// very same processors that build the history API's state changes — all in
+// memory, nothing written to the database. The point is for a preview to look
+// exactly like history.
 type TransactionSimulationService interface {
 	SimulateStateChanges(ctx context.Context, transactionXDR string) (*SimulatedStateChanges, error)
 }
@@ -72,14 +78,223 @@ func (s *transactionSimulationService) SimulateStateChanges(ctx context.Context,
 		return nil, fmt.Errorf("%w: transaction has no operations", ErrInvalidTransactionXDR)
 	}
 
-	if !isSorobanTransaction(envelope) {
-		return nil, fmt.Errorf("%w: classic transactions are not supported", ErrUnsupportedTransaction)
+	// Where the ledger-entry changes come from depends on the transaction type:
+	// Soroban transactions get them from RPC simulation, classic transactions by
+	// deriving them ourselves. From here both paths share the same synthesis and
+	// processors below.
+	var (
+		tx           ingest.LedgerTransaction
+		latestLedger uint32
+		err          error
+	)
+	if isSorobanTransaction(envelope) {
+		tx, latestLedger, err = s.ledgerTransactionFromContract(transactionXDR, envelope)
+	} else {
+		tx, latestLedger, err = s.ledgerTransactionFromClassic(ctx, envelope)
+	}
+	if err != nil {
+		return nil, err
 	}
 
-	// TODO(#618, phase 1): call rpcService.SimulateTransaction, map its
-	// stateChanges/events into a synthesized ingest.LedgerTransaction, and run
-	// it through stateChangesForTransaction.
-	return nil, fmt.Errorf("%w: contract transaction simulation is not implemented yet", ErrUnsupportedTransaction)
+	stateChanges, err := s.stateChangesForTransaction(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	return &SimulatedStateChanges{
+		LatestLedger: latestLedger,
+		StateChanges: stateChanges,
+	}, nil
+}
+
+// ledgerTransactionFromContract builds the simulated ledger transaction for a
+// Soroban transaction. It asks RPC to simulate the transaction and turns that
+// result into the ledger-entry changes and events the processors expect.
+func (s *transactionSimulationService) ledgerTransactionFromContract(transactionXDR string, envelope xdr.TransactionEnvelope) (ingest.LedgerTransaction, uint32, error) {
+	result, err := s.rpcService.SimulateTransaction(transactionXDR, entities.RPCResourceConfig{})
+	if err != nil {
+		return ingest.LedgerTransaction{}, 0, fmt.Errorf("simulating transaction via RPC: %w", err)
+	}
+	if result.Error != "" {
+		return ingest.LedgerTransaction{}, 0, fmt.Errorf("%w: %s", ErrSimulationFailed, result.Error)
+	}
+
+	tx, err := buildSimulatedLedgerTransaction(envelope, result)
+	if err != nil {
+		return ingest.LedgerTransaction{}, 0, fmt.Errorf("synthesizing ledger transaction: %w", err)
+	}
+	return tx, uint32(result.LatestLedger), nil
+}
+
+// ledgerTransactionFromClassic will build the simulated ledger transaction for a
+// classic transaction. RPC can't simulate classic operations, so we derive the
+// changes ourselves: work out which ledger entries the operation touches, fetch
+// their current state with GetLedgerEntries, then compute what they would become.
+// Not implemented yet.
+func (s *transactionSimulationService) ledgerTransactionFromClassic(_ context.Context, _ xdr.TransactionEnvelope) (ingest.LedgerTransaction, uint32, error) {
+	return ingest.LedgerTransaction{}, 0, fmt.Errorf("%w: classic transactions are not supported yet", ErrUnsupportedTransaction)
+}
+
+// buildSimulatedLedgerTransaction turns an RPC simulateTransaction result into a
+// LedgerTransaction that looks just like one from a real ledger, so the existing
+// processors can read it without knowing it came from a simulation. It puts the
+// simulation's before/after ledger entries where the processors look for
+// per-operation changes, pulls the contract events out of the diagnostic events
+// for the token-transfer processor, and marks the transaction as successful at
+// the ledger the simulation ran against. Nothing is executed or written.
+func buildSimulatedLedgerTransaction(envelope xdr.TransactionEnvelope, result entities.RPCSimulateTransactionResult) (ingest.LedgerTransaction, error) {
+	changes, err := ledgerEntryChangesFromSimulation(result.StateChanges)
+	if err != nil {
+		return ingest.LedgerTransaction{}, fmt.Errorf("building ledger entry changes: %w", err)
+	}
+	events, err := contractEventsFromSimulation(result.Events)
+	if err != nil {
+		return ingest.LedgerTransaction{}, fmt.Errorf("extracting contract events: %w", err)
+	}
+	opResults, err := successOperationResults(envelope)
+	if err != nil {
+		return ingest.LedgerTransaction{}, err
+	}
+
+	// minResourceFee should be a decimal integer; if it is missing or malformed,
+	// fall back to 0 (the fee row is only an estimate anyway).
+	feeCharged, parseErr := strconv.ParseInt(result.MinResourceFee, 10, 64)
+	if parseErr != nil {
+		feeCharged = 0
+	}
+
+	return ingest.LedgerTransaction{
+		Index:    1,
+		Envelope: envelope,
+		Ledger: xdr.LedgerCloseMeta{
+			V: 0,
+			V0: &xdr.LedgerCloseMetaV0{
+				LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+					Header: xdr.LedgerHeader{LedgerSeq: xdr.Uint32(result.LatestLedger)},
+				},
+			},
+		},
+		Result: xdr.TransactionResultPair{
+			Result: xdr.TransactionResult{
+				FeeCharged: xdr.Int64(feeCharged),
+				Result: xdr.TransactionResultResult{
+					Code:    xdr.TransactionResultCodeTxSuccess,
+					Results: opResults,
+				},
+			},
+		},
+		UnsafeMeta: xdr.TransactionMeta{
+			V: 3,
+			V3: &xdr.TransactionMetaV3{
+				Operations:  []xdr.OperationMeta{{Changes: changes}},
+				SorobanMeta: &xdr.SorobanTransactionMeta{Events: events},
+			},
+		},
+	}, nil
+}
+
+// ledgerEntryChangesFromSimulation turns the simulation's before/after entries
+// into the xdr.LedgerEntryChanges the processors expect: the same
+// State/Created/Updated/Removed shape GetOperationChanges hands back as {Pre,
+// Post} pairs. Which one it is comes from which side is present. Before only
+// means the entry was removed, after only means it was created, both means it
+// was updated.
+func ledgerEntryChangesFromSimulation(stateChanges []entities.RPCSimulateStateChange) (xdr.LedgerEntryChanges, error) {
+	changes := make(xdr.LedgerEntryChanges, 0, len(stateChanges))
+	for _, sc := range stateChanges {
+		before, err := decodeLedgerEntry(sc.Before)
+		if err != nil {
+			return nil, fmt.Errorf("decoding before entry: %w", err)
+		}
+		after, err := decodeLedgerEntry(sc.After)
+		if err != nil {
+			return nil, fmt.Errorf("decoding after entry: %w", err)
+		}
+
+		switch {
+		case before == nil && after != nil:
+			changes = append(changes, xdr.LedgerEntryChange{
+				Type:    xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+				Created: after,
+			})
+		case before != nil && after != nil:
+			changes = append(changes,
+				xdr.LedgerEntryChange{Type: xdr.LedgerEntryChangeTypeLedgerEntryState, State: before},
+				xdr.LedgerEntryChange{Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated, Updated: after},
+			)
+		case before != nil && after == nil:
+			var key xdr.LedgerKey
+			if err := xdr.SafeUnmarshalBase64(sc.Key, &key); err != nil {
+				return nil, fmt.Errorf("decoding removed entry key: %w", err)
+			}
+			changes = append(changes,
+				xdr.LedgerEntryChange{Type: xdr.LedgerEntryChangeTypeLedgerEntryState, State: before},
+				xdr.LedgerEntryChange{Type: xdr.LedgerEntryChangeTypeLedgerEntryRemoved, Removed: &key},
+			)
+		}
+	}
+	return changes, nil
+}
+
+func decodeLedgerEntry(encoded *string) (*xdr.LedgerEntry, error) {
+	if encoded == nil {
+		return nil, nil
+	}
+	var entry xdr.LedgerEntry
+	if err := xdr.SafeUnmarshalBase64(*encoded, &entry); err != nil {
+		return nil, fmt.Errorf("decoding ledger entry: %w", err)
+	}
+	return &entry, nil
+}
+
+// contractEventsFromSimulation pulls the contract events out of the simulation's
+// diagnostic events. In real ingestion the token-transfer processor only sees
+// the contract's own emitted events (SorobanMeta.Events). The diagnostic stream
+// also carries bookkeeping events like fn_call and logs, which never reach that
+// processor, so we drop them to keep the preview matching history.
+func contractEventsFromSimulation(encoded []string) ([]xdr.ContractEvent, error) {
+	events := make([]xdr.ContractEvent, 0, len(encoded))
+	for _, e := range encoded {
+		var diagnostic xdr.DiagnosticEvent
+		if err := xdr.SafeUnmarshalBase64(e, &diagnostic); err != nil {
+			return nil, fmt.Errorf("decoding diagnostic event: %w", err)
+		}
+		if diagnostic.Event.Type == xdr.ContractEventTypeDiagnostic {
+			continue
+		}
+		events = append(events, diagnostic.Event)
+	}
+	return events, nil
+}
+
+// successOperationResults builds one "succeeded" OperationResult per operation,
+// matching each operation's type. The processors look results up by position, so
+// the slice has to be there and each entry's type has to line up with the
+// matching operation in the envelope.
+func successOperationResults(envelope xdr.TransactionEnvelope) (*[]xdr.OperationResult, error) {
+	ops := envelope.Operations()
+	results := make([]xdr.OperationResult, 0, len(ops))
+	for _, op := range ops {
+		tr := xdr.OperationResultTr{Type: op.Body.Type}
+		switch op.Body.Type {
+		case xdr.OperationTypeInvokeHostFunction:
+			tr.InvokeHostFunctionResult = &xdr.InvokeHostFunctionResult{
+				Code:    xdr.InvokeHostFunctionResultCodeInvokeHostFunctionSuccess,
+				Success: &xdr.Hash{},
+			}
+		case xdr.OperationTypeExtendFootprintTtl:
+			tr.ExtendFootprintTtlResult = &xdr.ExtendFootprintTtlResult{
+				Code: xdr.ExtendFootprintTtlResultCodeExtendFootprintTtlSuccess,
+			}
+		case xdr.OperationTypeRestoreFootprint:
+			tr.RestoreFootprintResult = &xdr.RestoreFootprintResult{
+				Code: xdr.RestoreFootprintResultCodeRestoreFootprintSuccess,
+			}
+		default:
+			return nil, fmt.Errorf("%w: operation type %s", ErrUnsupportedTransaction, op.Body.Type)
+		}
+		results = append(results, xdr.OperationResult{Code: xdr.OperationResultCodeOpInner, Tr: &tr})
+	}
+	return &results, nil
 }
 
 // isSorobanTransaction reports whether the envelope carries a Soroban operation

--- a/internal/services/transaction_simulation.go
+++ b/internal/services/transaction_simulation.go
@@ -78,10 +78,9 @@ func (s *transactionSimulationService) SimulateStateChanges(ctx context.Context,
 		return nil, fmt.Errorf("%w: transaction has no operations", ErrInvalidTransactionXDR)
 	}
 
-	// Where the ledger-entry changes come from depends on the transaction type:
-	// Soroban transactions get them from RPC simulation, classic transactions by
-	// deriving them ourselves. From here both paths share the same synthesis and
-	// processors below.
+	// Soroban transactions get ledger-entry changes from RPC simulation. Classic
+	// derivation is not implemented yet and returns ErrUnsupportedTransaction.
+	// Successful simulation paths then share the synthesis and processing below.
 	var (
 		tx           ingest.LedgerTransaction
 		latestLedger uint32

--- a/internal/services/transaction_simulation.go
+++ b/internal/services/transaction_simulation.go
@@ -130,6 +130,8 @@ func (s *transactionSimulationService) ledgerTransactionFromContract(transaction
 // changes ourselves: work out which ledger entries the operation touches, fetch
 // their current state with GetLedgerEntries, then compute what they would become.
 // Not implemented yet.
+//
+//nolint:unparam // stub: returns a nil LedgerTransaction until classic derivation is implemented.
 func (s *transactionSimulationService) ledgerTransactionFromClassic(_ context.Context, _ xdr.TransactionEnvelope) (ingest.LedgerTransaction, uint32, error) {
 	return ingest.LedgerTransaction{}, 0, fmt.Errorf("%w: classic transactions are not supported yet", ErrUnsupportedTransaction)
 }
@@ -155,12 +157,20 @@ func buildSimulatedLedgerTransaction(envelope xdr.TransactionEnvelope, result en
 		return ingest.LedgerTransaction{}, err
 	}
 
-	// minResourceFee should be a decimal integer; if it is missing or malformed,
-	// fall back to 0 (the fee row is only an estimate anyway).
-	feeCharged, parseErr := strconv.ParseInt(result.MinResourceFee, 10, 64)
-	if parseErr != nil {
-		feeCharged = 0
+	// The fee row should reflect what the network would charge: the transaction's
+	// inclusion fee plus the resource fee. tx.Fee already bundles the inclusion fee
+	// with the resource-fee bid, so subtract the declared bid to isolate the inclusion
+	// portion, then add the freshly simulated resource fee. A missing or malformed
+	// minResourceFee is a synthesis error rather than a silent zero-fee preview.
+	minResourceFee, err := strconv.ParseInt(result.MinResourceFee, 10, 64)
+	if err != nil {
+		return ingest.LedgerTransaction{}, fmt.Errorf("parsing minResourceFee %q: %w", result.MinResourceFee, err)
 	}
+	inclusionFee := int64(envelope.Fee()) - envelopeResourceFee(envelope)
+	if inclusionFee < 0 {
+		inclusionFee = 0
+	}
+	feeCharged := inclusionFee + minResourceFee
 
 	return ingest.LedgerTransaction{
 		Index:    1,
@@ -190,6 +200,29 @@ func buildSimulatedLedgerTransaction(envelope xdr.TransactionEnvelope, result en
 			},
 		},
 	}, nil
+}
+
+// envelopeResourceFee returns the Soroban resource fee the transaction declares in
+// its SorobanData, or 0 if it declares none. tx.Fee already includes this bid, so
+// subtracting it leaves the inclusion fee.
+func envelopeResourceFee(envelope xdr.TransactionEnvelope) int64 {
+	var ext xdr.TransactionExt
+	switch envelope.Type {
+	case xdr.EnvelopeTypeEnvelopeTypeTx:
+		if envelope.V1 != nil {
+			ext = envelope.V1.Tx.Ext
+		}
+	case xdr.EnvelopeTypeEnvelopeTypeTxFeeBump:
+		if envelope.FeeBump != nil && envelope.FeeBump.Tx.InnerTx.V1 != nil {
+			ext = envelope.FeeBump.Tx.InnerTx.V1.Tx.Ext
+		}
+	default:
+		// TxV0 and non-transaction envelope types carry no SorobanData.
+	}
+	if ext.SorobanData != nil {
+		return int64(ext.SorobanData.ResourceFee)
+	}
+	return 0
 }
 
 // ledgerEntryChangesFromSimulation turns the simulation's before/after entries
@@ -248,9 +281,15 @@ func decodeLedgerEntry(encoded *string) (*xdr.LedgerEntry, error) {
 
 // contractEventsFromSimulation pulls the contract events out of the simulation's
 // diagnostic events. In real ingestion the token-transfer processor only sees
-// the contract's own emitted events (SorobanMeta.Events). The diagnostic stream
-// also carries bookkeeping events like fn_call and logs, which never reach that
-// processor, so we drop them to keep the preview matching history.
+// the contract's own emitted events (SorobanMeta.Events), so we keep only the
+// events that would land there and drop the rest:
+//   - diagnostic-type bookkeeping events (fn_call, logs, …), which never reach
+//     that processor; and
+//   - events from a failed nested call the outer invocation caught
+//     (InSuccessfulContractCall=false), which are absent from committed
+//     SorobanMeta.Events.
+//
+// Including either would produce state changes history never shows.
 func contractEventsFromSimulation(encoded []string) ([]xdr.ContractEvent, error) {
 	events := make([]xdr.ContractEvent, 0, len(encoded))
 	for _, e := range encoded {
@@ -258,7 +297,7 @@ func contractEventsFromSimulation(encoded []string) ([]xdr.ContractEvent, error)
 		if err := xdr.SafeUnmarshalBase64(e, &diagnostic); err != nil {
 			return nil, fmt.Errorf("decoding diagnostic event: %w", err)
 		}
-		if diagnostic.Event.Type == xdr.ContractEventTypeDiagnostic {
+		if !diagnostic.InSuccessfulContractCall || diagnostic.Event.Type == xdr.ContractEventTypeDiagnostic {
 			continue
 		}
 		events = append(events, diagnostic.Event)

--- a/internal/services/transaction_simulation_test.go
+++ b/internal/services/transaction_simulation_test.go
@@ -301,3 +301,82 @@ func strkeyContractID(contractID [32]byte) (string, error) {
 	addr := xdr.ScAddress{Type: xdr.ScAddressTypeScAddressTypeContract, ContractId: (*xdr.ContractId)(&contractID)}
 	return addr.String()
 }
+
+func TestLedgerEntryChangesFromSimulation(t *testing.T) {
+	accountEntry := xdr.LedgerEntry{
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeAccount,
+			Account: &xdr.AccountEntry{
+				AccountId: xdr.MustAddress("GAFOZZL77R57WMGES6BO6WJDEIFJ6662GMCVEX6ZESULRX3FRBGSSV5N"),
+				Balance:   100,
+			},
+		},
+	}
+	entryB64, err := xdr.MarshalBase64(accountEntry)
+	require.NoError(t, err)
+
+	accountKey := xdr.LedgerKey{
+		Type: xdr.LedgerEntryTypeAccount,
+		Account: &xdr.LedgerKeyAccount{
+			AccountId: xdr.MustAddress("GAFOZZL77R57WMGES6BO6WJDEIFJ6662GMCVEX6ZESULRX3FRBGSSV5N"),
+		},
+	}
+	keyB64, err := xdr.MarshalBase64(accountKey)
+	require.NoError(t, err)
+
+	t.Run("created (after only) becomes a Created change", func(t *testing.T) {
+		changes, err := ledgerEntryChangesFromSimulation([]entities.RPCSimulateStateChange{
+			{Type: "created", After: &entryB64},
+		})
+		require.NoError(t, err)
+		require.Len(t, changes, 1)
+		assert.Equal(t, xdr.LedgerEntryChangeTypeLedgerEntryCreated, changes[0].Type)
+		require.NotNil(t, changes[0].Created)
+		assert.Equal(t, accountEntry, *changes[0].Created)
+	})
+
+	t.Run("updated (before+after) becomes State + Updated", func(t *testing.T) {
+		changes, err := ledgerEntryChangesFromSimulation([]entities.RPCSimulateStateChange{
+			{Type: "updated", Before: &entryB64, After: &entryB64},
+		})
+		require.NoError(t, err)
+		require.Len(t, changes, 2)
+		assert.Equal(t, xdr.LedgerEntryChangeTypeLedgerEntryState, changes[0].Type)
+		assert.Equal(t, xdr.LedgerEntryChangeTypeLedgerEntryUpdated, changes[1].Type)
+	})
+
+	t.Run("removed (before only) becomes State + Removed with the decoded key", func(t *testing.T) {
+		changes, err := ledgerEntryChangesFromSimulation([]entities.RPCSimulateStateChange{
+			{Type: "deleted", Before: &entryB64, Key: keyB64},
+		})
+		require.NoError(t, err)
+		require.Len(t, changes, 2)
+		assert.Equal(t, xdr.LedgerEntryChangeTypeLedgerEntryState, changes[0].Type)
+		assert.Equal(t, xdr.LedgerEntryChangeTypeLedgerEntryRemoved, changes[1].Type)
+		require.NotNil(t, changes[1].Removed)
+		assert.Equal(t, accountKey, *changes[1].Removed)
+	})
+
+	t.Run("invalid before XDR is an error", func(t *testing.T) {
+		bad := "not-valid-xdr"
+		_, err := ledgerEntryChangesFromSimulation([]entities.RPCSimulateStateChange{
+			{Type: "updated", Before: &bad, After: &entryB64},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("invalid after XDR is an error", func(t *testing.T) {
+		bad := "not-valid-xdr"
+		_, err := ledgerEntryChangesFromSimulation([]entities.RPCSimulateStateChange{
+			{Type: "created", After: &bad},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("invalid removed key XDR is an error", func(t *testing.T) {
+		_, err := ledgerEntryChangesFromSimulation([]entities.RPCSimulateStateChange{
+			{Type: "deleted", Before: &entryB64, Key: "not-valid-xdr"},
+		})
+		require.Error(t, err)
+	})
+}

--- a/internal/services/transaction_simulation_test.go
+++ b/internal/services/transaction_simulation_test.go
@@ -12,8 +12,10 @@ import (
 	"github.com/stellar/go-stellar-sdk/txnbuild"
 	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stellar/wallet-backend/internal/entities"
 	"github.com/stellar/wallet-backend/internal/indexer/types"
 )
 
@@ -36,20 +38,100 @@ func TestTransactionSimulationService_SimulateStateChanges_errors(t *testing.T) 
 		assert.ErrorIs(t, err, ErrUnsupportedTransaction)
 	})
 
-	t.Run("🔴 soroban transaction not implemented yet", func(t *testing.T) {
-		nativeContractID, err := xdr.Asset{Type: xdr.AssetTypeAssetTypeNative}.ContractID(network.TestNetworkPassphrase)
+	t.Run("🔴 RPC simulation error surfaced", func(t *testing.T) {
+		rpcMock := &RPCServiceMock{}
+		rpcMock.On("SimulateTransaction", mock.Anything, mock.Anything).
+			Return(entities.RPCSimulateTransactionResult{Error: "contract trapped"}, nil).Once()
+		errSvc, err := NewTransactionSimulationService(rpcMock, network.TestNetworkPassphrase)
 		require.NoError(t, err)
-		contractID := xdr.ContractId(nativeContractID)
-		_, err = svc.SimulateStateChanges(ctx, buildTxXDR(t, &txnbuild.InvokeHostFunction{
-			HostFunction: xdr.HostFunction{
-				Type: xdr.HostFunctionTypeHostFunctionTypeInvokeContract,
-				InvokeContract: &xdr.InvokeContractArgs{
-					ContractAddress: xdr.ScAddress{Type: xdr.ScAddressTypeScAddressTypeContract, ContractId: &contractID},
-					FunctionName:    "transfer",
-				},
+
+		_, err = errSvc.SimulateStateChanges(ctx, nativeSACTransferXDR(t, keypair.MustRandom().Address()))
+		assert.ErrorIs(t, err, ErrSimulationFailed)
+		rpcMock.AssertExpectations(t)
+	})
+}
+
+// TestTransactionSimulationService_SimulateStateChanges_soroban drives the full
+// Phase 1 path: a canned RPC simulateTransaction result (a native-SAC transfer
+// event) is synthesized into a ledger transaction and run through the real
+// processors, which must emit a DEBIT for the sender and a CREDIT for the
+// receiver, the same state changes history would show.
+func TestTransactionSimulationService_SimulateStateChanges_soroban(t *testing.T) {
+	from := keypair.MustRandom().Address()
+	to := keypair.MustRandom().Address()
+	amount := big.NewInt(10_000_000)
+	nativeAsset := xdr.Asset{Type: xdr.AssetTypeAssetTypeNative}
+
+	transferEvent := contractevents.GenerateEvent(
+		contractevents.EventTypeTransfer,
+		from, to, "",
+		nativeAsset,
+		amount,
+		network.TestNetworkPassphrase,
+	)
+
+	diagnosticB64, err := xdr.MarshalBase64(xdr.DiagnosticEvent{InSuccessfulContractCall: true, Event: transferEvent})
+	require.NoError(t, err)
+
+	txXDR := nativeSACTransferXDR(t, from)
+
+	rpcMock := &RPCServiceMock{}
+	rpcMock.On("SimulateTransaction", txXDR, entities.RPCResourceConfig{}).
+		Return(entities.RPCSimulateTransactionResult{
+			LatestLedger:   2900148,
+			MinResourceFee: "100",
+			Events:         []string{diagnosticB64},
+		}, nil).Once()
+
+	svc, err := NewTransactionSimulationService(rpcMock, network.TestNetworkPassphrase)
+	require.NoError(t, err)
+
+	result, err := svc.SimulateStateChanges(context.Background(), txXDR)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2900148), result.LatestLedger)
+
+	nativeContractID, err := nativeAsset.ContractID(network.TestNetworkPassphrase)
+	require.NoError(t, err)
+	nativeContractAddress, err := strkeyContractID(nativeContractID)
+	require.NoError(t, err)
+
+	byReason := map[types.StateChangeReason]types.StateChange{}
+	for _, sc := range result.StateChanges {
+		if sc.StateChangeCategory == types.StateChangeCategoryBalance {
+			byReason[sc.StateChangeReason] = sc
+		}
+	}
+
+	debit, ok := byReason[types.StateChangeReasonDebit]
+	require.True(t, ok, "expected a DEBIT balance change for the sender")
+	assert.Equal(t, from, string(debit.AccountID))
+	assert.Equal(t, "10000000", debit.Amount.String)
+	assert.Equal(t, nativeContractAddress, debit.TokenID.String())
+
+	credit, ok := byReason[types.StateChangeReasonCredit]
+	require.True(t, ok, "expected a CREDIT balance change for the receiver")
+	assert.Equal(t, to, string(credit.AccountID))
+	assert.Equal(t, "10000000", credit.Amount.String)
+	assert.Equal(t, nativeContractAddress, credit.TokenID.String())
+
+	rpcMock.AssertExpectations(t)
+}
+
+// nativeSACTransferXDR builds an unsigned InvokeHostFunction envelope invoking
+// the native SAC's transfer: a minimal, fully-encodable Soroban transaction.
+func nativeSACTransferXDR(t *testing.T, sourceAccount string) string {
+	t.Helper()
+	nativeContractID, err := xdr.Asset{Type: xdr.AssetTypeAssetTypeNative}.ContractID(network.TestNetworkPassphrase)
+	require.NoError(t, err)
+	contractID := xdr.ContractId(nativeContractID)
+	return buildTxXDRFrom(t, sourceAccount, &txnbuild.InvokeHostFunction{
+		HostFunction: xdr.HostFunction{
+			Type: xdr.HostFunctionTypeHostFunctionTypeInvokeContract,
+			InvokeContract: &xdr.InvokeContractArgs{
+				ContractAddress: xdr.ScAddress{Type: xdr.ScAddressTypeScAddressTypeContract, ContractId: &contractID},
+				FunctionName:    "transfer",
 			},
-		}))
-		assert.ErrorIs(t, err, ErrUnsupportedTransaction)
+		},
 	})
 }
 
@@ -191,10 +273,16 @@ func synthesizeSorobanTransaction(t *testing.T, sourceAccount string, events ...
 	}
 }
 
-// buildTxXDR builds an unsigned single-op transaction envelope.
+// buildTxXDR builds an unsigned single-op transaction envelope from a random source.
 func buildTxXDR(t *testing.T, op txnbuild.Operation) string {
 	t.Helper()
-	src := txnbuild.SimpleAccount{AccountID: keypair.MustRandom().Address(), Sequence: 1}
+	return buildTxXDRFrom(t, keypair.MustRandom().Address(), op)
+}
+
+// buildTxXDRFrom builds an unsigned single-op transaction envelope from the given source.
+func buildTxXDRFrom(t *testing.T, sourceAccount string, op txnbuild.Operation) string {
+	t.Helper()
+	src := txnbuild.SimpleAccount{AccountID: sourceAccount, Sequence: 1}
 	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount:        &src,
 		Operations:           []txnbuild.Operation{op},


### PR DESCRIPTION
### What

Implement `SimulateStateChanges`for SAC transaction. It now returns the real state changes the transaction would
produce if submitted, by reusing the ingestion pipeline:

1. Simulates the transaction via RPC `simulateTransaction`.
2.Synthesizes an `ingest.LedgerTransaction` from the result (before/after ledger entries + contract events, as `TransactionMetaV4`).
3. Run it through the same in-memory processors real ingestion uses, so the preview is identical to the history API. 

### Why

Part of https://github.com/stellar/wallet-backend/issues/618. 

### Known limitations

- Classic transactions are not supported yet .
- Equivalence test (re-simulate a real already-ingested Soroban transaction and assert it matches the history path) is a tracked follow-up.
- Intended as an internal service; no untrusted public access assumed.

### Issue that this PR addresses

Part of https://github.com/stellar/wallet-backend/issues/618.

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [ ] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [ ] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
