### PR TITLE
fix: handle CAP-40 signed-payload signers in ingestion

### DIFF
--- a/internal/data/query_utils.go
+++ b/internal/data/query_utils.go
@@ -59,16 +59,6 @@ func pgtypeTextFromReason(r types.StateChangeReason) pgtype.Text {
 	return pgtype.Text{String: string(r), Valid: true}
 }
 
-// jsonbFromMap converts types.NullableJSONB to any for pgx CopyFrom.
-// pgx automatically handles map[string]any → JSONB conversion.
-func jsonbFromMap(m types.NullableJSONB) any {
-	if m == nil {
-		return nil
-	}
-	// Return the map directly; pgx handles JSON marshaling automatically
-	return map[string]any(m)
-}
-
 // pgtypeInt2FromNullInt16 converts sql.NullInt16 to pgtype.Int2 for efficient binary COPY.
 func pgtypeInt2FromNullInt16(ni sql.NullInt16) pgtype.Int2 {
 	return pgtype.Int2{Int16: ni.Int16, Valid: ni.Valid}
@@ -87,6 +77,31 @@ func pgtypeBytesFromNullAddressBytea(na types.NullAddressBytea) ([]byte, error) 
 		return nil, nil
 	}
 	return val.([]byte), nil
+}
+
+// pgtypeBytesFromNullSignerKeyBytea converts NullSignerKeyBytea to bytes for BYTEA insert.
+func pgtypeBytesFromNullSignerKeyBytea(nk types.NullSignerKeyBytea) ([]byte, error) {
+	if !nk.Valid {
+		return nil, nil
+	}
+	val, err := nk.Value()
+	if err != nil {
+		return nil, fmt.Errorf("converting signer key to bytes: %w", err)
+	}
+	if val == nil {
+		return nil, nil
+	}
+	return val.([]byte), nil
+}
+
+// jsonbFromMap converts types.NullableJSONB to any for pgx CopyFrom.
+// pgx automatically handles map[string]any → JSONB conversion.
+func jsonbFromMap(m types.NullableJSONB) any {
+	if m == nil {
+		return nil
+	}
+	// Return the map directly; pgx handles JSON marshaling automatically
+	return map[string]any(m)
 }
 
 // CursorColumn represents a column name and its cursor value for decomposed pagination.

--- a/internal/data/query_utils.go
+++ b/internal/data/query_utils.go
@@ -94,16 +94,6 @@ func pgtypeBytesFromNullSignerKeyBytea(nk types.NullSignerKeyBytea) ([]byte, err
 	return val.([]byte), nil
 }
 
