### PR TITLE
fix(integrationtests): replace minio with seaweedfs

### DIFF
--- a/internal/integrationtests/data_migration_test.go
+++ b/internal/integrationtests/data_migration_test.go
@@ -106,17 +106,17 @@ func (s *DataMigrationTestSuite) TestProtocolSetupThenCurrentStateMigration() {
 
 	// Phase 3: protocol-migrate current-state builds SEP-41 balances from start ledger to
 	// the tip, coalescing with --window-size 10, using the production datastore backend
-	// (optimizedStorageBackend reading from the in-test minio object store) — the same path
-	// live migrations use. A host-side exporter streams standalone ledgers into minio and
+	// (optimizedStorageBackend reading from the in-test object store) — the same path
+	// live migrations use. A host-side exporter streams standalone ledgers into it and
 	// keeps following the tip, so the unbounded datastore backend never starves; the
 	// migration converges and hands off to live ingestion at the tip exactly as it would
 	// with the RPC backend. The migrate container persists as "wallet-backend-protocol-migrate"
 	// for `docker logs`.
 	rpcURL, err := s.testEnv.Containers.RPCContainer.GetConnectionString(ctx)
 	s.Require().NoError(err)
-	minioEndpoint, err := s.testEnv.Containers.MinioContainer.GetConnectionString(ctx)
+	objectStoreEndpoint, err := s.testEnv.Containers.ObjectStoreContainer.GetConnectionString(ctx)
 	s.Require().NoError(err)
-	stopExporter := infrastructure.StartLedgerExporter(s.T(), rpcURL, minioEndpoint, startLedger)
+	stopExporter := infrastructure.StartLedgerExporter(s.T(), rpcURL, objectStoreEndpoint, startLedger)
 	defer stopExporter()
 
 	// Datastore config (bucket, endpoint, schema, buffer/worker tuning) arrives via env from

--- a/internal/integrationtests/infrastructure/containers.go
+++ b/internal/integrationtests/infrastructure/containers.go
@@ -317,32 +317,34 @@ func createRPCContainer(ctx context.Context, testNetwork *testcontainers.DockerN
 	}, nil
 }
 
-// createMinioContainer starts a minio (S3-compatible) object store that backs the
+// createObjectStoreContainer starts a SeaweedFS S3-compatible object store that backs the
 // datastore ledger backend exercised by the protocol-migrate test. The host process
 // exports ledgers into it (see ledger_exporter.go) and the migrate container reads them
 // back through the production optimizedStorageBackend.
 //
 // The data dir lives only inside the container (no host bind-mount), so exported ledger
