### PR TITLE
ci: make deploying a dev image to shared dev opt-in

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,14 @@ on:
           - dev
           - stg
           - prd
+      deploy_to_dev:
+        description: >-
+          Also deploy this image to the SHARED wallet-eng-dev environment.
+          Only has an effect when environment is dev. Leave unchecked for
+          sandbox/preview builds — the sandbox pins the plain <sha> tag
+          either way and does not need this.
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -46,9 +54,41 @@ jobs:
           echo "Target namespace: $namespace"
           echo "namespace=$namespace" >> "$GITHUB_OUTPUT"
 
+      # The plain <sha> tag is what per-engineer sandboxes pin, and is always
+      # pushed. The `dev-` prefixed tag is what the shared wallet-eng-dev
+      # ArgoCD ImageUpdater watches (allowTags: regexp:^dev-), so it is pushed
+      # only when a dev build explicitly opts in.
+      #
+      # Before this split the updater followed the plain <sha> tags with
+      # newest-build and no filter, so ANY branch build captured shared dev.
+      # That is not hypothetical: as of 2026-08-31 shared dev is running
+      # 4711f6ca, built from the still-open PR #699.
       - name: Build and push image
         env:
-          TAG: ${{ steps.ecr-login.outputs.ecr-registry }}/${{ steps.target.outputs.namespace }}/wallet-backend:${{ github.sha }}
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.ecr-registry }}
+          NAMESPACE: ${{ steps.target.outputs.namespace }}
+          SHA: ${{ github.sha }}
+          DEPLOY_TO_DEV: ${{ inputs.deploy_to_dev }}
         run: |
+          set -eu
+          export TAG="${ECR_REGISTRY}/${NAMESPACE}/wallet-backend:${SHA}"
           make docker-build
           ecr-push "$TAG"
+
+          # Only the dev namespace has an opt-in shared environment. Say so
+          # out loud rather than ignoring the checkbox silently, so a stg or
+          # prd build with the box ticked does not look like it deployed.
+          if [ "${DEPLOY_TO_DEV}" != "true" ]; then
+            echo "Pushed ${TAG}. No dev- tag was published."
+            echo "Pin this tag in your sandbox."
+          elif [ "${NAMESPACE}" != "dev" ]; then
+            echo "Pushed ${TAG}."
+            echo "deploy_to_dev was checked but environment is '${NAMESPACE}', not 'dev'."
+            echo "No dev- tag was published and shared wallet-eng-dev is unchanged."
+          else
+            DEV_TAG="${ECR_REGISTRY}/dev/wallet-backend:dev-${SHA}"
+            docker tag "$TAG" "$DEV_TAG"
+            ecr-push "$DEV_TAG"
+            echo "Pushed ${TAG} and ${DEV_TAG}."
+            echo "The dev- tag is the one shared wallet-eng-dev follows."
+          fi


### PR DESCRIPTION
## TL;DR

Makes deploying to the shared `wallet-eng-dev` environment something a build **opts in to**, instead of something that happens to whoever built last.

Same change already merged for `freighter-backend-v2` (stellar/freighter-backend-v2#155). Nothing about the per-engineer sandbox flow changes — sandboxes keep pinning the same tag they always did, and pushes to `main` are untouched.

Worth knowing regardless of this PR: **shared dev has been running an image built from PR #699 since 25 August.** That PR is still open and is now five commits behind `main`, so anyone who tested against shared dev's wallet-backend in the past week was testing against unmerged ingestion changes. That's the bug this fixes, and it may be worth a separate look at whether it explains anything anyone has hit.

**Merge stellar/kube#5089 first** — until that filter exists, this PR only adds a tag and changes nothing.

<details>
<summary>Implementation details (for agents)</summary>

**The defect.** The `wallet-backend` alias in the shared-dev ImageUpdater uses `updateStrategy: newest-build` with no `allowTags`, so it followed the single `<sha>` tag this workflow publishes to the dev namespace. Any dev build was therefore a deploy candidate. `forceUpdate: true` compounds it: the updater re-asserts over manual edits within seconds, so a captured environment can't be released by hand — that was demonstrated on the v2 alias, where a manual repin was reverted five seconds after merge.

Dev builds from branches are routine, not exceptional — the sandbox action takes a `wb_tag` input, so building wallet-backend from a branch is a normal part of testing a Freighter PR full-stack.

**Evidence.** Shared dev pins `dev/wallet-backend:4711f6ca937fcf46983cc702f44eb475a9e741fa`, set 2026-08-25T18:50Z. That commit is not an ancestor of `main`; it belongs to `live-ingest-persist-opts` / PR #699, still open.

**The change.** `deploy_to_dev` boolean input, default `false`. The plain `<sha>` tag is pushed unconditionally as before; `dev-<sha>` is pushed only when a **dev** build ticks the box.

Two details specific to this workflow, which differs from the other two repos:

1. The `dev-` tag is gated on the resolved namespace as well as the checkbox, so only a dev build can produce one. A push to `main` resolves to `stg` and is completely untouched — no new tag, no behaviour change.
2. A `stg` or `prd` dispatch with the box ticked logs that the checkbox had no effect, rather than ignoring it silently. Silently dropping it would read as a deploy that didn't happen.

The `TAG` env var was moved into the run script so the conditional can build a second tag from it; `LABEL` is deliberately *not* exported, since the Makefile defines it as `LABEL ?=` and it feeds the `GIT_COMMIT` build arg baked into the binary — exporting it would silently change what's compiled in.

**After both land**, shared dev will have no `dev-*` tag and so will freeze on `4711f6ca`. Releasing it means running this workflow with `environment: dev` and the box checked — which is also the end-to-end test of the new path.

**Verification:** `actionlint` clean. All six combinations of namespace × checkbox state dry-run correctly, including the unset case that a push to `main` produces.

</details>
