### PR TITLE
chore(ingest): remove dead SAC metadata enrichment path

### DIFF
--- a/cmd/protocol_migrate.go
+++ b/cmd/protocol_migrate.go
@@ -234,7 +234,7 @@ func runMigration(
 		}
 		metadataPool := pond.NewPool(0)
 		defer metadataPool.StopAndWait()
-		cms, cmsErr := services.NewContractMetadataService(rpcService, models.Contract, metadataPool)
+		cms, cmsErr := services.NewContractMetadataService(rpcService, metadataPool)
 		if cmsErr != nil {
 			return fmt.Errorf("instantiating contract metadata service: %w", cmsErr)
 		}

--- a/cmd/protocol_migrate.go
+++ b/cmd/protocol_migrate.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/alitto/pond/v2"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/lib/pq"
 	"github.com/prometheus/client_golang/prometheus"
@@ -232,9 +231,7 @@ func runMigration(
 			}
 			return h.LatestLedger, nil
 		}
-		metadataPool := pond.NewPool(0)
-		defer metadataPool.StopAndWait()
-		cms, cmsErr := services.NewContractMetadataService(rpcService, metadataPool)
+		cms, cmsErr := services.NewContractMetadataService(rpcService)
 		if cmsErr != nil {
 			return fmt.Errorf("instantiating contract metadata service: %w", cmsErr)
 		}