-// jsonbFromMap converts types.NullableJSONB to any for pgx CopyFrom.
-// pgx automatically handles map[string]any → JSONB conversion.
-func jsonbFromMap(m types.NullableJSONB) any {
-	if m == nil {
-		return nil
-	}
-	// Return the map directly; pgx handles JSON marshaling automatically
-	return map[string]any(m)
-}
-
 // CursorColumn represents a column name and its cursor value for decomposed pagination.
 type CursorColumn struct {
 	Name  string

--- a/internal/data/statechanges.go
+++ b/internal/data/statechanges.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -28,6 +29,11 @@ type StateChangeWriter interface {
 }
 
 var _ StateChangeWriter = (*StateChangeModel)(nil)
+
+// ErrRowEncoding marks a client-side failure converting a row's Go values for COPY.
+// Retrying the same rows can never succeed, so persistence treats it as permanent
+// (see isPermanentPersistError in the services package).
+var ErrRowEncoding = errors.New("encoding row for COPY")
 
 // stateChangeMandatoryColumns is always selected regardless of the GraphQL field
 // projection: the cursor/key columns, plus the discriminators (state_change_category,
@@ -154,6 +160,19 @@ func (m *StateChangeModel) BatchCopy(
 
 	start := time.Now()
 
+	// Encode every row before opening the COPY stream. Encoding failures are
+	// deterministic, so they are wrapped in ErrRowEncoding and classified as
+	// permanent by callers. Failing here also keeps the pgx transaction usable:
+	// once a COPY stream aborts, the whole transaction is doomed.
+	rows := make([][]any, len(stateChanges))
+	for i, sc := range stateChanges {
+		row, err := stateChangeCopyRow(sc)
+		if err != nil {
+			return 0, fmt.Errorf("%w: state change %d (to_id %d, state_change_id %d): %w", ErrRowEncoding, i, sc.ToID, sc.StateChangeID, err)
+		}
+		rows[i] = row
+	}
+
 	// COPY state_changes using pgx binary format with native pgtype types
 	copyCount, err := pgxTx.CopyFrom(
 		ctx,
@@ -170,66 +189,7 @@ func (m *StateChangeModel) BatchCopy(
 			"data_entry_name", "key_value",
 			"to_muxed_id",
 		},
-		pgx.CopyFromSlice(len(stateChanges), func(i int) ([]any, error) {
-			sc := stateChanges[i]
-
-			// Convert account_id to BYTEA (required field)
-			accountBytes, err := sc.AccountID.Value()
-			if err != nil {
-				return nil, fmt.Errorf("converting account_id: %w", err)
-			}
-
-			// Convert nullable account_id fields to BYTEA
-			signerBytes, err := pgtypeBytesFromNullAddressBytea(sc.SignerAccountID)
-			if err != nil {
-				return nil, fmt.Errorf("converting signer_account_id: %w", err)
-			}
-			spenderBytes, err := pgtypeBytesFromNullAddressBytea(sc.SpenderAccountID)
-			if err != nil {
-				return nil, fmt.Errorf("converting spender_account_id: %w", err)
-			}
-			creatorBytes, err := pgtypeBytesFromNullAddressBytea(sc.CreatorAccountID)
-			if err != nil {
-				return nil, fmt.Errorf("converting creator_account_id: %w", err)
-			}
-			destinationBytes, err := pgtypeBytesFromNullAddressBytea(sc.DestinationAccountID)
-			if err != nil {
-				return nil, fmt.Errorf("converting destination_account_id: %w", err)
-			}
-			tokenBytes, err := pgtypeBytesFromNullAddressBytea(sc.TokenID)
-			if err != nil {
-				return nil, fmt.Errorf("converting token_id: %w", err)
-			}
-
-			return []any{
-				pgtype.Int8{Int64: sc.ToID, Valid: true},
-				pgtype.Int8{Int64: sc.StateChangeID, Valid: true},
-				pgtype.Text{String: string(sc.StateChangeCategory), Valid: true},
-				pgtypeTextFromReason(sc.StateChangeReason),
-				pgtype.Timestamptz{Time: sc.LedgerCreatedAt, Valid: true},
-				pgtype.Int4{Int32: int32(sc.LedgerNumber), Valid: true},
-				accountBytes,
-				pgtype.Int8{Int64: sc.OperationID, Valid: true},
-				tokenBytes,
-				pgtypeTextFromNullString(sc.Amount),
-				signerBytes,
-				spenderBytes,
-				creatorBytes,
-				destinationBytes,
-				pgtypeTextFromNullString(sc.LiquidityPoolID),
-				pgtypeInt2FromNullInt16(sc.SignerWeightOld),
-				pgtypeInt2FromNullInt16(sc.SignerWeightNew),
-				pgtypeTextFromNullString(sc.Threshold),
-				pgtypeInt2FromNullInt16(sc.ThresholdOld),
-				pgtypeInt2FromNullInt16(sc.ThresholdNew),
-				pgtypeTextFromNullString(sc.TrustlineLimitOld),
-				pgtypeTextFromNullString(sc.TrustlineLimitNew),
-				pgtypeInt2FromNullInt16(sc.Flags),
-				pgtypeTextFromNullString(sc.DataEntryName),
-				jsonbFromMap(sc.KeyValue),
-				pgtypeTextFromNullString(sc.ToMuxedID),
-			}, nil
-		}),
+		pgx.CopyFromRows(rows),
 	)
 	if err != nil {
 		duration := time.Since(start).Seconds()
@@ -254,6 +214,67 @@ func (m *StateChangeModel) BatchCopy(
 	m.Metrics.QueriesTotal.WithLabelValues("BatchCopy", "state_changes").Inc()
 
 	return len(stateChanges), nil
+}
+
+// stateChangeCopyRow converts one state change into the COPY column values,
+// in the same order as BatchCopy's column list.
+func stateChangeCopyRow(sc types.StateChange) ([]any, error) {
+	// Convert account_id to BYTEA (required field)
+	accountBytes, err := sc.AccountID.Value()
+	if err != nil {
+		return nil, fmt.Errorf("converting account_id: %w", err)
+	}
+
+	// Convert nullable account_id fields to BYTEA
+	signerBytes, err := pgtypeBytesFromNullAddressBytea(sc.SignerAccountID)
+	if err != nil {
+		return nil, fmt.Errorf("converting signer_account_id: %w", err)
+	}
+	spenderBytes, err := pgtypeBytesFromNullAddressBytea(sc.SpenderAccountID)
+	if err != nil {
+		return nil, fmt.Errorf("converting spender_account_id: %w", err)
+	}
+	creatorBytes, err := pgtypeBytesFromNullAddressBytea(sc.CreatorAccountID)
+	if err != nil {
+		return nil, fmt.Errorf("converting creator_account_id: %w", err)
+	}
+	destinationBytes, err := pgtypeBytesFromNullAddressBytea(sc.DestinationAccountID)
+	if err != nil {
+		return nil, fmt.Errorf("converting destination_account_id: %w", err)
+	}
+	tokenBytes, err := pgtypeBytesFromNullAddressBytea(sc.TokenID)
+	if err != nil {
+		return nil, fmt.Errorf("converting token_id: %w", err)
+	}
+
+	return []any{
+		pgtype.Int8{Int64: sc.ToID, Valid: true},
+		pgtype.Int8{Int64: sc.StateChangeID, Valid: true},
+		pgtype.Text{String: string(sc.StateChangeCategory), Valid: true},
+		pgtypeTextFromReason(sc.StateChangeReason),
+		pgtype.Timestamptz{Time: sc.LedgerCreatedAt, Valid: true},
+		pgtype.Int4{Int32: int32(sc.LedgerNumber), Valid: true},
+		accountBytes,
+		pgtype.Int8{Int64: sc.OperationID, Valid: true},
+		tokenBytes,
+		pgtypeTextFromNullString(sc.Amount),
+		signerBytes,
+		spenderBytes,
+		creatorBytes,
+		destinationBytes,
+		pgtypeTextFromNullString(sc.LiquidityPoolID),
+		pgtypeInt2FromNullInt16(sc.SignerWeightOld),
+		pgtypeInt2FromNullInt16(sc.SignerWeightNew),
+		pgtypeTextFromNullString(sc.Threshold),
+		pgtypeInt2FromNullInt16(sc.ThresholdOld),
+		pgtypeInt2FromNullInt16(sc.ThresholdNew),
+		pgtypeTextFromNullString(sc.TrustlineLimitOld),
+		pgtypeTextFromNullString(sc.TrustlineLimitNew),
+		pgtypeInt2FromNullInt16(sc.Flags),
+		pgtypeTextFromNullString(sc.DataEntryName),
+		jsonbFromMap(sc.KeyValue),
+		pgtypeTextFromNullString(sc.ToMuxedID),
+	}, nil
 }
 
 // BatchGetByToID gets state changes for a single transaction with pagination support, pinned to

--- a/internal/data/statechanges.go
+++ b/internal/data/statechanges.go
@@ -247,6 +247,18 @@ func stateChangeCopyRow(sc types.StateChange) ([]any, error) {
 		return nil, fmt.Errorf("converting token_id: %w", err)
 	}
 
+	// Marshal key_value here rather than handing pgx the raw map: pgx would only
+	// marshal it after the COPY stream opens, and a marshalling failure there
+	// bypasses ErrRowEncoding and aborts the transaction. A nil map stays SQL NULL.
+	var keyValueBytes any
+	if sc.KeyValue != nil {
+		kv, err := sc.KeyValue.Value()
+		if err != nil {
+			return nil, fmt.Errorf("converting key_value: %w", err)
+		}
+		keyValueBytes = kv
+	}
+
 	return []any{
 		pgtype.Int8{Int64: sc.ToID, Valid: true},
 		pgtype.Int8{Int64: sc.StateChangeID, Valid: true},
@@ -272,7 +284,7 @@ func stateChangeCopyRow(sc types.StateChange) ([]any, error) {
 		pgtypeTextFromNullString(sc.TrustlineLimitNew),
 		pgtypeInt2FromNullInt16(sc.Flags),
 		pgtypeTextFromNullString(sc.DataEntryName),
-		jsonbFromMap(sc.KeyValue),
+		keyValueBytes,
 		pgtypeTextFromNullString(sc.ToMuxedID),
 	}, nil
 }

--- a/internal/data/statechanges.go
+++ b/internal/data/statechanges.go
@@ -168,6 +168,11 @@ func (m *StateChangeModel) BatchCopy(
 	for i, sc := range stateChanges {
 		row, err := stateChangeCopyRow(sc)
 		if err != nil {
+			duration := time.Since(start).Seconds()
+			m.Metrics.QueryDuration.WithLabelValues("BatchCopy", "state_changes").Observe(duration)
+			m.Metrics.BatchSize.WithLabelValues("BatchCopy", "state_changes").Observe(float64(len(stateChanges)))
+			m.Metrics.QueriesTotal.WithLabelValues("BatchCopy", "state_changes").Inc()
+			m.Metrics.QueryErrors.WithLabelValues("BatchCopy", "state_changes", "row_encoding").Inc()
 			return 0, fmt.Errorf("%w: state change %d (to_id %d, state_change_id %d): %w", ErrRowEncoding, i, sc.ToID, sc.StateChangeID, err)
 		}
 		rows[i] = row

--- a/internal/data/statechanges.go
+++ b/internal/data/statechanges.go
@@ -226,7 +226,7 @@ func stateChangeCopyRow(sc types.StateChange) ([]any, error) {
 	}
 
 	// Convert nullable account_id fields to BYTEA
-	signerBytes, err := pgtypeBytesFromNullAddressBytea(sc.SignerAccountID)
+	signerBytes, err := pgtypeBytesFromNullSignerKeyBytea(sc.SignerAccountID)
 	if err != nil {
 		return nil, fmt.Errorf("converting signer_account_id: %w", err)
 	}

--- a/internal/data/statechanges_test.go
+++ b/internal/data/statechanges_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/stellar/wallet-backend/internal/db/dbtest"
 	"github.com/stellar/wallet-backend/internal/indexer/types"
 	"github.com/stellar/wallet-backend/internal/metrics"
+	"github.com/stellar/wallet-backend/internal/utils"
 )
 
 // generateTestStateChanges creates n test state changes for benchmarking.
@@ -1193,4 +1195,111 @@ func TestStateChangeModel_MinimalProjectionHydratesLedgerCreatedAt(t *testing.T)
 	require.NoError(t, err)
 	require.Len(t, byOpID, 1)
 	assert.True(t, now.Equal(byOpID[0].StateChange.LedgerCreatedAt), "BatchGetByOperationID with minimal projection must hydrate ledger_created_at")
+}
+
+// TestStateChangeModel_BatchCopy_SignedPayloadSignerStoresBaseAccount verifies that a
+// CAP-40 signed-payload signer (P...) survives the COPY encode path and lands in
+// signer_account_id as the ed25519 account it is built over.
+func TestStateChangeModel_BatchCopy_SignedPayloadSignerStoresBaseAccount(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	ctx := context.Background()
+	dbConnectionPool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	now := time.Now()
+	kp := keypair.MustRandom()
+
+	// A signed-payload signer over kp's account.
+	sp, err := strkey.NewSignedPayload(kp.Address(), []byte{0xDE, 0xAD, 0xBE, 0xEF})
+	require.NoError(t, err)
+	signedPayloadAddress, err := sp.Encode()
+	require.NoError(t, err)
+
+	_, err = dbConnectionPool.Exec(ctx, `
+		INSERT INTO transactions (hash, to_id, fee_charged, result_code, ledger_number, ledger_created_at, is_fee_bump)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`, "f176b7b0133690fbfb2de8fa9ca2273cb4f2e29447e0cf0e14a5f82d0daa4877", int64(1), 100, "TransactionResultCodeTxSuccess", uint32(1), now, false)
+	require.NoError(t, err)
+
+	reg := prometheus.NewRegistry()
+	dbMetrics := metrics.NewMetrics(reg).DB
+	m := &StateChangeModel{DB: dbConnectionPool, Metrics: dbMetrics}
+
+	conn, err := pgx.Connect(ctx, dbt.DSN)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	sc := types.StateChange{
+		ToID:                1,
+		StateChangeID:       1,
+		StateChangeCategory: types.StateChangeCategorySigner,
+		StateChangeReason:   types.StateChangeReasonAdd,
+		LedgerCreatedAt:     now,
+		LedgerNumber:        1,
+		AccountID:           types.AddressBytea(kp.Address()),
+		OperationID:         123,
+		SignerAccountID:     utils.NullAddressBytea(signedPayloadAddress),
+	}
+
+	pgxTx, err := conn.Begin(ctx)
+	require.NoError(t, err)
+	gotCount, err := m.BatchCopy(ctx, pgxTx, []types.StateChange{sc})
+	require.NoError(t, err)
+	require.NoError(t, pgxTx.Commit(ctx))
+	assert.Equal(t, 1, gotCount)
+
+	storedSigner, err := db.QueryOne[types.AddressBytea](ctx, dbConnectionPool,
+		"SELECT signer_account_id FROM state_changes WHERE to_id = 1")
+	require.NoError(t, err)
+	assert.Equal(t, types.AddressBytea(kp.Address()), storedSigner,
+		"the P... signer must be stored as its ed25519 account")
+}
+
+// TestStateChangeModel_BatchCopy_RowEncodeErrorIsSentinel verifies that a row whose
+// address fails to encode is reported as ErrRowEncoding and that the failure happens
+// before the COPY stream opens, leaving the caller's transaction usable.
+func TestStateChangeModel_BatchCopy_RowEncodeErrorIsSentinel(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	ctx := context.Background()
+	dbConnectionPool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	now := time.Now()
+	kp := keypair.MustRandom()
+
+	reg := prometheus.NewRegistry()
+	dbMetrics := metrics.NewMetrics(reg).DB
+	m := &StateChangeModel{DB: dbConnectionPool, Metrics: dbMetrics}
+
+	conn, err := pgx.Connect(ctx, dbt.DSN)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	sc := types.StateChange{
+		ToID:                1,
+		StateChangeID:       1,
+		StateChangeCategory: types.StateChangeCategorySigner,
+		StateChangeReason:   types.StateChangeReasonAdd,
+		LedgerCreatedAt:     now,
+		LedgerNumber:        1,
+		AccountID:           types.AddressBytea(kp.Address()),
+		OperationID:         123,
+		SignerAccountID:     utils.NullAddressBytea("not-a-strkey"),
+	}
+
+	pgxTx, err := conn.Begin(ctx)
+	require.NoError(t, err)
+	defer pgxTx.Rollback(ctx)
+
+	_, err = m.BatchCopy(ctx, pgxTx, []types.StateChange{sc})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrRowEncoding)
+
+	// No COPY stream was opened, so the transaction is still usable.
+	_, err = pgxTx.Exec(ctx, "SELECT 1")
+	require.NoError(t, err)
 }

--- a/internal/data/statechanges_test.go
+++ b/internal/data/statechanges_test.go
@@ -44,8 +44,8 @@ func generateTestStateChanges(n int, accountID string, startToID int64, auxAddre
 			// NullAddressBytea token field
 			TokenID: types.NullAddressBytea{AddressBytea: types.AddressBytea(auxAddresses[(auxIdx+6)%len(auxAddresses)]), Valid: true},
 			Amount:  sql.NullString{String: fmt.Sprintf("%d", (i+1)*100), Valid: true},
-			// NullAddressBytea fields
-			SignerAccountID:  types.NullAddressBytea{AddressBytea: types.AddressBytea(auxAddresses[auxIdx]), Valid: true},
+			// Nullable address and signer-key fields
+			SignerAccountID:  types.NullSignerKeyBytea{SignerKeyBytea: types.SignerKeyBytea(auxAddresses[auxIdx]), Valid: true},
 			SpenderAccountID: types.NullAddressBytea{AddressBytea: types.AddressBytea(auxAddresses[(auxIdx+1)%len(auxAddresses)]), Valid: true},
 			CreatorAccountID: types.NullAddressBytea{AddressBytea: types.AddressBytea(auxAddresses[(auxIdx+4)%len(auxAddresses)]), Valid: true},
 			// Typed fields (previously JSONB)
@@ -1197,10 +1197,10 @@ func TestStateChangeModel_MinimalProjectionHydratesLedgerCreatedAt(t *testing.T)
 	assert.True(t, now.Equal(byOpID[0].StateChange.LedgerCreatedAt), "BatchGetByOperationID with minimal projection must hydrate ledger_created_at")
 }
 
-// TestStateChangeModel_BatchCopy_SignedPayloadSignerStoresBaseAccount verifies that a
-// CAP-40 signed-payload signer (P...) survives the COPY encode path and lands in
-// signer_account_id as the ed25519 account it is built over.
-func TestStateChangeModel_BatchCopy_SignedPayloadSignerStoresBaseAccount(t *testing.T) {
+// TestStateChangeModel_BatchCopy_SignedPayloadSignerStoresFullKey verifies that a
+// CAP-40 signed-payload signer (P...) survives the COPY encode path and reads back out
+// of signer_account_id as the same P... strkey, payload included.
+func TestStateChangeModel_BatchCopy_SignedPayloadSignerStoresFullKey(t *testing.T) {
 	dbt := dbtest.Open(t)
 	defer dbt.Close()
 	ctx := context.Background()
@@ -1240,7 +1240,7 @@ func TestStateChangeModel_BatchCopy_SignedPayloadSignerStoresBaseAccount(t *test
 		LedgerNumber:        1,
 		AccountID:           types.AddressBytea(kp.Address()),
 		OperationID:         123,
-		SignerAccountID:     utils.NullAddressBytea(signedPayloadAddress),
+		SignerAccountID:     utils.NullSignerKeyBytea(signedPayloadAddress),
 	}
 
 	pgxTx, err := conn.Begin(ctx)
@@ -1250,15 +1250,15 @@ func TestStateChangeModel_BatchCopy_SignedPayloadSignerStoresBaseAccount(t *test
 	require.NoError(t, pgxTx.Commit(ctx))
 	assert.Equal(t, 1, gotCount)
 
-	storedSigner, err := db.QueryOne[types.AddressBytea](ctx, dbConnectionPool,
+	storedSigner, err := db.QueryOne[types.SignerKeyBytea](ctx, dbConnectionPool,
 		"SELECT signer_account_id FROM state_changes WHERE to_id = 1")
 	require.NoError(t, err)
-	assert.Equal(t, types.AddressBytea(kp.Address()), storedSigner,
-		"the P... signer must be stored as its ed25519 account")
+	assert.Equal(t, types.SignerKeyBytea(signedPayloadAddress), storedSigner,
+		"the P... signer must be stored as the full signed-payload key")
 }
 
 // TestStateChangeModel_BatchCopy_RowEncodeErrorIsSentinel verifies that a row whose
-// address fails to encode is reported as ErrRowEncoding and that the failure happens
+// signer key fails to encode is reported as ErrRowEncoding and that the failure happens
 // before the COPY stream opens, leaving the caller's transaction usable.
 func TestStateChangeModel_BatchCopy_RowEncodeErrorIsSentinel(t *testing.T) {
 	dbt := dbtest.Open(t)
@@ -1288,7 +1288,55 @@ func TestStateChangeModel_BatchCopy_RowEncodeErrorIsSentinel(t *testing.T) {
 		LedgerNumber:        1,
 		AccountID:           types.AddressBytea(kp.Address()),
 		OperationID:         123,
-		SignerAccountID:     utils.NullAddressBytea("not-a-strkey"),
+		SignerAccountID:     utils.NullSignerKeyBytea("not-a-strkey"),
+	}
+
+	pgxTx, err := conn.Begin(ctx)
+	require.NoError(t, err)
+	defer pgxTx.Rollback(ctx)
+
+	_, err = m.BatchCopy(ctx, pgxTx, []types.StateChange{sc})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrRowEncoding)
+
+	// No COPY stream was opened, so the transaction is still usable.
+	_, err = pgxTx.Exec(ctx, "SELECT 1")
+	require.NoError(t, err)
+}
+
+// TestStateChangeModel_BatchCopy_KeyValueEncodeErrorIsSentinel verifies that a row whose
+// key_value cannot be marshalled to JSON is reported as ErrRowEncoding and that the
+// failure happens before the COPY stream opens, leaving the caller's transaction usable.
+func TestStateChangeModel_BatchCopy_KeyValueEncodeErrorIsSentinel(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	ctx := context.Background()
+	dbConnectionPool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+	defer dbConnectionPool.Close()
+
+	now := time.Now()
+	kp := keypair.MustRandom()
+
+	reg := prometheus.NewRegistry()
+	dbMetrics := metrics.NewMetrics(reg).DB
+	m := &StateChangeModel{DB: dbConnectionPool, Metrics: dbMetrics}
+
+	conn, err := pgx.Connect(ctx, dbt.DSN)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	sc := types.StateChange{
+		ToID:                1,
+		StateChangeID:       1,
+		StateChangeCategory: types.StateChangeCategoryHomeDomain,
+		StateChangeReason:   types.StateChangeReasonSet,
+		LedgerCreatedAt:     now,
+		LedgerNumber:        1,
+		AccountID:           types.AddressBytea(kp.Address()),
+		OperationID:         123,
+		// A channel has no JSON representation, so json.Marshal fails on this map.
+		KeyValue: types.NullableJSONB{"bad": make(chan int)},
 	}
 
 	pgxTx, err := conn.Begin(ctx)

--- a/internal/indexer/processors/effects.go
+++ b/internal/indexer/processors/effects.go
@@ -7,9 +7,11 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/stellar/go-stellar-sdk/ingest"
+	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/go-stellar-sdk/support/log"
@@ -560,10 +562,18 @@ func (p *EffectsProcessor) parseSigners(changeBuilder *StateChangeBuilder, effec
 	}
 	newWeight := int16(weight)
 
+	// The signer_account_id column stores 32-byte keys, so a CAP-40 signed-payload
+	// signer (P...) is stored as its underlying ed25519 account (G...). The full
+	// P... key is still needed below: the account's signer summary is keyed on it.
+	storedSigner, err := reduceSignedPayloadSigner(signerPublicKey)
+	if err != nil {
+		return nil, err
+	}
+
 	//exhaustive:ignore
 	switch effectType {
 	case EffectSignerCreated:
-		changeBuilder = changeBuilder.WithSigner(signerPublicKey, nil, &newWeight)
+		changeBuilder = changeBuilder.WithSigner(storedSigner, nil, &newWeight)
 	case EffectSignerUpdated, EffectSignerRemoved:
 		// The GraphQL schema declares oldWeight non-null on signer updates and
 		// removals, so the previous weight must be recovered from the account
@@ -586,12 +596,25 @@ func (p *EffectsProcessor) parseSigners(changeBuilder *StateChangeBuilder, effec
 		}
 		oldWeight := int16(oldVal)
 		if effectType == EffectSignerUpdated {
-			changeBuilder = changeBuilder.WithSigner(signerPublicKey, &oldWeight, &newWeight)
+			changeBuilder = changeBuilder.WithSigner(storedSigner, &oldWeight, &newWeight)
 		} else {
-			changeBuilder = changeBuilder.WithSigner(signerPublicKey, &oldWeight, nil)
+			changeBuilder = changeBuilder.WithSigner(storedSigner, &oldWeight, nil)
 		}
 	}
 	return []types.StateChange{changeBuilder.Build()}, nil
+}
+
+// reduceSignedPayloadSigner converts a CAP-40 signed-payload signer (P...) to its
+// underlying ed25519 account (G...). Any other signer key is returned unchanged.
+func reduceSignedPayloadSigner(signer string) (string, error) {
+	if !strings.HasPrefix(signer, "P") {
+		return signer, nil
+	}
+	signedPayload, err := strkey.DecodeSignedPayload(signer)
+	if err != nil {
+		return "", fmt.Errorf("decoding signed payload signer %s: %w", signer, err)
+	}
+	return signedPayload.Signer(), nil
 }
 
 // parseThresholds processes threshold-related effects and creates state changes for each threshold type.

--- a/internal/indexer/processors/effects.go
+++ b/internal/indexer/processors/effects.go
@@ -7,11 +7,9 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/stellar/go-stellar-sdk/ingest"
-	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/go-stellar-sdk/support/log"
@@ -562,18 +560,10 @@ func (p *EffectsProcessor) parseSigners(changeBuilder *StateChangeBuilder, effec
 	}
 	newWeight := int16(weight)
 
-	// The signer_account_id column stores 32-byte keys, so a CAP-40 signed-payload
-	// signer (P...) is stored as its underlying ed25519 account (G...). The full
-	// P... key is still needed below: the account's signer summary is keyed on it.
-	storedSigner, err := reduceSignedPayloadSigner(signerPublicKey)
-	if err != nil {
-		return nil, err
-	}
-
 	//exhaustive:ignore
 	switch effectType {
 	case EffectSignerCreated:
-		changeBuilder = changeBuilder.WithSigner(storedSigner, nil, &newWeight)
+		changeBuilder = changeBuilder.WithSigner(signerPublicKey, nil, &newWeight)
 	case EffectSignerUpdated, EffectSignerRemoved:
 		// The GraphQL schema declares oldWeight non-null on signer updates and
 		// removals, so the previous weight must be recovered from the account
@@ -596,25 +586,12 @@ func (p *EffectsProcessor) parseSigners(changeBuilder *StateChangeBuilder, effec
 		}
 		oldWeight := int16(oldVal)
 		if effectType == EffectSignerUpdated {
-			changeBuilder = changeBuilder.WithSigner(storedSigner, &oldWeight, &newWeight)
+			changeBuilder = changeBuilder.WithSigner(signerPublicKey, &oldWeight, &newWeight)
 		} else {
-			changeBuilder = changeBuilder.WithSigner(storedSigner, &oldWeight, nil)
+			changeBuilder = changeBuilder.WithSigner(signerPublicKey, &oldWeight, nil)
 		}
 	}
 	return []types.StateChange{changeBuilder.Build()}, nil
-}
-
-// reduceSignedPayloadSigner converts a CAP-40 signed-payload signer (P...) to its
-// underlying ed25519 account (G...). Any other signer key is returned unchanged.
-func reduceSignedPayloadSigner(signer string) (string, error) {
-	if !strings.HasPrefix(signer, "P") {
-		return signer, nil
-	}
-	signedPayload, err := strkey.DecodeSignedPayload(signer)
-	if err != nil {
-		return "", fmt.Errorf("decoding signed payload signer %s: %w", signer, err)
-	}
-	return signedPayload.Signer(), nil
 }
 
 // parseThresholds processes threshold-related effects and creates state changes for each threshold type.

--- a/internal/indexer/processors/effects_test.go
+++ b/internal/indexer/processors/effects_test.go
@@ -3,6 +3,7 @@ package processors
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 	"time"
 
@@ -100,6 +101,61 @@ func TestEffects_ProcessTransaction(t *testing.T) {
 				}
 			}
 		}
+	})
+
+	t.Run("SetOptions - signed payload signer", func(t *testing.T) {
+		// The signer added here is a CAP-40 signed-payload key; the resulting state change
+		// must carry its underlying ed25519 account, not the P... strkey.
+		const baseSigner = "GAQHWQYBBW272OOXNQMMLCA5WY2XAZPODGB7Q3S5OKKIXVESKO55ZQ7C"
+		signerKey := signedPayloadSignerKey(t, baseSigner)
+
+		// Master key weight stays 0, so the only signer summary entry is the new P key and
+		// the operation produces exactly one signer_created effect.
+		sourceAccount := someTxAccount.ToAccountId()
+		preAccount := &xdr.AccountEntry{AccountId: sourceAccount, Balance: 1000, SeqNum: 1}
+		postAccount := &xdr.AccountEntry{
+			AccountId: sourceAccount,
+			Balance:   1000,
+			SeqNum:    1,
+			Signers:   []xdr.Signer{{Key: signerKey, Weight: 2}},
+		}
+		setOptionsOp := xdr.Operation{
+			Body: xdr.OperationBody{
+				Type:         xdr.OperationTypeSetOptions,
+				SetOptionsOp: &xdr.SetOptionsOp{Signer: &xdr.Signer{Key: signerKey, Weight: 2}},
+			},
+		}
+		transaction := createTx(setOptionsOp, xdr.LedgerEntryChanges{
+			generateAccountEntryChangeState(preAccount),
+			{
+				Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
+				Updated: &xdr.LedgerEntry{Data: xdr.LedgerEntryData{
+					Type:    xdr.LedgerEntryTypeAccount,
+					Account: postAccount,
+				}},
+			},
+		}, nil, false)
+
+		op, found := transaction.GetOperation(0)
+		require.True(t, found)
+		processor := NewEffectsProcessor(networkPassphrase, nil)
+		opWrapper := &TransactionOperationWrapper{
+			Index:          0,
+			Operation:      op,
+			Network:        network.TestNetworkPassphrase,
+			Transaction:    transaction,
+			LedgerSequence: 12345,
+		}
+		changes, err := processor.ProcessOperation(context.Background(), opWrapper)
+		require.NoError(t, err)
+		require.Len(t, changes, 1)
+
+		assert.Equal(t, types.StateChangeCategorySigner, changes[0].StateChangeCategory)
+		assert.Equal(t, types.StateChangeReasonAdd, changes[0].StateChangeReason)
+		require.True(t, changes[0].SignerAccountID.Valid)
+		assert.Equal(t, baseSigner, changes[0].SignerAccountID.String())
+		assert.False(t, changes[0].SignerWeightOld.Valid)
+		assert.Equal(t, int16(2), changes[0].SignerWeightNew.Int16)
 	})
 
 	t.Run("SetTrustlineFlags - generates balance authorization state changes", func(t *testing.T) {
@@ -617,5 +673,133 @@ func TestEffects_GetPrevLedgerEntryState_MatchesEntity(t *testing.T) {
 		pre := p.getPrevLedgerEntryState(dataEffect, xdr.LedgerEntryTypeData, changes)
 		require.NotNil(t, pre)
 		assert.Equal(t, xdr.DataValue("v2"), pre.Data.MustData().DataValue)
+	})
+}
+
+// signedPayloadSignerKey builds a CAP-40 signed-payload signer key over the given ed25519
+// account. Going through the xdr form keeps the P... strkey and an account entry's signer
+// list in agreement, because SignerSummary keys the map on SignerKey.Address().
+func signedPayloadSignerKey(t *testing.T, account string) xdr.SignerKey {
+	t.Helper()
+	accountID := xdr.MustAddress(account)
+	return xdr.SignerKey{
+		Type: xdr.SignerKeyTypeSignerKeyTypeEd25519SignedPayload,
+		Ed25519SignedPayload: &xdr.SignerKeyEd25519SignedPayload{
+			Ed25519: *accountID.Ed25519,
+			Payload: []byte{0xde, 0xad, 0xbe, 0xef},
+		},
+	}
+}
+
+// TestEffects_ParseSigners_SignedPayloadSigner pins the split between lookup and storage for a
+// CAP-40 signed-payload signer. signer_account_id stores 32-byte keys, so the state change holds
+// the signer's underlying ed25519 account (G...), while the account pre-image's signer summary
+// is keyed on the full P... strkey and the old-weight lookup must still use that.
+func TestEffects_ParseSigners_SignedPayloadSigner(t *testing.T) {
+	const (
+		accountAddress = "GC4XF7RE3R4P77GY5XNGICM56IOKUURWAAANPXHFC7G5H6FCNQVVH3OH"
+		baseSigner     = "GAQHWQYBBW272OOXNQMMLCA5WY2XAZPODGB7Q3S5OKKIXVESKO55ZQ7C"
+	)
+	payloadSignerKey := signedPayloadSignerKey(t, baseSigner)
+	payloadSigner := payloadSignerKey.Address()
+	require.True(t, strings.HasPrefix(payloadSigner, "P"), "fixture must be a signed-payload strkey")
+
+	plainSignerKey := xdr.SignerKey{
+		Type:    xdr.SignerKeyTypeSignerKeyTypeEd25519,
+		Ed25519: xdr.MustAddress(baseSigner).Ed25519,
+	}
+
+	// The account pre-image the old weight is recovered from. Master key weight stays 0 so
+	// the account itself is absent from the signer summary.
+	preImage := func(signers ...xdr.Signer) []ingest.Change {
+		return []ingest.Change{{
+			Type: xdr.LedgerEntryTypeAccount,
+			Pre: &xdr.LedgerEntry{Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeAccount,
+				Account: &xdr.AccountEntry{
+					AccountId: xdr.MustAddress(accountAddress),
+					Signers:   signers,
+				},
+			}},
+		}}
+	}
+
+	testCases := []struct {
+		name          string
+		effectType    EffectType
+		details       map[string]interface{}
+		changes       []ingest.Change
+		wantOldWeight sql.NullInt16
+		wantNewWeight sql.NullInt16
+	}{
+		{
+			name:          "signer_created stores the signer's base account",
+			effectType:    EffectSignerCreated,
+			details:       map[string]interface{}{"public_key": payloadSigner, "weight": int32(3)},
+			wantNewWeight: sql.NullInt16{Int16: 3, Valid: true},
+		},
+		{
+			name:          "signer_updated finds the old weight under the full P key",
+			effectType:    EffectSignerUpdated,
+			details:       map[string]interface{}{"public_key": payloadSigner, "weight": int32(5)},
+			changes:       preImage(xdr.Signer{Key: payloadSignerKey, Weight: 2}),
+			wantOldWeight: sql.NullInt16{Int16: 2, Valid: true},
+			wantNewWeight: sql.NullInt16{Int16: 5, Valid: true},
+		},
+		{
+			// A removal effect carries no weight detail, so only the old weight is set.
+			name:          "signer_removed finds the old weight under the full P key",
+			effectType:    EffectSignerRemoved,
+			details:       map[string]interface{}{"public_key": payloadSigner},
+			changes:       preImage(xdr.Signer{Key: payloadSignerKey, Weight: 2}),
+			wantOldWeight: sql.NullInt16{Int16: 2, Valid: true},
+		},
+		{
+			name:          "a plain ed25519 signer passes through unchanged",
+			effectType:    EffectSignerUpdated,
+			details:       map[string]interface{}{"public_key": baseSigner, "weight": int32(4)},
+			changes:       preImage(xdr.Signer{Key: plainSignerKey, Weight: 1}),
+			wantOldWeight: sql.NullInt16{Int16: 1, Valid: true},
+			wantNewWeight: sql.NullInt16{Int16: 4, Valid: true},
+		},
+	}
+
+	processor := NewEffectsProcessor(networkPassphrase, nil)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			changeBuilder := NewStateChangeBuilder(12345, 12345*100, toid.New(12345, 1, 1).ToInt64(), nil).
+				WithAccount(accountAddress).
+				WithCategory(types.StateChangeCategorySigner)
+			effect := &EffectOutput{
+				Address:    accountAddress,
+				TypeString: EffectTypeNames[tc.effectType],
+				Details:    tc.details,
+			}
+
+			signerChanges, err := processor.parseSigners(changeBuilder, effect, tc.effectType, tc.changes)
+			require.NoError(t, err)
+			require.Len(t, signerChanges, 1)
+
+			require.True(t, signerChanges[0].SignerAccountID.Valid)
+			assert.Equal(t, baseSigner, signerChanges[0].SignerAccountID.String())
+			assert.Equal(t, tc.wantOldWeight, signerChanges[0].SignerWeightOld)
+			assert.Equal(t, tc.wantNewWeight, signerChanges[0].SignerWeightNew)
+		})
+	}
+
+	t.Run("a P signer missing from the pre-image is an error", func(t *testing.T) {
+		changeBuilder := NewStateChangeBuilder(12345, 12345*100, toid.New(12345, 1, 1).ToInt64(), nil).
+			WithAccount(accountAddress).
+			WithCategory(types.StateChangeCategorySigner)
+		effect := &EffectOutput{
+			Address:    accountAddress,
+			TypeString: EffectTypeNames[EffectSignerUpdated],
+			Details:    map[string]interface{}{"public_key": payloadSigner, "weight": int32(5)},
+		}
+
+		// The pre-image carries the plain ed25519 signer, so the P key is not in the summary.
+		_, err := processor.parseSigners(changeBuilder, effect, EffectSignerUpdated, preImage(xdr.Signer{Key: plainSignerKey, Weight: 1}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing from previous account state")
 	})
 }

--- a/internal/indexer/processors/effects_test.go
+++ b/internal/indexer/processors/effects_test.go
@@ -105,7 +105,7 @@ func TestEffects_ProcessTransaction(t *testing.T) {
 
 	t.Run("SetOptions - signed payload signer", func(t *testing.T) {
 		// The signer added here is a CAP-40 signed-payload key; the resulting state change
-		// must carry its underlying ed25519 account, not the P... strkey.
+		// must carry the full P... strkey, payload included.
 		const baseSigner = "GAQHWQYBBW272OOXNQMMLCA5WY2XAZPODGB7Q3S5OKKIXVESKO55ZQ7C"
 		signerKey := signedPayloadSignerKey(t, baseSigner)
 
@@ -153,7 +153,7 @@ func TestEffects_ProcessTransaction(t *testing.T) {
 		assert.Equal(t, types.StateChangeCategorySigner, changes[0].StateChangeCategory)
 		assert.Equal(t, types.StateChangeReasonAdd, changes[0].StateChangeReason)
 		require.True(t, changes[0].SignerAccountID.Valid)
-		assert.Equal(t, baseSigner, changes[0].SignerAccountID.String())
+		assert.Equal(t, signerKey.Address(), changes[0].SignerAccountID.String())
 		assert.False(t, changes[0].SignerWeightOld.Valid)
 		assert.Equal(t, int16(2), changes[0].SignerWeightNew.Int16)
 	})
@@ -691,10 +691,9 @@ func signedPayloadSignerKey(t *testing.T, account string) xdr.SignerKey {
 	}
 }
 
-// TestEffects_ParseSigners_SignedPayloadSigner pins the split between lookup and storage for a
-// CAP-40 signed-payload signer. signer_account_id stores 32-byte keys, so the state change holds
-// the signer's underlying ed25519 account (G...), while the account pre-image's signer summary
-// is keyed on the full P... strkey and the old-weight lookup must still use that.
+// TestEffects_ParseSigners_SignedPayloadSigner pins how a CAP-40 signed-payload signer flows
+// through parseSigners: the state change holds the full P... strkey, and the old-weight lookup
+// reads the account pre-image's signer summary, which is keyed on that same full strkey.
 func TestEffects_ParseSigners_SignedPayloadSigner(t *testing.T) {
 	const (
 		accountAddress = "GC4XF7RE3R4P77GY5XNGICM56IOKUURWAAANPXHFC7G5H6FCNQVVH3OH"
@@ -729,13 +728,15 @@ func TestEffects_ParseSigners_SignedPayloadSigner(t *testing.T) {
 		effectType    EffectType
 		details       map[string]interface{}
 		changes       []ingest.Change
+		wantSigner    string
 		wantOldWeight sql.NullInt16
 		wantNewWeight sql.NullInt16
 	}{
 		{
-			name:          "signer_created stores the signer's base account",
+			name:          "signer_created stores the full P key",
 			effectType:    EffectSignerCreated,
 			details:       map[string]interface{}{"public_key": payloadSigner, "weight": int32(3)},
+			wantSigner:    payloadSigner,
 			wantNewWeight: sql.NullInt16{Int16: 3, Valid: true},
 		},
 		{
@@ -743,6 +744,7 @@ func TestEffects_ParseSigners_SignedPayloadSigner(t *testing.T) {
 			effectType:    EffectSignerUpdated,
 			details:       map[string]interface{}{"public_key": payloadSigner, "weight": int32(5)},
 			changes:       preImage(xdr.Signer{Key: payloadSignerKey, Weight: 2}),
+			wantSigner:    payloadSigner,
 			wantOldWeight: sql.NullInt16{Int16: 2, Valid: true},
 			wantNewWeight: sql.NullInt16{Int16: 5, Valid: true},
 		},
@@ -752,13 +754,17 @@ func TestEffects_ParseSigners_SignedPayloadSigner(t *testing.T) {
 			effectType:    EffectSignerRemoved,
 			details:       map[string]interface{}{"public_key": payloadSigner},
 			changes:       preImage(xdr.Signer{Key: payloadSignerKey, Weight: 2}),
+			wantSigner:    payloadSigner,
 			wantOldWeight: sql.NullInt16{Int16: 2, Valid: true},
 		},
 		{
+			// The P key and the plain key share one ed25519 account, and each is stored
+			// as itself: a signer summary can hold both at once.
 			name:          "a plain ed25519 signer passes through unchanged",
 			effectType:    EffectSignerUpdated,
 			details:       map[string]interface{}{"public_key": baseSigner, "weight": int32(4)},
 			changes:       preImage(xdr.Signer{Key: plainSignerKey, Weight: 1}),
+			wantSigner:    baseSigner,
 			wantOldWeight: sql.NullInt16{Int16: 1, Valid: true},
 			wantNewWeight: sql.NullInt16{Int16: 4, Valid: true},
 		},
@@ -781,7 +787,7 @@ func TestEffects_ParseSigners_SignedPayloadSigner(t *testing.T) {
 			require.Len(t, signerChanges, 1)
 
 			require.True(t, signerChanges[0].SignerAccountID.Valid)
-			assert.Equal(t, baseSigner, signerChanges[0].SignerAccountID.String())
+			assert.Equal(t, tc.wantSigner, signerChanges[0].SignerAccountID.String())
 			assert.Equal(t, tc.wantOldWeight, signerChanges[0].SignerWeightOld)
 			assert.Equal(t, tc.wantNewWeight, signerChanges[0].SignerWeightNew)
 		})

--- a/internal/indexer/processors/state_change_builder.go
+++ b/internal/indexer/processors/state_change_builder.go
@@ -91,9 +91,9 @@ func (b *StateChangeBuilder) WithAccount(accountID string) *StateChangeBuilder {
 	return b
 }
 
-// WithSigner sets the signer account ID and the weights directly
+// WithSigner sets the signer key and the weights directly
 func (b *StateChangeBuilder) WithSigner(signer string, oldWeight, newWeight *int16) *StateChangeBuilder {
-	b.base.SignerAccountID = utils.NullAddressBytea(signer)
+	b.base.SignerAccountID = utils.NullSignerKeyBytea(signer)
 	if oldWeight != nil {
 		b.base.SignerWeightOld = sql.NullInt16{Int16: *oldWeight, Valid: true}
 	}

--- a/internal/indexer/types/types.go
+++ b/internal/indexer/types/types.go
@@ -78,9 +78,15 @@ func (a *AddressBytea) Scan(value any) error {
 // 8-byte multiplexing id (SEP-23). They are reduced to their base account here: the id is
 // off-chain routing metadata, not part of the stored key. This is a storage-layer backstop;
 // ingestion is expected to normalize muxed addresses to their base account before this point
-// (see the SEP-41 processor and the classic path's MuxedAccount.ToAccountId()). Any other
-// payload length is rejected rather than silently truncated, so a malformed address surfaces
-// as an error instead of corrupt data.
+// (see the SEP-41 processor and the classic path's MuxedAccount.ToAccountId()).
+//
+// Signed-payload signers (P..., CAP-40) carry a 32-byte ed25519 key followed by a 4-byte
+// length and the payload itself (36-100 bytes total). They are reduced to their ed25519
+// account the same way: the payload is a signing condition, not a separate identity.
+// Ingestion normalizes these before this point too (see EffectsProcessor.parseSigners).
+//
+// Any other payload length is rejected rather than silently truncated, so a malformed
+// address surfaces as an error instead of corrupt data.
 func (a AddressBytea) Value() (driver.Value, error) {
 	if a == "" {
 		return nil, nil
@@ -97,6 +103,16 @@ func (a AddressBytea) Value() (driver.Value, error) {
 		}
 		versionByte = strkey.VersionByteAccountID
 		rawBytes = rawBytes[:32] // keep the ed25519 key; drop the trailing 8-byte id
+	}
+	if versionByte == strkey.VersionByteSignedPayload {
+		// Guard the payload length before slicing: a signed payload is at least
+		// 36 bytes (32-byte ed25519 key + 4-byte payload length). DecodeAny already
+		// validates the full CAP-40 structure, so this guard is defensive.
+		if len(rawBytes) < 36 {
+			return nil, fmt.Errorf("stellar signed payload address %s has a %d-byte payload; expected at least 36 bytes", a, len(rawBytes))
+		}
+		versionByte = strkey.VersionByteAccountID
+		rawBytes = rawBytes[:32] // keep the ed25519 key; drop the payload
 	}
 	if len(rawBytes) != 32 {
 		return nil, fmt.Errorf("stellar address %s has a %d-byte key payload; the account_id column stores only 32-byte account/contract keys", a, len(rawBytes))

--- a/internal/indexer/types/types.go
+++ b/internal/indexer/types/types.go
@@ -78,16 +78,11 @@ func (a *AddressBytea) Scan(value any) error {
 // 8-byte multiplexing id (SEP-23). They are reduced to their base account here: the id is
 // off-chain routing metadata, not part of the stored key. This is a storage-layer backstop;
 // ingestion is expected to normalize muxed addresses to their base account before this point
-// (see the SEP-41 processor and the classic path's MuxedAccount.ToAccountId()).
-//
-// Signed-payload keys (P..., CAP-40) carry a 32-byte ed25519 key followed by a 4-byte
-// length and the XDR-padded payload (40-100 bytes total). They are reduced to their ed25519
-// account the same way. Signer columns store the full key via SignerKeyBytea instead,
-// so a P... reaching an account column is unexpected; reducing it here is a last resort
-// that keeps ingestion alive rather than halting on the row.
-//
-// Any other payload length is rejected rather than silently truncated, so a malformed
-// address surfaces as an error instead of corrupt data.
+// (see the SEP-41 processor and the classic path's MuxedAccount.ToAccountId()). Any other
+// payload length is rejected rather than silently truncated, so a malformed address surfaces
+// as an error instead of corrupt data. That covers signer keys too: signer columns store
+// them via SignerKeyBytea, so a signed-payload key (P...) reaching an account column is a
+// bug and errors here.
 func (a AddressBytea) Value() (driver.Value, error) {
 	if a == "" {
 		return nil, nil
@@ -104,16 +99,6 @@ func (a AddressBytea) Value() (driver.Value, error) {
 		}
 		versionByte = strkey.VersionByteAccountID
 		rawBytes = rawBytes[:32] // keep the ed25519 key; drop the trailing 8-byte id
-	}
-	if versionByte == strkey.VersionByteSignedPayload {
-		// Guard the payload length before slicing: a signed payload is at least
-		// 36 bytes (32-byte ed25519 key + 4-byte payload length). DecodeAny already
-		// validates the full CAP-40 structure, so this guard is defensive.
-		if len(rawBytes) < 36 {
-			return nil, fmt.Errorf("stellar signed payload address %s has a %d-byte payload; expected at least 36 bytes", a, len(rawBytes))
-		}
-		versionByte = strkey.VersionByteAccountID
-		rawBytes = rawBytes[:32] // keep the ed25519 key; drop the payload
 	}
 	if len(rawBytes) != 32 {
 		return nil, fmt.Errorf("stellar address %s has a %d-byte key payload; the account_id column stores only 32-byte account/contract keys", a, len(rawBytes))

--- a/internal/indexer/types/types.go
+++ b/internal/indexer/types/types.go
@@ -809,9 +809,9 @@ type StateChange struct {
 
 	// Nullable address fields (stored as BYTEA in database):
 	SignerAccountID      NullSignerKeyBytea `json:"signerAccountId,omitempty" db:"signer_account_id"`
-	SpenderAccountID     NullAddressBytea `json:"spenderAccountId,omitempty" db:"spender_account_id"`
-	CreatorAccountID     NullAddressBytea `json:"creatorAccountId,omitempty" db:"creator_account_id"`
-	DestinationAccountID NullAddressBytea `json:"destinationAccountId,omitempty" db:"destination_account_id"`
+	SpenderAccountID     NullAddressBytea   `json:"spenderAccountId,omitempty" db:"spender_account_id"`
+	CreatorAccountID     NullAddressBytea   `json:"creatorAccountId,omitempty" db:"creator_account_id"`
+	DestinationAccountID NullAddressBytea   `json:"destinationAccountId,omitempty" db:"destination_account_id"`
 
 	// Entity identifiers (moved from key_value JSONB):
 	LiquidityPoolID sql.NullString `json:"liquidityPoolId,omitempty" db:"liquidity_pool_id"`

--- a/internal/indexer/types/types.go
+++ b/internal/indexer/types/types.go
@@ -81,7 +81,7 @@ func (a *AddressBytea) Scan(value any) error {
 // (see the SEP-41 processor and the classic path's MuxedAccount.ToAccountId()).
 //
 // Signed-payload keys (P..., CAP-40) carry a 32-byte ed25519 key followed by a 4-byte
-// length and the payload itself (36-100 bytes total). They are reduced to their ed25519
+// length and the XDR-padded payload (40-100 bytes total). They are reduced to their ed25519
 // account the same way. Signer columns store the full key via SignerKeyBytea instead,
 // so a P... reaching an account column is unexpected; reducing it here is a last resort
 // that keeps ingestion alive rather than halting on the row.
@@ -166,7 +166,8 @@ func (n NullAddressBytea) String() string {
 // Signers are not always accounts: the four signer key types have different payload
 // sizes, so the column stores the version byte followed by the full key payload.
 // Storage format: 33 bytes for ed25519 (G...), pre-auth tx (T...) and hash-x (X...)
-// keys; 37-101 bytes for CAP-40 signed-payload (P...) keys.
+// keys; 41-101 bytes for CAP-40 signed-payload (P...) keys (the 1-64-byte payload is
+// XDR-padded to a multiple of four).
 // Go representation: StrKey string.
 type SignerKeyBytea string
 
@@ -186,6 +187,12 @@ func (s *SignerKeyBytea) Scan(value any) error {
 	encoded, err := strkey.Encode(strkey.VersionByte(bytes[0]), bytes[1:])
 	if err != nil {
 		return fmt.Errorf("encoding stellar signer key: %w", err)
+	}
+	// Encode checksums but does not validate payload shape, so run the result
+	// back through Value: it enforces the G/T/X/P allowlist and the CAP-40
+	// structure, keeping corrupt column bytes from surfacing as a signer key.
+	if _, err := SignerKeyBytea(encoded).Value(); err != nil {
+		return fmt.Errorf("validating stored signer key: %w", err)
 	}
 	*s = SignerKeyBytea(encoded)
 	return nil

--- a/internal/indexer/types/types.go
+++ b/internal/indexer/types/types.go
@@ -80,10 +80,11 @@ func (a *AddressBytea) Scan(value any) error {
 // ingestion is expected to normalize muxed addresses to their base account before this point
 // (see the SEP-41 processor and the classic path's MuxedAccount.ToAccountId()).
 //
-// Signed-payload signers (P..., CAP-40) carry a 32-byte ed25519 key followed by a 4-byte
+// Signed-payload keys (P..., CAP-40) carry a 32-byte ed25519 key followed by a 4-byte
 // length and the payload itself (36-100 bytes total). They are reduced to their ed25519
-// account the same way: the payload is a signing condition, not a separate identity.
-// Ingestion normalizes these before this point too (see EffectsProcessor.parseSigners).
+// account the same way. Signer columns store the full key via SignerKeyBytea instead,
+// so a P... reaching an account column is unexpected; reducing it here is a last resort
+// that keeps ingestion alive rather than halting on the row.
 //
 // Any other payload length is rejected rather than silently truncated, so a malformed
 // address surfaces as an error instead of corrupt data.
@@ -159,6 +160,99 @@ func (n NullAddressBytea) Value() (driver.Value, error) {
 // String returns the Stellar address as a string (convenience accessor).
 func (n NullAddressBytea) String() string {
 	return string(n.AddressBytea)
+}
+
+// SignerKeyBytea represents a Stellar signer key stored as BYTEA in the database.
+// Signers are not always accounts: the four signer key types have different payload
+// sizes, so the column stores the version byte followed by the full key payload.
+// Storage format: 33 bytes for ed25519 (G...), pre-auth tx (T...) and hash-x (X...)
+// keys; 37-101 bytes for CAP-40 signed-payload (P...) keys.
+// Go representation: StrKey string.
+type SignerKeyBytea string
+
+// Scan implements sql.Scanner - converts BYTEA (version byte + payload) to StrKey string
+func (s *SignerKeyBytea) Scan(value any) error {
+	if value == nil {
+		*s = ""
+		return nil
+	}
+	bytes, ok := value.([]byte)
+	if !ok {
+		return fmt.Errorf("expected []byte, got %T", value)
+	}
+	if len(bytes) < 33 {
+		return fmt.Errorf("expected at least 33 bytes, got %d", len(bytes))
+	}
+	encoded, err := strkey.Encode(strkey.VersionByte(bytes[0]), bytes[1:])
+	if err != nil {
+		return fmt.Errorf("encoding stellar signer key: %w", err)
+	}
+	*s = SignerKeyBytea(encoded)
+	return nil
+}
+
+// Value implements driver.Valuer - converts StrKey string to version byte + payload.
+// The four signer key types (G, T, X, P) are stored as-is; anything else is rejected.
+func (s SignerKeyBytea) Value() (driver.Value, error) {
+	if s == "" {
+		return nil, nil
+	}
+	versionByte, rawBytes, err := strkey.DecodeAny(string(s))
+	if err != nil {
+		return nil, fmt.Errorf("decoding stellar signer key %s: %w", s, err)
+	}
+	switch versionByte {
+	case strkey.VersionByteAccountID, strkey.VersionByteHashTx, strkey.VersionByteHashX:
+		if len(rawBytes) != 32 {
+			return nil, fmt.Errorf("stellar signer key %s has a %d-byte payload; expected 32 bytes", s, len(rawBytes))
+		}
+	case strkey.VersionByteSignedPayload:
+		// DecodeAny already validates the CAP-40 structure (36-100 bytes).
+	default:
+		return nil, fmt.Errorf("stellar signer key %s is not an account, pre-auth tx, hash-x or signed-payload key", s)
+	}
+	result := make([]byte, 1+len(rawBytes))
+	result[0] = byte(versionByte)
+	copy(result[1:], rawBytes)
+	return result, nil
+}
+
+// String returns the signer key as a string.
+func (s SignerKeyBytea) String() string {
+	return string(s)
+}
+
+// NullSignerKeyBytea represents a nullable Stellar signer key stored as BYTEA in the
+// database. Similar to sql.NullString but handles BYTEA encoding/decoding for signer keys.
+type NullSignerKeyBytea struct {
+	SignerKeyBytea SignerKeyBytea // The signer key (G.../T.../X.../P...)
+	Valid          bool           // Valid is true if SignerKeyBytea is not NULL
+}
+
+// Scan implements sql.Scanner - converts nullable BYTEA to StrKey string
+func (n *NullSignerKeyBytea) Scan(value any) error {
+	if value == nil {
+		n.SignerKeyBytea, n.Valid = "", false
+		return nil
+	}
+	if err := n.SignerKeyBytea.Scan(value); err != nil {
+		return err
+	}
+	n.Valid = true
+	return nil
+}
+
+// Value implements driver.Valuer - converts StrKey string to version byte + payload or nil
+func (n NullSignerKeyBytea) Value() (driver.Value, error) {
+	if !n.Valid {
+		return nil, nil
+	}
+	return n.SignerKeyBytea.Value()
+}
+
+// String returns the signer key as a string (convenience accessor).
+func (n NullSignerKeyBytea) String() string {
+	return string(n.SignerKeyBytea)
 }
 
 // HashBytea represents a transaction hash stored as BYTEA in the database.
@@ -714,7 +808,7 @@ type StateChange struct {
 	ToMuxedID sql.NullString `json:"toMuxedId,omitempty" db:"to_muxed_id"`
 
 	// Nullable address fields (stored as BYTEA in database):
-	SignerAccountID      NullAddressBytea `json:"signerAccountId,omitempty" db:"signer_account_id"`
+	SignerAccountID      NullSignerKeyBytea `json:"signerAccountId,omitempty" db:"signer_account_id"`
 	SpenderAccountID     NullAddressBytea `json:"spenderAccountId,omitempty" db:"spender_account_id"`
 	CreatorAccountID     NullAddressBytea `json:"creatorAccountId,omitempty" db:"creator_account_id"`
 	DestinationAccountID NullAddressBytea `json:"destinationAccountId,omitempty" db:"destination_account_id"`

--- a/internal/indexer/types/types_test.go
+++ b/internal/indexer/types/types_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"database/sql/driver"
 	"encoding/hex"
 	"testing"
@@ -122,6 +123,16 @@ func TestAddressBytea_Value(t *testing.T) {
 	expectedBytes[0] = byte(strkey.VersionByteAccountID)
 	copy(expectedBytes[1:], rawBytes)
 
+	// Signed-payload signers (P...) over the same account. The payload is a signing
+	// condition, so each of these stores as the same base-account key.
+	spTiny := signedPayloadOver(t, validAddress, bytes.Repeat([]byte{0x01}, 4))
+	spSmall := signedPayloadOver(t, validAddress, bytes.Repeat([]byte{0x02}, 8))
+	spMax := signedPayloadOver(t, validAddress, bytes.Repeat([]byte{0x03}, 64))
+
+	// Checksum-valid P... strkey whose payload is one byte short of the CAP-40
+	// minimum (32-byte key + 4-byte length). DecodeAny rejects the structure.
+	shortSignedPayload := strkey.MustEncode(strkey.VersionByteSignedPayload, make([]byte, 35))
+
 	testCases := []struct {
 		name            string
 		input           AddressBytea
@@ -139,8 +150,28 @@ func TestAddressBytea_Value(t *testing.T) {
 			want:  expectedBytes,
 		},
 		{
+			name:  "🟢signed payload, 4-byte payload",
+			input: AddressBytea(spTiny),
+			want:  expectedBytes,
+		},
+		{
+			name:  "🟢signed payload, 8-byte payload",
+			input: AddressBytea(spSmall),
+			want:  expectedBytes,
+		},
+		{
+			name:  "🟢signed payload, 64-byte payload",
+			input: AddressBytea(spMax),
+			want:  expectedBytes,
+		},
+		{
 			name:            "🔴invalid address",
 			input:           "not-a-valid-address",
+			wantErrContains: "decoding stellar address",
+		},
+		{
+			name:            "🔴signed payload with a too-short payload",
+			input:           AddressBytea(shortSignedPayload),
 			wantErrContains: "decoding stellar address",
 		},
 	}
@@ -563,6 +594,54 @@ func TestMuxedAddressBytea_NormalizesToBaseAccount(t *testing.T) {
 	vOther, err := AddressBytea(gOther).Value()
 	require.NoError(t, err)
 	assert.NotEqual(t, baseBytes, vOther)
+}
+
+// signedPayloadOver builds the P... strkey for a CAP-40 signed-payload signer over baseG.
+func signedPayloadOver(t *testing.T, baseG string, payload []byte) string {
+	t.Helper()
+	sp, err := strkey.NewSignedPayload(baseG, payload)
+	require.NoError(t, err)
+	addr, err := sp.Encode()
+	require.NoError(t, err)
+	return addr
+}
+
+// TestSignedPayloadAddressBytea_ReducesToEd25519Half verifies that a signed-payload signer
+// encodes to the same 33-byte key as the ed25519 account it is built over — the payload is
+// a signing condition, not part of the stored key.
+func TestSignedPayloadAddressBytea_ReducesToEd25519Half(t *testing.T) {
+	base := keypair.MustRandom().Address() // one base G... account
+
+	pA := signedPayloadOver(t, base, bytes.Repeat([]byte{0xAA}, 8))
+	pB := signedPayloadOver(t, base, bytes.Repeat([]byte{0xBB}, 32))
+	require.NotEqual(t, pA, pB, "the two signed-payload strkeys must differ as strings")
+	require.Equal(t, byte('P'), pA[0], "sanity: these are P-addresses")
+
+	baseBytes, err := AddressBytea(base).Value()
+	require.NoError(t, err)
+	vA, err := AddressBytea(pA).Value()
+	require.NoError(t, err)
+	vB, err := AddressBytea(pB).Value()
+	require.NoError(t, err)
+
+	require.Len(t, baseBytes.([]byte), 33)
+	assert.Equal(t, baseBytes, vA, "signed payload #1 must store as its ed25519 account")
+	assert.Equal(t, byte(strkey.VersionByteAccountID), vA.([]byte)[0],
+		"stored version byte must be the base-account (G) byte, not the signed-payload (P) byte")
+
+	// This is the accepted lossiness: two signed-payload signers that share an
+	// ed25519 key are stored as the same account.
+	assert.Equal(t, vA, vB)
+
+	// Distinct ed25519 accounts still stay distinct — the reduction only drops the payload.
+	vOther, err := AddressBytea(signedPayloadOver(t, keypair.MustRandom().Address(), []byte{0xAA})).Value()
+	require.NoError(t, err)
+	assert.NotEqual(t, baseBytes, vOther)
+
+	// Roundtrip: the stored bytes read back as the base G... address, not the P... one.
+	var restored AddressBytea
+	require.NoError(t, restored.Scan(vA))
+	assert.Equal(t, AddressBytea(base), restored)
 }
 
 // TestAddressBytea_RejectsMalformedPayload verifies that Value rejects a well-formed

--- a/internal/indexer/types/types_test.go
+++ b/internal/indexer/types/types_test.go
@@ -785,6 +785,20 @@ func TestSignerKeyBytea_Scan(t *testing.T) {
 			input:           bytes.Repeat([]byte{0x00}, 32),
 			wantErrContains: "expected at least 33 bytes",
 		},
+		{
+			// 33 stored bytes with a contract version byte encode to a C... strkey,
+			// which is not a signer key.
+			name:            "🔴contract version byte",
+			input:           append([]byte{byte(strkey.VersionByteContract)}, bytes.Repeat([]byte{0x01}, 32)...),
+			wantErrContains: "validating stored signer key",
+		},
+		{
+			// A signed-payload version byte over a bare 32-byte key is missing the
+			// CAP-40 length and payload, so the re-encoded strkey fails validation.
+			name:            "🔴malformed signed payload bytes",
+			input:           append([]byte{byte(strkey.VersionByteSignedPayload)}, bytes.Repeat([]byte{0x02}, 32)...),
+			wantErrContains: "validating stored signer key",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/indexer/types/types_test.go
+++ b/internal/indexer/types/types_test.go
@@ -123,12 +123,6 @@ func TestAddressBytea_Value(t *testing.T) {
 	expectedBytes[0] = byte(strkey.VersionByteAccountID)
 	copy(expectedBytes[1:], rawBytes)
 
-	// Signed-payload signers (P...) over the same account. The payload is a signing
-	// condition, so each of these stores as the same base-account key.
-	spTiny := signedPayloadOver(t, validAddress, bytes.Repeat([]byte{0x01}, 4))
-	spSmall := signedPayloadOver(t, validAddress, bytes.Repeat([]byte{0x02}, 8))
-	spMax := signedPayloadOver(t, validAddress, bytes.Repeat([]byte{0x03}, 64))
-
 	// Checksum-valid P... strkey whose payload is one byte short of the CAP-40
 	// minimum (32-byte key + 4-byte length). DecodeAny rejects the structure.
 	shortSignedPayload := strkey.MustEncode(strkey.VersionByteSignedPayload, make([]byte, 35))
@@ -150,19 +144,11 @@ func TestAddressBytea_Value(t *testing.T) {
 			want:  expectedBytes,
 		},
 		{
-			name:  "🟢signed payload, 4-byte payload",
-			input: AddressBytea(spTiny),
-			want:  expectedBytes,
-		},
-		{
-			name:  "🟢signed payload, 8-byte payload",
-			input: AddressBytea(spSmall),
-			want:  expectedBytes,
-		},
-		{
-			name:  "🟢signed payload, 64-byte payload",
-			input: AddressBytea(spMax),
-			want:  expectedBytes,
+			// Signer columns store P... keys via SignerKeyBytea; an account column
+			// rejects them.
+			name:            "🔴signed payload key",
+			input:           AddressBytea(signedPayloadOver(t, validAddress, bytes.Repeat([]byte{0x01}, 8))),
+			wantErrContains: "stores only 32-byte account/contract keys",
 		},
 		{
 			name:            "🔴invalid address",
@@ -604,44 +590,6 @@ func signedPayloadOver(t *testing.T, baseG string, payload []byte) string {
 	addr, err := sp.Encode()
 	require.NoError(t, err)
 	return addr
-}
-
-// TestSignedPayloadAddressBytea_ReducesToEd25519Half verifies that a signed-payload signer
-// encodes to the same 33-byte key as the ed25519 account it is built over — the payload is
-// a signing condition, not part of the stored key.
-func TestSignedPayloadAddressBytea_ReducesToEd25519Half(t *testing.T) {
-	base := keypair.MustRandom().Address() // one base G... account
-
-	pA := signedPayloadOver(t, base, bytes.Repeat([]byte{0xAA}, 8))
-	pB := signedPayloadOver(t, base, bytes.Repeat([]byte{0xBB}, 32))
-	require.NotEqual(t, pA, pB, "the two signed-payload strkeys must differ as strings")
-	require.Equal(t, byte('P'), pA[0], "sanity: these are P-addresses")
-
-	baseBytes, err := AddressBytea(base).Value()
-	require.NoError(t, err)
-	vA, err := AddressBytea(pA).Value()
-	require.NoError(t, err)
-	vB, err := AddressBytea(pB).Value()
-	require.NoError(t, err)
-
-	require.Len(t, baseBytes.([]byte), 33)
-	assert.Equal(t, baseBytes, vA, "signed payload #1 must store as its ed25519 account")
-	assert.Equal(t, byte(strkey.VersionByteAccountID), vA.([]byte)[0],
-		"stored version byte must be the base-account (G) byte, not the signed-payload (P) byte")
-
-	// This is the accepted lossiness: two signed-payload signers that share an
-	// ed25519 key are stored as the same account.
-	assert.Equal(t, vA, vB)
-
-	// Distinct ed25519 accounts still stay distinct — the reduction only drops the payload.
-	vOther, err := AddressBytea(signedPayloadOver(t, keypair.MustRandom().Address(), []byte{0xAA})).Value()
-	require.NoError(t, err)
-	assert.NotEqual(t, baseBytes, vOther)
-
-	// Roundtrip: the stored bytes read back as the base G... address, not the P... one.
-	var restored AddressBytea
-	require.NoError(t, restored.Scan(vA))
-	assert.Equal(t, AddressBytea(base), restored)
 }
 
 // TestAddressBytea_RejectsMalformedPayload verifies that Value rejects a well-formed

--- a/internal/indexer/types/types_test.go
+++ b/internal/indexer/types/types_test.go
@@ -672,3 +672,227 @@ func TestAddressBytea_RejectsMalformedPayload(t *testing.T) {
 	_, err = AddressBytea("CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA").Value()
 	require.NoError(t, err)
 }
+
+func TestSignerKeyBytea_Value(t *testing.T) {
+	account := keypair.MustRandom().Address()
+
+	_, accountRaw, err := strkey.DecodeAny(account)
+	require.NoError(t, err)
+	accountBytes := append([]byte{byte(strkey.VersionByteAccountID)}, accountRaw...)
+
+	preAuthTxRaw := bytes.Repeat([]byte{0x11}, 32)
+	preAuthTx := strkey.MustEncode(strkey.VersionByteHashTx, preAuthTxRaw)
+	preAuthTxBytes := append([]byte{byte(strkey.VersionByteHashTx)}, preAuthTxRaw...)
+
+	hashXRaw := bytes.Repeat([]byte{0x22}, 32)
+	hashX := strkey.MustEncode(strkey.VersionByteHashX, hashXRaw)
+	hashXBytes := append([]byte{byte(strkey.VersionByteHashX)}, hashXRaw...)
+
+	signedPayload := signedPayloadOver(t, account, bytes.Repeat([]byte{0xAA}, 8))
+	_, signedPayloadRaw, err := strkey.DecodeAny(signedPayload)
+	require.NoError(t, err)
+	signedPayloadBytes := append([]byte{byte(strkey.VersionByteSignedPayload)}, signedPayloadRaw...)
+
+	testCases := []struct {
+		name            string
+		input           SignerKeyBytea
+		want            driver.Value
+		wantErrContains string
+	}{
+		{
+			name:  "🟢empty string",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "🟢ed25519 account key",
+			input: SignerKeyBytea(account),
+			want:  accountBytes,
+		},
+		{
+			name:  "🟢pre-auth tx key",
+			input: SignerKeyBytea(preAuthTx),
+			want:  preAuthTxBytes,
+		},
+		{
+			name:  "🟢hash-x key",
+			input: SignerKeyBytea(hashX),
+			want:  hashXBytes,
+		},
+		{
+			name:  "🟢signed payload key keeps its payload",
+			input: SignerKeyBytea(signedPayload),
+			want:  signedPayloadBytes,
+		},
+		{
+			name:            "🔴contract address",
+			input:           "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA",
+			wantErrContains: "is not an account, pre-auth tx, hash-x or signed-payload key",
+		},
+		{
+			name:            "🔴muxed account",
+			input:           SignerKeyBytea(muxedOver(t, account, 7)),
+			wantErrContains: "is not an account, pre-auth tx, hash-x or signed-payload key",
+		},
+		{
+			name:            "🔴garbage string",
+			input:           "not-a-strkey",
+			wantErrContains: "decoding stellar signer key",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.input.Value()
+			if tc.wantErrContains != "" {
+				assert.ErrorContains(t, err, tc.wantErrContains)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestSignerKeyBytea_Scan(t *testing.T) {
+	account := keypair.MustRandom().Address()
+	accountBytes, err := SignerKeyBytea(account).Value()
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name            string
+		input           any
+		want            SignerKeyBytea
+		wantErrContains string
+	}{
+		{
+			name:  "🟢nil value",
+			input: nil,
+			want:  "",
+		},
+		{
+			name:  "🟢33-byte account key",
+			input: accountBytes,
+			want:  SignerKeyBytea(account),
+		},
+		{
+			name:            "🔴wrong type",
+			input:           "a string",
+			wantErrContains: "expected []byte",
+		},
+		{
+			name:            "🔴fewer than 33 bytes",
+			input:           bytes.Repeat([]byte{0x00}, 32),
+			wantErrContains: "expected at least 33 bytes",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got SignerKeyBytea
+			err := got.Scan(tc.input)
+			if tc.wantErrContains != "" {
+				assert.ErrorContains(t, err, tc.wantErrContains)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+// TestSignerKeyBytea_Roundtrip verifies that each of the four signer key types survives
+// Value -> Scan as the exact strkey it started as.
+func TestSignerKeyBytea_Roundtrip(t *testing.T) {
+	account := keypair.MustRandom().Address()
+
+	keys := map[string]SignerKeyBytea{
+		"ed25519 account":                SignerKeyBytea(account),
+		"pre-auth tx":                    SignerKeyBytea(strkey.MustEncode(strkey.VersionByteHashTx, bytes.Repeat([]byte{0x11}, 32))),
+		"hash-x":                         SignerKeyBytea(strkey.MustEncode(strkey.VersionByteHashX, bytes.Repeat([]byte{0x22}, 32))),
+		"signed payload, 8-byte payload": SignerKeyBytea(signedPayloadOver(t, account, bytes.Repeat([]byte{0xAA}, 8))),
+		"signed payload, max payload":    SignerKeyBytea(signedPayloadOver(t, account, bytes.Repeat([]byte{0xBB}, 64))),
+	}
+
+	for name, original := range keys {
+		t.Run(name, func(t *testing.T) {
+			stored, err := original.Value()
+			require.NoError(t, err)
+
+			var restored SignerKeyBytea
+			require.NoError(t, restored.Scan(stored))
+			assert.Equal(t, original, restored)
+		})
+	}
+}
+
+// TestSignerKeyBytea_SignedPayloadKeepsPayload verifies that two signed-payload signers over
+// one ed25519 account stay distinct in storage, and that neither collides with the plain
+// account key over the same ed25519 half. An account can hold all three at once.
+func TestSignerKeyBytea_SignedPayloadKeepsPayload(t *testing.T) {
+	base := keypair.MustRandom().Address()
+
+	pA := signedPayloadOver(t, base, bytes.Repeat([]byte{0xAA}, 8))
+	pB := signedPayloadOver(t, base, bytes.Repeat([]byte{0xBB}, 8))
+	require.NotEqual(t, pA, pB, "the two signed-payload strkeys must differ as strings")
+
+	vA, err := SignerKeyBytea(pA).Value()
+	require.NoError(t, err)
+	vB, err := SignerKeyBytea(pB).Value()
+	require.NoError(t, err)
+	vBase, err := SignerKeyBytea(base).Value()
+	require.NoError(t, err)
+
+	assert.NotEqual(t, vA, vB, "signers differing only in payload must store differently")
+	assert.NotEqual(t, vBase, vA, "the plain account key must not collide with a payload signer over it")
+
+	assert.Equal(t, byte(strkey.VersionByteSignedPayload), vA.([]byte)[0])
+	assert.GreaterOrEqual(t, len(vA.([]byte)), 37)
+	assert.LessOrEqual(t, len(vA.([]byte)), 101)
+	assert.Len(t, vBase.([]byte), 33)
+}
+
+func TestSignerKeyBytea_String(t *testing.T) {
+	account := keypair.MustRandom().Address()
+	assert.Equal(t, "", SignerKeyBytea("").String())
+	assert.Equal(t, account, SignerKeyBytea(account).String())
+}
+
+func TestNullSignerKeyBytea(t *testing.T) {
+	account := keypair.MustRandom().Address()
+
+	t.Run("🟢nil scan is invalid", func(t *testing.T) {
+		n := NullSignerKeyBytea{SignerKeyBytea: SignerKeyBytea(account), Valid: true}
+		require.NoError(t, n.Scan(nil))
+		assert.False(t, n.Valid)
+		assert.Equal(t, "", n.String())
+	})
+
+	t.Run("🟢invalid value is nil", func(t *testing.T) {
+		got, err := NullSignerKeyBytea{}.Value()
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("🟢empty string value is nil", func(t *testing.T) {
+		got, err := NullSignerKeyBytea{SignerKeyBytea: "", Valid: true}.Value()
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("🟢roundtrips a signed payload key", func(t *testing.T) {
+		signedPayload := signedPayloadOver(t, account, bytes.Repeat([]byte{0xCC}, 16))
+		stored, err := NullSignerKeyBytea{SignerKeyBytea: SignerKeyBytea(signedPayload), Valid: true}.Value()
+		require.NoError(t, err)
+
+		var restored NullSignerKeyBytea
+		require.NoError(t, restored.Scan(stored))
+		assert.True(t, restored.Valid)
+		assert.Equal(t, signedPayload, restored.String())
+	})
+
+	t.Run("🔴scan of fewer than 33 bytes errors", func(t *testing.T) {
+		var n NullSignerKeyBytea
+		assert.ErrorContains(t, n.Scan(bytes.Repeat([]byte{0x00}, 32)), "expected at least 33 bytes")
+	})
+}

--- a/internal/serve/graphql/resolvers/resolver.go
+++ b/internal/serve/graphql/resolvers/resolver.go
@@ -108,6 +108,15 @@ func (r *Resolver) resolveRequiredAddress(field types.NullAddressBytea, fieldNam
 	return field.String(), nil
 }
 
+// resolveRequiredSignerKey resolves a required signer key field into its strkey string.
+// Returns an error when the field is null, since the GraphQL schema declares it non-nullable.
+func (r *Resolver) resolveRequiredSignerKey(field types.NullSignerKeyBytea, fieldName string) (string, error) {
+	if !field.Valid {
+		return "", fmt.Errorf("state change is missing required %s", fieldName)
+	}
+	return field.String(), nil
+}
+
 // resolveRequiredInt16 resolves a required int16 field into an int32.
 // Returns an error when the field is null, since the GraphQL schema declares it non-nullable.
 func (r *Resolver) resolveRequiredInt16(field sql.NullInt16, fieldName string) (int32, error) {

--- a/internal/serve/graphql/resolvers/statechange.resolvers.go
+++ b/internal/serve/graphql/resolvers/statechange.resolvers.go
@@ -528,7 +528,7 @@ func (r *signerAddedChangeResolver) Transaction(ctx context.Context, obj *types.
 
 // SignerAddress is the resolver for the signerAddress field.
 func (r *signerAddedChangeResolver) SignerAddress(ctx context.Context, obj *types.SignerAddedChangeModel) (string, error) {
-	return r.resolveRequiredAddress(obj.SignerAccountID, "signerAddress")
+	return r.resolveRequiredSignerKey(obj.SignerAccountID, "signerAddress")
 }
 
 // NewWeight is the resolver for the newWeight field.
@@ -563,7 +563,7 @@ func (r *signerRemovedChangeResolver) Transaction(ctx context.Context, obj *type
 
 // SignerAddress is the resolver for the signerAddress field.
 func (r *signerRemovedChangeResolver) SignerAddress(ctx context.Context, obj *types.SignerRemovedChangeModel) (string, error) {
-	return r.resolveRequiredAddress(obj.SignerAccountID, "signerAddress")
+	return r.resolveRequiredSignerKey(obj.SignerAccountID, "signerAddress")
 }
 
 // OldWeight is the resolver for the oldWeight field.
@@ -598,7 +598,7 @@ func (r *signerUpdatedChangeResolver) Transaction(ctx context.Context, obj *type
 
 // SignerAddress is the resolver for the signerAddress field.
 func (r *signerUpdatedChangeResolver) SignerAddress(ctx context.Context, obj *types.SignerUpdatedChangeModel) (string, error) {
-	return r.resolveRequiredAddress(obj.SignerAccountID, "signerAddress")
+	return r.resolveRequiredSignerKey(obj.SignerAccountID, "signerAddress")
 }
 
 // OldWeight is the resolver for the oldWeight field.

--- a/internal/services/ingest_backfill.go
+++ b/internal/services/ingest_backfill.go
@@ -290,6 +290,10 @@ func (m *ingestService) flushBatchBufferWithRetry(ctx context.Context, buffer *i
 			return nil
 		}
 		lastErr = err
+		if isPermanentPersistError(err) {
+			m.appMetrics.Ingestion.ErrorsTotal.WithLabelValues("batch_flush").Inc()
+			return fmt.Errorf("flushing batch buffer failed with a permanent error: %w", err)
+		}
 		m.appMetrics.Ingestion.RetriesTotal.WithLabelValues("batch_flush").Inc()
 		if attempt == maxIngestProcessedDataRetries-1 {
 			break

--- a/internal/services/ingest_backfill_test.go
+++ b/internal/services/ingest_backfill_test.go
@@ -2,11 +2,23 @@
 package services
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/internal/data"
+	"github.com/stellar/wallet-backend/internal/db"
+	"github.com/stellar/wallet-backend/internal/db/dbtest"
+	"github.com/stellar/wallet-backend/internal/indexer"
+	"github.com/stellar/wallet-backend/internal/indexer/types"
+	"github.com/stellar/wallet-backend/internal/metrics"
+	"github.com/stellar/wallet-backend/internal/utils"
 )
 
 // newTestRecompressor creates a progressiveRecompressor for testing watermark logic.
@@ -173,4 +185,65 @@ func Test_progressiveRecompressor_MarkDone_allSimultaneous(t *testing.T) {
 	require.Len(t, windows, 1)
 	assert.Equal(t, endTime(3), windows[0]) // safeEnd = last batch
 	assert.Equal(t, 3, r.watermarkIdx)
+}
+
+// Test_flushBatchBufferWithRetry_PermanentErrorFailsFast verifies that a buffer the
+// database can never accept — here a state change whose signer key does not encode —
+// is abandoned on the first attempt instead of consuming the retry budget.
+func Test_flushBatchBufferWithRetry_PermanentErrorFailsFast(t *testing.T) {
+	dbt := dbtest.Open(t)
+	defer dbt.Close()
+	ctx := context.Background()
+
+	pool, err := db.OpenDBConnectionPool(ctx, dbt.DSN)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	appMetrics := metrics.NewMetrics(prometheus.NewRegistry())
+	models, err := data.NewModels(pool, appMetrics.DB)
+	require.NoError(t, err)
+
+	// flushBatchBufferWithRetry only touches the models and the ingestion metrics when
+	// no cursor update is requested, so a struct literal with those two is the whole
+	// service surface under test.
+	m := &ingestService{models: models, appMetrics: appMetrics}
+
+	now := time.Now()
+	account := keypair.MustRandom().Address()
+	transaction := &types.Transaction{
+		Hash:            "f176b7b0133690fbfb2de8fa9ca2273cb4f2e29447e0cf0e14a5f82d0daa4877",
+		ToID:            1,
+		FeeCharged:      100,
+		ResultCode:      "TransactionResultCodeTxSuccess",
+		LedgerNumber:    1,
+		LedgerCreatedAt: now,
+	}
+
+	buffer := indexer.NewIndexerBuffer()
+	buffer.PushStateChange(transaction, nil, types.StateChange{
+		ToID:                1,
+		StateChangeID:       1,
+		StateChangeCategory: types.StateChangeCategorySigner,
+		StateChangeReason:   types.StateChangeReasonAdd,
+		LedgerCreatedAt:     now,
+		LedgerNumber:        1,
+		AccountID:           types.AddressBytea(account),
+		SignerAccountID:     utils.NullSignerKeyBytea("not-a-strkey"),
+	})
+
+	start := time.Now()
+	err = m.flushBatchBufferWithRetry(ctx, buffer, nil)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, data.ErrRowEncoding)
+
+	// The first retry sleeps a second, so returning well inside that proves no retry ran.
+	assert.Less(t, elapsed, time.Second)
+	assert.Equal(t, 0.0, testutil.ToFloat64(
+		appMetrics.Ingestion.RetriesTotal.WithLabelValues("batch_flush")))
+	assert.Equal(t, 0.0, testutil.ToFloat64(
+		appMetrics.Ingestion.RetryExhaustionsTotal.WithLabelValues("batch_flush")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(
+		appMetrics.Ingestion.ErrorsTotal.WithLabelValues("batch_flush")))
 }

--- a/internal/services/ingest_backfill_test.go
+++ b/internal/services/ingest_backfill_test.go
@@ -231,15 +231,12 @@ func Test_flushBatchBufferWithRetry_PermanentErrorFailsFast(t *testing.T) {
 		SignerAccountID:     utils.NullSignerKeyBytea("not-a-strkey"),
 	})
 
-	start := time.Now()
 	err = m.flushBatchBufferWithRetry(ctx, buffer, nil)
-	elapsed := time.Since(start)
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, data.ErrRowEncoding)
 
-	// The first retry sleeps a second, so returning well inside that proves no retry ran.
-	assert.Less(t, elapsed, time.Second)
+	// No retry ran: the retry counters never moved and the permanent-error counter did.
 	assert.Equal(t, 0.0, testutil.ToFloat64(
 		appMetrics.Ingestion.RetriesTotal.WithLabelValues("batch_flush")))
 	assert.Equal(t, 0.0, testutil.ToFloat64(

--- a/internal/services/ingest_live.go
+++ b/internal/services/ingest_live.go
@@ -725,8 +725,10 @@ func (m *ingestService) ingestProcessedDataWithRetry(
 // ErrCASCursorMissing (see IngestStoreModel.CompareAndSwap) is likewise permanent: the cursor row
 // this ledger's protocol CAS targets is gone, and no retry of the same transaction can recreate
 // it — failing fast surfaces the incident instead of burning the whole retry ladder.
+// ErrRowEncoding (see StateChangeModel.BatchCopy) is also permanent: converting a row's
+// Go values for COPY is deterministic, so retrying the same rows can never succeed.
 func isPermanentPersistError(err error) bool {
-	if errors.Is(err, data.ErrCursorGuardFailed) || errors.Is(err, data.ErrCASCursorMissing) {
+	if errors.Is(err, data.ErrCursorGuardFailed) || errors.Is(err, data.ErrCASCursorMissing) || errors.Is(err, data.ErrRowEncoding) {
 		return true
 	}
 	var pgErr *pgconn.PgError

--- a/internal/services/ingest_live_test.go
+++ b/internal/services/ingest_live_test.go
@@ -92,7 +92,8 @@ func Test_startLiveIngestion_ReleasesAdvisoryLockWhenContextCancelledMidStartup(
 }
 
 // Test_isPermanentPersistError covers ING-06's classifier: SQLSTATE class 22/23/42 (and the
-// ErrCursorGuardFailed / ErrCASCursorMissing cursor sentinels) must fail an ingestion attempt
+// ErrCursorGuardFailed / ErrCASCursorMissing cursor sentinels and the ErrRowEncoding
+// COPY-encoding sentinel) must fail an ingestion attempt
 // immediately instead of burning the full 5-attempt retry ladder; every other error (including
 // no PgError at all) must still retry, same as before this classifier existed.
 func Test_isPermanentPersistError(t *testing.T) {
@@ -135,6 +136,19 @@ func Test_isPermanentPersistError(t *testing.T) {
 			name:          "wrapped_cas_cursor_missing_is_permanent",
 			err:           fmt.Errorf("persisting ledger data for ledger 100: comparing and swapping protocol cursor blend: %w", data.ErrCASCursorMissing),
 			wantPermanent: true,
+		},
+		{name: "row_encoding_is_permanent", err: data.ErrRowEncoding, wantPermanent: true},
+		{
+			name:          "wrapped_row_encoding_is_permanent",
+			err:           fmt.Errorf("pgx CopyFrom state_changes: %w", fmt.Errorf("%w: state change 0: bad", data.ErrRowEncoding)),
+			wantPermanent: true,
+		},
+		{
+			// A COPY abort surfaces as SQLSTATE 57014 and stays retryable; encode
+			// failures are caught client-side before the COPY starts.
+			name:          "query_canceled_57014_is_transient",
+			err:           pgErrWithCode("57014"),
+			wantPermanent: false,
 		},
 	}
 

--- a/internal/utils/sql.go
+++ b/internal/utils/sql.go
@@ -27,3 +27,10 @@ func NullAddressBytea(s string) types.NullAddressBytea {
 		Valid:        s != "",
 	}
 }
+
+func NullSignerKeyBytea(s string) types.NullSignerKeyBytea {
+	return types.NullSignerKeyBytea{
+		SignerKeyBytea: types.SignerKeyBytea(s),
+		Valid:          s != "",
+	}
+}


### PR DESCRIPTION
Fixes ingestion halting when a ledger contains a CAP-40 signed-payload signer (`P...` strkey). Reported in stellar/wallet-eng-monorepo#71.

## The bug

A signed-payload signer decodes to 40–100 bytes: a 32-byte ed25519 key, a 4-byte length, and the 1–64-byte payload XDR-padded to a multiple of four. `AddressBytea.Value()` only special-cases muxed addresses (`M...`) and rejects every other key that is not 32 bytes. When a `SetOptions` adds a `P...` signer, the signer state change carries the full `P...` strkey into `signer_account_id`, the COPY encode fails, and the whole persist transaction rolls back — including the cursor update. Ingestion retries the same ledger forever. Backfill fails the same way. Testnet already contains such a signer (ledger 4437357), so any instance ingesting across it stops there.

## The fix

1. **`signer_account_id` stores the full signer key.** A new `SignerKeyBytea` type stores the version byte plus the full key payload: 33 bytes for `G`/`T`/`X` keys, up to 101 bytes for `P...`. Signers are keys, not accounts — an account can hold both a plain `G` signer and a `P` signer built over the same ed25519 key, so reducing `P...` to its base account would make those two signers indistinguishable. No migration: the column is an unconstrained `BYTEA` with no index or SQL filter, and `T`/`X` signers already store their own version bytes in it. The GraphQL `signerAddress` field now returns the `P...` strkey as stored on-chain.
2. **`BatchCopy` encodes all rows — including the `key_value` JSON — before opening the COPY stream.** A row that fails to encode returns `ErrRowEncoding` without aborting the pgx transaction. (pgx discards the Go error from a COPY callback — only a server-side SQLSTATE 57014 comes back — so encode errors have to be caught before the stream opens.)
3. **Both retry loops treat encode failures as permanent.** `isPermanentPersistError` classifies `ErrRowEncoding` as permanent, and the backfill flush loop now consults it too, so a deterministic failure surfaces immediately instead of burning the 5-attempt retry ladder.

## Notes

- No database migration in this PR.
- Existing rows are unaffected: `G`/`T`/`X` signer rows already have the stored version-byte format `SignerKeyBytea` reads.

## Testing

- `SignerKeyBytea` tests: `G`/`T`/`X`/`P` keys round-trip through Value/Scan unchanged; two `P` keys over one ed25519 key store distinct bytes; contract and muxed strkeys are rejected.
- `AddressBytea` tests: a `P...` key in an account column is rejected (signer columns are the only place signer keys belong); structurally invalid `P...` is rejected.
- `parseSigners` tests: created/updated/removed with a `P...` signer store the full key while the old weight resolves from the account's signer summary; plain `G...` signers unchanged; end-to-end `SetOptions` test through `ProcessOperation`.
- `BatchCopy` tests: a `P...` signer persists through real COPY and reads back unchanged; an un-encodable signer or `key_value` returns `ErrRowEncoding` and leaves the transaction usable.
- Retry tests: `ErrRowEncoding` (bare and wrapped) is permanent; SQLSTATE 57014 stays transient; the backfill flush returns on the first attempt for a permanent error.
- `make check` and `make unit-test` pass.
