### PR TITLE
sep41: parse map-form burn, clawback, and approve events

### DIFF
--- a/internal/services/sep41/events.go
+++ b/internal/services/sep41/events.go
@@ -120,7 +120,8 @@ func ParseMintEvent(event xdr.ContractEvent) (*MintEvent, error) {
 	return &MintEvent{To: to, Amount: amt, ToMuxedID: muxedID}, nil
 }
 
-// ParseBurnEvent decodes a SEP-41 burn event: [sym("burn"), from: Address], data = i128.
+// ParseBurnEvent decodes a SEP-41 burn event: [sym("burn"), from: Address],
+// data = i128 or { amount: i128 }.
 func ParseBurnEvent(event xdr.ContractEvent) (*BurnEvent, error) {
 	topics, err := eventTopics(event, EventBurn, 2)
 	if err != nil {
@@ -130,7 +131,7 @@ func ParseBurnEvent(event xdr.ContractEvent) (*BurnEvent, error) {
 	if err != nil {
 		return nil, fmt.Errorf("decoding burn.from: %w", err)
 	}
-	amt, err := extractI128(event.Body.V0.Data)
+	amt, err := extractAmount(event.Body.V0.Data)
 	if err != nil {
 		return nil, fmt.Errorf("decoding burn amount: %w", err)
 	}
@@ -159,7 +160,7 @@ func ParseClawbackEvent(event xdr.ContractEvent) (*ClawbackEvent, error) {
 	if err != nil {
 		return nil, fmt.Errorf("decoding clawback.from: %w", err)
 	}
-	amt, err := extractI128(event.Body.V0.Data)
+	amt, err := extractAmount(event.Body.V0.Data)
 	if err != nil {
 		return nil, fmt.Errorf("decoding clawback amount: %w", err)
 	}
@@ -168,7 +169,8 @@ func ParseClawbackEvent(event xdr.ContractEvent) (*ClawbackEvent, error) {
 
 // ParseApproveEvent decodes a SEP-41 approve event:
 // topics: [sym("approve"), from: Address, spender: Address]
-// data:   [ i128 amount, u32 live_until_ledger ]  (ScVec of 2 elements)
+// data:   [i128 amount, u32 live_until_ledger] or
+// { amount: i128, live_until_ledger: u32 }.
 func ParseApproveEvent(event xdr.ContractEvent) (*ApproveEvent, error) {
 	topics, err := eventTopics(event, EventApprove, 3)
 	if err != nil {
@@ -183,22 +185,34 @@ func ParseApproveEvent(event xdr.ContractEvent) (*ApproveEvent, error) {
 		return nil, fmt.Errorf("decoding approve.spender: %w", err)
 	}
 
+	var amountVal, liveUntilVal xdr.ScVal
 	data := event.Body.V0.Data
-	if data.Type != xdr.ScValTypeScvVec {
-		return nil, fmt.Errorf("approve data must be ScVec, got %v", data.Type)
-	}
-	vec, ok := data.GetVec()
-	if !ok || vec == nil || len(*vec) != 2 {
-		return nil, fmt.Errorf("approve data must be a 2-element ScVec")
+	switch data.Type {
+	case xdr.ScValTypeScvVec:
+		vec, ok := data.GetVec()
+		if !ok || vec == nil || len(*vec) != 2 {
+			return nil, fmt.Errorf("approve data must be a 2-element ScVec")
+		}
+		amountVal = (*vec)[0]
+		liveUntilVal = (*vec)[1]
+	case xdr.ScValTypeScvMap:
+		fields, err := extractRequiredMapFields(data, "amount", "live_until_ledger")
+		if err != nil {
+			return nil, fmt.Errorf("decoding approve data: %w", err)
+		}
+		amountVal = fields["amount"]
+		liveUntilVal = fields["live_until_ledger"]
+	default:
+		return nil, fmt.Errorf("approve data must be ScVec or ScMap, got %v", data.Type)
 	}
 
-	amt, err := extractI128((*vec)[0])
+	amt, err := extractI128(amountVal)
 	if err != nil {
 		return nil, fmt.Errorf("decoding approve amount: %w", err)
 	}
-	liveUntil, ok := (*vec)[1].GetU32()
+	liveUntil, ok := liveUntilVal.GetU32()
 	if !ok {
-		return nil, fmt.Errorf("approve live_until_ledger must be u32, got %v", (*vec)[1].Type)
+		return nil, fmt.Errorf("approve live_until_ledger must be u32, got %v", liveUntilVal.Type)
 	}
 
 	return &ApproveEvent{
@@ -251,6 +265,72 @@ func extractI128(val xdr.ScVal) (*big.Int, error) {
 	bi.Lsh(bi, 64)
 	bi.Add(bi, new(big.Int).SetUint64(uint64(parts.Lo)))
 	return bi, nil
+}
+
+// extractAmount decodes the two SEP-41 amount data formats used by burn and
+// clawback events: a single i128 value or a Symbol-keyed map containing amount.
+func extractAmount(val xdr.ScVal) (*big.Int, error) {
+	switch val.Type {
+	case xdr.ScValTypeScvI128:
+		return extractI128(val)
+	case xdr.ScValTypeScvMap:
+		fields, err := extractRequiredMapFields(val, "amount")
+		if err != nil {
+			return nil, err
+		}
+		amt, err := extractI128(fields["amount"])
+		if err != nil {
+			return nil, fmt.Errorf("map amount: %w", err)
+		}
+		return amt, nil
+	default:
+		return nil, fmt.Errorf("amount must be i128 or ScMap, got %v", val.Type)
+	}
+}
+
+// extractRequiredMapFields validates a SEP-41 map data value and returns the
+// requested fields. SEP-41 permits additional fields, but requires every map
+// key to be a Symbol.
+func extractRequiredMapFields(val xdr.ScVal, requiredFields ...string) (map[string]xdr.ScVal, error) {
+	if val.Type != xdr.ScValTypeScvMap {
+		return nil, fmt.Errorf("event data must be ScMap, got %v", val.Type)
+	}
+	if val.Map == nil {
+		return nil, fmt.Errorf("event data map was nil")
+	}
+	m, ok := val.GetMap()
+	if !ok || m == nil {
+		return nil, fmt.Errorf("event data map was nil")
+	}
+
+	required := make(map[string]struct{}, len(requiredFields))
+	for _, field := range requiredFields {
+		required[field] = struct{}{}
+	}
+
+	fields := make(map[string]xdr.ScVal, len(requiredFields))
+	seen := make(map[string]struct{}, len(*m))
+	for _, entry := range *m {
+		keySym, ok := entry.Key.GetSym()
+		if !ok {
+			return nil, fmt.Errorf("event data map key must be Symbol, got %v", entry.Key.Type)
+		}
+		key := string(keySym)
+		if _, ok := seen[key]; ok {
+			return nil, fmt.Errorf("event data map contains duplicate key %q", key)
+		}
+		seen[key] = struct{}{}
+		if _, ok := required[key]; ok {
+			fields[key] = entry.Val
+		}
+	}
+
+	for _, field := range requiredFields {
+		if _, ok := fields[field]; !ok {
+			return nil, fmt.Errorf("event data map missing %q", field)
+		}
+	}
+	return fields, nil
 }
 
 // extractAmountAndMuxedID decodes either a raw i128 (classic transfer/mint) or the

--- a/internal/services/sep41/events.go
+++ b/internal/services/sep41/events.go
@@ -288,41 +288,28 @@ func extractAmount(val xdr.ScVal) (*big.Int, error) {
 	}
 }
 
-// extractRequiredMapFields validates a SEP-41 map data value and returns the
-// requested fields. SEP-41 permits additional fields, but requires every map
-// key to be a Symbol.
+// extractRequiredMapFields validates a SEP-41 map data value and returns all
+// its fields after checking that the requested fields are present. SEP-41
+// permits additional fields, but requires every map key to be a Symbol.
 func extractRequiredMapFields(val xdr.ScVal, requiredFields ...string) (map[string]xdr.ScVal, error) {
 	if val.Type != xdr.ScValTypeScvMap {
 		return nil, fmt.Errorf("event data must be ScMap, got %v", val.Type)
 	}
-	if val.Map == nil {
+	if val.Map == nil || *val.Map == nil {
 		return nil, fmt.Errorf("event data map was nil")
 	}
-	m, ok := val.GetMap()
-	if !ok || m == nil {
-		return nil, fmt.Errorf("event data map was nil")
-	}
+	m := *val.Map
 
-	required := make(map[string]struct{}, len(requiredFields))
-	for _, field := range requiredFields {
-		required[field] = struct{}{}
-	}
-
-	fields := make(map[string]xdr.ScVal, len(requiredFields))
-	seen := make(map[string]struct{}, len(*m))
+	fields := make(map[string]xdr.ScVal, len(*m))
 	for _, entry := range *m {
-		keySym, ok := entry.Key.GetSym()
-		if !ok {
+		if entry.Key.Type != xdr.ScValTypeScvSymbol || entry.Key.Sym == nil {
 			return nil, fmt.Errorf("event data map key must be Symbol, got %v", entry.Key.Type)
 		}
-		key := string(keySym)
-		if _, ok := seen[key]; ok {
+		key := string(*entry.Key.Sym)
+		if _, ok := fields[key]; ok {
 			return nil, fmt.Errorf("event data map contains duplicate key %q", key)
 		}
-		seen[key] = struct{}{}
-		if _, ok := required[key]; ok {
-			fields[key] = entry.Val
-		}
+		fields[key] = entry.Val
 	}
 
 	for _, field := range requiredFields {
@@ -342,35 +329,20 @@ func extractAmountAndMuxedID(val xdr.ScVal) (*big.Int, *uint64, error) {
 		amt, err := extractI128(val)
 		return amt, nil, err
 	case xdr.ScValTypeScvMap:
-		m, ok := val.GetMap()
-		if !ok || m == nil {
-			return nil, nil, fmt.Errorf("amount map was nil")
+		fields, err := extractRequiredMapFields(val, "amount")
+		if err != nil {
+			return nil, nil, err
 		}
-		var (
-			amt     *big.Int
-			muxedID *uint64
-		)
-		for _, entry := range *m {
-			keySym, ok := entry.Key.GetSym()
-			if !ok {
-				continue
-			}
-			switch string(keySym) {
-			case "amount":
-				a, err := extractI128(entry.Val)
-				if err != nil {
-					return nil, nil, fmt.Errorf("map amount: %w", err)
-				}
-				amt = a
-			case "to_muxed_id":
-				if id, ok := entry.Val.GetU64(); ok {
-					v := uint64(id)
-					muxedID = &v
-				}
-			}
+		amt, err := extractI128(fields["amount"])
+		if err != nil {
+			return nil, nil, fmt.Errorf("map amount: %w", err)
 		}
-		if amt == nil {
-			return nil, nil, fmt.Errorf("map missing amount key")
+		var muxedID *uint64
+		if muxedVal, ok := fields["to_muxed_id"]; ok {
+			if id, ok := muxedVal.GetU64(); ok {
+				v := uint64(id)
+				muxedID = &v
+			}
 		}
 		return amt, muxedID, nil
 	default:

--- a/internal/services/sep41/events_test.go
+++ b/internal/services/sep41/events_test.go
@@ -124,6 +124,42 @@ func TestParseTransferEvent(t *testing.T) {
 		assert.Equal(t, uint64(7), *got.ToMuxedID)
 	})
 
+	t.Run("rejects a CAP-67 map with a non-Symbol key", func(t *testing.T) {
+		dataMap := mapScVal(
+			xdr.ScMapEntry{Key: symScVal("amount"), Val: i128ScVal(42)},
+			xdr.ScMapEntry{Key: strScVal("extension"), Val: u32ScVal(1)},
+		)
+		event := contractEvent(
+			[]xdr.ScVal{
+				symScVal(EventTransfer),
+				mustAddressScVal(t, testAccountA),
+				mustAddressScVal(t, testAccountB),
+			},
+			dataMap,
+		)
+
+		_, err := ParseTransferEvent(event)
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects a CAP-67 map with duplicate keys", func(t *testing.T) {
+		dataMap := mapScVal(
+			xdr.ScMapEntry{Key: symScVal("amount"), Val: i128ScVal(42)},
+			xdr.ScMapEntry{Key: symScVal("amount"), Val: i128ScVal(43)},
+		)
+		event := contractEvent(
+			[]xdr.ScVal{
+				symScVal(EventTransfer),
+				mustAddressScVal(t, testAccountA),
+				mustAddressScVal(t, testAccountB),
+			},
+			dataMap,
+		)
+
+		_, err := ParseTransferEvent(event)
+		assert.Error(t, err)
+	})
+
 	t.Run("rejects a transfer event whose topic count is not 3", func(t *testing.T) {
 		event := contractEvent(
 			[]xdr.ScVal{symScVal(EventTransfer), mustAddressScVal(t, testAccountA)},
@@ -275,7 +311,7 @@ func TestParseClawbackEvent(t *testing.T) {
 		assert.Equal(t, big.NewInt(77), got.Amount)
 	})
 
-	t.Run("parses an OpenZeppelin map amount", func(t *testing.T) {
+	t.Run("parses a SEP-41 map amount", func(t *testing.T) {
 		event := contractEvent(
 			[]xdr.ScVal{symScVal(EventClawback), mustAddressScVal(t, testAccountA)},
 			mapScVal(xdr.ScMapEntry{Key: symScVal("amount"), Val: i128ScVal(25)}),

--- a/internal/services/sep41/events_test.go
+++ b/internal/services/sep41/events_test.go
@@ -202,14 +202,48 @@ func TestParseMintEvent(t *testing.T) {
 }
 
 func TestParseBurnEvent(t *testing.T) {
-	event := contractEvent(
-		[]xdr.ScVal{symScVal(EventBurn), mustAddressScVal(t, testAccountA)},
-		i128ScVal(50),
-	)
-	got, err := ParseBurnEvent(event)
-	require.NoError(t, err)
-	assert.Equal(t, testAccountA, got.From)
-	assert.Equal(t, big.NewInt(50), got.Amount)
+	t.Run("parses a bare i128 amount", func(t *testing.T) {
+		event := contractEvent(
+			[]xdr.ScVal{symScVal(EventBurn), mustAddressScVal(t, testAccountA)},
+			i128ScVal(50),
+		)
+		got, err := ParseBurnEvent(event)
+		require.NoError(t, err)
+		assert.Equal(t, testAccountA, got.From)
+		assert.Equal(t, big.NewInt(50), got.Amount)
+	})
+
+	t.Run("parses an OpenZeppelin map amount", func(t *testing.T) {
+		event := contractEvent(
+			[]xdr.ScVal{symScVal(EventBurn), mustAddressScVal(t, testAccountA)},
+			mapScVal(
+				xdr.ScMapEntry{Key: symScVal("amount"), Val: i128ScVal(75)},
+				xdr.ScMapEntry{Key: symScVal("extension"), Val: u32ScVal(1)},
+			),
+		)
+		got, err := ParseBurnEvent(event)
+		require.NoError(t, err)
+		assert.Equal(t, testAccountA, got.From)
+		assert.Equal(t, big.NewInt(75), got.Amount)
+	})
+
+	t.Run("rejects a map without amount", func(t *testing.T) {
+		event := contractEvent(
+			[]xdr.ScVal{symScVal(EventBurn), mustAddressScVal(t, testAccountA)},
+			mapScVal(xdr.ScMapEntry{Key: symScVal("extension"), Val: u32ScVal(1)}),
+		)
+		_, err := ParseBurnEvent(event)
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects a map with a non-i128 amount", func(t *testing.T) {
+		event := contractEvent(
+			[]xdr.ScVal{symScVal(EventBurn), mustAddressScVal(t, testAccountA)},
+			mapScVal(xdr.ScMapEntry{Key: symScVal("amount"), Val: u32ScVal(75)}),
+		)
+		_, err := ParseBurnEvent(event)
+		assert.Error(t, err)
+	})
 }
 
 func TestParseClawbackEvent(t *testing.T) {
@@ -241,6 +275,26 @@ func TestParseClawbackEvent(t *testing.T) {
 		assert.Equal(t, big.NewInt(77), got.Amount)
 	})
 
+	t.Run("parses an OpenZeppelin map amount", func(t *testing.T) {
+		event := contractEvent(
+			[]xdr.ScVal{symScVal(EventClawback), mustAddressScVal(t, testAccountA)},
+			mapScVal(xdr.ScMapEntry{Key: symScVal("amount"), Val: i128ScVal(25)}),
+		)
+		got, err := ParseClawbackEvent(event)
+		require.NoError(t, err)
+		assert.Equal(t, testAccountA, got.From)
+		assert.Equal(t, big.NewInt(25), got.Amount)
+	})
+
+	t.Run("rejects a map without amount", func(t *testing.T) {
+		event := contractEvent(
+			[]xdr.ScVal{symScVal(EventClawback), mustAddressScVal(t, testAccountA)},
+			mapScVal(xdr.ScMapEntry{Key: symScVal("extension"), Val: u32ScVal(1)}),
+		)
+		_, err := ParseClawbackEvent(event)
+		assert.Error(t, err)
+	})
+
 	t.Run("rejects a 3-topic shape whose admin slot is not an Address", func(t *testing.T) {
 		// Mirrors the mint guard: a 3-topic clawback whose admin slot isn't an Address
 		// isn't the legacy shape and must be rejected.
@@ -258,21 +312,94 @@ func TestParseClawbackEvent(t *testing.T) {
 }
 
 func TestParseApproveEvent(t *testing.T) {
-	data := vecScVal(i128ScVal(500), u32ScVal(1234))
-	event := contractEvent(
-		[]xdr.ScVal{
-			symScVal(EventApprove),
-			mustAddressScVal(t, testAccountA),
-			mustAddressScVal(t, testAccountB),
+	topics := []xdr.ScVal{
+		symScVal(EventApprove),
+		mustAddressScVal(t, testAccountA),
+		mustAddressScVal(t, testAccountB),
+	}
+
+	t.Run("parses the positional ScVec format", func(t *testing.T) {
+		event := contractEvent(topics, vecScVal(i128ScVal(500), u32ScVal(1234)))
+		got, err := ParseApproveEvent(event)
+		require.NoError(t, err)
+		assert.Equal(t, testAccountA, got.From)
+		assert.Equal(t, testAccountB, got.Spender)
+		assert.Equal(t, big.NewInt(500), got.Amount)
+		assert.Equal(t, uint32(1234), got.LiveUntilLedger)
+	})
+
+	t.Run("parses the OpenZeppelin map format", func(t *testing.T) {
+		event := contractEvent(topics, mapScVal(
+			xdr.ScMapEntry{Key: symScVal("amount"), Val: i128ScVal(750)},
+			xdr.ScMapEntry{Key: symScVal("extension"), Val: u32ScVal(1)},
+			xdr.ScMapEntry{Key: symScVal("live_until_ledger"), Val: u32ScVal(4321)},
+		))
+		got, err := ParseApproveEvent(event)
+		require.NoError(t, err)
+		assert.Equal(t, testAccountA, got.From)
+		assert.Equal(t, testAccountB, got.Spender)
+		assert.Equal(t, big.NewInt(750), got.Amount)
+		assert.Equal(t, uint32(4321), got.LiveUntilLedger)
+	})
+
+	tests := []struct {
+		name string
+		data xdr.ScVal
+	}{
+		{
+			name: "map missing amount",
+			data: mapScVal(xdr.ScMapEntry{Key: symScVal("live_until_ledger"), Val: u32ScVal(4321)}),
 		},
-		data,
-	)
-	got, err := ParseApproveEvent(event)
-	require.NoError(t, err)
-	assert.Equal(t, testAccountA, got.From)
-	assert.Equal(t, testAccountB, got.Spender)
-	assert.Equal(t, big.NewInt(500), got.Amount)
-	assert.Equal(t, uint32(1234), got.LiveUntilLedger)
+		{
+			name: "map missing live_until_ledger",
+			data: mapScVal(xdr.ScMapEntry{Key: symScVal("amount"), Val: i128ScVal(750)}),
+		},
+		{
+			name: "map with non-i128 amount",
+			data: mapScVal(
+				xdr.ScMapEntry{Key: symScVal("amount"), Val: u32ScVal(750)},
+				xdr.ScMapEntry{Key: symScVal("live_until_ledger"), Val: u32ScVal(4321)},
+			),
+		},
+		{
+			name: "map with non-u32 live_until_ledger",
+			data: mapScVal(
+				xdr.ScMapEntry{Key: symScVal("amount"), Val: i128ScVal(750)},
+				xdr.ScMapEntry{Key: symScVal("live_until_ledger"), Val: i128ScVal(4321)},
+			),
+		},
+		{
+			name: "map with a non-Symbol key",
+			data: mapScVal(
+				xdr.ScMapEntry{Key: symScVal("amount"), Val: i128ScVal(750)},
+				xdr.ScMapEntry{Key: strScVal("extension"), Val: u32ScVal(1)},
+				xdr.ScMapEntry{Key: symScVal("live_until_ledger"), Val: u32ScVal(4321)},
+			),
+		},
+		{
+			name: "map with a duplicate field",
+			data: mapScVal(
+				xdr.ScMapEntry{Key: symScVal("amount"), Val: i128ScVal(750)},
+				xdr.ScMapEntry{Key: symScVal("amount"), Val: i128ScVal(751)},
+				xdr.ScMapEntry{Key: symScVal("live_until_ledger"), Val: u32ScVal(4321)},
+			),
+		},
+		{
+			name: "nil map",
+			data: xdr.ScVal{Type: xdr.ScValTypeScvMap},
+		},
+		{
+			name: "unrelated data type",
+			data: i128ScVal(750),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("rejects "+tt.name, func(t *testing.T) {
+			_, err := ParseApproveEvent(contractEvent(topics, tt.data))
+			assert.Error(t, err)
+		})
+	}
 }
 
 func TestContractIDString(t *testing.T) {


### PR DESCRIPTION
### What

- Accept SEP-41 Symbol-keyed map data for burn, clawback, and approve events.
- Require amount as i128 and approve live_until_ledger as u32.
- Reject missing, incorrectly typed, nil, non-Symbol-keyed, and duplicate fields while tolerating additional valid Symbol-keyed fields.
- Preserve existing SAC, legacy Soroban, positional, and CAP-67 encodings.

### Why

OpenZeppelin #[contractevent] uses map-form event data. The existing parsers only accepted a bare i128 for burn and clawback and a two-element ScVec for approve, so otherwise-valid events failed parsing and their balance, supply, or allowance changes were not recorded.

### Known limitations

The transfer observation from the issue was not reproduced. Transfer already accepts bare-i128 and map-form amounts, and existing processor tests verify that debit and credit state changes are staged together, so transfer processing is intentionally unchanged.

### Testing

- go test ./internal/services/sep41 -count=1
- go test ./internal/services/sep41 -run 'TestParseTransferEvent|TestProcessor_ProcessEvent' -count=1
- go vet ./internal/services/sep41
- make fmt
- git diff --check

### Issue that this PR addresses

Fixes https://github.com/stellar/wallet-backend/issues/726

Priority: not assigned on the issue.

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or all if the changes are broad or impact many packages.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.
- [x] All updated queries have been tested (no queries were modified).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production (not applicable; this fix is ready for production).