--- a/cmd/protocol_setup.go
+++ b/cmd/protocol_setup.go
@@ -9,7 +9,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/alitto/pond/v2"
 	_ "github.com/lib/pq"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -109,9 +108,7 @@ func (c *protocolSetupCmd) Run(databaseURL, rpcURL, networkPassphrase string, pr
 	// Build the contract metadata service. Per-protocol validators that need
 	// it (e.g. SEP-41) pull it from ProtocolDeps; the framework itself is
 	// agnostic.
-	metadataPool := pond.NewPool(0)
-	defer metadataPool.StopAndWait()
-	metadataService, err := services.NewContractMetadataService(rpcService, metadataPool)
+	metadataService, err := services.NewContractMetadataService(rpcService)
 	if err != nil {
 		return fmt.Errorf("creating contract metadata service: %w", err)
 	}

--- a/cmd/protocol_setup.go
+++ b/cmd/protocol_setup.go
@@ -111,7 +111,7 @@ func (c *protocolSetupCmd) Run(databaseURL, rpcURL, networkPassphrase string, pr
 	// agnostic.
 	metadataPool := pond.NewPool(0)
 	defer metadataPool.StopAndWait()
-	metadataService, err := services.NewContractMetadataService(rpcService, models.Contract, metadataPool)
+	metadataService, err := services.NewContractMetadataService(rpcService, metadataPool)
 	if err != nil {
 		return fmt.Errorf("creating contract metadata service: %w", err)
 	}

--- a/internal/data/contract_tokens.go
+++ b/internal/data/contract_tokens.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/stellar/wallet-backend/internal/db"
-	"github.com/stellar/wallet-backend/internal/indexer/types"
 	"github.com/stellar/wallet-backend/internal/metrics"
 	"github.com/stellar/wallet-backend/internal/utils"
 )
@@ -30,13 +29,6 @@ func DeterministicContractID(contractID string) uuid.UUID {
 // ContractModelInterface defines the interface for contract token operations.
 type ContractModelInterface interface {
 	GetExisting(ctx context.Context, dbTx pgx.Tx, contractIDs []string) ([]string, error)
-	// GetSACContractsMissingMetadata returns the contract_id of every SAC-typed row
-	// whose name is still NULL, i.e. whose RPC enrichment has not yet succeeded.
-	// Enrichment populates name (see BatchUpdateMetadata), so an enriched row drops
-	// out of the result and the set converges to empty. Instance-derived SAC rows are
-	// created with full metadata, so only rows from pre-existing data can match.
-	// Reads through any db.Querier (pool or transaction).
-	GetSACContractsMissingMetadata(ctx context.Context, q db.Querier) ([]string, error)
 	// BatchInsert inserts multiple contracts with pre-computed IDs.
 	// Uses INSERT ... ON CONFLICT (contract_id) DO NOTHING for idempotent operations.
 	// Contracts must have their ID field set via DeterministicContractID before calling.
@@ -86,23 +78,6 @@ func (m *ContractModel) GetExisting(ctx context.Context, dbTx pgx.Tx, contractID
 	if err != nil {
 		m.Metrics.QueryErrors.WithLabelValues("GetExisting", "contract_tokens", utils.GetDBErrorType(err)).Inc()
 		return nil, fmt.Errorf("querying existing contract IDs: %w", err)
-	}
-	return ids, nil
-}
-
-// GetSACContractsMissingMetadata returns the contract_id of every SAC-typed
-// contract_tokens row whose name is still NULL. See the interface godoc for why
-// name (not code) is the convergent staleness marker.
-func (m *ContractModel) GetSACContractsMissingMetadata(ctx context.Context, q db.Querier) ([]string, error) {
-	const query = `SELECT contract_id FROM contract_tokens WHERE type = $1 AND name IS NULL`
-
-	start := time.Now()
-	ids, err := db.QueryMany[string](ctx, q, query, string(types.ContractTypeSAC))
-	m.Metrics.QueryDuration.WithLabelValues("GetSACContractsMissingMetadata", "contract_tokens").Observe(time.Since(start).Seconds())
-	m.Metrics.QueriesTotal.WithLabelValues("GetSACContractsMissingMetadata", "contract_tokens").Inc()
-	if err != nil {
-		m.Metrics.QueryErrors.WithLabelValues("GetSACContractsMissingMetadata", "contract_tokens", utils.GetDBErrorType(err)).Inc()
-		return nil, fmt.Errorf("querying SAC contracts missing metadata: %w", err)
 	}
 	return ids, nil
 }

--- a/internal/data/contract_tokens_test.go
+++ b/internal/data/contract_tokens_test.go
@@ -135,41 +135,6 @@ func TestContractModel_GetExisting(t *testing.T) {
 	})
 }
 
-func TestContractModel_GetSACContractsMissingMetadata(t *testing.T) {
-	ctx := context.Background()
-
-	dbt := dbtest.Open(t)
-	defer dbt.Close()
-	dbConnectionPool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
-	require.NoError(t, err)
-	defer dbConnectionPool.Close()
-
-	reg := prometheus.NewRegistry()
-	dbMetrics := metrics.NewMetrics(reg).DB
-	m := &ContractModel{DB: dbConnectionPool, Metrics: dbMetrics}
-
-	name := "Enriched"
-	symbol := "ENR"
-	contracts := []*Contract{
-		// Stale SAC (name NULL) — the only row that should be returned.
-		{ID: DeterministicContractID("sac-stale"), ContractID: "sac-stale", Type: "SAC", Decimals: 0},
-		// Enriched SAC (name set) — excluded, since enrichment populates name.
-		{ID: DeterministicContractID("sac-enriched"), ContractID: "sac-enriched", Type: "SAC", Name: &name, Symbol: &symbol, Decimals: 7},
-		// Non-SAC row with a NULL name — excluded, wrong type.
-		{ID: DeterministicContractID("sep41-null"), ContractID: "sep41-null", Type: "SEP41", Decimals: 0},
-	}
-
-	err = db.RunInTransaction(ctx, dbConnectionPool, func(dbTx pgx.Tx) error {
-		return m.BatchInsert(ctx, dbTx, contracts)
-	})
-	require.NoError(t, err)
-
-	// Read through the pool — the production caller path (db.Querier).
-	ids, err := m.GetSACContractsMissingMetadata(ctx, dbConnectionPool)
-	require.NoError(t, err)
-	require.ElementsMatch(t, []string{"sac-stale"}, ids)
-}
-
 func TestContractModel_BatchInsert(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/data/mocks.go
+++ b/internal/data/mocks.go
@@ -42,14 +42,6 @@ func (m *ContractModelMock) GetExisting(ctx context.Context, dbTx pgx.Tx, contra
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *ContractModelMock) GetSACContractsMissingMetadata(ctx context.Context, q db.Querier) ([]string, error) {
-	args := m.Called(ctx, q)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).([]string), args.Error(1)
-}
-
 func (m *ContractModelMock) BatchInsert(ctx context.Context, dbTx pgx.Tx, contracts []*Contract) error {
 	args := m.Called(ctx, dbTx, contracts)
 	return args.Error(0)

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -200,7 +200,7 @@ func setupDeps(ctx context.Context, cfg Configs) (services.IngestService, func()
 	metrics.RegisterPoolMetrics(m.Registry(), "contract_metadata", contractMetadataPool)
 
 	// Create ContractMetadataService for fetching and storing token metadata
-	contractMetadataService, err := services.NewContractMetadataService(rpcService, models.Contract, contractMetadataPool)
+	contractMetadataService, err := services.NewContractMetadataService(rpcService, contractMetadataPool)
 	if err != nil {
 		return nil, nil, fmt.Errorf("instantiating contract metadata service: %w", err)
 	}
@@ -241,7 +241,6 @@ func setupDeps(ctx context.Context, cfg Configs) (services.IngestService, func()
 	checkpointService := services.NewCheckpointService(services.CheckpointServiceConfig{
 		DB:                        models.DB,
 		Archive:                   archive,
-		ContractMetadataService:   contractMetadataService,
 		TrustlineAssetModel:       models.TrustlineAsset,
 		TrustlineBalanceModel:     models.TrustlineBalance,
 		NativeBalanceModel:        models.NativeBalance,
@@ -304,7 +303,6 @@ func setupDeps(ctx context.Context, cfg Configs) (services.IngestService, func()
 		ProtocolProcessors:        protocolProcessors,
 		ProtocolValidators:        protocolValidators,
 		WasmSpecExtractor:         wasmExtractor,
-		ContractMetadataService:   contractMetadataService,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("instantiating ingest service: %w", err)

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/alitto/pond/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -194,13 +193,8 @@ func setupDeps(ctx context.Context, cfg Configs) (services.IngestService, func()
 		return nil, nil, fmt.Errorf("creating ledger backend: %w", err)
 	}
 
-	// Create pond pool for contract metadata fetching, bounded to the batch size
-	// ContractMetadataService itself submits per round-trip (pond.NewPool(0) is unbounded).
-	contractMetadataPool := pond.NewPool(services.SimulateTransactionBatchSize)
-	metrics.RegisterPoolMetrics(m.Registry(), "contract_metadata", contractMetadataPool)
-
-	// Create ContractMetadataService for fetching and storing token metadata
-	contractMetadataService, err := services.NewContractMetadataService(rpcService, contractMetadataPool)
+	// Create ContractMetadataService for fetching token metadata via RPC
+	contractMetadataService, err := services.NewContractMetadataService(rpcService)
 	if err != nil {
 		return nil, nil, fmt.Errorf("instantiating contract metadata service: %w", err)
 	}
@@ -328,10 +322,9 @@ func setupDeps(ctx context.Context, cfg Configs) (services.IngestService, func()
 		}
 		log.Info("Servers gracefully stopped")
 
-		// Stop the ingest service's worker pools and the contract-metadata pool
-		// before the DB pool, so no pooled task outlives the connection pool.
+		// Stop the ingest service's worker pools before the DB pool, so no
+		// pooled task outlives the connection pool.
 		ingestService.Close()
-		contractMetadataPool.StopAndWait()
 
 		if err := ledgerBackend.Close(); err != nil {
 			log.Ctx(ctx).Warnf("closing ledger backend: %v", err)

--- a/internal/services/checkpoint.go
+++ b/internal/services/checkpoint.go
@@ -24,26 +24,17 @@ import (
 	"github.com/stellar/wallet-backend/internal/indexer/processors"
 	"github.com/stellar/wallet-backend/internal/indexer/types"
 	"github.com/stellar/wallet-backend/internal/metrics"
-	"github.com/stellar/wallet-backend/internal/utils"
 )
 
 const (
 	// flushBatchSize is the number of entries to buffer before flushing to DB.
 	flushBatchSize = 250_000
-	// maxSACEnrichmentRetries bounds retries of the RPC-backed SAC metadata enrichment. A
-	// failure that outlasts the retries falls back to ledger-derived defaults, which the
-	// restartable EnrichStaleSACMetadata pass re-attempts on the next startup.
-	maxSACEnrichmentRetries = 5
 )
 
 // CheckpointService orchestrates checkpoint population by coordinating
 // token and WASM ingestion.
 type CheckpointService interface {
 	PopulateFromCheckpoint(ctx context.Context, checkpointLedger uint32, initializeCursors func(pgx.Tx) error) error
-	// EnrichStaleSACMetadata enriches any SAC contract_tokens rows still left at their
-	// ledger-derived defaults. Safe and cheap to call on every startup; it is a no-op
-	// once all SAC rows are enriched. See the method godoc.
-	EnrichStaleSACMetadata(ctx context.Context) error
 }
 
 var _ CheckpointService = (*checkpointService)(nil)
@@ -64,7 +55,6 @@ func defaultReaderFactory(ctx context.Context, archive historyarchive.ArchiveInt
 type CheckpointServiceConfig struct {
 	DB                        *pgxpool.Pool
 	Archive                   historyarchive.ArchiveInterface
-	ContractMetadataService   ContractMetadataService
 	TrustlineAssetModel       wbdata.TrustlineAssetModelInterface
 	TrustlineBalanceModel     wbdata.TrustlineBalanceModelInterface
 	NativeBalanceModel        wbdata.NativeBalanceModelInterface
@@ -81,7 +71,6 @@ type CheckpointServiceConfig struct {
 type checkpointService struct {
 	db                        *pgxpool.Pool
 	archive                   historyarchive.ArchiveInterface
-	contractMetadataService   ContractMetadataService
 	trustlineAssetModel       wbdata.TrustlineAssetModelInterface
 	trustlineBalanceModel     wbdata.TrustlineBalanceModelInterface
 	nativeBalanceModel        wbdata.NativeBalanceModelInterface
@@ -94,11 +83,6 @@ type checkpointService struct {
 	networkPassphrase         string
 	metricsService            *metrics.IngestionMetrics
 	readerFactory             readerFactory
-	// sacEnrichmentRetries / sacEnrichmentBackoff bound the SAC metadata enrichment
-	// retry. Defaulted in NewCheckpointService; overridable in tests to keep the
-	// retry path fast.
-	sacEnrichmentRetries int
-	sacEnrichmentBackoff time.Duration
 }
 
 // NewCheckpointService creates a CheckpointService.
@@ -106,7 +90,6 @@ func NewCheckpointService(cfg CheckpointServiceConfig) *checkpointService {
 	return &checkpointService{
 		db:                        cfg.DB,
 		archive:                   cfg.Archive,
-		contractMetadataService:   cfg.ContractMetadataService,
 		trustlineAssetModel:       cfg.TrustlineAssetModel,
 		trustlineBalanceModel:     cfg.TrustlineBalanceModel,
 		nativeBalanceModel:        cfg.NativeBalanceModel,
@@ -119,8 +102,6 @@ func NewCheckpointService(cfg CheckpointServiceConfig) *checkpointService {
 		networkPassphrase:         cfg.NetworkPassphrase,
 		metricsService:            cfg.MetricsService,
 		readerFactory:             defaultReaderFactory,
-		sacEnrichmentRetries:      maxSACEnrichmentRetries,
-		sacEnrichmentBackoff:      maxRetryBackoff,
 	}
 }
 
@@ -248,12 +229,6 @@ type checkpointProcessor struct {
 	contractAddressesByWasmHash                       map[xdr.Hash][]xdr.Hash
 	entries, trustlineCount, accountCount, batchCount int
 	startTime                                         time.Time
-	// pendingSACMetadata holds contract IDs of SAC rows still missing
-	// name/symbol/decimals after the load. Instance-derived SAC rows carry
-	// full metadata, so this is normally empty. finalize populates this
-	// without making any RPC call; PopulateFromCheckpoint fetches metadata
-	// for these IDs in a short follow-up transaction after the load commits.
-	pendingSACMetadata []string
 	// pendingSACBalances holds SAC-shaped balance entries seen during the scan. They
 	// are not written to the batch during the pass because a balance entry's shape does
 	// not by itself identify its contract as a SAC. finalize keeps only those whose
@@ -353,83 +328,7 @@ func (s *checkpointService) PopulateFromCheckpoint(ctx context.Context, checkpoi
 		return fmt.Errorf("running db transaction for checkpoint population: %w", err)
 	}
 
-	// Enrich SAC metadata via RPC in a short follow-up transaction, after the
-	// load (including cursor initialization) has already committed. The enrichment
-	// retries on transient failures; if it still fails it is logged and leaves these
-	// rows at their ledger-derived defaults — it must not undo the completed load.
-	// The restartable EnrichStaleSACMetadata pass re-attempts them on the next startup.
-	if len(proc.pendingSACMetadata) > 0 {
-		if enrichErr := s.enrichSACMetadataWithRetry(ctx, proc.pendingSACMetadata); enrichErr != nil {
-			log.Ctx(ctx).Errorf("enriching SAC metadata after checkpoint load (defaults retained, retried on restart): %v", enrichErr)
-		}
-	}
 	return nil
-}
-
-// enrichSACMetadata fetches name/symbol/decimals for the given SAC contracts
-// via RPC and updates their contract_tokens rows in a short transaction. It
-// runs after PopulateFromCheckpoint's load transaction has already committed,
-// so RPC round-trips (batches of 20 with a sleep between batches) never hold
-// the load's row locks. Any error here (fetch or write) is returned for the
-// caller to log — it never rolls back the already-completed load.
-func (s *checkpointService) enrichSACMetadata(ctx context.Context, contractIDs []string) error {
-	sacContracts, err := s.contractMetadataService.FetchSACMetadata(ctx, contractIDs)
-	if err != nil {
-		return fmt.Errorf("fetching SAC metadata: %w", err)
-	}
-	if len(sacContracts) == 0 {
-		return nil
-	}
-	err = db.RunInTransaction(ctx, s.db, func(dbTx pgx.Tx) error {
-		if txErr := s.contractModel.BatchUpdateMetadata(ctx, dbTx, sacContracts); txErr != nil {
-			return fmt.Errorf("updating SAC contract_tokens metadata: %w", txErr)
-		}
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("running SAC metadata enrichment transaction: %w", err)
-	}
-	log.Ctx(ctx).Infof("Enriched %d SAC contract_tokens rows after checkpoint load", len(sacContracts))
-	return nil
-}
-
-// enrichSACMetadataWithRetry runs enrichSACMetadata under a bounded backoff so a
-// transient RPC/DB blip does not immediately drop these rows to their ledger-derived
-// defaults. A failure that outlasts the retries is returned to the caller; the
-// restartable EnrichStaleSACMetadata pass is the backstop.
-func (s *checkpointService) enrichSACMetadataWithRetry(ctx context.Context, contractIDs []string) error {
-	_, err := utils.RetryWithBackoff(ctx, s.sacEnrichmentRetries, s.sacEnrichmentBackoff,
-		func(ctx context.Context) (struct{}, error) {
-			return struct{}{}, s.enrichSACMetadata(ctx, contractIDs)
-		},
-		func(attempt int, retryErr error, backoff time.Duration) {
-			log.Ctx(ctx).Warnf("enriching SAC metadata (attempt %d/%d): %v, retrying in %v...",
-				attempt+1, s.sacEnrichmentRetries, retryErr, backoff)
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("enriching SAC metadata with retry: %w", err)
-	}
-	return nil
-}
-
-// EnrichStaleSACMetadata finds SAC contract_tokens rows still missing their metadata
-// (name left NULL because a prior enrichment never completed) and enriches them via
-// RPC. It runs on every startup, so an enrichment that failed during checkpoint load
-// — or in an earlier run — is retried until it succeeds; once every SAC row is
-// enriched it finds nothing and is a cheap no-op. A failure is returned for the caller
-// to log: it must not block ingestion, since the rows keep their working defaults and
-// the next startup retries.
-func (s *checkpointService) EnrichStaleSACMetadata(ctx context.Context) error {
-	contractIDs, err := s.contractModel.GetSACContractsMissingMetadata(ctx, s.db)
-	if err != nil {
-		return fmt.Errorf("finding SAC contracts missing metadata: %w", err)
-	}
-	if len(contractIDs) == 0 {
-		return nil
-	}
-	log.Ctx(ctx).Infof("Found %d SAC contract_tokens rows missing metadata; enriching", len(contractIDs))
-	return s.enrichSACMetadataWithRetry(ctx, contractIDs)
 }
 
 // processEntry handles Account, Trustline, and ContractData entries from a checkpoint.
@@ -572,18 +471,6 @@ func (p *checkpointProcessor) flushRemainingBatch(ctx context.Context) error {
 // finalize identifies SEP-41 contracts, fetches metadata, stores tokens in DB,
 // and persists protocol WASMs and contracts.
 func (p *checkpointProcessor) finalize(ctx context.Context, dbTx pgx.Tx) error {
-	// Identify SAC contracts missing code/issuer. SAC rows are created from
-	// their instance entry with full metadata, so this is normally empty; any
-	// row still missing metadata gets it fetched via RPC afterward, in a short
-	// follow-up transaction once this load has committed (see
-	// PopulateFromCheckpoint / enrichSACMetadata) so RPC round-trips never
-	// extend this transaction's row locks.
-	for _, contract := range p.data.uniqueContractTokens {
-		if contract.Type == string(types.ContractTypeSAC) && contract.Code == nil {
-			p.pendingSACMetadata = append(p.pendingSACMetadata, contract.ContractID)
-		}
-	}
-
 	// Store contract tokens and trustline assets in DB
 	if err := p.service.storeTokensInDB(ctx, dbTx, p.data.uniqueAssets, p.data.uniqueContractTokens); err != nil {
 		return fmt.Errorf("storing tokens in postgres: %w", err)

--- a/internal/services/checkpoint_test.go
+++ b/internal/services/checkpoint_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"testing"
-	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/prometheus/client_golang/prometheus"
@@ -94,7 +93,6 @@ func makeContractInstanceChange(contractHash [32]byte, wasmHash xdr.Hash) ingest
 type checkpointTestFixture struct {
 	svc                       *checkpointService
 	reader                    *ChangeReaderMock
-	contractMetadataService   *ContractMetadataServiceMock
 	trustlineAssetModel       *wbdata.TrustlineAssetModelMock
 	trustlineBalanceModel     *wbdata.TrustlineBalanceModelMock
 	nativeBalanceModel        *wbdata.NativeBalanceModelMock
@@ -117,7 +115,6 @@ func setupCheckpointTest(t *testing.T) checkpointTestFixture {
 	t.Cleanup(func() { dbPool.Close() })
 
 	readerMock := NewChangeReaderMock(t)
-	contractMetadataServiceMock := NewContractMetadataServiceMock(t)
 	trustlineAssetModelMock := wbdata.NewTrustlineAssetModelMock(t)
 	trustlineBalanceModelMock := wbdata.NewTrustlineBalanceModelMock(t)
 	nativeBalanceModelMock := wbdata.NewNativeBalanceModelMock(t)
@@ -135,7 +132,6 @@ func setupCheckpointTest(t *testing.T) checkpointTestFixture {
 	svc := &checkpointService{
 		db:                        dbPool,
 		archive:                   &HistoryArchiveMock{},
-		contractMetadataService:   contractMetadataServiceMock,
 		trustlineAssetModel:       trustlineAssetModelMock,
 		trustlineBalanceModel:     trustlineBalanceModelMock,
 		nativeBalanceModel:        nativeBalanceModelMock,
@@ -149,15 +145,11 @@ func setupCheckpointTest(t *testing.T) checkpointTestFixture {
 		readerFactory: func(_ context.Context, _ historyarchive.ArchiveInterface, _ uint32) (ingest.ChangeReader, error) {
 			return readerMock, nil
 		},
-		// Keep the SAC-enrichment retry path exercised but fast in tests.
-		sacEnrichmentRetries: 3,
-		sacEnrichmentBackoff: time.Millisecond,
 	}
 
 	return checkpointTestFixture{
 		svc:                       svc,
 		reader:                    readerMock,
-		contractMetadataService:   contractMetadataServiceMock,
 		trustlineAssetModel:       trustlineAssetModelMock,
 		trustlineBalanceModel:     trustlineBalanceModelMock,
 		nativeBalanceModel:        nativeBalanceModelMock,
@@ -460,8 +452,6 @@ func TestCheckpointService_PopulateFromCheckpoint_VerifiedSACBalanceRecorded(t *
 			cs[0].Code != nil && *cs[0].Code == "USDC"
 	})).Return(nil).Once()
 
-	// FetchSACMetadata must NOT be called: the verified instance already provides metadata.
-
 	err := f.svc.PopulateFromCheckpoint(context.Background(), 100, func(_ pgx.Tx) error { return nil })
 	require.NoError(t, err)
 }
@@ -484,50 +474,10 @@ func TestCheckpointService_PopulateFromCheckpoint_UnverifiedSACBalanceDropped(t 
 	f.reader.On("Close").Return(nil).Once()
 
 	// The unverified balance is dropped, so nothing is written: no SAC BatchCopy (finalize
-	// skips the empty set), no contractModel.BatchInsert from the shape, and no
-	// FetchSACMetadata. The strict mocks fail the test on any such unexpected call.
+	// skips the empty set) and no contractModel.BatchInsert from the shape. The strict
+	// mocks fail the test on any such unexpected call.
 
 	err := f.svc.PopulateFromCheckpoint(context.Background(), 100, func(_ pgx.Tx) error { return nil })
-	require.NoError(t, err)
-}
-
-// TestCheckpointService_EnrichStaleSACMetadata_NoStaleRowsIsNoOp proves the restartable pass
-// is a no-op when no SAC row is missing metadata: it must call neither RPC nor the write.
-func TestCheckpointService_EnrichStaleSACMetadata_NoStaleRowsIsNoOp(t *testing.T) {
-	f := setupCheckpointTest(t)
-	f.contractModel.On("GetSACContractsMissingMetadata", mock.Anything, mock.Anything).
-		Return([]string{}, nil).Once()
-
-	err := f.svc.EnrichStaleSACMetadata(context.Background())
-	require.NoError(t, err)
-}
-
-// TestCheckpointService_EnrichStaleSACMetadata_EnrichesStaleRows proves the restartable pass
-// enriches SAC rows still left at their ledger-derived defaults.
-func TestCheckpointService_EnrichStaleSACMetadata_EnrichesStaleRows(t *testing.T) {
-	f := setupCheckpointTest(t)
-
-	tokenHash := [32]byte{5, 5, 5}
-	tokenAddr := strkey.MustEncode(strkey.VersionByteContract, tokenHash[:])
-
-	f.contractModel.On("GetSACContractsMissingMetadata", mock.Anything, mock.Anything).
-		Return([]string{tokenAddr}, nil).Once()
-
-	enrichedName := "Stale Token"
-	enrichedSymbol := "STL"
-	f.contractMetadataService.On("FetchSACMetadata", mock.Anything, []string{tokenAddr}).
-		Return([]*wbdata.Contract{{
-			ID:         wbdata.DeterministicContractID(tokenAddr),
-			ContractID: tokenAddr,
-			Type:       string(types.ContractTypeSAC),
-			Name:       &enrichedName,
-			Symbol:     &enrichedSymbol,
-		}}, nil).Once()
-	f.contractModel.On("BatchUpdateMetadata", mock.Anything, mock.Anything, mock.MatchedBy(func(cs []*wbdata.Contract) bool {
-		return len(cs) == 1 && cs[0].ContractID == tokenAddr && cs[0].Name != nil && *cs[0].Name == enrichedName
-	})).Return(nil).Once()
-
-	err := f.svc.EnrichStaleSACMetadata(context.Background())
 	require.NoError(t, err)
 }
 

--- a/internal/services/contract_metadata.go
+++ b/internal/services/contract_metadata.go
@@ -1,5 +1,6 @@
 // Package services provides business logic for the wallet-backend.
-// This file implements ContractMetadataService for fetching SAC token metadata via RPC.
+// This file implements ContractMetadataService, an RPC-simulation helper for
+// reading single contract fields (name, symbol, decimals, balance, ...).
 package services
 
 import (
@@ -9,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/alitto/pond/v2"
 	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stellar/go-stellar-sdk/support/log"
@@ -24,13 +24,9 @@ import (
 const (
 	// SimulateTransactionBatchSize is the number of contracts to process in parallel
 	// when fetching metadata via RPC simulation. Exported so callers that size a
-	// worker pool to serve this batch size (cmd/ingest's contract-metadata pool,
-	// the SEP-41 validator's private pool) reference the same value instead of a
-	// hardcoded copy that can drift out of sync.
+	// worker pool to serve this batch size (the SEP-41 validator's private pool)
+	// reference the same value instead of a hardcoded copy that can drift out of sync.
 	SimulateTransactionBatchSize = 20
-
-	// batchSleepDuration is the delay between batches to avoid overwhelming the RPC.
-	batchSleepDuration = 2 * time.Second
 )
 
 // simulateMaxAttempts is the upper bound on retries for transient RPC failures
@@ -77,10 +73,9 @@ func isTransientSimulateErr(err error) bool {
 	return false
 }
 
-// ContractMetadataService handles fetching metadata for Stellar Asset Contract
-// (SAC) tokens via RPC simulation. Protocol-specific metadata (e.g. SEP-41
-// name/symbol/decimals) lives inside the per-protocol package — this surface
-// is intentionally limited to SAC (a Stellar primitive) plus the
+// ContractMetadataService fetches contract state via RPC simulation.
+// Protocol-specific metadata (e.g. SEP-41 name/symbol/decimals) lives inside
+// the per-protocol package; this surface is intentionally limited to the
 // FetchSingleField primitive that any per-protocol validator can compose on.
 type ContractMetadataService interface {
 	// FetchSingleField fetches a single contract method (name, symbol, decimals, balance, etc...) via RPC simulation.
@@ -92,25 +87,17 @@ var _ ContractMetadataService = (*contractMetadataService)(nil)
 
 type contractMetadataService struct {
 	rpcService   RPCService
-	pool         pond.Pool
 	dummyAccount *keypair.Full
 }
 
 // NewContractMetadataService creates a new ContractMetadataService instance.
-func NewContractMetadataService(
-	rpcService RPCService,
-	pool pond.Pool,
-) (ContractMetadataService, error) {
+func NewContractMetadataService(rpcService RPCService) (ContractMetadataService, error) {
 	if rpcService == nil {
 		return nil, fmt.Errorf("rpcService cannot be nil")
-	}
-	if pool == nil {
-		return nil, fmt.Errorf("pool cannot be nil")
 	}
 
 	return &contractMetadataService{
 		rpcService:   rpcService,
-		pool:         pool,
 		dummyAccount: keypair.MustRandom(),
 	}, nil
 }

--- a/internal/services/contract_metadata.go
+++ b/internal/services/contract_metadata.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/alitto/pond/v2"
@@ -17,9 +16,7 @@ import (
 	"github.com/stellar/go-stellar-sdk/txnbuild"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
-	"github.com/stellar/wallet-backend/internal/data"
 	"github.com/stellar/wallet-backend/internal/entities"
-	"github.com/stellar/wallet-backend/internal/indexer/types"
 )
 
 // errors / strings imports above already cover everything the retry helpers need.
@@ -86,10 +83,6 @@ func isTransientSimulateErr(err error) bool {
 // is intentionally limited to SAC (a Stellar primitive) plus the
 // FetchSingleField primitive that any per-protocol validator can compose on.
 type ContractMetadataService interface {
-	// FetchSACMetadata fetches metadata for SAC contracts by calling name() via RPC.
-	// SAC name() returns "code:issuer" format (or "native" for XLM).
-	// Returns []*data.Contract with Code, Issuer, Name, Symbol, and Decimals=7.
-	FetchSACMetadata(ctx context.Context, contractIDs []string) ([]*data.Contract, error)
 	// FetchSingleField fetches a single contract method (name, symbol, decimals, balance, etc...) via RPC simulation.
 	// The args parameter allows passing arguments to the contract function (e.g., address for balance(id) function).
 	FetchSingleField(ctx context.Context, contractAddress, functionName string, args ...xdr.ScVal) (xdr.ScVal, error)
@@ -98,130 +91,27 @@ type ContractMetadataService interface {
 var _ ContractMetadataService = (*contractMetadataService)(nil)
 
 type contractMetadataService struct {
-	rpcService    RPCService
-	contractModel data.ContractModelInterface
-	pool          pond.Pool
-	dummyAccount  *keypair.Full
+	rpcService   RPCService
+	pool         pond.Pool
+	dummyAccount *keypair.Full
 }
 
 // NewContractMetadataService creates a new ContractMetadataService instance.
 func NewContractMetadataService(
 	rpcService RPCService,
-	contractModel data.ContractModelInterface,
 	pool pond.Pool,
 ) (ContractMetadataService, error) {
 	if rpcService == nil {
 		return nil, fmt.Errorf("rpcService cannot be nil")
-	}
-	if contractModel == nil {
-		return nil, fmt.Errorf("contractModel cannot be nil")
 	}
 	if pool == nil {
 		return nil, fmt.Errorf("pool cannot be nil")
 	}
 
 	return &contractMetadataService{
-		rpcService:    rpcService,
-		contractModel: contractModel,
-		pool:          pool,
-		dummyAccount:  keypair.MustRandom(),
-	}, nil
-}
-
-// FetchSACMetadata fetches metadata for SAC contracts by calling name() via RPC.
-// SAC contracts return "code:issuer" format from name() (or "native" for XLM).
-// Returns []*data.Contract with Code, Issuer, Name, Symbol, and Decimals=7 (hardcoded for Stellar assets).
-// This function fails fast if any contract metadata fetch fails - partial results are not returned.
-func (s *contractMetadataService) FetchSACMetadata(ctx context.Context, contractIDs []string) ([]*data.Contract, error) {
-	if len(contractIDs) == 0 {
-		return []*data.Contract{}, nil
-	}
-
-	start := time.Now()
-	var (
-		contracts   []*data.Contract
-		mu          sync.Mutex
-		fetchErrors []error
-	)
-
-	// Process in batches to avoid overwhelming the RPC
-	for i := 0; i < len(contractIDs); i += SimulateTransactionBatchSize {
-		end := min(i+SimulateTransactionBatchSize, len(contractIDs))
-		batch := contractIDs[i:end]
-
-		group := s.pool.NewGroupContext(ctx)
-		for _, contractID := range batch {
-			group.Submit(func() {
-				contract, err := s.fetchSACMetadataForContract(ctx, contractID)
-				if err != nil {
-					mu.Lock()
-					fetchErrors = append(fetchErrors, fmt.Errorf("contract %s: %w", contractID, err))
-					mu.Unlock()
-					return
-				}
-				mu.Lock()
-				contracts = append(contracts, contract)
-				mu.Unlock()
-			})
-		}
-
-		if err := group.Wait(); err != nil {
-			return nil, fmt.Errorf("error in SAC metadata batch: %w", err)
-		}
-
-		// Sleep between batches to avoid overwhelming the RPC (skip for last batch)
-		if end < len(contractIDs) {
-			time.Sleep(batchSleepDuration)
-		}
-	}
-
-	// Fail if any contract metadata fetch failed - partial results are not acceptable
-	if len(fetchErrors) > 0 {
-		return nil, fmt.Errorf("failed to fetch metadata for %d SAC contracts: %w", len(fetchErrors), errors.Join(fetchErrors...))
-	}
-
-	log.Ctx(ctx).Infof("Fetched metadata for %d SAC contracts in %.4f seconds", len(contracts), time.Since(start).Seconds())
-	return contracts, nil
-}
-
-// fetchSACMetadataForContract fetches metadata for a single SAC contract by calling name().
-// Parses the name as "code:issuer" format or handles "native" as XLM.
-func (s *contractMetadataService) fetchSACMetadataForContract(ctx context.Context, contractID string) (*data.Contract, error) {
-	nameVal, err := s.FetchSingleField(ctx, contractID, "name")
-	if err != nil {
-		return nil, fmt.Errorf("fetching name: %w", err)
-	}
-
-	nameStr, ok := nameVal.GetStr()
-	if !ok {
-		return nil, fmt.Errorf("name value is not a string")
-	}
-	name := string(nameStr)
-
-	var code, issuer string
-	if name == "native" {
-		// Native XLM asset
-		code = "XLM"
-		issuer = ""
-	} else {
-		// Parse "code:issuer" format
-		parts := strings.SplitN(name, ":", 2)
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("malformed SAC name '%s': expected 'code:issuer' format", name)
-		}
-		code = parts[0]
-		issuer = parts[1]
-	}
-
-	return &data.Contract{
-		ID:         data.DeterministicContractID(contractID),
-		ContractID: contractID,
-		Type:       string(types.ContractTypeSAC),
-		Code:       &code,
-		Issuer:     &issuer,
-		Name:       &name,
-		Symbol:     &code,
-		Decimals:   7, // Stellar assets always use 7 decimals
+		rpcService:   rpcService,
+		pool:         pool,
+		dummyAccount: keypair.MustRandom(),
 	}, nil
 }
 

--- a/internal/services/contract_metadata_test.go
+++ b/internal/services/contract_metadata_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/alitto/pond/v2"
 	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -32,24 +31,15 @@ func ptrToScString(s string) *xdr.ScString {
 
 func TestNewContractMetadataService(t *testing.T) {
 	t.Run("returns error when rpcService is nil", func(t *testing.T) {
-		_, err := NewContractMetadataService(nil, pond.NewPool(0))
+		_, err := NewContractMetadataService(nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "rpcService cannot be nil")
 	})
 
-	t.Run("returns error when pool is nil", func(t *testing.T) {
-		mockRPCService := NewRPCServiceMock(t)
-		_, err := NewContractMetadataService(mockRPCService, nil)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "pool cannot be nil")
-	})
-
 	t.Run("creates service successfully", func(t *testing.T) {
 		mockRPCService := NewRPCServiceMock(t)
-		pool := pond.NewPool(0)
-		defer pool.Stop()
 
-		service, err := NewContractMetadataService(mockRPCService, pool)
+		service, err := NewContractMetadataService(mockRPCService)
 		assert.NoError(t, err)
 		assert.NotNil(t, service)
 	})
@@ -60,10 +50,7 @@ func TestFetchSingleField(t *testing.T) {
 
 	t.Run("returns error for invalid contract address", func(t *testing.T) {
 		mockRPCService := NewRPCServiceMock(t)
-		pool := pond.NewPool(2)
-		defer pool.Stop()
-
-		service, err := NewContractMetadataService(mockRPCService, pool)
+		service, err := NewContractMetadataService(mockRPCService)
 		require.NoError(t, err)
 
 		cms := service.(*contractMetadataService)
@@ -75,16 +62,13 @@ func TestFetchSingleField(t *testing.T) {
 
 	t.Run("returns error when RPC simulation fails", func(t *testing.T) {
 		mockRPCService := NewRPCServiceMock(t)
-		pool := pond.NewPool(2)
-		defer pool.Stop()
-
 		contractID := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
 
 		mockRPCService.On("SimulateTransaction", mock.Anything, mock.Anything).Return(
 			entities.RPCSimulateTransactionResult{}, errors.New("network error"),
 		)
 
-		service, err := NewContractMetadataService(mockRPCService, pool)
+		service, err := NewContractMetadataService(mockRPCService)
 		require.NoError(t, err)
 
 		cms := service.(*contractMetadataService)
@@ -97,9 +81,6 @@ func TestFetchSingleField(t *testing.T) {
 
 	t.Run("returns error when simulation result has error", func(t *testing.T) {
 		mockRPCService := NewRPCServiceMock(t)
-		pool := pond.NewPool(2)
-		defer pool.Stop()
-
 		contractID := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
 
 		mockRPCService.On("SimulateTransaction", mock.Anything, mock.Anything).Return(
@@ -107,7 +88,7 @@ func TestFetchSingleField(t *testing.T) {
 			nil,
 		)
 
-		service, err := NewContractMetadataService(mockRPCService, pool)
+		service, err := NewContractMetadataService(mockRPCService)
 		require.NoError(t, err)
 
 		cms := service.(*contractMetadataService)
@@ -120,9 +101,6 @@ func TestFetchSingleField(t *testing.T) {
 
 	t.Run("returns error when no results returned", func(t *testing.T) {
 		mockRPCService := NewRPCServiceMock(t)
-		pool := pond.NewPool(2)
-		defer pool.Stop()
-
 		contractID := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
 
 		mockRPCService.On("SimulateTransaction", mock.Anything, mock.Anything).Return(
@@ -130,7 +108,7 @@ func TestFetchSingleField(t *testing.T) {
 			nil,
 		)
 
-		service, err := NewContractMetadataService(mockRPCService, pool)
+		service, err := NewContractMetadataService(mockRPCService)
 		require.NoError(t, err)
 
 		cms := service.(*contractMetadataService)
@@ -142,9 +120,6 @@ func TestFetchSingleField(t *testing.T) {
 
 	t.Run("returns correct value for successful simulation", func(t *testing.T) {
 		mockRPCService := NewRPCServiceMock(t)
-		pool := pond.NewPool(2)
-		defer pool.Stop()
-
 		contractID := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
 
 		expectedScVal := xdr.ScVal{Type: xdr.ScValTypeScvString, Str: ptrToScString("TestToken")}
@@ -156,7 +131,7 @@ func TestFetchSingleField(t *testing.T) {
 			nil,
 		)
 
-		service, err := NewContractMetadataService(mockRPCService, pool)
+		service, err := NewContractMetadataService(mockRPCService)
 		require.NoError(t, err)
 
 		cms := service.(*contractMetadataService)
@@ -170,16 +145,13 @@ func TestFetchSingleField(t *testing.T) {
 
 	t.Run("returns error when context is cancelled", func(t *testing.T) {
 		mockRPCService := NewRPCServiceMock(t)
-		pool := pond.NewPool(2)
-		defer pool.Stop()
-
 		contractID := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
 
 		// Create cancelled context
 		cancelledCtx, cancel := context.WithCancel(ctx)
 		cancel()
 
-		service, err := NewContractMetadataService(mockRPCService, pool)
+		service, err := NewContractMetadataService(mockRPCService)
 		require.NoError(t, err)
 
 		cms := service.(*contractMetadataService)
@@ -196,9 +168,6 @@ func TestFetchSingleField(t *testing.T) {
 		t.Cleanup(func() { simulateMaxAttempts, simulateInitialBackoff = origAttempts, origBackoff })
 
 		mockRPCService := NewRPCServiceMock(t)
-		pool := pond.NewPool(2)
-		defer pool.Stop()
-
 		contractID := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
 
 		// Two transient failures (a "latency" message we whitelisted) then success.
@@ -213,7 +182,7 @@ func TestFetchSingleField(t *testing.T) {
 			}, nil,
 		).Once()
 
-		service, err := NewContractMetadataService(mockRPCService, pool)
+		service, err := NewContractMetadataService(mockRPCService)
 		require.NoError(t, err)
 
 		cms := service.(*contractMetadataService)
@@ -230,9 +199,6 @@ func TestFetchSingleField(t *testing.T) {
 		t.Cleanup(func() { simulateMaxAttempts, simulateInitialBackoff = origAttempts, origBackoff })
 
 		mockRPCService := NewRPCServiceMock(t)
-		pool := pond.NewPool(2)
-		defer pool.Stop()
-
 		contractID := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
 
 		// Permanent-shaped error (no transient marker) — must bail on first attempt.
@@ -240,7 +206,7 @@ func TestFetchSingleField(t *testing.T) {
 			entities.RPCSimulateTransactionResult{}, errors.New("invalid contract: function not found"),
 		).Once()
 
-		service, err := NewContractMetadataService(mockRPCService, pool)
+		service, err := NewContractMetadataService(mockRPCService)
 		require.NoError(t, err)
 
 		cms := service.(*contractMetadataService)

--- a/internal/services/contract_metadata_test.go
+++ b/internal/services/contract_metadata_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/stellar/wallet-backend/internal/data"
 	"github.com/stellar/wallet-backend/internal/entities"
 )
 
@@ -33,33 +32,24 @@ func ptrToScString(s string) *xdr.ScString {
 
 func TestNewContractMetadataService(t *testing.T) {
 	t.Run("returns error when rpcService is nil", func(t *testing.T) {
-		_, err := NewContractMetadataService(nil, data.NewContractModelMock(t), pond.NewPool(0))
+		_, err := NewContractMetadataService(nil, pond.NewPool(0))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "rpcService cannot be nil")
 	})
 
-	t.Run("returns error when contractModel is nil", func(t *testing.T) {
-		mockRPCService := NewRPCServiceMock(t)
-		_, err := NewContractMetadataService(mockRPCService, nil, pond.NewPool(0))
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "contractModel cannot be nil")
-	})
-
 	t.Run("returns error when pool is nil", func(t *testing.T) {
 		mockRPCService := NewRPCServiceMock(t)
-		mockContractModel := data.NewContractModelMock(t)
-		_, err := NewContractMetadataService(mockRPCService, mockContractModel, nil)
+		_, err := NewContractMetadataService(mockRPCService, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "pool cannot be nil")
 	})
 
 	t.Run("creates service successfully", func(t *testing.T) {
 		mockRPCService := NewRPCServiceMock(t)
-		mockContractModel := data.NewContractModelMock(t)
 		pool := pond.NewPool(0)
 		defer pool.Stop()
 
-		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
+		service, err := NewContractMetadataService(mockRPCService, pool)
 		assert.NoError(t, err)
 		assert.NotNil(t, service)
 	})
@@ -70,11 +60,10 @@ func TestFetchSingleField(t *testing.T) {
 
 	t.Run("returns error for invalid contract address", func(t *testing.T) {
 		mockRPCService := NewRPCServiceMock(t)
-		mockContractModel := data.NewContractModelMock(t)
 		pool := pond.NewPool(2)
 		defer pool.Stop()
 
-		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
+		service, err := NewContractMetadataService(mockRPCService, pool)
 		require.NoError(t, err)
 
 		cms := service.(*contractMetadataService)
@@ -86,7 +75,6 @@ func TestFetchSingleField(t *testing.T) {
 
 	t.Run("returns error when RPC simulation fails", func(t *testing.T) {
 		mockRPCService := NewRPCServiceMock(t)
-		mockContractModel := data.NewContractModelMock(t)
 		pool := pond.NewPool(2)
 		defer pool.Stop()
 
@@ -96,7 +84,7 @@ func TestFetchSingleField(t *testing.T) {
 			entities.RPCSimulateTransactionResult{}, errors.New("network error"),
 		)
 
-		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
+		service, err := NewContractMetadataService(mockRPCService, pool)
 		require.NoError(t, err)
 
 		cms := service.(*contractMetadataService)
@@ -109,7 +97,6 @@ func TestFetchSingleField(t *testing.T) {
 
 	t.Run("returns error when simulation result has error", func(t *testing.T) {
 		mockRPCService := NewRPCServiceMock(t)
-		mockContractModel := data.NewContractModelMock(t)
 		pool := pond.NewPool(2)
 		defer pool.Stop()
 
@@ -120,7 +107,7 @@ func TestFetchSingleField(t *testing.T) {
 			nil,
 		)
 
-		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
+		service, err := NewContractMetadataService(mockRPCService, pool)
 		require.NoError(t, err)
 
 		cms := service.(*contractMetadataService)
@@ -133,7 +120,6 @@ func TestFetchSingleField(t *testing.T) {
 
 	t.Run("returns error when no results returned", func(t *testing.T) {
 		mockRPCService := NewRPCServiceMock(t)
-		mockContractModel := data.NewContractModelMock(t)
 		pool := pond.NewPool(2)
 		defer pool.Stop()
 
@@ -144,7 +130,7 @@ func TestFetchSingleField(t *testing.T) {
 			nil,
 		)
 
-		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
+		service, err := NewContractMetadataService(mockRPCService, pool)
 		require.NoError(t, err)
 
 		cms := service.(*contractMetadataService)
@@ -156,7 +142,6 @@ func TestFetchSingleField(t *testing.T) {
 
 	t.Run("returns correct value for successful simulation", func(t *testing.T) {
 		mockRPCService := NewRPCServiceMock(t)
-		mockContractModel := data.NewContractModelMock(t)
 		pool := pond.NewPool(2)
 		defer pool.Stop()
 
@@ -171,7 +156,7 @@ func TestFetchSingleField(t *testing.T) {
 			nil,
 		)
 
-		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
+		service, err := NewContractMetadataService(mockRPCService, pool)
 		require.NoError(t, err)
 
 		cms := service.(*contractMetadataService)
@@ -185,7 +170,6 @@ func TestFetchSingleField(t *testing.T) {
 
 	t.Run("returns error when context is cancelled", func(t *testing.T) {
 		mockRPCService := NewRPCServiceMock(t)
-		mockContractModel := data.NewContractModelMock(t)
 		pool := pond.NewPool(2)
 		defer pool.Stop()
 
@@ -195,7 +179,7 @@ func TestFetchSingleField(t *testing.T) {
 		cancelledCtx, cancel := context.WithCancel(ctx)
 		cancel()
 
-		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
+		service, err := NewContractMetadataService(mockRPCService, pool)
 		require.NoError(t, err)
 
 		cms := service.(*contractMetadataService)
@@ -212,7 +196,6 @@ func TestFetchSingleField(t *testing.T) {
 		t.Cleanup(func() { simulateMaxAttempts, simulateInitialBackoff = origAttempts, origBackoff })
 
 		mockRPCService := NewRPCServiceMock(t)
-		mockContractModel := data.NewContractModelMock(t)
 		pool := pond.NewPool(2)
 		defer pool.Stop()
 
@@ -230,7 +213,7 @@ func TestFetchSingleField(t *testing.T) {
 			}, nil,
 		).Once()
 
-		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
+		service, err := NewContractMetadataService(mockRPCService, pool)
 		require.NoError(t, err)
 
 		cms := service.(*contractMetadataService)
@@ -247,7 +230,6 @@ func TestFetchSingleField(t *testing.T) {
 		t.Cleanup(func() { simulateMaxAttempts, simulateInitialBackoff = origAttempts, origBackoff })
 
 		mockRPCService := NewRPCServiceMock(t)
-		mockContractModel := data.NewContractModelMock(t)
 		pool := pond.NewPool(2)
 		defer pool.Stop()
 
@@ -258,222 +240,12 @@ func TestFetchSingleField(t *testing.T) {
 			entities.RPCSimulateTransactionResult{}, errors.New("invalid contract: function not found"),
 		).Once()
 
-		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
+		service, err := NewContractMetadataService(mockRPCService, pool)
 		require.NoError(t, err)
 
 		cms := service.(*contractMetadataService)
 		_, err = cms.FetchSingleField(ctx, contractID, "name")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "function not found")
-	})
-}
-
-func TestFetchSACMetadata(t *testing.T) {
-	ctx := context.Background()
-
-	t.Run("returns empty slice for empty input", func(t *testing.T) {
-		mockRPCService := NewRPCServiceMock(t)
-		mockContractModel := data.NewContractModelMock(t)
-		pool := pond.NewPool(5)
-		defer pool.Stop()
-
-		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
-		require.NoError(t, err)
-
-		result, err := service.FetchSACMetadata(ctx, []string{})
-
-		require.NoError(t, err)
-		assert.Empty(t, result)
-		// Verify no RPC calls were made
-		mockRPCService.AssertNotCalled(t, "SimulateTransaction", mock.Anything, mock.Anything)
-	})
-
-	t.Run("parses code:issuer format successfully", func(t *testing.T) {
-		mockRPCService := NewRPCServiceMock(t)
-		mockContractModel := data.NewContractModelMock(t)
-		pool := pond.NewPool(5)
-		defer pool.Stop()
-
-		contractID := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
-
-		// Mock name() returning "USDC:GCNY..."
-		nameScVal := xdr.ScVal{Type: xdr.ScValTypeScvString, Str: ptrToScString("USDC:GCNY5OXYSY4FKHOPT2SPOQZAOEIGXB5LBYW3HVU3OWSTQITS65M5RCNY")}
-
-		mockRPCService.On("SimulateTransaction", mock.Anything, mock.Anything).Return(
-			entities.RPCSimulateTransactionResult{
-				Results: []entities.RPCSimulateHostFunctionResult{{XDR: nameScVal}},
-			}, nil,
-		)
-
-		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
-		require.NoError(t, err)
-
-		result, err := service.FetchSACMetadata(ctx, []string{contractID})
-
-		require.NoError(t, err)
-		require.Len(t, result, 1)
-
-		contract := result[0]
-		assert.Equal(t, contractID, contract.ContractID)
-		assert.Equal(t, "SAC", contract.Type)
-		assert.Equal(t, "USDC", *contract.Code)
-		assert.Equal(t, "GCNY5OXYSY4FKHOPT2SPOQZAOEIGXB5LBYW3HVU3OWSTQITS65M5RCNY", *contract.Issuer)
-		assert.Equal(t, "USDC:GCNY5OXYSY4FKHOPT2SPOQZAOEIGXB5LBYW3HVU3OWSTQITS65M5RCNY", *contract.Name)
-		assert.Equal(t, "USDC", *contract.Symbol)
-		assert.Equal(t, uint32(7), contract.Decimals)
-	})
-
-	t.Run("handles native XLM asset", func(t *testing.T) {
-		mockRPCService := NewRPCServiceMock(t)
-		mockContractModel := data.NewContractModelMock(t)
-		pool := pond.NewPool(5)
-		defer pool.Stop()
-
-		contractID := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
-
-		// Mock name() returning "native"
-		nameScVal := xdr.ScVal{Type: xdr.ScValTypeScvString, Str: ptrToScString("native")}
-
-		mockRPCService.On("SimulateTransaction", mock.Anything, mock.Anything).Return(
-			entities.RPCSimulateTransactionResult{
-				Results: []entities.RPCSimulateHostFunctionResult{{XDR: nameScVal}},
-			}, nil,
-		)
-
-		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
-		require.NoError(t, err)
-
-		result, err := service.FetchSACMetadata(ctx, []string{contractID})
-
-		require.NoError(t, err)
-		require.Len(t, result, 1)
-
-		contract := result[0]
-		assert.Equal(t, contractID, contract.ContractID)
-		assert.Equal(t, "SAC", contract.Type)
-		assert.Equal(t, "XLM", *contract.Code)
-		assert.Equal(t, "", *contract.Issuer)
-		assert.Equal(t, "native", *contract.Name)
-		assert.Equal(t, "XLM", *contract.Symbol)
-		assert.Equal(t, uint32(7), contract.Decimals)
-	})
-
-	t.Run("returns error for contract with malformed name", func(t *testing.T) {
-		mockRPCService := NewRPCServiceMock(t)
-		mockContractModel := data.NewContractModelMock(t)
-		pool := pond.NewPool(5)
-		defer pool.Stop()
-
-		contractID := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
-
-		// Mock name() returning malformed value (no colon)
-		nameScVal := xdr.ScVal{Type: xdr.ScValTypeScvString, Str: ptrToScString("MALFORMED_NO_COLON")}
-
-		mockRPCService.On("SimulateTransaction", mock.Anything, mock.Anything).Return(
-			entities.RPCSimulateTransactionResult{
-				Results: []entities.RPCSimulateHostFunctionResult{{XDR: nameScVal}},
-			}, nil,
-		)
-
-		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
-		require.NoError(t, err)
-
-		result, err := service.FetchSACMetadata(ctx, []string{contractID})
-
-		// Should return error for malformed contract name
-		require.Error(t, err)
-		assert.Nil(t, result)
-		assert.Contains(t, err.Error(), "failed to fetch metadata")
-		assert.Contains(t, err.Error(), "malformed SAC name")
-	})
-
-	t.Run("returns error when RPC fails", func(t *testing.T) {
-		mockRPCService := NewRPCServiceMock(t)
-		mockContractModel := data.NewContractModelMock(t)
-		pool := pond.NewPool(5)
-		defer pool.Stop()
-
-		contractID := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
-
-		mockRPCService.On("SimulateTransaction", mock.Anything, mock.Anything).Return(
-			entities.RPCSimulateTransactionResult{}, errors.New("RPC timeout"),
-		)
-
-		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
-		require.NoError(t, err)
-
-		result, err := service.FetchSACMetadata(ctx, []string{contractID})
-
-		// Should return error when RPC fails
-		require.Error(t, err)
-		assert.Nil(t, result)
-		assert.Contains(t, err.Error(), "failed to fetch metadata")
-		assert.Contains(t, err.Error(), "RPC timeout")
-	})
-
-	t.Run("processes multiple contracts successfully", func(t *testing.T) {
-		mockRPCService := NewRPCServiceMock(t)
-		mockContractModel := data.NewContractModelMock(t)
-		pool := pond.NewPool(5)
-		defer pool.Stop()
-
-		contractID1 := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
-		contractID2 := "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA"
-
-		// Mock responses for two contracts - use mock.Anything for both calls
-		nameScVal1 := xdr.ScVal{Type: xdr.ScValTypeScvString, Str: ptrToScString("USDC:GCNY5OXYSY4FKHOPT2SPOQZAOEIGXB5LBYW3HVU3OWSTQITS65M5RCNY")}
-		nameScVal2 := xdr.ScVal{Type: xdr.ScValTypeScvString, Str: ptrToScString("native")}
-
-		// Return different values for the two calls
-		mockRPCService.On("SimulateTransaction", mock.Anything, mock.Anything).Return(
-			entities.RPCSimulateTransactionResult{
-				Results: []entities.RPCSimulateHostFunctionResult{{XDR: nameScVal1}},
-			}, nil,
-		).Once()
-		mockRPCService.On("SimulateTransaction", mock.Anything, mock.Anything).Return(
-			entities.RPCSimulateTransactionResult{
-				Results: []entities.RPCSimulateHostFunctionResult{{XDR: nameScVal2}},
-			}, nil,
-		).Once()
-
-		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
-		require.NoError(t, err)
-
-		result, err := service.FetchSACMetadata(ctx, []string{contractID1, contractID2})
-
-		require.NoError(t, err)
-		assert.Len(t, result, 2)
-	})
-
-	t.Run("returns error and no partial results when one contract fails", func(t *testing.T) {
-		mockRPCService := NewRPCServiceMock(t)
-		mockContractModel := data.NewContractModelMock(t)
-		pool := pond.NewPool(5)
-		defer pool.Stop()
-
-		contractID1 := "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
-		contractID2 := "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA"
-
-		// First contract succeeds, second fails
-		nameScVal1 := xdr.ScVal{Type: xdr.ScValTypeScvString, Str: ptrToScString("USDC:GCNY5OXYSY4FKHOPT2SPOQZAOEIGXB5LBYW3HVU3OWSTQITS65M5RCNY")}
-
-		mockRPCService.On("SimulateTransaction", mock.Anything, mock.Anything).Return(
-			entities.RPCSimulateTransactionResult{
-				Results: []entities.RPCSimulateHostFunctionResult{{XDR: nameScVal1}},
-			}, nil,
-		).Once()
-		mockRPCService.On("SimulateTransaction", mock.Anything, mock.Anything).Return(
-			entities.RPCSimulateTransactionResult{}, errors.New("RPC timeout"),
-		).Once()
-
-		service, err := NewContractMetadataService(mockRPCService, mockContractModel, pool)
-		require.NoError(t, err)
-
-		result, err := service.FetchSACMetadata(ctx, []string{contractID1, contractID2})
-
-		// Should return error and no partial results
-		require.Error(t, err)
-		assert.Nil(t, result)
-		assert.Contains(t, err.Error(), "failed to fetch metadata for 1 SAC contracts")
 	})
 }

--- a/internal/services/ingest.go
+++ b/internal/services/ingest.go
@@ -88,10 +88,6 @@ type IngestServiceConfig struct {
 	// dispatcher uses it to extract spec entries from candidate wasm bytecode.
 	WasmSpecExtractor WasmSpecExtractor
 
-	// === Metadata Service (used for SAC; per-protocol validators/processors get
-	// it via ProtocolDeps and are responsible for their own protocol metadata) ===
-	ContractMetadataService ContractMetadataService
-
 	// === Processing Options ===
 	GetLedgersLimit int
 
@@ -141,7 +137,6 @@ type ingestService struct {
 	backfillBatchSize         uint32
 	backfillDBInsertBatchSize uint32
 	knownContractIDs          set.Set[string]
-	contractMetadataService   ContractMetadataService
 	protocolProcessors        map[string]ProtocolProcessor
 	protocolValidators        []ProtocolValidator
 	wasmSpecExtractor         WasmSpecExtractor
@@ -206,7 +201,6 @@ func NewIngestService(cfg IngestServiceConfig) (*ingestService, error) {
 		getLedgersLimit:           cfg.GetLedgersLimit,
 		ledgerIndexer:             ledgerIndexer,
 		ledgerIndexerPool:         ledgerIndexerPool,
-		contractMetadataService:   cfg.ContractMetadataService,
 		protocolValidators:        cfg.ProtocolValidators,
 		wasmSpecExtractor:         cfg.WasmSpecExtractor,
 		archive:                   cfg.Archive,

--- a/internal/services/ingest_live.go
+++ b/internal/services/ingest_live.go
@@ -322,15 +322,6 @@ func (m *ingestService) startLiveIngestion(ctx context.Context) error {
 		m.appMetrics.Ingestion.LatestLedger.Set(float64(latestIngestedLedger))
 	}
 
-	// Re-enrich any SAC contract_tokens rows still left at their ledger-derived
-	// defaults — covering both a fresh load whose enrichment just failed and rows
-	// left stale by an earlier run. This is a best-effort startup pass: a failure is
-	// logged and ingestion proceeds, because the rows keep working defaults and the
-	// next restart retries.
-	if err := m.checkpointService.EnrichStaleSACMetadata(ctx); err != nil {
-		log.Ctx(ctx).Errorf("enriching stale SAC metadata at startup (defaults retained, retried on restart): %v", err)
-	}
-
 	// Start unbounded ingestion from latest ledger ingested onwards
 	ledgerRange := ledgerbackend.UnboundedRange(startLedger)
 	if err := m.ledgerBackend.PrepareRange(ctx, ledgerRange); err != nil {

--- a/internal/services/ingest_live_test.go
+++ b/internal/services/ingest_live_test.go
@@ -52,10 +52,8 @@ func Test_startLiveIngestion_ReleasesAdvisoryLockWhenContextCancelledMidStartup(
 		Run(func(mock.Arguments) { cancel() }).
 		Return(nil)
 
-	// The startup path runs the stale-SAC enrichment pass before preparing the
-	// ledger range; production always wires a checkpoint service, so provide one.
+	// Production always wires a checkpoint service, so provide one.
 	checkpointMock := NewCheckpointServiceMock(t)
-	checkpointMock.On("EnrichStaleSACMetadata", mock.Anything).Return(nil)
 
 	const testNetwork = "advisory-lock-release-test"
 	svc, err := NewIngestService(IngestServiceConfig{

--- a/internal/services/mocks.go
+++ b/internal/services/mocks.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/stellar/wallet-backend/internal/data"
 	"github.com/stellar/wallet-backend/internal/entities"
 	"github.com/stellar/wallet-backend/internal/indexer"
 	"github.com/stellar/wallet-backend/internal/indexer/types"
@@ -374,14 +373,6 @@ type ContractMetadataServiceMock struct {
 
 var _ ContractMetadataService = (*ContractMetadataServiceMock)(nil)
 
-func (c *ContractMetadataServiceMock) FetchSACMetadata(ctx context.Context, contractIDs []string) ([]*data.Contract, error) {
-	args := c.Called(ctx, contractIDs)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).([]*data.Contract), args.Error(1)
-}
-
 func (c *ContractMetadataServiceMock) FetchSingleField(ctx context.Context, contractAddress, functionName string, funcArgs ...xdr.ScVal) (xdr.ScVal, error) {
 	args := c.Called(ctx, contractAddress, functionName, funcArgs)
 	return args.Get(0).(xdr.ScVal), args.Error(1)
@@ -410,11 +401,6 @@ var _ CheckpointService = (*CheckpointServiceMock)(nil)
 
 func (c *CheckpointServiceMock) PopulateFromCheckpoint(ctx context.Context, checkpointLedger uint32, initializeCursors func(pgx.Tx) error) error {
 	args := c.Called(ctx, checkpointLedger, initializeCursors)
-	return args.Error(0)
-}
-
-func (c *CheckpointServiceMock) EnrichStaleSACMetadata(ctx context.Context) error {
-	args := c.Called(ctx)
 	return args.Error(0)
 }
 


### PR DESCRIPTION
### What

Delete the RPC-based SAC metadata enrichment machinery, which is unreachable after #695 :

- `enrichSACMetadata`, `enrichSACMetadataWithRetry`, and the restartable `EnrichStaleSACMetadata` pass.
- `ContractModel.GetSACContractsMissingMetadata`.
- `ContractMetadataService.FetchSACMetadata` / `fetchSACMetadataForContract`. The service keeps `FetchSingleField`, which per-protocol validators still use.
- The service's `contractModel` and `pool` dependency is dropped due to no readers left after the above.
- The corresponding mocks and tests.

No behavior change: none of this code could execute anymore.

### Why

The enrichment path existed to fill in metadata for SAC `contract_tokens` rows created with blank code/issuer/name/symbol. The only writer that produced such rows was the balance-shape path removed in #695. 

### Issue that this PR addresses

Follow-up to #695 

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [ ] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