-// files are discarded when the container is reaped at teardown. Pre-creating the bucket
-// directory makes minio expose "ledgers" as a bucket at startup, so no bucket-creation
-// code or AWS SDK dependency is needed.
-func createMinioContainer(ctx context.Context, testNetwork *testcontainers.DockerNetwork) (*TestContainer, error) {
+// files are discarded when the container is reaped at teardown. `weed server -s3` runs
+// the whole stack (master, volume, filer, S3 gateway) in one process with no auth, and
+// the startup loop creates the bucket once the filer is up; the wait strategy lists the
+// bucket, so the container only reports ready when the bucket exists.
+func createObjectStoreContainer(ctx context.Context, testNetwork *testcontainers.DockerNetwork) (*TestContainer, error) {
+	startupCmd := fmt.Sprintf(
+		"weed server -dir=/data -s3 & "+
+			"until echo s3.bucket.list | weed shell -master localhost:9333 2>/dev/null | grep -q %[1]s; do "+
+			"echo s3.bucket.create -name %[1]s | weed shell -master localhost:9333 2>/dev/null; sleep 1; done; wait",
+		datastoreBucket)
 	containerRequest := testcontainers.ContainerRequest{
-		Name:  minioNetworkAlias,
-		Image: minioImage,
+		Name:  objectStoreNetworkAlias,
+		Image: objectStoreImage,
 		Labels: map[string]string{
 			"org.testcontainers.session-id": "wallet-backend-integration-tests",
 		},
-		Entrypoint: []string{"sh", "-c"},
-		Cmd:        []string{fmt.Sprintf("mkdir -p /data/%s && minio server /data --address :%s", datastoreBucket, minioPort)},
-		Env: map[string]string{
-			"MINIO_ROOT_USER":     minioRootUser,
-			"MINIO_ROOT_PASSWORD": minioRootPassword,
-		},
+		Entrypoint:   []string{"sh", "-c"},
+		Cmd:          []string{startupCmd},
 		Networks:     []string{testNetwork.Name},
-		ExposedPorts: []string{minioPort + "/tcp"},
-		WaitingFor: wait.ForHTTP("/minio/health/live").
-			WithPort(nat.Port(minioPort + "/tcp")).
+		ExposedPorts: []string{objectStorePort + "/tcp"},
+		WaitingFor: wait.ForHTTP("/" + datastoreBucket).
+			WithPort(nat.Port(objectStorePort + "/tcp")).
 			WithStartupTimeout(60 * time.Second),
 	}
 
@@ -352,13 +354,13 @@ func createMinioContainer(ctx context.Context, testNetwork *testcontainers.Docke
 		Started:          true,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("creating minio container: %w", err)
+		return nil, fmt.Errorf("creating object-store container: %w", err)
 	}
-	log.Ctx(ctx).Infof("🔄 Created minio container")
+	log.Ctx(ctx).Infof("🔄 Created object-store container")
 
 	return &TestContainer{
 		Container:     container,
-		MappedPortStr: minioPort,
+		MappedPortStr: objectStorePort,
 	}, nil
 }
 

--- a/internal/integrationtests/infrastructure/ledger_exporter.go
+++ b/internal/integrationtests/infrastructure/ledger_exporter.go
@@ -14,18 +14,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Shared minio + datastore settings. The schema constants MUST match what DatastoreEnv()
-// advertises to the migrate container so the exporter's object keys line up with what the
-// migrate container's optimizedStorageBackend reads.
+// Shared object-store + datastore settings. The schema constants MUST match what
+// DatastoreEnv() advertises to the migrate container so the exporter's object keys line
+// up with what the migrate container's optimizedStorageBackend reads.
 const (
-	minioImage        = "minio/minio:latest"
-	minioNetworkAlias = "minio"
-	minioPort         = "9000"
-	minioRootUser     = "minioadmin"
-	minioRootPassword = "minioadmin"
-	// minioNetworkEndpoint is how a sibling container (e.g. the migrate container) reaches minio
-	// over the docker network. The host test process uses the testcontainers connection string.
-	minioNetworkEndpoint = "http://" + minioNetworkAlias + ":" + minioPort
+	// SeaweedFS provides the S3-compatible store; the tag is pinned so
+	// registry-side changes cannot break CI.
+	objectStoreImage        = "chrislusf/seaweedfs:4.46"
+	objectStoreNetworkAlias = "object-store"
+	// The weed S3 gateway's default port.
+	objectStorePort = "8333"
+	// SeaweedFS runs without S3 authentication here, but the AWS SDK's default
+	// credential chain still needs non-empty credentials to sign requests.
+	objectStoreAccessKey = "test"
+	objectStoreSecretKey = "test"
+	// objectStoreNetworkEndpoint is how a sibling container (e.g. the migrate container)
+	// reaches the store over the docker network. The host test process uses the
+	// testcontainers connection string.
+	objectStoreNetworkEndpoint = "http://" + objectStoreNetworkAlias + ":" + objectStorePort
 
 	datastoreBucket            = "ledgers"
 	datastoreRegion            = "us-east-1"
@@ -33,24 +39,23 @@ const (
 	datastoreFilesPerPartition = uint32(1)
 )
 
-// DatastoreEnv returns the env a wallet-backend container needs to read the minio-backed
-// datastore. AWS_* feed the S3 datastore's default credential chain (it falls back to anonymous
-// access, which a private bucket rejects, if absent). DATASTORE_* drive the datastore ledger
-// backend; the schema values MUST match the exporter's object keys, hence the shared datastore*
-// constants.
+// DatastoreEnv returns the env a wallet-backend container needs to read the object-store-backed
+// datastore. AWS_* feed the S3 datastore's default credential chain (the SDK refuses to sign
+// without them). DATASTORE_* drive the datastore ledger backend; the schema values MUST match
+// the exporter's object keys, hence the shared datastore* constants.
 func (s *SharedContainers) DatastoreEnv() map[string]string {
 	return map[string]string{
-		"AWS_ACCESS_KEY_ID":     minioRootUser,
-		"AWS_SECRET_ACCESS_KEY": minioRootPassword,
+		"AWS_ACCESS_KEY_ID":     objectStoreAccessKey,
+		"AWS_SECRET_ACCESS_KEY": objectStoreSecretKey,
 		"AWS_REGION":            datastoreRegion,
 
 		"DATASTORE_BUCKET_PATH":         datastoreBucket,
 		"DATASTORE_REGION":              datastoreRegion,
-		"DATASTORE_ENDPOINT_URL":        minioNetworkEndpoint,
+		"DATASTORE_ENDPOINT_URL":        objectStoreNetworkEndpoint,
 		"DATASTORE_LEDGERS_PER_FILE":    fmt.Sprintf("%d", datastoreLedgersPerFile),
 		"DATASTORE_FILES_PER_PARTITION": fmt.Sprintf("%d", datastoreFilesPerPartition),
 		// Shallow buffer/worker counts: the test sits at the live tip almost immediately, where a
-		// deep prefetch only spams minio with 404s for not-yet-exported ledgers.
+		// deep prefetch only spams the store with 404s for not-yet-exported ledgers.
 		"DATASTORE_BUFFER_SIZE": "10",
 		"DATASTORE_NUM_WORKERS": "2",
 		"DATASTORE_RETRY_LIMIT": "3",
@@ -58,7 +63,7 @@ func (s *SharedContainers) DatastoreEnv() map[string]string {
 	}
 }
 
-// StartLedgerExporter continuously exports ledgers from the RPC server into the minio-backed
+// StartLedgerExporter continuously exports ledgers from the RPC server into the object-store-backed
 // datastore, starting at startLedger and following the live tip. It is a minimal galexie: read
 // LedgerCloseMeta, wrap one ledger per batch, zstd+XDR encode, and PutFile under the schema's
 // object key — the exact bytes the migration's optimizedStorageBackend expects to decode.
@@ -68,12 +73,12 @@ func (s *SharedContainers) DatastoreEnv() map[string]string {
 // The first ledger is exported synchronously so the datastore is non-empty before the caller
 // launches the migration (its LoadSchema probe and first GetFile then succeed). Returns a stop
 // func that halts the exporter and waits for its goroutine to exit.
-func StartLedgerExporter(t *testing.T, rpcURL, minioEndpoint string, startLedger uint32) func() {
+func StartLedgerExporter(t *testing.T, rpcURL, objectStoreEndpoint string, startLedger uint32) func() {
 	t.Helper()
 
-	// minio root creds for the SDK's default credential chain (S3 datastore writes).
-	t.Setenv("AWS_ACCESS_KEY_ID", minioRootUser)
-	t.Setenv("AWS_SECRET_ACCESS_KEY", minioRootPassword)
+	// Object-store creds for the SDK's default credential chain (S3 datastore writes).
+	t.Setenv("AWS_ACCESS_KEY_ID", objectStoreAccessKey)
+	t.Setenv("AWS_SECRET_ACCESS_KEY", objectStoreSecretKey)
 	t.Setenv("AWS_REGION", datastoreRegion)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -83,7 +88,7 @@ func StartLedgerExporter(t *testing.T, rpcURL, minioEndpoint string, startLedger
 		Params: map[string]string{
 			"destination_bucket_path": datastoreBucket,
 			"region":                  datastoreRegion,
-			"endpoint_url":            minioEndpoint,
+			"endpoint_url":            objectStoreEndpoint,
 		},
 	})
 	require.NoError(t, err, "creating exporter datastore")

--- a/internal/integrationtests/infrastructure/main_setup.go
+++ b/internal/integrationtests/infrastructure/main_setup.go
@@ -35,7 +35,7 @@ type SharedContainers struct {
 	StellarCoreContainer   *TestContainer
 	RPCContainer           *TestContainer
 	WalletDBContainer      *TestContainer
-	MinioContainer         *TestContainer // S3-compatible object store backing the datastore ledger backend
+	ObjectStoreContainer   *TestContainer // S3-compatible object store backing the datastore ledger backend
 	WalletBackendContainer *WalletBackendContainer
 	BackfillContainer      *TestContainer // Separate container for backfill testing
 
@@ -117,10 +117,10 @@ func (s *SharedContainers) initializeContainerInfrastructure(ctx context.Context
 		return fmt.Errorf("creating RPC container: %w", err)
 	}
 
-	// Start minio (object store for the datastore ledger backend exercised by the migration test)
-	s.MinioContainer, err = createMinioContainer(ctx, s.TestNetwork)
+	// Start the object store for the datastore ledger backend exercised by the migration test
+	s.ObjectStoreContainer, err = createObjectStoreContainer(ctx, s.TestNetwork)
 	if err != nil {
-		return fmt.Errorf("creating minio container: %w", err)
+		return fmt.Errorf("creating object-store container: %w", err)
 	}
 
 	return nil
@@ -510,8 +510,8 @@ func (s *SharedContainers) Cleanup(ctx context.Context) {
 	if s.RPCContainer != nil {
 		_ = (*s.RPCContainer).Terminate(ctx) //nolint:errcheck
 	}
-	if s.MinioContainer != nil {
-		_ = (*s.MinioContainer).Terminate(ctx) //nolint:errcheck
+	if s.ObjectStoreContainer != nil {
+		_ = (*s.ObjectStoreContainer).Terminate(ctx) //nolint:errcheck
 	}
 	if s.StellarCoreContainer != nil {
 		_ = (*s.StellarCoreContainer).Terminate(ctx) //nolint:errcheck


### PR DESCRIPTION
### What

Replace the MinIO test container with SeaweedFS (chrislusf/seaweedfs:4.46) 

### Why

MinIO deleted its Docker Hub images and breaks CI run.

### Known limitations

N/A

### Issue that this PR addresses

N/A

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR's title starts with name of package that is most changed in the PR, or `all` if the changes are broad or impact many packages.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.
- [ ] All updated queries have been tested (refer to [this](https://stackoverflow.com/a/29163465) check if the data set returned by the updated query is expected to be same as the original one).

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
