### PR TITLE
fix: record SAC-created trustline state changes

### DIFF
--- a/internal/indexer/processors/contracts/sac.go
+++ b/internal/indexer/processors/contracts/sac.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/stellar/go-stellar-sdk/amount"
 	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/xdr"
@@ -90,8 +91,11 @@ func (p *SACEventsProcessor) ProcessOperation(_ context.Context, opWrapper *proc
 		return nil, fmt.Errorf("getting operation changes for operation %d: %w", opWrapper.ID(), err)
 	}
 
-	stateChanges := make([]types.StateChange, 0)
 	builder := processors.NewStateChangeBuilder(ledgerNumber, ledgerCloseTime, txID, p.metricsService).WithOperationID(opWrapper.ID())
+	stateChanges, err := p.processCreatedTrustlines(changes, builder)
+	if err != nil {
+		return nil, fmt.Errorf("processing created trustlines for operation %d: %w", opWrapper.ID(), err)
+	}
 	for _, event := range contractEvents {
 		// Validate basic contract contractEvent structure
 		if event.Type != xdr.ContractEventTypeContract || event.ContractId == nil || event.Body.V != 0 {
@@ -178,7 +182,11 @@ func (p *SACEventsProcessor) ProcessOperation(_ context.Context, opWrapper *proc
 			} else {
 				// For classic account addresses, check trustline flag changes
 				wasAuthorized, wasMaintainLiabilities, err = p.extractTrustlineFlagChanges(changes, accountToAuthorize, contractID)
-				if err != nil && !errors.Is(err, errNoPreviousTrustlineFlagChangesFound) {
+				if errors.Is(err, errNoPreviousTrustlineFlagChangesFound) {
+					// The creation pass already emitted the trustline's initial authorization state.
+					continue
+				}
+				if err != nil {
 					// We dont want to log errors for no trustline change found. We can simply skip processing.
 					if !errors.Is(err, errNoTrustlineChangeFound) {
 						log.Debugf("processor: %s: extracting trustline flag changes: txHash=%s opID=%d contractId=%s accountAddress=%s error=%v",
@@ -249,6 +257,43 @@ func (p *SACEventsProcessor) ProcessOperation(_ context.Context, opWrapper *proc
 		default:
 			continue
 		}
+	}
+	return stateChanges, nil
+}
+
+func (p *SACEventsProcessor) processCreatedTrustlines(changes []ingest.Change, builder *processors.StateChangeBuilder) ([]types.StateChange, error) {
+	stateChanges := make([]types.StateChange, 0)
+	for _, change := range changes {
+		if change.Type != xdr.LedgerEntryTypeTrustline || change.Pre != nil || change.Post == nil {
+			continue
+		}
+
+		trustline := change.Post.Data.MustTrustLine()
+		if trustline.Asset.Type == xdr.AssetTypeAssetTypePoolShare {
+			continue
+		}
+
+		asset, err := trustLineAssetToAsset(trustline.Asset)
+		if err != nil {
+			return nil, fmt.Errorf("converting trustline asset: %w", err)
+		}
+		assetContractID, err := asset.ContractID(p.networkPassphrase)
+		if err != nil {
+			return nil, fmt.Errorf("getting trustline asset contract ID: %w", err)
+		}
+
+		contractID := strkey.MustEncode(strkey.VersionByteContract, assetContractID[:])
+		account := trustline.AccountId.Address()
+		baseBuilder := builder.Clone().WithAccount(account).WithToken(contractID)
+		limit := amount.String(trustline.Limit)
+		stateChanges = append(stateChanges,
+			baseBuilder.Clone().
+				WithCategory(types.StateChangeCategoryTrustline).
+				WithReason(types.StateChangeReasonAdd).
+				WithTrustlineLimit(nil, &limit).
+				Build(),
+			processors.BuildBalanceAuthorizationForNewTrustline(baseBuilder, xdr.TrustLineFlags(trustline.Flags)),
+		)
 	}
 	return stateChanges, nil
 }

--- a/internal/indexer/processors/contracts/sac_test.go
+++ b/internal/indexer/processors/contracts/sac_test.go
@@ -3,8 +3,10 @@ package contracts
 import (
 	"context"
 	"database/sql"
+	"math"
 	"testing"
 
+	"github.com/stellar/go-stellar-sdk/ingest"
 	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stellar/go-stellar-sdk/xdr"
@@ -13,6 +15,102 @@ import (
 	"github.com/stellar/wallet-backend/internal/indexer/processors"
 	"github.com/stellar/wallet-backend/internal/indexer/types"
 )
+
+func TestSACEventsProcessor_ProcessCreatedTrustline(t *testing.T) {
+	processor := NewSACEventsProcessor(networkPassphrase, nil)
+	admin := "GBNOOJYISY7Y5IKJFDOGDTVQMPO6DZ46SCS64O2IB4NSCAMXGCKOLORN"
+	account := "GC4XF7RE3R4P77GY5XNGICM56IOKUURWAAANPXHFC7G5H6FCNQVVH3OH"
+
+	t.Run("CAP-73 trust creates trustline state changes without contract event", func(t *testing.T) {
+		asset := xdr.MustNewCreditAsset("TEST", admin)
+		assetContractID, err := asset.ContractID(networkPassphrase)
+		require.NoError(t, err)
+		expectedContractID := strkey.MustEncode(strkey.VersionByteContract, assetContractID[:])
+		flags := xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag | xdr.TrustLineFlagsTrustlineClawbackEnabledFlag)
+		tx := createCAP73TrustTx(account, admin, asset.ToTrustLineAsset(), flags)
+		events, err := tx.GetContractEventsForOperation(0)
+		require.NoError(t, err)
+		require.Empty(t, events)
+		changes, err := tx.GetOperationChanges(0)
+		require.NoError(t, err)
+		require.Len(t, changes, 1)
+		require.Nil(t, changes[0].Pre)
+		require.NotNil(t, changes[0].Post)
+		op, found := tx.GetOperation(0)
+		require.True(t, found)
+
+		stateChanges, err := processor.ProcessOperation(context.Background(), &processors.TransactionOperationWrapper{
+			Index:          0,
+			Operation:      op,
+			Network:        networkPassphrase,
+			Transaction:    tx,
+			LedgerSequence: 12345,
+		})
+		require.NoError(t, err)
+		require.Len(t, stateChanges, 2)
+
+		trustlineChange := stateChanges[0]
+		require.Equal(t, types.StateChangeCategoryTrustline, trustlineChange.StateChangeCategory)
+		require.Equal(t, types.StateChangeReasonAdd, trustlineChange.StateChangeReason)
+		require.Equal(t, account, trustlineChange.AccountID.String())
+		require.Equal(t, expectedContractID, trustlineChange.TokenID.String())
+		require.False(t, trustlineChange.TrustlineLimitOld.Valid)
+		require.Equal(t, "922337203685.4775807", trustlineChange.TrustlineLimitNew.String)
+
+		authorizationChange := stateChanges[1]
+		require.Equal(t, types.StateChangeCategoryBalanceAuthorization, authorizationChange.StateChangeCategory)
+		require.Equal(t, types.StateChangeReasonSet, authorizationChange.StateChangeReason)
+		require.Equal(t, account, authorizationChange.AccountID.String())
+		require.Equal(t, expectedContractID, authorizationChange.TokenID.String())
+		require.Equal(t, sql.NullInt16{
+			Int16: types.FlagBitAuthorized | types.FlagBitClawbackEnabled,
+			Valid: true,
+		}, authorizationChange.Flags)
+	})
+
+	t.Run("pool-share trustline is ignored", func(t *testing.T) {
+		poolID := xdr.PoolId{1}
+		tx := createCAP73TrustTx(account, admin, xdr.TrustLineAsset{
+			Type:            xdr.AssetTypeAssetTypePoolShare,
+			LiquidityPoolId: &poolID,
+		}, 0)
+		op, found := tx.GetOperation(0)
+		require.True(t, found)
+
+		stateChanges, err := processor.ProcessOperation(context.Background(), &processors.TransactionOperationWrapper{
+			Index:          0,
+			Operation:      op,
+			Network:        networkPassphrase,
+			Transaction:    tx,
+			LedgerSequence: 12345,
+		})
+		require.NoError(t, err)
+		require.Empty(t, stateChanges)
+	})
+}
+
+func createCAP73TrustTx(account, admin string, asset xdr.TrustLineAsset, flags xdr.Uint32) ingest.LedgerTransaction {
+	builder := newTestTxBuilder(account, admin, xdr.MustNewCreditAsset("DUMMY", admin), true, 4)
+	tx := builder.createBaseTx()
+	tx.UnsafeMeta.V4.Operations[0].Events = nil
+	trustline := xdr.TrustLineEntry{
+		AccountId: xdr.MustAddress(account),
+		Asset:     asset,
+		Limit:     math.MaxInt64,
+		Flags:     flags,
+	}
+	builder.addChangesToTx(&tx, []xdr.LedgerEntryChange{{
+		Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+		Created: &xdr.LedgerEntry{
+			LastModifiedLedgerSeq: 12345,
+			Data: xdr.LedgerEntryData{
+				Type:      xdr.LedgerEntryTypeTrustline,
+				TrustLine: &trustline,
+			},
+		},
+	}})
+	return tx
+}
 
 func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 	processor := NewSACEventsProcessor(networkPassphrase, nil)
@@ -223,7 +321,7 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 		require.Empty(t, stateChanges) // Should skip the event due to missing trustline changes
 	})
 
-	t.Run("Trustline change missing previous state is ignored", func(t *testing.T) {
+	t.Run("Trustline creation with authorization event does not duplicate authorization", func(t *testing.T) {
 		admin := keypair.MustRandom().Address()
 		account := keypair.MustRandom().Address()
 		asset := xdr.MustNewCreditAsset("TESTASSET", admin)
@@ -243,11 +341,15 @@ func TestSACEventsProcessor_ProcessOperation(t *testing.T) {
 		}
 		stateChanges, err := processor.ProcessOperation(context.Background(), opWrapper)
 		require.NoError(t, err)
-		require.Len(t, stateChanges, 1) // Should create 1 state change for trustline authorization
-		assertContractEvent(t, stateChanges[0], types.StateChangeReasonSet,
+		require.Len(t, stateChanges, 2)
+		require.Equal(t, types.StateChangeCategoryTrustline, stateChanges[0].StateChangeCategory)
+		require.Equal(t, types.StateChangeReasonAdd, stateChanges[0].StateChangeReason)
+		require.Equal(t, account, stateChanges[0].AccountID.String())
+		require.Equal(t, strkey.MustEncode(strkey.VersionByteContract, assetContractID[:]), stateChanges[0].TokenID.String())
+		assertContractEvent(t, stateChanges[1], types.StateChangeReasonSet,
 			account,
 			strkey.MustEncode(strkey.VersionByteContract, assetContractID[:]))
-		require.Equal(t, sql.NullInt16{Int16: types.FlagBitAuthorized, Valid: true}, stateChanges[0].Flags)
+		require.Equal(t, sql.NullInt16{Int16: types.FlagBitAuthorized, Valid: true}, stateChanges[1].Flags)
 	})
 
 	// Error case tests

--- a/internal/indexer/processors/contracts/sac_test.go
+++ b/internal/indexer/processors/contracts/sac_test.go
@@ -68,6 +68,25 @@ func TestSACEventsProcessor_ProcessCreatedTrustline(t *testing.T) {
 		}, authorizationChange.Flags)
 	})
 
+	t.Run("zero trustline flags remain an explicit authorization state", func(t *testing.T) {
+		asset := xdr.MustNewCreditAsset("TEST", admin)
+		tx := createCAP73TrustTx(account, admin, asset.ToTrustLineAsset(), 0)
+		op, found := tx.GetOperation(0)
+		require.True(t, found)
+
+		stateChanges, err := processor.ProcessOperation(context.Background(), &processors.TransactionOperationWrapper{
+			Index:          0,
+			Operation:      op,
+			Network:        networkPassphrase,
+			Transaction:    tx,
+			LedgerSequence: 12345,
+		})
+		require.NoError(t, err)
+		require.Len(t, stateChanges, 2)
+		require.Equal(t, types.StateChangeCategoryBalanceAuthorization, stateChanges[1].StateChangeCategory)
+		require.Equal(t, sql.NullInt16{Int16: 0, Valid: true}, stateChanges[1].Flags)
+	})
+
 	t.Run("pool-share trustline is ignored", func(t *testing.T) {
 		poolID := xdr.PoolId{1}
 		tx := createCAP73TrustTx(account, admin, xdr.TrustLineAsset{

--- a/internal/indexer/processors/effects.go
+++ b/internal/indexer/processors/effects.go
@@ -315,7 +315,7 @@ func (p *EffectsProcessor) generateBalanceAuthorizationForNewTrustline(baseBuild
 		return types.StateChange{}, nil
 	}
 
-	var defaultFlags []string
+	var trustlineFlags xdr.TrustLineFlags
 	if assetType == "liquidity_pool_shares" {
 		poolID, err := safeStringFromDetails(effect.Details, "liquidity_pool_id")
 		if err != nil {
@@ -330,21 +330,22 @@ func (p *EffectsProcessor) generateBalanceAuthorizationForNewTrustline(baseBuild
 		baseBuilder = baseBuilder.WithToken(assetContractID)
 
 		// Extract trustline flags directly from the transaction changes
-		trustlineFlags, err := p.getTrustlineFlagsFromChanges(effect.Address, assetCode, assetIssuer, changes)
+		trustlineFlags, err = p.getTrustlineFlagsFromChanges(effect.Address, assetCode, assetIssuer, changes)
 		if err != nil {
 			return types.StateChange{}, fmt.Errorf("getting trustline flags from changes: %w", err)
 		}
-
-		// Map XDR trustline flags to our internal flag representation
-		defaultFlags = p.mapTrustlineFlagsToStrings(trustlineFlags)
 	}
 
-	// Generate state changes for each flag that should be set
+	return BuildBalanceAuthorizationForNewTrustline(baseBuilder, trustlineFlags), nil
+}
+
+// BuildBalanceAuthorizationForNewTrustline builds the initial authorization state from a new trustline's flags.
+func BuildBalanceAuthorizationForNewTrustline(baseBuilder *StateChangeBuilder, flags xdr.TrustLineFlags) types.StateChange {
 	return baseBuilder.Clone().
 		WithCategory(types.StateChangeCategoryBalanceAuthorization).
 		WithReason(types.StateChangeReasonSet).
-		WithFlags(defaultFlags).
-		Build(), nil
+		WithFlags(mapTrustlineFlagsToStrings(flags)).
+		Build()
 }
 
 func (p *EffectsProcessor) buildAssetContractIDFromTrustlineEffect(effect *EffectOutput) (string, string, string, error) {
@@ -427,8 +428,8 @@ func (p *EffectsProcessor) getTrustlineFlagsFromChanges(trustorAddress, assetCod
 	return 0, fmt.Errorf("trustline not found in changes for trustor: %s, asset: %s:%s", trustorAddress, assetCode, assetIssuer)
 }
 
-// mapTrustlineFlagsToStrings converts XDR trustline flags to our internal string representation
-func (p *EffectsProcessor) mapTrustlineFlagsToStrings(flags xdr.TrustLineFlags) []string {
+// mapTrustlineFlagsToStrings converts XDR trustline flags to the internal string representation.
+func mapTrustlineFlagsToStrings(flags xdr.TrustLineFlags) []string {
 	var flagStrings []string
 
 	if flags.IsAuthorized() {

--- a/internal/indexer/processors/state_change_builder.go
+++ b/internal/indexer/processors/state_change_builder.go
@@ -78,10 +78,8 @@ func (b *StateChangeBuilder) WithTrustlineLimit(oldValue, newValue *string) *Sta
 
 // WithFlags sets the flags as a bitmask from a slice of flag names
 func (b *StateChangeBuilder) WithFlags(flags []string) *StateChangeBuilder {
-	if len(flags) > 0 {
-		bitmask := types.EncodeFlagsToBitmask(flags)
-		b.base.Flags = sql.NullInt16{Int16: bitmask, Valid: true}
-	}
+	bitmask := types.EncodeFlagsToBitmask(flags)
+	b.base.Flags = sql.NullInt16{Int16: bitmask, Valid: true}
 	return b
 }
 

--- a/internal/indexer/types/types.go
+++ b/internal/indexer/types/types.go
@@ -743,9 +743,10 @@ func DecodeAccountFlags(bitmask int16) []AccountFlag {
 }
 
 // DecodeTrustlineFlags decodes only the trustline authorization bits of bitmask into
-// TrustlineFlag values, in fixed order. Returns nil when no trustline bits are set.
+// TrustlineFlag values, in fixed order. Returns an empty, non-nil slice when no
+// trustline bits are set, distinguishing an explicit zero bitmask from SQL NULL.
 func DecodeTrustlineFlags(bitmask int16) []TrustlineFlag {
-	var flags []TrustlineFlag
+	flags := make([]TrustlineFlag, 0)
 	for _, fb := range trustlineFlagBits {
 		if bitmask&fb.bit != 0 {
 			flags = append(flags, fb.flag)

--- a/internal/indexer/types/types_test.go
+++ b/internal/indexer/types/types_test.go
@@ -422,8 +422,10 @@ func TestDecodeAccountFlags(t *testing.T) {
 }
 
 func TestDecodeTrustlineFlags(t *testing.T) {
-	t.Run("zero decodes to nil", func(t *testing.T) {
-		assert.Nil(t, DecodeTrustlineFlags(0))
+	t.Run("zero decodes to an empty non-nil slice", func(t *testing.T) {
+		flags := DecodeTrustlineFlags(0)
+		assert.NotNil(t, flags)
+		assert.Empty(t, flags)
 	})
 
 	t.Run("decodes set bits in fixed order", func(t *testing.T) {

--- a/internal/serve/graphql/resolvers/statechange_resolvers_test.go
+++ b/internal/serve/graphql/resolvers/statechange_resolvers_test.go
@@ -699,6 +699,16 @@ func TestBalanceAuthorizationChangeResolver_Flags(t *testing.T) {
 		assert.Nil(t, flags)
 	})
 
+	t.Run("empty list when a classic trustline has no flags set", func(t *testing.T) {
+		obj := &types.BalanceAuthorizationChangeModel{StateChange: types.StateChange{
+			Flags: sql.NullInt16{Int16: 0, Valid: true},
+		}}
+		flags, err := r.Flags(ctx, obj)
+		require.NoError(t, err)
+		assert.NotNil(t, flags)
+		assert.Empty(t, flags)
+	})
+
 	t.Run("decodes only the trustline bits in fixed order", func(t *testing.T) {
 		// authorized (1) | clawback_enabled (32) = 33
 		obj := &types.BalanceAuthorizationChangeModel{StateChange: types.StateChange{


### PR DESCRIPTION
## Summary

Fixes #731.

CAP-0073 introduces `trust(address)` for Stellar Asset Contracts. For classic accounts, this invocation can create a trustline without emitting a corresponding contract event. Although the resulting balance was captured in `trustline_balances`, the state-change processor did not record the trustline creation or its initial authorization state.

## Changes

- Detect newly created `TrustLineEntry` records in SAC operation ledger-entry changes.
- Emit a `TRUSTLINE / ADD` state change containing the account, SAC contract ID, and trustline limit.
- Emit the corresponding `BALANCE_AUTHORIZATION / SET` state change based on the trustline flags.
- Ignore liquidity-pool-share trustlines, consistent with existing trustline processing.
- Reuse the existing trustline flag mapping used by the classic effects processor.
- Avoid duplicate authorization state changes when trustline creation is accompanied by a `set_authorized` event.
- Preserve the existing SAC state-change ordinal namespace.

## Tests

Added deterministic coverage for:

- CAP-73 trustline creation without contract events.
- Account and SAC contract identity.
- Unlimited trustline limit conversion.
- Initial authorization and clawback flags.
- Ignoring pool-share trustlines.
- Avoiding duplicate authorization changes during trustline creation.

Validation performed:

- `go test ./internal/indexer/processors/contracts/... -count=1`
- `go test ./internal/indexer/... ./internal/services/sep41/... -count=1`
- Regression test repeated 20 times.
- Race-enabled contracts package tests.
- Full CI-style unit suite: 2,530 tests passed, 3 intentionally skipped.
- Coverage: 76.1%, above the 65% CI threshold.
- `go build ./...`
- `go vet ./...`
- `golangci-lint`
- `deadcode`
- `gofmt`
- `goimports`
- Module verification and diff checks.

The unrelated SEP-41 current-state migration integration assertion also fails identically when run against an independently built, unmodified `upstream/main` image; it is not introduced by this change.
