### PR TITLE
fix(tests): make malformed-payload test assertions SDK-version agnostic

### DIFF
--- a/internal/indexer/types/types.go
+++ b/internal/indexer/types/types.go
@@ -90,9 +90,8 @@ func (a AddressBytea) Value() (driver.Value, error) {
 		return nil, fmt.Errorf("decoding stellar address %s: %w", a, err)
 	}
 	if versionByte == strkey.VersionByteMuxedAccount {
-		// strkey.DecodeAny validates the checksum and version byte but not the
-		// version-specific payload length, so guard it before slicing: a muxed payload
-		// must be exactly 40 bytes (32-byte ed25519 key + 8-byte id).
+		// Guard the payload length before slicing, since the decoder may not enforce
+		// it: a muxed payload must be exactly 40 bytes (32-byte ed25519 key + 8-byte id).
 		if len(rawBytes) != 40 {
 			return nil, fmt.Errorf("stellar muxed address %s has a %d-byte payload; expected 40 bytes", a, len(rawBytes))
 		}

--- a/internal/indexer/types/types_test.go
+++ b/internal/indexer/types/types_test.go
@@ -570,23 +570,24 @@ func TestMuxedAddressBytea_NormalizesToBaseAccount(t *testing.T) {
 // rather than truncating it. (Contract C... and account G... still pass.)
 func TestAddressBytea_RejectsMalformedPayload(t *testing.T) {
 	// A 5-byte-payload strkey encoded under the account version byte: not a real key.
+	// The rejection may come from the decoder or from Value's own length guard, so
+	// assert only that it errors and names the offending address.
 	bogus, err := strkey.Encode(strkey.VersionByteAccountID, []byte{1, 2, 3, 4, 5})
 	require.NoError(t, err)
 
 	_, err = AddressBytea(bogus).Value()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "5-byte")
+	assert.Contains(t, err.Error(), bogus)
 
 	// A checksum-valid muxed strkey with a short (<32-byte) payload must be rejected,
-	// not panic: strkey.DecodeAny does not enforce the version-specific payload length,
-	// so Value must guard before slicing the ed25519 key out of it.
+	// not panic, even when the decoder does not enforce the payload length itself.
 	shortMuxed, err := strkey.Encode(strkey.VersionByteMuxedAccount, []byte{1, 2, 3, 4, 5})
 	require.NoError(t, err)
 	require.NotPanics(t, func() {
 		_, err = AddressBytea(shortMuxed).Value()
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "expected 40 bytes")
+	assert.Contains(t, err.Error(), shortMuxed)
 
 	// Control: a normal contract address still encodes fine.
 	_, err = AddressBytea("CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA").Value()


### PR DESCRIPTION
### What

 Relax the assertions in `TestAddressBytea_RejectsMalformedPayload`  to check only that `Value()` returns an error naming the address, instead of matching the exact wording.
 
 `go test ./internal/indexer/types/` passes on top of current main (SDK v0.7.3).

### Why

The test was written in #693 against the go-stellar-sdk SDK version pinned on that branch (`v0.6.1-0.20260625225930`). Meanwhile main upgraded to `v0.7.3`, where assertions no longer matched.

### Known limitations

N/A

### Issue that this PR addresses

Test failure: https://github.com/stellar/wallet-backend/actions/runs/33118398719/job/98700363631

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
